### PR TITLE
feat(notations): add the issues notation

### DIFF
--- a/notations/12-issues.md
+++ b/notations/12-issues.md
@@ -1,0 +1,202 @@
+---
+notation: "Issues Register"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-05-25"
+status: "draft"
+file_extension: "*.issues.transitrix.yaml"
+---
+
+# Issues Notation — Issue Register
+
+**Scope:** Text-native catalogue of an organisation's issues — problems, defects, open questions, and risks-to-resolve. Issues form a parent/child hierarchy, so the same document also renders as a nested tree. The notation records *what is wrong or unresolved*; it complements `activities`, which records *what work is planned*.
+**Renderer:** Transitrix Studio (planned) — nested tree view.
+
+---
+
+## File header
+
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across the Transitrix notations and defined in [CONTRACT.md](CONTRACT.md). This notation's per-notation values:
+
+| Field | Value |
+|---|---|
+| `notation:` value | `issues` |
+| File extension | `*.issues.transitrix.yaml` |
+
+---
+
+## 1. Overview
+
+An **Issues** document is a register of issues an organisation is tracking. Each issue carries a lifecycle `status` and an optional `parent`, so the register is also a hierarchy: a broad issue decomposes into sub-issues, which decompose further.
+
+The notation answers the question **"what is wrong, open, or unresolved?"** — distinct from `activities`, which answers "what work is planned?". An issue is not a unit of scheduled work; it is a standing record of a problem or open question. The two notations link: an issue may reference, via `relates_to`, the activities or goals it concerns.
+
+Issues do **not** carry scheduling data — no duration, no dependencies, no critical path. Decomposition is by containment (`parent`), not by predecessor ordering. A renderer derives the tree from `issue_id` + `parent` and presents it as a nested, collapsible outline.
+
+---
+
+## 2. When to use this notation
+
+| Need | Use |
+|---|---|
+| Register a problem, defect, open question, or risk | Issues |
+| Break a broad issue into sub-issues | Issues — `parent` reference |
+| Track issue lifecycle (open → in progress → resolved / closed) | Issues — `status` |
+| Link an issue to the work or goal it concerns | Issues — `relates_to` |
+| Plan a project as a network of activities with dependencies | Activities (`*.activities.transitrix.yaml`) |
+| Decompose strategic goals hierarchically | Goals tree (`*.goals.transitrix.yaml`) |
+| Trace strategic factors → goals → changes → activities | FGCA (`*.fgca.transitrix.yaml`) |
+
+---
+
+## 3. File location and naming
+
+```
+organizations/<org>/views/issues/<NAME>.issues.transitrix.yaml
+```
+
+Examples:
+- `views/issues/platform-launch.issues.transitrix.yaml`
+- `views/issues/data-migration.issues.transitrix.yaml`
+
+Issues defined here MAY reference other elements by ID (activities, goals, roles) declared elsewhere in the organisation's repository.
+
+---
+
+## 4. Document structure
+
+```yaml
+notation: issues
+spec_version: "0.1"
+
+issues_catalogue:
+  id: ISSUES-CAT-1
+  name: "Platform Launch 2026 — Issue Register"
+  description: "Open issues, defects, and questions for the 2026 platform launch."
+  version: "0.1"
+  updated_at: "2026-05-25"
+
+  issues:
+    - issue_id: ISSUE-1
+      name: "Checkout latency above target under load"
+      status: in_progress                     # open | in_progress | blocked | resolved | closed
+      description: "p95 checkout response exceeds the 800 ms target above 2k concurrent users."
+      relates_to: [ACTIVITY-5, GOAL-CUST-1]    # optional — activities / goals this issue concerns
+      owner_role: ROLE-PLATFORM-1              # optional — role accountable for the issue
+
+    - issue_id: ISSUE-2
+      name: "Payment retry storms on gateway timeout"
+      status: blocked
+      parent: ISSUE-1                          # optional — makes this a sub-issue (nesting)
+
+    - issue_id: ISSUE-3
+      name: "Confirm idempotency-key TTL with the payments vendor"
+      status: open
+      parent: ISSUE-2
+```
+
+A document is a single `issues_catalogue` object holding catalogue metadata and a flat `issues` array. Nesting is expressed inside that flat array by the `parent` field — see §6.
+
+---
+
+## 5. Field reference
+
+### 5.1 Catalogue fields
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `issues` |
+| `spec_version` | no | string | reserved, see file header |
+| `issues_catalogue.id` | yes | string | catalogue ID — `ISSUES-CAT-<integer>` per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) |
+| `issues_catalogue.name` | yes | string | human-readable register name |
+| `issues_catalogue.description` | no | string | optional register description |
+| `issues_catalogue.version` | no | string | document version (semantic versioning recommended) |
+| `issues_catalogue.updated_at` | yes | ISO 8601 date | last update date (`YYYY-MM-DD`) |
+| `issues_catalogue.issues` | yes | array | the register entries (§5.2); MAY be empty |
+
+### 5.2 Issue fields
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `issue_id` | yes | string | unique within the catalogue — `ISSUE-<integer>` per the ID grammar |
+| `name` | yes | string | one-line summary of the issue; MUST NOT be empty |
+| `status` | yes | enum | one of `open`, `in_progress`, `blocked`, `resolved`, `closed` |
+| `parent` | no | string | `issue_id` of the parent issue — the nesting mechanism (§6) |
+| `description` | no | string | optional multi-line detail |
+| `relates_to` | no | array | typed IDs of `ACTIVITY` and/or `GOAL` elements this issue concerns |
+| `owner_role` | no | string | `ROLE` element ID of the role accountable for the issue |
+
+Severity, priority, assignee, dates, and labels are intentionally **not** in v1. They may be added later as backwards-compatible optional fields.
+
+### 5.3 Status vocabulary
+
+| Status | Meaning |
+|---|---|
+| `open` | Registered, not yet being worked. |
+| `in_progress` | Actively being worked. |
+| `blocked` | Cannot progress until something external is resolved. |
+| `resolved` | The underlying problem has been fixed or answered. |
+| `closed` | No longer tracked — resolved-and-verified, withdrawn, a duplicate, or a "won't fix". |
+
+---
+
+## 6. Nesting model
+
+The `issues` array is **flat**. A child issue declares its parent with `parent: <issue_id>`; an issue with no `parent` is a root. This matches how `activities` expresses WBS-style grouping and keeps the catalogue a single flat list.
+
+- Each issue has at most one parent — the hierarchy is a tree (or a forest, if there are several roots).
+- A renderer derives the tree from `issue_id` + `parent` and renders it as a nested, collapsible outline.
+- An issue whose `parent` does not resolve to a defined `issue_id` is rendered at the root and flagged (`ISS-004`).
+- A `parent` chain that loops back on itself is invalid (`ISS-005`).
+
+---
+
+## 7. Validation rules
+
+Shared header rules `HDR-001`…`HDR-004` apply (see [CONTRACT.md](CONTRACT.md)). A structurally malformed document — `issues_catalogue` missing, or `issues` not an array — is a schema error. Notation-specific rules:
+
+| Rule | Severity | Description |
+|---|---|---|
+| `ISS-001` | error | Duplicate `issue_id` within the catalogue. |
+| `ISS-002` | error | `status` is not one of the §5.3 vocabulary values. |
+| `ISS-003` | error | `issue_id` or `name` is missing or empty. |
+| `ISS-004` | warning | `parent` references an `issue_id` that is not defined — the issue is rendered at the root. |
+| `ISS-005` | error | Cycle in the `parent` chain (an issue is its own ancestor). |
+| `ISS-006` | error | A `relates_to` entry references an undefined ID, or an ID whose TYPE is neither `ACTIVITY` nor `GOAL`. |
+
+A document with any `error` is invalid; `warning`-level findings do not block rendering.
+
+---
+
+## 8. Rendering
+
+Transitrix Studio renders an issues document as a **nested, collapsible tree**:
+
+- Each issue is a node showing its `name` and a `status` badge; the badge colour encodes the status.
+- Sub-issues are nested under their parent; parents can be collapsed.
+- Root issues (no `parent`) and issues with a broken `parent` (`ISS-004`) appear at the top level.
+- `relates_to` and `owner_role` are shown as node detail; they are not edges of the tree.
+
+The viewer is read-only preview; editing happens in the text file.
+
+---
+
+## 9. Relationship to other notations
+
+```
+Goals tree          →  why the work matters (strategic goals)
+Activities          →  what work is planned to get there
+Issues Register     →  what is wrong, open, or unresolved along the way
+```
+
+An issue's `relates_to` points at the `ACTIVITY` or `GOAL` it concerns; `activities` and the goals tree do not point back — the dependency is one-directional, issue → element. Issues are a register laid alongside the plan, not a layer of it.
+
+---
+
+## 10. References
+
+- Shared header contract: [CONTRACT.md](CONTRACT.md)
+- ID grammar and TYPE registry (`ISSUE`, `ISSUES_CAT`): [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md)
+- Activities notation: [07-activities.md](07-activities.md)
+- Goals notation: [04-goals.md](04-goals.md)
+- Worked example: [`examples/issues/`](examples/issues/)

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -78,6 +78,7 @@ Elements that get referenced across documents.
 | `UNIT` | organisational unit | Activities |
 | `EMPLOYEE` | named employee | Activities |
 | `SCENARIO` | strategic scenario | Scenarios |
+| `ISSUE` | issue — problem, defect, or open question | Issues register |
 
 ### 3.2 Document-level types
 
@@ -95,6 +96,7 @@ Each notation file carries its own ID using the same grammar; the TYPE names the
 | `APPLICATIONS_CAT` | `*.applications.transitrix.yaml` |
 | `SCENARIOS` | `*.scenarios.transitrix.yaml` |
 | `BLOCKS` | `*.blocks.transitrix.txt` |
+| `ISSUES_CAT` | `*.issues.transitrix.yaml` |
 
 BPMN diagrams use their `process.id` as the document identifier; that field is a free-form string defined by the spec, not by this appendix.
 
@@ -114,6 +116,7 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | `CAPABILITY` | within the capability set (`set_name`, per [`05-capability-map.md`](05-capability-map.md) §5). |
 | `PROCESS` | within the organisation's element catalogue (`elements/02_business/`). |
 | `PRODUCT`, `APPLICATION`, `INTEGRATION` | within the catalogue document. |
+| `ISSUE` | within the issues catalogue document. |
 | `ROLE`, `UNIT`, `EMPLOYEE` | within the organisation's element catalogue (`elements/02_business/`). |
 | `SCENARIO` | within the organisation. |
 

--- a/notations/README.md
+++ b/notations/README.md
@@ -1,6 +1,6 @@
 # Notations
 
-Transitrix is a text-native methodology: every architecture artefact lives in a YAML (or Svgbob) file whose syntax is governed by one of the notations below. This index lists the twelve notations, what each is for, and how the strategy-chain family fits together.
+Transitrix is a text-native methodology: every architecture artefact lives in a YAML (or Svgbob) file whose syntax is governed by one of the notations below. This index lists the thirteen notations, what each is for, and how the strategy-chain family fits together.
 
 ## Catalogue
 
@@ -17,6 +17,7 @@ Transitrix is a text-native methodology: every architecture artefact lives in a 
 | [09-products.md](09-products.md) | `products` | Inventory of products and services — text-and-table catalogue, no diagram. | `*.products.transitrix.yaml` | draft |
 | [10-applications.md](10-applications.md) | `applications` | Inventory of applications and integrations — text-and-table catalogue, no diagram. | `*.applications.transitrix.yaml` | draft |
 | [11-scenarios.md](11-scenarios.md) | `scenarios` | Alternative strategic development paths — each scenario scopes its own goals, capabilities, activities, products, processes, applications. | `*.scenarios.transitrix.yaml` | documented |
+| [12-issues.md](12-issues.md) | `issues` | Register of issues — problems, defects, open questions — in a parent/child tree, complementing the activities plan. | `*.issues.transitrix.yaml` | draft |
 | [13-process-blueprint.md](13-process-blueprint.md) | `process-blueprint` | Wide blueprint of a value chain — stages laid out left-to-right, each carrying its goal, result, and supporting systems / actors / equipment / information entities. | `*.process-blueprint.transitrix.yaml` | draft |
 
 All notations share the same file-extension convention `.<short-name>.transitrix.<ext>` (`yaml` for everything except `blocks`, which uses `txt`), and every file begins with a `notation: <short-name>` header — see each spec's "File header" section for the rule.

--- a/notations/examples/issues/README.md
+++ b/notations/examples/issues/README.md
@@ -1,0 +1,34 @@
+# Issues notation — examples
+
+File extension: **`.issues.transitrix.yaml`**
+
+## Format overview
+
+An issues register catalogues the problems, defects, open questions, and risks an organisation is tracking. Each entry records a lifecycle `status` and an optional `parent`, so the flat list also forms a parent/child tree. It complements the `activities` notation: activities are *what work is planned*, issues are *what is wrong or unresolved*.
+
+## Files in this folder
+
+| File | Description |
+|---|---|
+| [`platform-launch.issues.transitrix.yaml`](platform-launch.issues.transitrix.yaml) | Seven-issue register covering all five statuses, three levels of nesting, and `relates_to` / `owner_role` cross-references |
+
+## Notation header
+
+Every file must start with:
+
+```yaml
+notation: issues
+```
+
+## Required fields
+
+| Field | Description |
+|---|---|
+| `issues_catalogue.id` | Unique identifier for the catalogue (`ISSUES-CAT-<integer>`) |
+| `issues_catalogue.name` | Display name |
+| `issues_catalogue.updated_at` | Date in `YYYY-MM-DD` format |
+| `issues[].issue_id` | Unique identifier within the catalogue (`ISSUE-<integer>`) |
+| `issues[].name` | One-line summary of the issue |
+| `issues[].status` | One of `open`, `in_progress`, `blocked`, `resolved`, `closed` |
+
+See [`../../12-issues.md`](../../12-issues.md) for the full specification.

--- a/notations/examples/issues/platform-launch.issues.transitrix.yaml
+++ b/notations/examples/issues/platform-launch.issues.transitrix.yaml
@@ -1,0 +1,55 @@
+notation: issues
+spec_version: "0.1"
+
+issues_catalogue:
+  id: ISSUES-CAT-1
+  name: "Platform Launch 2026 — Issue Register"
+  description: "Open issues, defects, and questions tracked during the 2026 customer-facing platform launch."
+  version: "0.1"
+  updated_at: "2026-05-25"
+
+  issues:
+    - issue_id: ISSUE-1
+      name: "Checkout latency above target under load"
+      status: in_progress
+      description: |
+        p95 checkout response exceeds the 800 ms target above 2,000 concurrent users.
+        Umbrella issue for the launch-blocking performance work.
+      relates_to: [ACTIVITY-5, GOAL-CUST-1]
+      owner_role: ROLE-PLATFORM-1
+
+    - issue_id: ISSUE-2
+      name: "Payment retry storms on gateway timeout"
+      status: blocked
+      parent: ISSUE-1
+      description: "Client retries amplify load when the payment gateway times out; needs a backoff policy."
+      relates_to: [ACTIVITY-5]
+
+    - issue_id: ISSUE-3
+      name: "Confirm idempotency-key TTL with the payments vendor"
+      status: open
+      parent: ISSUE-2
+      description: "The vendor has not confirmed how long idempotency keys are retained."
+
+    - issue_id: ISSUE-4
+      name: "Catalogue search slow on a cold cache"
+      status: in_progress
+      parent: ISSUE-1
+      relates_to: [ACTIVITY-3]
+      owner_role: ROLE-PLATFORM-1
+
+    - issue_id: ISSUE-5
+      name: "Onboarding email links break in the staging environment"
+      status: resolved
+      description: "Links pointed at the production host; fixed by templating the environment base URL."
+      relates_to: [ACTIVITY-4]
+
+    - issue_id: ISSUE-6
+      name: "Decide whether to keep the legacy promo-code path"
+      status: open
+      relates_to: [GOAL-CUST-1]
+
+    - issue_id: ISSUE-7
+      name: "Duplicate analytics events on the launch dashboard"
+      status: closed
+      description: "Reported as a defect; turned out to be expected dual-tag behaviour. Closed without change."


### PR DESCRIPTION
Adds a new `issues` notation — a text-native register of issues (problems, defects, open questions) with parent/child nesting. It complements `activities` rather than replacing anything: `activities` is *what work is planned*, `issues` is *what is wrong or unresolved*.

## Contents

- `notations/12-issues.md` — the specification: a catalogue wrapper, a flat `issues` array, nesting via a `parent` reference, a status lifecycle (`open` / `in_progress` / `blocked` / `resolved` / `closed`), validation rules `ISS-001…006`, and nested-tree rendering.
- `notations/README.md` — a catalogue row for `issues` and the notation count.
- `notations/IDS_AND_REFERENCES.md` — `ISSUE` and `ISSUES_CAT` TYPE-registry entries plus a uniqueness-scope row.
- `notations/examples/issues/` — a worked seven-issue example and a folder README.

## Notes

- `notation: issues`; file extension `*.issues.transitrix.yaml`; spec status `draft`.
- The wording "all eleven Transitrix notations" in `CONTRACT.md` and `IDS_AND_REFERENCES.md` was already stale before this change (the catalogue already held twelve). Left untouched to keep this PR scoped — worth a separate cleanup.
- The Transitrix Studio viewer for this notation is a separate change.

Do not merge without review — gating is intentional.