### PR TITLE
notations: define and apply status vocabulary

### DIFF
--- a/notations/01-bpmn.md
+++ b/notations/01-bpmn.md
@@ -3,7 +3,7 @@ notation: "BPMN Process Diagram"
 version: "1.1"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-19"
-status: "implemented"
+status: "documented"
 file_extension: "*.bpmn.transitrix.yaml"
 ---
 

--- a/notations/03-fga.md
+++ b/notations/03-fga.md
@@ -3,7 +3,7 @@ notation: "FGA Strategy-to-Execution Chain"
 version: "0.1"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-08"
-status: "planned"
+status: "draft"
 file_extension: "*.fga.transitrix.yaml"
 ---
 

--- a/notations/04-goals.md
+++ b/notations/04-goals.md
@@ -3,7 +3,7 @@ notation: "Goals Tree"
 version: "0.2"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-08"
-status: "implemented"
+status: "documented"
 file_extension: "*.goals.transitrix.yaml"
 dsm_status: "implemented — Goals & Activities section, Visual Editor (G)"
 ---

--- a/notations/05-capability-map.md
+++ b/notations/05-capability-map.md
@@ -3,7 +3,7 @@ notation: "Capabilities Map"
 version: "0.3"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-19"
-status: "implemented"
+status: "documented"
 file_extension: "*.capability-map.transitrix.yaml"
 dsm_status: "implemented — Capabilities page, Editor (C), BCM tab"
 ---

--- a/notations/06-process-map.md
+++ b/notations/06-process-map.md
@@ -3,7 +3,7 @@ notation: "Process Landscape Map"
 version: "0.2"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-19"
-status: "planned"
+status: "draft"
 file_extension: "*.process-map.transitrix.yaml"
 ---
 

--- a/notations/07-activities.md
+++ b/notations/07-activities.md
@@ -3,7 +3,7 @@ notation: "Activities — Project Schedule"
 version: "0.3"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-21"
-status: "standard"
+status: "documented"
 file_extension: "*.activities.transitrix.yaml"
 dsm_status: "partially implemented — Activities page; multi-value fields (predecessors, goals, tags) planned in 0.2.5; CPM analysis planned in 0.3.x; Gantt view planned in 0.4.x"
 ---

--- a/notations/08-blocks.md
+++ b/notations/08-blocks.md
@@ -3,7 +3,7 @@ notation: "Nested Block Diagrams"
 version: "0.2"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-19"
-status: "implemented"
+status: "documented"
 file_extension: "*.blocks.transitrix.txt"
 ---
 

--- a/notations/09-products.md
+++ b/notations/09-products.md
@@ -3,7 +3,7 @@ notation: "Products Catalogue"
 version: "0.1"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-08"
-status: "planned"
+status: "draft"
 file_extension: "*.products.transitrix.yaml"
 ---
 

--- a/notations/10-applications.md
+++ b/notations/10-applications.md
@@ -3,7 +3,7 @@ notation: "Applications Catalogue"
 version: "0.1"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-08"
-status: "planned"
+status: "draft"
 file_extension: "*.applications.transitrix.yaml"
 ---
 

--- a/notations/11-scenarios.md
+++ b/notations/11-scenarios.md
@@ -3,7 +3,7 @@ notation: "Scenario Planning"
 version: "0.2"
 author: "Valerii Korobeinikov"
 last_updated: "2026-05-19"
-status: "implemented"
+status: "documented"
 file_extension: "*.scenarios.transitrix.yaml"
 dsm_status: "implemented — Scenarios page; scenario-scoped entities planned in release 0.2.4"
 ---

--- a/notations/README.md
+++ b/notations/README.md
@@ -6,19 +6,31 @@ Transitrix is a text-native methodology: every architecture artefact lives in a 
 
 | Spec | Short name | Purpose | File extension | Status |
 |---|---|---|---|---|
-| [01-bpmn.md](01-bpmn.md) | `bpmn` | BPMN 2.0 process flow — lanes, gateways, sequence flows. | `*.bpmn.transitrix.yaml` | implemented |
+| [01-bpmn.md](01-bpmn.md) | `bpmn` | BPMN 2.0 process flow — lanes, gateways, sequence flows. | `*.bpmn.transitrix.yaml` | documented |
 | [02-fgca.md](02-fgca.md) | `fgca` | Four-layer strategy-to-execution chain: Factor → Goal → Change → Activity. | `*.fgca.transitrix.yaml` | documented |
-| [03-fga.md](03-fga.md) | `fga` | Simplified strategy-to-execution chain: Factor → Goal → Activity (no Changes layer). | `*.fga.transitrix.yaml` | planned |
-| [04-goals.md](04-goals.md) | `goals` | Hierarchy of strategic and tactical goals as a tree. | `*.goals.transitrix.yaml` | implemented |
-| [05-capability-map.md](05-capability-map.md) | `capability-map` | Capability hierarchy with CMMI V2.0 maturity, addressing, vertical/horizontal orientation. | `*.capability-map.transitrix.yaml` | implemented |
-| [06-process-map.md](06-process-map.md) | `process-map` | Top-level catalogue of processes grouped into Operating, Supporting, and Management. | `*.process-map.transitrix.yaml` | planned |
-| [07-activities.md](07-activities.md) | `activities` | Project Schedule Network Diagram in Activity-on-Node (AoN) form — activities and dependencies. | `*.activities.transitrix.yaml` | standard |
-| [08-blocks.md](08-blocks.md) | `blocks` | Multi-level container layouts for deep architectural overviews, rendered via Svgbob. | `*.blocks.transitrix.txt` | implemented |
-| [09-products.md](09-products.md) | `products` | Inventory of products and services — text-and-table catalogue, no diagram. | `*.products.transitrix.yaml` | planned |
-| [10-applications.md](10-applications.md) | `applications` | Inventory of applications and integrations — text-and-table catalogue, no diagram. | `*.applications.transitrix.yaml` | planned |
-| [11-scenarios.md](11-scenarios.md) | `scenarios` | Alternative strategic development paths — each scenario scopes its own goals, capabilities, activities, products, processes, applications. | `*.scenarios.transitrix.yaml` | implemented |
+| [03-fga.md](03-fga.md) | `fga` | Simplified strategy-to-execution chain: Factor → Goal → Activity (no Changes layer). | `*.fga.transitrix.yaml` | draft |
+| [04-goals.md](04-goals.md) | `goals` | Hierarchy of strategic and tactical goals as a tree. | `*.goals.transitrix.yaml` | documented |
+| [05-capability-map.md](05-capability-map.md) | `capability-map` | Capability hierarchy with CMMI V2.0 maturity, addressing, vertical/horizontal orientation. | `*.capability-map.transitrix.yaml` | documented |
+| [06-process-map.md](06-process-map.md) | `process-map` | Top-level catalogue of processes grouped into Operating, Supporting, and Management. | `*.process-map.transitrix.yaml` | draft |
+| [07-activities.md](07-activities.md) | `activities` | Project Schedule Network Diagram in Activity-on-Node (AoN) form — activities and dependencies. | `*.activities.transitrix.yaml` | documented |
+| [08-blocks.md](08-blocks.md) | `blocks` | Multi-level container layouts for deep architectural overviews, rendered via Svgbob. | `*.blocks.transitrix.txt` | documented |
+| [09-products.md](09-products.md) | `products` | Inventory of products and services — text-and-table catalogue, no diagram. | `*.products.transitrix.yaml` | draft |
+| [10-applications.md](10-applications.md) | `applications` | Inventory of applications and integrations — text-and-table catalogue, no diagram. | `*.applications.transitrix.yaml` | draft |
+| [11-scenarios.md](11-scenarios.md) | `scenarios` | Alternative strategic development paths — each scenario scopes its own goals, capabilities, activities, products, processes, applications. | `*.scenarios.transitrix.yaml` | documented |
 
 All notations share the same file-extension convention `.<short-name>.transitrix.<ext>` (`yaml` for everything except `blocks`, which uses `txt`), and every file begins with a `notation: <short-name>` header — see each spec's "File header" section for the rule.
+
+## Status vocabulary
+
+The `status:` field in each spec's front-matter describes the **spec's maturity** — how stable and complete the notation specification is. It does **not** describe whether a tool implements the notation; tool implementation is tracked separately in the `dsm_status:` field on the same spec.
+
+| Value | Meaning |
+|---|---|
+| `draft` | The spec is incomplete or has known open structural questions; content may change in non-backwards-compatible ways. |
+| `documented` | The spec is complete and internally consistent. No open structural questions. Minor additive revisions are expected. |
+| `stable` | The schema is locked. Future changes must be backwards-compatible (additive only). |
+
+The vocabulary is intentionally small. A future `deprecated` value will be added when a notation is retired.
 
 ## Picking between FGCA, FGA, Goals, Activities
 


### PR DESCRIPTION
## Summary
- Add a "Status vocabulary" section to `notations/README.md` defining a small finite set of values for the `status:` front-matter field.
- Apply the vocabulary across all eleven spec front-matters, replacing the inconsistent mix of `implemented` / `documented` / `planned` / `standard`.
- Update the catalogue table in `notations/README.md` so the status column matches the new values.

Closes vkgeorgia/strategy#11.

## Proposed vocabulary — for review

Per the issue refinement, the values themselves are a proposal; final decision is yours.

| Value | Meaning |
|---|---|
| `draft` | The spec is incomplete or has known open structural questions; content may change in non-backwards-compatible ways. |
| `documented` | The spec is complete and internally consistent. No open structural questions. Minor additive revisions are expected. |
| `stable` | The schema is locked. Future changes must be backwards-compatible (additive only). |

- `status:` describes **spec maturity**, not whether a tool implements the notation — tool implementation stays in `dsm_status:`, untouched.
- Vocabulary kept intentionally small (three values). A `deprecated` entry will be added when a notation is retired.
- None of the eleven specs use `stable` today; it exists for the post-1.0 future once a notation's schema is frozen.

## Applied mapping

| Spec | Old | New | Why |
|---|---|---|---|
| 01-bpmn | `implemented` | `documented` | spec complete and stable; "implemented" referred to tool support, which is `dsm_status` |
| 02-fgca | `documented` | `documented` | unchanged |
| 03-fga | `planned` | `draft` | flat-vs-nested decision still recent; minor open questions |
| 04-goals | `implemented` | `documented` | as 01-bpmn |
| 05-capability-map | `implemented` | `documented` | as 01-bpmn |
| 06-process-map | `planned` | `draft` | schema still ahead of any tool consumer |
| 07-activities | `standard` | `documented` | "standard" was about PMBoK origin, not spec maturity |
| 08-blocks | `implemented` | `documented` | as 01-bpmn |
| 09-products | `planned` | `draft` | schema not yet exercised |
| 10-applications | `planned` | `draft` | as 09 |
| 11-scenarios | `implemented` | `documented` | as 01-bpmn |

## Scope guard
Per the issue refinement, this PR touches **only** the `status:` field across the eleven specs plus the new vocabulary section + status column in `notations/README.md`. No other spec edits, no example edits, no audit items.

## Test plan
- [x] Vocabulary section added to `notations/README.md` with definitions and explicit `status:` vs `dsm_status:` distinction.
- [x] Status column in the README catalogue table matches the new front-matter values across all eleven rows.
- [x] All eleven spec front-matters carry a value from the vocabulary (`grep ^status:` shows only `documented` and `draft`).
- [x] No other changes in the eleven specs (verify with `git diff --stat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)