### PR TITLE
docs(13-process-blueprint): drop validation rule BP-012

### DIFF
--- a/notations/13-process-blueprint.md
+++ b/notations/13-process-blueprint.md
@@ -208,7 +208,6 @@ For `equipment[]` and `information_entities[]`, no canonical TYPE prefix exists 
 | `BP-009` | error | if an aspect entry has an `id`, the ID must match the canonical grammar `<TYPE>-[<middle>-]<INTEGER>`. |
 | `BP-010` | error | for `systems[]`, an entry's `id` (when present) MUST use the `APPLICATION-` prefix. For `actors[]`, the prefix MUST be `ROLE-`. |
 | `BP-011` | warn | a stage with no aspect entries pointing at it from any of the four aspect arrays is structurally empty and SHOULD be reviewed. |
-| `BP-012` | warn | an aspect entry whose `stages: [...]` is a singleton MAY be a candidate for inlining into the stage's description — informational only. |
 
 ---
 


### PR DESCRIPTION
## Summary

Removes the `BP-012` validation rule from `notations/13-process-blueprint.md` §6.

BP-012 (`warn`) fired on every aspect entry whose `stages: [...]` references a single stage, suggesting it "may be a candidate for inlining into the stage's description." But a single-stage aspect — a barcode scanner used only in one stage, a payment gateway used only at order intake — is **normal, valid blueprint content**. The notation maps each stage to its supporting aspects regardless of whether those aspects are shared across stages. The rule therefore fired on the common case, producing a wall of warnings on entirely correct files (observed during hand-testing: 8 BP-012 warnings on a valid 3-stage blueprint) and training authors to ignore the warning panel.

## Change

One row deleted from the §6 validation-rules table. `BP-011` remains the last rule — no renumbering. No other part of the spec references BP-012.

## Downstream

The Transitrix Studio validator (`packages/diagrams/src/process-blueprint/validate.ts`) implements BP-012 faithfully and is being updated to match in `transitrix/transitrix-studio` (the BP-012 emission and its test removed there). Merge order is not strict — the two changes are independent — but merging this first keeps the canonical spec ahead of the implementation.

Decision by Valerii, 2026-05-21, during 1.0.0 pre-release hand-testing.