### PR TITLE
docs(12-issues): register ISS-000 in the §7 validation table

### DIFF
--- a/notations/12-issues.md
+++ b/notations/12-issues.md
@@ -2,7 +2,7 @@
 notation: "Issues Register"
 version: "0.1"
 author: "Valerii Korobeinikov"
-last_updated: "2026-05-25"
+last_updated: "2026-05-26"
 status: "draft"
 file_extension: "*.issues.transitrix.yaml"
 ---
@@ -153,10 +153,11 @@ The `issues` array is **flat**. A child issue declares its parent with `parent: 
 
 ## 7. Validation rules
 
-Shared header rules `HDR-001`…`HDR-004` apply (see [CONTRACT.md](CONTRACT.md)). A structurally malformed document — `issues_catalogue` missing, or `issues` not an array — is a schema error. Notation-specific rules:
+Shared header rules `HDR-001`…`HDR-004` apply (see [CONTRACT.md](CONTRACT.md)). Notation-specific rules:
 
 | Rule | Severity | Description |
 |---|---|---|
+| `ISS-000` | error | Structural / header problem — input is not an object, the `notation` value is not `issues`, the `issues_catalogue` root key is missing, or a required catalogue field (`id` / `name` / `updated_at`) is missing. |
 | `ISS-001` | error | Duplicate `issue_id` within the catalogue. |
 | `ISS-002` | error | `status` is not one of the §5.3 vocabulary values. |
 | `ISS-003` | error | `issue_id` or `name` is missing or empty. |


### PR DESCRIPTION
The Studio validator emits `ISS-000` for structural / header problems (input not an object, the `notation` value not `issues`, the `issues_catalogue` root key missing, or a required catalogue field missing). The spec §7 table only enumerated `ISS-001…006` and described structural errors generically in prose without a code — a small spec-vs-implementation gap.

## Changes

- §7: add the `ISS-000` row at the top of the rules table.
- §7: drop the now-redundant prose sentence describing structural errors as "a schema error" — the code-typed row replaces it.
- Front-matter `last_updated` bumped to 2026-05-26.

`notations/12-issues.md` only — no other notation touched.

Do not merge without review — gating is intentional.