### PR TITLE
docs(notations): register PROCESS_BLUEPRINT + EQUIPMENT + INFORMATION_ENTITY

### DIFF
--- a/notations/13-process-blueprint.md
+++ b/notations/13-process-blueprint.md
@@ -184,12 +184,14 @@ All four aspect arrays share the same entry shape. Each entry is an object with 
 |---|---|---|
 | `systems[]` | `APPLICATION-…` | applications catalogue (`*.applications.transitrix.yaml`) |
 | `actors[]` | `ROLE-…` | roles in the organisation's element catalogue |
-| `equipment[]` | *(none registered today)* | — entries are notation-local labels for v0.1 |
-| `information_entities[]` | *(none registered today)* | — entries are notation-local labels for v0.1 |
+| `equipment[]` | `EQUIPMENT-…` | notation-local in v0.1; promotable to a catalogue (see below) |
+| `information_entities[]` | `INFORMATION_ENTITY-…` | notation-local in v0.1; promotable to a catalogue (see below) |
 
-For `systems[]` and `actors[]`, an entry with an `id` MUST use the TYPE prefix listed above (and the validator MUST resolve the reference against the relevant catalogue once cross-document linking is wired up). An entry without an `id` is a free-form label — useful for sketches and for elements that have not yet been promoted into a catalogue.
+For every aspect category, an entry with an `id` MUST use the TYPE prefix listed above. An entry without an `id` is a free-form label — useful for sketches and for elements that have not yet been promoted into a catalogue.
 
-For `equipment[]` and `information_entities[]`, no canonical TYPE prefix exists yet — the corresponding registry entries (e.g. `EQUIPMENT`, `INFORMATION_ENTITY`) require a separate decision and are tracked as a follow-up to [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1. In v0.1, entries in these two arrays are notation-local labels with optional, unenforced `id` values.
+`systems[]` and `actors[]` cross-reference established catalogues: `APPLICATION-…` resolves into the applications catalogue (`*.applications.transitrix.yaml`); `ROLE-…` resolves into the organisation's roles list. A validator MUST resolve these references against the relevant catalogue once cross-document linking is wired up.
+
+`EQUIPMENT` and `INFORMATION_ENTITY` were registered alongside `PROCESS_BLUEPRINT` (see [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1). No organisation-wide catalogue is mandated for these element TYPEs in v0.1: an entry's `id` is currently a document-local typed label, scoped to the blueprint that declares it. If and when a catalogue is introduced, the IDs already conform to the canonical grammar and can be promoted out of the blueprint without renaming.
 
 ---
 
@@ -206,7 +208,7 @@ For `equipment[]` and `information_entities[]`, no canonical TYPE prefix exists 
 | `BP-007` | error | every aspect entry (`systems[]`, `actors[]`, `equipment[]`, `information_entities[]`) must have a non-empty `name` and a non-empty `stages: [STAGE-…]` array. |
 | `BP-008` | error | every ID in any aspect entry's `stages: [...]` must reference a stage declared in `stages[]`. |
 | `BP-009` | error | if an aspect entry has an `id`, the ID must match the canonical grammar `<TYPE>-[<middle>-]<INTEGER>`. |
-| `BP-010` | error | for `systems[]`, an entry's `id` (when present) MUST use the `APPLICATION-` prefix. For `actors[]`, the prefix MUST be `ROLE-`. |
+| `BP-010` | error | for `systems[]`, an entry's `id` (when present) MUST use the `APPLICATION-` prefix. For `actors[]`, the prefix MUST be `ROLE-`. For `equipment[]`, the prefix MUST be `EQUIPMENT-`. For `information_entities[]`, the prefix MUST be `INFORMATION_ENTITY-`. |
 | `BP-011` | warn | a stage with no aspect entries pointing at it from any of the four aspect arrays is structurally empty and SHOULD be reviewed. |
 
 ---
@@ -254,7 +256,7 @@ What the renderer MUST NOT do:
 ## 9. References
 
 - File header contract: [`CONTRACT.md`](CONTRACT.md)
-- ID grammar and TYPE registry: [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) — note: the `PROCESS_BLUEPRINT` document-level TYPE and any future `EQUIPMENT` / `INFORMATION_ENTITY` element TYPEs are follow-ups to that appendix.
+- ID grammar and TYPE registry: [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) — registers `PROCESS_BLUEPRINT` (§3.2) and the aspect element TYPEs `EQUIPMENT` and `INFORMATION_ENTITY` (§3.1).
 - Goals notation (uses the same diagram engine): [`04-goals.md`](04-goals.md)
 - BPMN notation (procedural flow of one process): [`01-bpmn.md`](01-bpmn.md)
 - Process landscape map (catalogue of all processes): [`06-process-map.md`](06-process-map.md)

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -12,7 +12,7 @@ Recorded 2026-05-20 as the canonical decision for the methodology.
 <TYPE>-[<middle segment(s)>-]<INTEGER>
 ```
 
-- **TYPE** — uppercase entity-type prefix from the registry in §3. The prefix names *what kind of thing* the ID refers to.
+- **TYPE** — uppercase entity-type prefix from the registry in §3. The prefix names *what kind of thing* the ID refers to. The TYPE segment is composed of uppercase letters `A`–`Z`, digits `0`–`9`, and the underscore `_`; it MUST start with a letter. The underscore allows multi-word TYPE names — `PROCESS_BLUEPRINT` (the first registered TYPE to use one, decided 2026-05-21) and `INFORMATION_ENTITY` (registered alongside it).
 - **Middle segments** — optional, notation-specific. Add for disambiguation (a domain code, a period, a programme name). The grammar fixes only the start and the end of an ID; a notation MAY define one or more middle segments where needed.
 - **INTEGER** — terminal positive integer, ≥ 1, **no leading zeros**. Sorting and comparison MUST parse it numerically, never lexically. There is no fixed width and no upper bound.
 
@@ -26,6 +26,8 @@ Recorded 2026-05-20 as the canonical decision for the methodology.
 | `FACTOR-CHURN-001` | — | — | — | **invalid** — leading zero. Use `FACTOR-CHURN-1`. |
 | `factor-1` | — | — | — | **invalid** — TYPE must be uppercase. |
 | `FACTOR-` | — | — | — | **invalid** — missing terminal integer. |
+| `PROCESS_BLUEPRINT-FULFIL-1` | PROCESS_BLUEPRINT | FULFIL | 1 | underscore in TYPE — permitted |
+| `INFORMATION_ENTITY-ORDER-3` | INFORMATION_ENTITY | ORDER | 3 | underscore in TYPE — permitted |
 
 ---
 
@@ -79,6 +81,8 @@ Elements that get referenced across documents.
 | `EMPLOYEE` | named employee | Activities |
 | `SCENARIO` | strategic scenario | Scenarios |
 | `ISSUE` | issue — problem, defect, or open question | Issues register |
+| `EQUIPMENT` | physical instrument, device, or facility a process stage depends on | Process Blueprint |
+| `INFORMATION_ENTITY` | data, document, or record produced or consumed by a process stage | Process Blueprint |
 
 ### 3.2 Document-level types
 
@@ -97,6 +101,7 @@ Each notation file carries its own ID using the same grammar; the TYPE names the
 | `SCENARIOS` | `*.scenarios.transitrix.yaml` |
 | `BLOCKS` | `*.blocks.transitrix.txt` |
 | `ISSUES_CAT` | `*.issues.transitrix.yaml` |
+| `PROCESS_BLUEPRINT` | `*.process-blueprint.transitrix.yaml` |
 
 BPMN diagrams use their `process.id` as the document identifier; that field is a free-form string defined by the spec, not by this appendix.
 
@@ -119,6 +124,7 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | `ISSUE` | within the issues catalogue document. |
 | `ROLE`, `UNIT`, `EMPLOYEE` | within the organisation's element catalogue (`elements/02_business/`). |
 | `SCENARIO` | within the organisation. |
+| `EQUIPMENT`, `INFORMATION_ENTITY` | within the notation document that defines them (today: a Process Blueprint). No organisation-wide catalogue is mandated yet; the TYPEs are registered so the IDs already conform to the canonical grammar and can be promoted to a future catalogue without renaming. |
 
 Document-level IDs (`FGCA-…`, `FGA-…`, etc.) are unique within the organisation.
 


### PR DESCRIPTION
## Summary

Resolves the two registry follow-ups the Process Blueprint notation shipped with: `PROCESS_BLUEPRINT` as the document-level TYPE, and `EQUIPMENT` / `INFORMATION_ENTITY` as the aspect-level element TYPEs.

`IDS_AND_REFERENCES.md`
- §1 Grammar — TYPE segment composition spelled out: uppercase letters, digits, underscore; first char is a letter. Underscore note records the 2026-05-21 decision; `PROCESS_BLUEPRINT` is the first registered TYPE to use one.
- §1 Examples — adds `PROCESS_BLUEPRINT-FULFIL-1` and `INFORMATION_ENTITY-ORDER-3` so the underscore rule is visible in the example table, not only the prose.
- §3.1 Element types — adds `EQUIPMENT` and `INFORMATION_ENTITY`.
- §3.2 Document-level types — adds `PROCESS_BLUEPRINT`.
- §4 Uniqueness scope — adds a row covering the two new element TYPEs: document-local in v0.1; promotable to a catalogue later without renaming.

`13-process-blueprint.md`
- §5.3 TYPE prefix table — equipment / information_entities now point at their registered TYPEs.
- §5.3 trailing paragraph rewritten: explains the v0.1 stance (no org-wide catalogue mandated yet) and the promotion path, without leaving stale "(none registered today)" or "follow-up" wording behind.
- §6 BP-010 — extended to cover all four aspect categories symmetrically. Studio's validator (`packages/diagrams/src/process-blueprint/validate.ts`) currently checks only APPLICATION/ROLE; it catches up in a separate task. BP-009 (generic grammar) still catches malformed equipment / information-entity IDs in the meantime, so behaviour does not silently degrade before Studio catches up.
- §9 References — replaces the "follow-up" note with direct citations of the new §3.1 / §3.2 entries.

## Proposal direction (acceptance criterion: "agent proposes a direction; Valerii gates the decision")

Register `EQUIPMENT` and `INFORMATION_ENTITY` as first-class element TYPEs rather than leaving them as notation-local labels. Reasoning:

- They are natural counterparts to `APPLICATION` (systems) and `ROLE` (actors) in the same aspect-array shape — registering them makes the four-aspect-arrays symmetric instead of two-canonical / two-local.
- `BP-010` extends symmetrically: every aspect entry's `id` is prefix-checked the same way. Without registration, equipment / information_entities would need a separate carve-out.
- `BP-009` (generic-grammar check) becomes meaningful for these two arrays — today it accepts anything matching `<TYPE>-…-<INTEGER>` regardless of TYPE prefix, so an entry's `id` is effectively unenforced.
- v0.1 still leaves them document-local — no org-wide catalogue is mandated — but the TYPE registration means existing blueprint IDs can be promoted into a future catalogue without renaming, which preserves authoring continuity.

Counter-proposal worth naming: keep both as notation-local labels until a real catalogue is on the roadmap. That's the smaller change but it leaves the four-aspect array's `id` semantics asymmetric, and any future catalogue would force a TYPE-prefix rename across existing blueprints. Open to redirecting if you prefer that path.

## Test plan

- [ ] Visual review of `IDS_AND_REFERENCES.md` — TYPE registry tables read cleanly with new rows; §1 grammar still parses (no contradictory text); §4 uniqueness scope row sensible.
- [ ] Visual review of `13-process-blueprint.md` — §5.3 table and trailing paragraph no longer carry "(none registered today)" or "follow-up" wording; §6 BP-010 reads symmetrically; §9 reference is clean.
- [ ] Confirm no Process Blueprint spec example IDs in this repo break under the new rules (`PROCESS_BLUEPRINT-FULFIL-1` in the existing example already matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
