### PR TITLE
notations: add IDs and cross-references appendix

### DIFF
--- a/notations/03-fga.md
+++ b/notations/03-fga.md
@@ -142,4 +142,5 @@ When converting FGA to FGCA: identify the implicit change each goal demands and 
 - FGCA notation: `notations/02-fgca.md`
 - Goals tree notation: `notations/04-goals.md`
 - Goal elements: `elements/01_motivation/*.yaml` (type: Goal)
+- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
 - Methodology section 6.2: `method/methodology.md`

--- a/notations/04-goals.md
+++ b/notations/04-goals.md
@@ -138,6 +138,7 @@ goals_tree:
 - Goal elements: `elements/01_motivation/*.yaml` (type: Goal)
 - FGCA notation: `notations/02-fgca.md`
 - FGA notation: `notations/03-fga.md`
+- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
 - Methodology section 6.1: `method/methodology.md`
 
 ---

--- a/notations/05-capability-map.md
+++ b/notations/05-capability-map.md
@@ -292,6 +292,7 @@ properties:
 - Capability elements: `elements/02_business/*.yaml` (type: Capability)
 - Element template: `organizations/acme_corp/.templates/elements/02_business_template.yaml`
 - Capability template: `organizations/acme_corp/.templates/capability-map_template.yaml`
+- ID grammar (including the `CAPABILITY-V`/`H` exception) and TYPE registry: `notations/IDS_AND_REFERENCES.md`
 - Methodology section 6.3: `method/methodology.md`
 - DSM: `docs/docs/concepts/bcm-explained.md` — BCM concept and addressing rules
 - DSM assignment: `assignments/06_0_1_capabilities.md` — detailed requirements (addressing, validation, sets)

--- a/notations/06-process-map.md
+++ b/notations/06-process-map.md
@@ -158,4 +158,5 @@ Process Landscape Map    →  lists all processes
 - BusinessProcess elements: `elements/02_business/*.yaml` (type: BusinessProcess)
 - BPMN notation: `notations/01-bpmn.md`
 - Capabilities map: `notations/05-capability-map.md`
+- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
 - Methodology section 6.4: `method/methodology.md`

--- a/notations/07-activities.md
+++ b/notations/07-activities.md
@@ -477,3 +477,4 @@ activities:
 - Transitrix BPMN notation: `notations/01-bpmn.md` (for procedural-flow processes)
 - Transitrix FGCA notation: `notations/02-fgca.md` (for Factor → Goal → Change → Activity decomposition; this notation's `delivers_changes` field links into FGCA)
 - Transitrix Goals notation: `notations/04-goals.md` (this notation's `goals` field references Goal IDs)
+- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`

--- a/notations/09-products.md
+++ b/notations/09-products.md
@@ -144,4 +144,5 @@ Capabilities Map         →  what capabilities are required
 - Process landscape map: `notations/06-process-map.md`
 - Applications catalogue: `notations/10-applications.md`
 - Capabilities map: `notations/05-capability-map.md`
+- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
 - Methodology section 6: `method/methodology.md`

--- a/notations/10-applications.md
+++ b/notations/10-applications.md
@@ -164,4 +164,5 @@ ArchiMate                →  formal model of application layer elements and rel
 - Nested block diagrams: `notations/08-blocks.md`
 - ArchiMate vocabulary: `method/methodology.md` §3a
 - Products catalogue: `notations/09-products.md`
+- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
 - Methodology section 6: `method/methodology.md`

--- a/notations/11-scenarios.md
+++ b/notations/11-scenarios.md
@@ -216,4 +216,5 @@ A second application of scenarios — **planning the development of a market sit
 - Goals tree: `notations/04-goals.md`
 - FGCA: `notations/02-fgca.md`
 - Capabilities map: `notations/05-capability-map.md`
+- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
 - Methodology section 6: `method/methodology.md`

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -1,0 +1,159 @@
+# IDs and cross-references — canonical grammar
+
+This appendix defines the ID grammar used across all eleven Transitrix notations and enumerates the TYPE registry. Every element ID and every cross-reference in any notation file follows this grammar.
+
+Recorded 2026-05-20 as the canonical decision for the methodology.
+
+---
+
+## 1. Grammar
+
+```
+<TYPE>-[<middle segment(s)>-]<INTEGER>
+```
+
+- **TYPE** — uppercase entity-type prefix from the registry in §3. The prefix names *what kind of thing* the ID refers to.
+- **Middle segments** — optional, notation-specific. Add for disambiguation (a domain code, a period, a programme name). The grammar fixes only the start and the end of an ID; a notation MAY define one or more middle segments where needed.
+- **INTEGER** — terminal positive integer, ≥ 1, **no leading zeros**. Sorting and comparison MUST parse it numerically, never lexically. There is no fixed width and no upper bound.
+
+**Examples:**
+
+| ID | TYPE | Middle | Integer | Notes |
+|---|---|---|---|---|
+| `FACTOR-1` | FACTOR | — | 1 | minimal form |
+| `GOAL-RETENTION-12` | GOAL | RETENTION | 12 | one middle segment |
+| `ACTIVITY-Q3-2026-7` | ACTIVITY | Q3, 2026 | 7 | two middle segments |
+| `FACTOR-CHURN-001` | — | — | — | **invalid** — leading zero. Use `FACTOR-CHURN-1`. |
+| `factor-1` | — | — | — | **invalid** — TYPE must be uppercase. |
+| `FACTOR-` | — | — | — | **invalid** — missing terminal integer. |
+
+---
+
+## 2. Exception — `CAPABILITY`
+
+Capability IDs end with a V/H diagram address instead of a plain integer:
+
+```
+CAPABILITY-V<L1[.L2[.L3]]>
+CAPABILITY-H<L1[.L2[.L3]]>
+```
+
+- `V` = vertical capability (column in the diagram).
+- `H` = horizontal capability (row cutting across columns).
+- Each address component (`L1`, `L2`, `L3`) is a positive integer ≥ 1, no leading zeros, no upper bound.
+- `0` is reserved for the root node and is never used in a capability ID.
+- Depth is **capped at three levels** (`L1.L2.L3`). A fourth level (`L1.L2.L3.L4`) is invalid.
+
+**Examples:**
+
+- `CAPABILITY-V1`
+- `CAPABILITY-V1.2`
+- `CAPABILITY-V1.2.3`
+- `CAPABILITY-H1.2`
+
+The diagram address derives from the V/H positional addressing system documented in [`05-capability-map.md`](05-capability-map.md) §4–5. Capability IDs are the only place the trailing integer is replaced by a multi-component path; every other TYPE follows §1 unchanged.
+
+---
+
+## 3. TYPE registry
+
+The complete set of canonical TYPE prefixes. Use exactly the listed form — abbreviations like `ACT`, `CHG`, `FAC`, `CAP`, `SCN` are deprecated and being migrated out (see §6).
+
+### 3.1 Element types
+
+Elements that get referenced across documents.
+
+| TYPE | What it is | Used by |
+|---|---|---|
+| `FACTOR` | strategic driver — external or internal | FGCA, FGA |
+| `GOAL` | strategic or tactical goal | Goals tree, FGCA, FGA, Activities |
+| `CHANGE` | business transformation (the BDN change layer) | FGCA, Activities (`delivers_changes:`) |
+| `ACTIVITY` | initiative / workstream | FGCA, FGA, Activities |
+| `CAPABILITY` | capability — V/H sub-grammar, see §2 | Capability map, Products, Applications, Process map |
+| `PROCESS` | business process | Process landscape map, BPMN |
+| `PRODUCT` | product or service | Products catalogue |
+| `APPLICATION` | application | Applications catalogue |
+| `INTEGRATION` | integration between applications | Applications catalogue |
+| `ROLE` | business role | referenced as `owner_role` across notations |
+| `UNIT` | organisational unit | Activities |
+| `EMPLOYEE` | named employee | Activities |
+| `SCENARIO` | strategic scenario | Scenarios |
+
+### 3.2 Document-level types
+
+Each notation file carries its own ID using the same grammar; the TYPE names the notation.
+
+| TYPE | Notation file |
+|---|---|
+| `FGCA` | `*.fgca.transitrix.yaml` |
+| `FGA` | `*.fga.transitrix.yaml` |
+| `GOALS_TREE` | `*.goals.transitrix.yaml` |
+| `CAPABILITY_MAP` | `*.capability-map.transitrix.yaml` |
+| `PROCESS_MAP` | `*.process-map.transitrix.yaml` |
+| `ACTIVITIES_NET` | `*.activities.transitrix.yaml` |
+| `PRODUCTS_CAT` | `*.products.transitrix.yaml` |
+| `APPLICATIONS_CAT` | `*.applications.transitrix.yaml` |
+| `SCENARIOS` | `*.scenarios.transitrix.yaml` |
+| `BLOCKS` | `*.blocks.transitrix.txt` |
+
+BPMN diagrams use their `process.id` as the document identifier; that field is a free-form string defined by the spec, not by this appendix.
+
+### 3.3 File-local labels (out of scope)
+
+BPMN element IDs inside a single file (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) are local labels, not cross-document references. They identify nodes within one BPMN document and are not part of the TYPE registry above. Each BPMN file may use its own labelling convention.
+
+---
+
+## 4. Uniqueness scope
+
+Each TYPE has a scope within which its IDs must be unique. Cross-document references rely on the wider scope holding.
+
+| TYPE | Uniqueness scope |
+|---|---|
+| `FACTOR`, `GOAL`, `CHANGE`, `ACTIVITY` | within the FGCA / FGA / Goals / Activities document that defines them. When referenced from across documents, IDs must also be unique within the organisation's element catalogue (`elements/01_motivation/`, `elements/02_business/`). |
+| `CAPABILITY` | within the capability set (`set_name`, per [`05-capability-map.md`](05-capability-map.md) §5). |
+| `PROCESS` | within the organisation's element catalogue (`elements/02_business/`). |
+| `PRODUCT`, `APPLICATION`, `INTEGRATION` | within the catalogue document. |
+| `ROLE`, `UNIT`, `EMPLOYEE` | within the organisation's element catalogue (`elements/02_business/`). |
+| `SCENARIO` | within the organisation. |
+
+Document-level IDs (`FGCA-…`, `FGA-…`, etc.) are unique within the organisation.
+
+---
+
+## 5. Cross-references
+
+A cross-reference is a field whose value is an ID (or array of IDs) of another element. The pattern is consistent across notations:
+
+- **Plural field name → array of typed IDs.** Example: `activities[].goals: [GOAL-1, GOAL-2]`.
+- **Singular field name → single typed ID.** Example: `activities[].parent: PHASE-DESIGN`.
+- **Child references parent.** A Goal references its driving Factors via `factors: [FACTOR-…]`; a Change references its Goals via `goals: [GOAL-…]`; an Activity references its Changes via `changes: [CHANGE-…]`. Any deviations are documented in the relevant notation spec.
+
+A validator MUST check that every cross-reference resolves to a defined element of the correct TYPE. A reference to an undefined ID is an error; a reference whose target has the wrong TYPE prefix is also an error.
+
+---
+
+## 6. Migration checklist
+
+The TYPE registry above was confirmed 2026-05-20. Several notations and example files still carry older, abbreviated, or untyped forms. Each row below is a follow-up migration: rewriting existing files is **out of scope for this appendix** and rolls out per notation as separate tasks.
+
+| Old form | Canonical form | Where it appears | Notes |
+|---|---|---|---|
+| `ACT-…` | `ACTIVITY-…` | examples under `examples/fga/`, `examples/fgca/`, `examples/activities/`; spec example in `03-fga.md` §4; `07-activities.md` §4 (`delivers_changes: [CHG-001]`). | follow-up |
+| `CHG-…` | `CHANGE-…` | spec example in `07-activities.md` §4; FGCA when its schema lands | follow-up |
+| `FAC-…` | `FACTOR-…` | scenarios examples (`FAC-MARKET-001`, etc.); some FGA references | follow-up |
+| `CAP-…` | `CAPABILITY-V…` / `CAPABILITY-H…` | products and applications examples (cross-refs into capabilities); process-map examples | follow-up |
+| `SCN-…` / `SCEN-…` | `SCENARIO-…` | `11-scenarios.md`; scenarios examples; `07-activities.md` (`scenario: SCEN-2026-OPT`) | follow-up — variant `SCEN` vs `SCN` also needs unifying |
+| Integer-only IDs (`1`, `2`, …) | typed string IDs (`GOAL-1`, `FACTOR-1`, …) | originally the FGCA example | covered in the in-flight FGCA schema PR — see [transitrix/methodology#7](https://github.com/transitrix/methodology/pull/7) |
+| `V1`, `V1.2`, `H1.2` (no `CAPABILITY-` prefix) | `CAPABILITY-V1`, `CAPABILITY-V1.2`, `CAPABILITY-H1.2` | capability-map examples (own IDs); products / applications / process-map examples (cross-refs into capabilities) | follow-up |
+| Zero-padded sequences (`001`, `002`, …) | no-leading-zero integers (`1`, `2`, …) | most example files | follow-up — purely a string-form change; sort order is unaffected because comparison is numeric |
+
+**Migration policy:** one follow-up issue per notation (spec + its examples). Do not bundle migrations into a single mega-PR — they touch different files and benefit from independent review.
+
+---
+
+## 7. References
+
+- Notation catalogue and the index of all eleven notations: [`README.md`](README.md).
+- Capability addressing (the V/H system that the `CAPABILITY` exception relies on): [`05-capability-map.md`](05-capability-map.md) §4–5.
+- Methodology: `method/methodology.md`.


### PR DESCRIPTION
## Summary
- New `notations/IDS_AND_REFERENCES.md` defines the canonical ID grammar `<TYPE>-[<middle segment(s)>-]<INTEGER>`, documents the `CAPABILITY` V/H exception, enumerates the complete TYPE registry (element types + document-level prefixes), states uniqueness scope per TYPE, the cross-reference pattern, and a migration checklist for files still using old forms.
- Eight specs (`03`, `04`, `05`, `06`, `07`, `09`, `10`, `11`) gain a one-line link to the appendix in their References section.

Closes vkgeorgia/strategy#13.

## Scope guard
Per the issue refinement, this PR produces only the new appendix file and adds a cross-link from each spec that references IDs. No other spec content changes; no example rewrites; no audit items.

### Which specs are linked vs not
- **Linked (8):** 03-fga, 04-goals, 05-capability-map, 06-process-map, 07-activities, 09-products, 10-applications, 11-scenarios.
- **Not linked, by design (3):**
  - `01-bpmn` uses only file-local labels (POOL, TASK, GW…), explicitly noted as out of scope in the appendix §3.3.
  - `02-fgca` on main has no schema and therefore no IDs yet; it will gain the link as part of [transitrix/methodology#7](https://github.com/transitrix/methodology/pull/7) which introduces its schema.
  - `08-blocks` uses ASCII art with no element IDs.

## Migration
The appendix carries a migration checklist documenting which existing files still use old ID forms (`ACT-`, `CHG-`, `FAC-`, `CAP-`, `SCN-`, integer-only IDs, zero-padded sequences). **The migration itself is out of scope** — per-notation follow-ups will do it gradually. The integer-IDs row in the FGCA example is already in flight via transitrix/methodology#7.

## Test plan
- [x] `notations/IDS_AND_REFERENCES.md` exists with all seven sections (Grammar, Capability exception, TYPE registry, Uniqueness scope, Cross-references, Migration checklist, References).
- [x] Every listed spec contains exactly one new link to the appendix in its References section.
- [x] No links to the private `vkgeorgia/strategy` repo in any shipped file.
- [x] Existing References-section content untouched apart from the inserted line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)