### PR TITLE
notations/02-fgca: add flat-form schema and rewrite example

### DIFF
--- a/notations/02-fgca.md
+++ b/notations/02-fgca.md
@@ -1,8 +1,8 @@
 ---
 notation: "FGCA Strategy-to-Execution Chain"
-version: "1.1"
+version: "1.2"
 author: "Valerii Korobeinikov"
-last_updated: "2026-05-08"
+last_updated: "2026-05-21"
 status: "documented"
 file_extension: "*.fgca.transitrix.yaml"
 dsm_status: "implemented — F, G, C, A layers active; column selection via localStorage"
@@ -104,3 +104,150 @@ Transitrix DSM implements the full 4-layer FGCA chain as of release 0.2.2:
 
 **Design decisions:** see `docs/decisions/2026-05-08-fgca-design.md` in the DSM repository.
 
+---
+
+## File location and naming
+
+```
+views/fgca/<DOMAIN>.fgca.transitrix.yaml
+```
+
+Examples:
+- `views/fgca/STRATEGY_2026.fgca.transitrix.yaml`
+- `views/fgca/Q3_OPERATIONS.fgca.transitrix.yaml`
+
+---
+
+## Top-level structure — flat form
+
+FGCA uses the **flat form**: a single `fgca:` root key carries document metadata, and the four layers (`factors`, `goals`, `changes`, `activities`) are parallel arrays under that key. Links between layers are id-references on each item, not nesting.
+
+This shape matches the FGCA semantic graph: one Change can deliver many Goals, one Activity can deliver many Changes (the `activity_change` join in DSM). A nested form would require duplicating nodes for every cross-layer link. The flat form expresses the DAG directly.
+
+For comparison: FGA and the Goals tree are tree-shaped (each child has a single parent) and use a nested form — see [`03-fga.md`](03-fga.md) and [`04-goals.md`](04-goals.md). The flat-vs-nested choice across the family follows the rule "nested for trees, flat for DAGs" — the family-selection guide will document this once the cross-notation relationship doc lands.
+
+```yaml
+notation: fgca
+spec_version: 0.1
+
+fgca:
+  id: FGCA-STRAT-1
+  name: "Strategy 2026 — FGCA chain"
+  description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
+  period: "2026"
+  version: "0.1"
+  date: "2026-05-21"
+  author: Transitrix
+
+  factors:
+    - id: FACTOR-1
+      name: "Competitive market pressure"
+      type: external          # external | internal
+
+  goals:
+    - id: GOAL-1
+      name: "Grow revenue by 20%"
+      factors: [FACTOR-1]     # id-references to factors[]
+
+  changes:
+    - id: CHANGE-1
+      name: "Launch new product line"
+      goals: [GOAL-1]         # id-references to goals[]
+
+  activities:
+    - id: ACTIVITY-1
+      name: "Market research"
+      changes: [CHANGE-1]     # id-references to changes[]
+```
+
+A complete example: [`examples/fgca/strategy-2026.fgca.transitrix.yaml`](examples/fgca/strategy-2026.fgca.transitrix.yaml).
+
+---
+
+## Fields
+
+### `fgca` root
+
+| Field | Required | Description |
+|---|---|---|
+| `fgca.id` | yes | document ID — `FGCA-[<middle>-]<INTEGER>` per the canonical grammar |
+| `fgca.name` | yes | human-readable name |
+| `fgca.description` | no | one-paragraph context |
+| `fgca.period` | no | time period the chain covers (e.g. `"2026"`, `"2026-Q3"`) |
+| `fgca.version` | no | document version |
+| `fgca.date` | no | document date (YYYY-MM-DD) |
+| `fgca.author` | no | document author |
+| `fgca.factors` | yes | array of factor entries — see below |
+| `fgca.goals` | yes | array of goal entries — see below |
+| `fgca.changes` | yes | array of change entries — see below |
+| `fgca.activities` | yes | array of activity entries — see below |
+
+### `factors[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | `FACTOR-[<middle>-]<INTEGER>` |
+| `name` | yes | what the factor is |
+| `type` | no | `external` or `internal` |
+| `description` | no | one-paragraph elaboration |
+
+### `goals[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | `GOAL-[<middle>-]<INTEGER>` |
+| `name` | yes | what the goal is |
+| `factors` | no | array of `FACTOR-…` IDs this goal is driven by |
+| `description` | no | one-paragraph elaboration |
+
+### `changes[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | `CHANGE-[<middle>-]<INTEGER>` |
+| `name` | yes | what the change is |
+| `goals` | no | array of `GOAL-…` IDs this change delivers |
+| `description` | no | one-paragraph elaboration |
+
+### `activities[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | `ACTIVITY-[<middle>-]<INTEGER>` |
+| `name` | yes | what the activity is |
+| `changes` | no | array of `CHANGE-…` IDs this activity delivers |
+| `goals` | no | array of `GOAL-…` IDs the activity supports directly (degenerate FGA-style link, used when the Change layer adds no information for that activity) |
+| `description` | no | one-paragraph elaboration |
+
+ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>`. Middle segments are optional and notation-specific. The terminal integer is positive (≥ 1) with no leading zeros. `ACTIVITY-` is the canonical activity prefix (replacing the older `ACT-` form); `CHANGE-` is the FGCA change-layer prefix. The full grammar and TYPE registry will live in a forthcoming `IDS_AND_REFERENCES.md` appendix.
+
+---
+
+## Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `FGCA-001` | error | `fgca` root key missing. |
+| `FGCA-002` | error | `fgca.id` missing or empty. |
+| `FGCA-003` | error | `fgca.name` missing or empty. |
+| `FGCA-004` | error | any of `fgca.factors` / `fgca.goals` / `fgca.changes` / `fgca.activities` missing or empty. |
+| `FGCA-005` | error | every entry in the four arrays must have a non-empty `id` and `name`. |
+| `FGCA-006` | error | IDs unique within their layer (and SHOULD be unique across all four layers within a document). |
+| `FGCA-007` | error | every ID matches the canonical grammar `<TYPE>-[<middle>-]<INTEGER>` with the right type prefix for its layer. |
+| `FGCA-008` | error | `goals[].factors[]` IDs must reference defined factors. |
+| `FGCA-009` | error | `changes[].goals[]` IDs must reference defined goals. |
+| `FGCA-010` | error | `activities[].changes[]` IDs must reference defined changes. |
+| `FGCA-011` | error | `activities[].goals[]` IDs must reference defined goals. |
+| `FGCA-012` | warn | a factor with no goal referencing it is orphan. |
+| `FGCA-013` | warn | a goal with no change (and no direct activity) referencing it is orphan. |
+| `FGCA-014` | warn | a change with no activity referencing it is orphan. |
+
+---
+
+## References
+
+- FGA notation (3-layer simplified variant, nested form): [`03-fga.md`](03-fga.md)
+- Goals tree notation: [`04-goals.md`](04-goals.md)
+- Activities notation: [`07-activities.md`](07-activities.md) — uses `delivers_changes:` to link into the FGCA chain
+- Canonical ID grammar and TYPE registry: forthcoming `IDS_AND_REFERENCES.md` appendix
+- Methodology section 6.2: `method/methodology.md`

--- a/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
+++ b/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
@@ -1,55 +1,58 @@
 notation: fgca
-spec_version: "0.1"
-title: Strategy 2026 — FGCA chain
-description: Factor → Goal → Change → Activity decomposition for the 2026 plan.
-version: "0.1"
-date: "2026-05-11"
-author: Transitrix
+spec_version: 0.1
 
-factors:
-  - id: 1
-    name: "Competitive market pressure"
-  - id: 2
-    name: "Digital adoption acceleration"
+fgca:
+  id: FGCA-STRAT-1
+  name: "Strategy 2026 — FGCA chain"
+  description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
+  period: "2026"
+  version: "0.1"
+  date: "2026-05-21"
+  author: Transitrix
 
-goals:
-  - id: 1
-    name: "Grow revenue by 20%"
-    factor: [{id: 1}, {id: 2}]
-  - id: 2
-    name: "Reduce operational costs"
-    factor: [{id: 2}]
-  - id: 3
-    name: "Improve customer retention"
-    factor: [{id: 1}]
+  factors:
+    - id: FACTOR-1
+      name: "Competitive market pressure"
+      type: external
+    - id: FACTOR-2
+      name: "Digital adoption acceleration"
+      type: external
 
-changes:
-  - id: 1
-    name: "Launch new product line"
-    goal_id: 1
-    activity_ids: [1, 2]
-  - id: 2
-    name: "Automate manual processes"
-    goal_id: 2
-    activity_ids: [3, 4]
-  - id: 3
-    name: "Enhance support platform"
-    goal_id: 3
-    activity_ids: [5]
+  goals:
+    - id: GOAL-1
+      name: "Grow revenue by 20%"
+      factors: [FACTOR-1, FACTOR-2]
+    - id: GOAL-2
+      name: "Reduce operational costs"
+      factors: [FACTOR-2]
+    - id: GOAL-3
+      name: "Improve customer retention"
+      factors: [FACTOR-1]
 
-activities:
-  - id: 1
-    name: "Market research"
-    goal_id: 1
-  - id: 2
-    name: "MVP development"
-    goal_id: 1
-  - id: 3
-    name: "Process audit"
-    goal_id: 2
-  - id: 4
-    name: "RPA tooling rollout"
-    goal_id: 2
-  - id: 5
-    name: "CRM implementation"
-    goal_id: 3
+  changes:
+    - id: CHANGE-1
+      name: "Launch new product line"
+      goals: [GOAL-1]
+    - id: CHANGE-2
+      name: "Automate manual processes"
+      goals: [GOAL-2]
+    - id: CHANGE-3
+      name: "Enhance support platform"
+      goals: [GOAL-3]
+
+  activities:
+    - id: ACTIVITY-1
+      name: "Market research"
+      changes: [CHANGE-1]
+    - id: ACTIVITY-2
+      name: "MVP development"
+      changes: [CHANGE-1]
+    - id: ACTIVITY-3
+      name: "Process audit"
+      changes: [CHANGE-2]
+    - id: ACTIVITY-4
+      name: "RPA tooling rollout"
+      changes: [CHANGE-2]
+    - id: ACTIVITY-5
+      name: "CRM implementation"
+      changes: [CHANGE-3]


### PR DESCRIPTION
## Summary
- `02-fgca.md` previously carried only the business description; no schema, no validation rules. Now adds File location, Top-level structure (flat form), Fields, Validation rules, References — matching the depth of `03-fga.md` / `04-goals.md`.
- Flat form: `fgca:` root key holds document metadata; `factors` / `goals` / `changes` / `activities` are parallel arrays under it; links between layers are id-references on each item, not nesting. FGA and Goals stay nested in their own specs — they are tree-shaped.
- Rewrote `notations/examples/fgca/strategy-2026.fgca.transitrix.yaml` to match the new schema: metadata under `fgca:`, string IDs (`FACTOR-1`, `GOAL-1`, `CHANGE-1`, `ACTIVITY-1`), id-reference cross-links.
- YAML parses; all factor/goal/change references resolve.

Closes vkgeorgia/strategy#15.

## Scope guard
Per the issue refinement, this PR touches only the FGCA spec and its example. FGA, Goals, and other specs are untouched. No audit items picked up.

## ID grammar (forthcoming appendix)
IDs use the canonical grammar `<TYPE>-[<middle segment(s)>-]<INTEGER>` with `ACTIVITY-` replacing the older `ACT-` and `CHANGE-` as the FGCA change-layer prefix. The full grammar and TYPE registry will land in a forthcoming `IDS_AND_REFERENCES.md` appendix; the spec body refers to it by anticipated filename rather than hyperlinking.

## Test plan
- [x] Example file parses as YAML (`yaml.safe_load`).
- [x] Cross-reference check: every `goals[].factors[]`, `changes[].goals[]`, `activities[].changes[]` ID resolves to a defined entity in its target layer.
- [x] Spec sections render in order and tail is intact.
- [x] No links to the private `vkgeorgia/strategy` repo in shipped files (lesson from `64d2e72`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)