### PR TITLE
docs(acme_corp): refresh views/ catalogue + blocks/activities READMEs (#51 Wave 1+2)

### DIFF
--- a/organizations/acme_corp/views/README.md
+++ b/organizations/acme_corp/views/README.md
@@ -9,15 +9,18 @@ See [`method/methodology.md` §6](../../../method/methodology.md) for the full n
 | Folder | Notation | File extension | What it holds |
 | --- | --- | --- | --- |
 | [`goals/`](goals/) | Goals tree | `*.goals.transitrix.yaml` | Hierarchical goals trees |
-| [`capabilities/`](capabilities/) | Capabilities map | `*.capmap.transitrix.yaml` | Capability hierarchies with maturity overlay |
-| [`processmap/`](processmap/) | Process landscape map | `*.processmap.transitrix.yaml` | Top-level process catalogues |
+| [`capabilities/`](capabilities/) | Capabilities map | `*.capability-map.transitrix.yaml` | Capability hierarchies with maturity overlay |
+| [`processmap/`](processmap/) | Process landscape map | `*.process-map.transitrix.yaml` | Top-level process catalogues |
 | [`bpmn/`](bpmn/) | Process diagram (BPMN) | `*.bpmn.transitrix.yaml` | Detailed process flows |
 | [`fgca/`](fgca/) | FGCA chain | `*.fgca.transitrix.yaml` | Factor → Goal → Change → Activity |
 | [`fga/`](fga/) | FGA chain | `*.fga.transitrix.yaml` | Factor → Goal → Activity |
-| [`blocks/`](blocks/) | Nested block diagrams | `*.blocks.transitrix.txt` | ASCII / Svgbob block layouts |
-| [`activities/`](activities/) | Activities (Mermaid) | `*.mmd` | Mermaid activity / sequence / flow diagrams |
+| [`blocks/`](blocks/) | Nested block diagrams | `*.blocks.transitrix.yaml` | Recursive `block` tree rendered as nested containers |
+| [`activities/`](activities/) | Activity network | `*.activities.transitrix.yaml` | PSND (Activity-on-Node) with Gantt projection and critical path |
 | [`products/`](products/) | Products view | `*.products.transitrix.yaml` | Filtered views over Product elements |
 | [`applications/`](applications/) | Applications view | `*.applications.transitrix.yaml` | Filtered views over Application elements |
+| [`scenarios/`](scenarios/) | Scenarios | `*.scenarios.transitrix.yaml` | Alternative strategic development paths |
+| [`process-blueprint/`](process-blueprint/) | Process Blueprint | `*.process-blueprint.transitrix.yaml` | Wide value-chain blueprint with stage aspects |
+| [`issues/`](issues/) | Issues register | `*.issues.transitrix.yaml` | Issue register with parent/child nesting |
 
 ## Naming
 
@@ -25,7 +28,7 @@ File names use `kebab-case` or descriptive `[DOMAIN]-[CONTEXT]` prefixes. Exampl
 
 ```
 views/goals/strategy-2026.goals.transitrix.yaml
-views/capabilities/customer-domain.capmap.transitrix.yaml
+views/capabilities/customer-domain.capability-map.transitrix.yaml
 views/bpmn/order-fulfillment.bpmn.transitrix.yaml
 views/fgca/eu-expansion.fgca.transitrix.yaml
 views/products/active-portfolio.products.transitrix.yaml

--- a/organizations/acme_corp/views/activities/README.md
+++ b/organizations/acme_corp/views/activities/README.md
@@ -1,28 +1,58 @@
 # `views/activities/`
 
-Activity / sequence / flow diagrams in **Mermaid** notation. Mermaid is a widely-supported open-source diagramming standard (MIT-licensed); it renders natively in GitHub, GitLab, VS Code, Notion, Obsidian, and most modern documentation tools.
+Project schedule as an **Activity-on-Node** precedence network (PSND), with an optional Gantt timeline projection. Activities reference Activity, Goal, and Change elements.
 
 ## File convention
 
-`*.mmd`
+`*.activities.transitrix.yaml`
 
-(Standard Mermaid extension. No Transitrix-specific suffix — Mermaid is an external standard, used as-is.)
+See [`notations/07-activities.md`](../../../../notations/07-activities.md) for the full spec — including PSND semantics, the critical-path computation, and the Gantt projection contract.
 
 ## Skeleton
 
-```mermaid
-flowchart LR
-    A[Receive Order] --> B{Items in stock?}
-    B -- Yes --> C[Reserve inventory]
-    B -- No  --> D[Trigger procurement]
-    C --> E[Confirm to customer]
+```yaml
+notation: activities
+spec_version: "0.1"
+
+activities:
+  - id: ACTIVITY-DISCOVERY-1
+    name: "Discovery & research"
+    duration_days: 10
+    start_date: "2026-06-01"
+    predecessors: []
+    goals: [GOAL-CUST-1]
+
+  - id: ACTIVITY-DESIGN-1
+    name: "Solution design"
+    duration_days: 14
+    predecessors: [ACTIVITY-DISCOVERY-1]
+    goals: [GOAL-CUST-1]
+
+  - id: ACTIVITY-BUILD-1
+    name: "Build & test"
+    duration_days: 30
+    predecessors: [ACTIVITY-DESIGN-1]
+    delivers_changes: [CHANGE-ONBOARD-1]
+
+  - id: ACTIVITY-LAUNCH-1
+    name: "Launch"
+    duration_days: 5
+    predecessors: [ACTIVITY-BUILD-1]
+    delivers_changes: [CHANGE-ONBOARD-1]
 ```
 
-## Inline alternative
+Activities form a DAG via `predecessors:`. The renderer computes Early Start / Late Finish / slack and highlights the critical path in both the PSND view and the Gantt projection. Transitrix Studio renders both views; the toolbar switches between them.
 
-For diagrams bound to a single markdown document, an inline ` ```mermaid ` block in the `.md` file is preferred over a separate `.mmd` file. Stand-alone `.mmd` files in this folder are for activities that have an independent life (referenced from multiple documents, exported to multiple tools).
+## Cross-references
+
+- `goals: [GOAL-…]` — Goal IDs from the goals tree / FGCA chain.
+- `delivers_changes: [CHANGE-…]` — Change IDs from the FGCA chain.
+- `predecessors: [ACTIVITY-…]` — other activity IDs in the same file.
+
+All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar from [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md).
 
 ## See also
 
-- [Mermaid documentation](https://mermaid.js.org/) — syntax reference
+- [`notations/07-activities.md`](../../../../notations/07-activities.md) — the notation spec
+- [`notations/examples/activities/platform-launch.activities.transitrix.yaml`](../../../../notations/examples/activities/platform-launch.activities.transitrix.yaml) — worked example
 - `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/views/blocks/README.md
+++ b/organizations/acme_corp/views/blocks/README.md
@@ -1,30 +1,57 @@
 # `views/blocks/`
 
-Nested block diagrams — multi-level container layouts where Mermaid / PlantUML / D2 fail to control horizontal layout beyond two levels of nesting. Rendered to SVG via **Svgbob** (Rust CLI).
+Nested block diagrams — multi-level container layouts where you want to show *what contains what* (an application landscape, a platform decomposition, an infrastructure zone map). Rendered as nested boxes by Transitrix Studio's native TypeScript renderer.
 
 ## File convention
 
-`*.blocks.transitrix.txt`
+`*.blocks.transitrix.yaml`
 
-The format is plain text (ASCII), not YAML, because the input *is* a hand-shaped diagram. Svgbob compiles it to SVG.
+The notation is structured YAML: a `nested_blocks:` root with a recursive `block` tree (`id`, `name`, optional `description`, optional `children[]`). See [`notations/08-blocks.md`](../../../../notations/08-blocks.md) for the full spec.
 
 ## Skeleton
 
+```yaml
+notation: blocks
+spec_version: "0.1"
+
+nested_blocks:
+  id: BLOCKS-ARCH-1
+  name: "Application architecture"
+  description: "Top-level container layout."
+
+  blocks:
+    - id: APPLICATION_LAYER
+      name: "Application Layer"
+      children:
+        - id: FRONTEND
+          name: "Frontend"
+        - id: BACKEND
+          name: "Backend"
+    - id: DATA_LAYER
+      name: "Data Layer"
+      children:
+        - id: POSTGRESQL
+          name: "PostgreSQL"
+        - id: REDIS_CACHE
+          name: "Redis Cache"
 ```
-+-----------------------------+
-| Operating: Order Fulfilment |
-| +---------+   +-----------+ |
-| | Receive |-->| Validate  | |
-| +---------+   +-----------+ |
-+-----------------------------+
-```
+
+Multiple independent top-level blocks in `nested_blocks.blocks[]` render as separate diagram sections, stacked in array order.
+
+## Nesting depth
+
+Recommended maximum: **5 levels** (root = level 1). The validator warns at depth 6+ (`BL-008`); inner boxes get too small to read.
+
+## Cross-references
+
+A block's `id` MAY use the canonical `<TYPE>-…-<INTEGER>` form to cross-link into an organisational catalogue (`APPLICATION-OMS-1`, `CAPABILITY-V1.2`). Otherwise it is a document-local label and is accepted as-is. See [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md).
 
 ## Tooling
 
-- Compile via Transitrix Studio (uses the in-tree Python+Svgbob backend).
-- Or directly: `svgbob input.blocks.transitrix.txt -o output.svg`.
+Rendered natively by Transitrix Studio — no external binaries required. The previous Python + `svgbob_cli` pipeline was retired in Studio 1.1.0.
 
 ## See also
 
+- [`notations/08-blocks.md`](../../../../notations/08-blocks.md) — the notation spec
+- [`notations/examples/blocks/architecture.blocks.transitrix.yaml`](../../../../notations/examples/blocks/architecture.blocks.transitrix.yaml) — worked example
 - `method/methodology.md` §6 — notation kit
-- Inline `*.txt` blocks may also live alongside the markdown they document, if the diagram is bound to a single document.

--- a/organizations/acme_corp/views/capabilities/README.md
+++ b/organizations/acme_corp/views/capabilities/README.md
@@ -4,7 +4,7 @@ Capability maps — hierarchical view of capabilities with CMM maturity overlay.
 
 ## File convention
 
-`*.capmap.transitrix.yaml`
+`*.capability-map.transitrix.yaml`
 
 ## Skeleton
 

--- a/organizations/acme_corp/views/issues/README.md
+++ b/organizations/acme_corp/views/issues/README.md
@@ -1,0 +1,14 @@
+# `views/issues/`
+
+Register of issues — problems, defects, open questions — in a parent/child tree, complementing the activities plan.
+
+## File convention
+
+`*.issues.transitrix.yaml`
+
+See [`notations/12-issues.md`](../../../../notations/12-issues.md) for the full spec.
+
+## See also
+
+- [`notations/examples/issues/`](../../../../notations/examples/issues/) — worked example
+- `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/views/process-blueprint/README.md
+++ b/organizations/acme_corp/views/process-blueprint/README.md
@@ -1,0 +1,14 @@
+# `views/process-blueprint/`
+
+Wide value-chain blueprint — stages laid out left-to-right, each carrying its goal, result, and supporting aspects (systems, actors, equipment, information entities).
+
+## File convention
+
+`*.process-blueprint.transitrix.yaml`
+
+See [`notations/13-process-blueprint.md`](../../../../notations/13-process-blueprint.md) for the full spec.
+
+## See also
+
+- [`notations/examples/process-blueprint/`](../../../../notations/examples/process-blueprint/) — worked example
+- `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/views/processmap/README.md
+++ b/organizations/acme_corp/views/processmap/README.md
@@ -4,7 +4,7 @@ Process landscape maps — top-level catalogues of an organisation's processes, 
 
 ## File convention
 
-`*.processmap.transitrix.yaml`
+`*.process-map.transitrix.yaml`
 
 ## Skeleton
 

--- a/organizations/acme_corp/views/scenarios/README.md
+++ b/organizations/acme_corp/views/scenarios/README.md
@@ -1,0 +1,14 @@
+# `views/scenarios/`
+
+Alternative strategic development paths — each scenario scopes its own goals, capabilities, activities, products, processes, and applications.
+
+## File convention
+
+`*.scenarios.transitrix.yaml`
+
+See [`notations/11-scenarios.md`](../../../../notations/11-scenarios.md) for the full spec.
+
+## See also
+
+- [`notations/examples/scenarios/`](../../../../notations/examples/scenarios/) — worked examples
+- `method/methodology.md` §6 — notation kit


### PR DESCRIPTION
## Summary

Closes Wave 1 + Wave 2 from the audit in strategy/#51 — surface refresh of `organizations/acme_corp/views/` so the example-organisation reflects the 1.0 notation set and the post-Studio-#54 state. Wave 3 (schema-conformant skeleton rewrites across all view READMEs) is intentionally out of scope; it overlaps with the onboarding-skill epic #22 and should be folded into that work.

### Files touched (8)

**Modified (5):**
- `views/README.md` — subfolder map: four extension fixes (`capmap → capability-map`, `processmap → process-map`, `blocks .txt → .yaml`, `activities .mmd → .activities.transitrix.yaml`); activities description rewritten (PSND + Gantt, not Mermaid); three folders added (scenarios, process-blueprint, issues); example file name corrected.
- `views/capabilities/README.md` — extension line corrected.
- `views/processmap/README.md` — extension line corrected.
- `views/blocks/README.md` — rewritten end-to-end (structured YAML, no svgbob).
- `views/activities/README.md` — rewritten end-to-end (PSND + Gantt YAML, not Mermaid).

**Added (3):**
- `views/scenarios/README.md` — stub pointer to `notations/11-scenarios.md`.
- `views/process-blueprint/README.md` — stub pointer to `notations/13-process-blueprint.md`.
- `views/issues/README.md` — stub pointer to `notations/12-issues.md`.

### Notable decisions

- **No folder rename for `processmap/`.** Initial plan included `processmap/ → process-map/` but on reflection the org-side folder convention is intentionally shorter than the kebab-case short-name — sibling folders use `capabilities/`, `bpmn/`, `fgca/`. The methodology spec's path examples in `notations/06-process-map.md` themselves use `views/processmap/`. Only the file extension inside the README needed correction.
- **Migration note in `views/blocks/README.md`** explicitly states "the previous Python + `svgbob_cli` pipeline was retired in Studio 1.1.0" so users who find the folder via old links know what changed.
- **Skeletons in the other view READMEs** (fga, fgca, goals, products, applications, capabilities, processmap) **stay on their older `title:`-root schemas in this PR**. They diverge from the canonical specs but rewriting all of them is Wave 3, and that work overlaps materially with the templates that the onboarding skill will ship under #22 — better to decide ordering before redoing them here.

### Cross-ref validation

All relative links in the new / rewritten READMEs were checked to resolve:

- `notations/{08-blocks,07-activities,11-scenarios,12-issues,13-process-blueprint,IDS_AND_REFERENCES}.md` ✅
- `notations/examples/blocks/architecture.blocks.transitrix.yaml` ✅
- `notations/examples/activities/platform-launch.activities.transitrix.yaml` ✅

### Test plan

- [x] `git diff --stat` matches the file-count claim above (5 M, 3 A).
- [x] No stale `.capmap.` / `.processmap.` / `.blocks.transitrix.txt` / `.mmd` / Mermaid / svgbob references remain in `organizations/acme_corp/views/` except the intentional historical note in `views/blocks/README.md`.
- [ ] Visual review — three stub READMEs read as a deliberate pointer pattern (not "TODO"); blocks/activities READMEs flow consistently with the sibling view READMEs that weren't rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
