### PR TITLE
docs(notations): normalize spec_version to the quoted string form

### DIFF
--- a/notations/02-fgca.md
+++ b/notations/02-fgca.md
@@ -121,7 +121,7 @@ For comparison: FGA and the Goals tree are tree-shaped (each child has a single 
 
 ```yaml
 notation: fgca
-spec_version: 0.1
+spec_version: "0.1"
 
 fgca:
   id: FGCA-STRAT-1

--- a/notations/07-activities.md
+++ b/notations/07-activities.md
@@ -71,7 +71,7 @@ Activities defined here MAY reference other elements by ID (goals, changes, scen
 
 ```yaml
 notation: activities
-spec_version: 0.1
+spec_version: "0.1"
 
 title: Platform Launch 2026
 description: |

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -12,7 +12,7 @@ Every Transitrix notation file MUST start with a header that declares which nota
 
 ```yaml
 notation: <short-name>      # required; this notation's short name
-spec_version: 0.1           # optional today; reserved field; will be required when this notation reaches v1.0
+spec_version: "0.1"         # optional today; reserved field; will be required when this notation reaches v1.0
 # … rest of the document
 ```
 

--- a/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
+++ b/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
@@ -1,5 +1,5 @@
 notation: fgca
-spec_version: 0.1
+spec_version: "0.1"
 
 fgca:
   id: FGCA-STRAT-1


### PR DESCRIPTION
## Summary

`spec_version` is typed as a **string** in `CONTRACT.md`, but the header block was written with the unquoted form `spec_version: 0.1` (a YAML float) in the contract's own example and in three notation specs / example files. This PR normalizes every occurrence to the quoted string form `"0.1"`, so the declared type and the literal agree across the whole family.

Files changed (one line each):

- `notations/CONTRACT.md` — the canonical header example.
- `notations/02-fgca.md` — §"Top-level structure" inline example.
- `notations/07-activities.md` — §4 document-structure inline example.
- `notations/examples/fgca/strategy-2026.fgca.transitrix.yaml` — the one example file still on the unquoted form (all other example files already use `"0.1"`).

`notations/13-process-blueprint.md` received the same fix on its own branch (PR #12).

## Scope

Pure normalization — exactly one line changed per file (`spec_version: 0.1` → `spec_version: "0.1"`). No semantic, schema, or wording changes.

Refs: vkgeorgia/strategy#25