### PR TITLE
docs(notations): strategy-chain family — flat form across FGCA / FGA / Goals (#60)

### DIFF
--- a/notations/02-fgca.md
+++ b/notations/02-fgca.md
@@ -1,8 +1,8 @@
 ---
 notation: "FGCA Strategy-to-Execution Chain"
-version: "1.2"
+version: "1.3"
 author: "Valerii Korobeinikov"
-last_updated: "2026-05-21"
+last_updated: "2026-05-26"
 status: "documented"
 file_extension: "*.fgca.transitrix.yaml"
 dsm_status: "implemented — F, G, C, A layers active; column selection via localStorage"
@@ -113,44 +113,43 @@ Examples:
 
 ## Top-level structure — flat form
 
-FGCA uses the **flat form**: a single `fgca:` root key carries document metadata, and the four layers (`factors`, `goals`, `changes`, `activities`) are parallel arrays under that key. Links between layers are id-references on each item, not nesting.
+FGCA uses the **flat form**: document metadata and the four layers (`factors`, `goals`, `changes`, `activities`) live at the document root as parallel arrays. There is no wrapper key. Links between layers are id-references on each item, not nesting.
 
-This shape matches the FGCA semantic graph: one Change can deliver many Goals, one Activity can deliver many Changes (the `activity_change` join in DSM). A nested form would require duplicating nodes for every cross-layer link. The flat form expresses the DAG directly.
+This shape matches the FGCA semantic graph: one Change can deliver many Goals, one Activity can deliver many Changes. A nested form would require duplicating nodes for every cross-layer link. The flat form expresses the DAG directly.
 
-For comparison: FGA and the Goals tree are tree-shaped (each child has a single parent) and use a nested form — see [`03-fga.md`](03-fga.md) and [`04-goals.md`](04-goals.md). The flat-vs-nested choice across the family follows the rule "nested for trees, flat for DAGs" — the family-selection guide will document this once the cross-notation relationship doc lands.
+The same flat-with-references shape applies family-wide across all four strategy-chain notations (FGCA, FGA, Goals, Activities) — see [`README.md`](README.md) § Family selection for the family-wide rule (decided 2026-05-26; supersedes the earlier "nested for trees, flat for DAGs" heuristic).
 
 ```yaml
 notation: fgca
 spec_version: "0.1"
 
-fgca:
-  id: FGCA-STRAT-1
-  name: "Strategy 2026 — FGCA chain"
-  description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
-  period: "2026"
-  version: "0.1"
-  date: "2026-05-21"
-  author: Transitrix
+id: FGCA-STRAT-1
+name: "Strategy 2026 — FGCA chain"
+description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
+period: "2026"
+version: "0.1"
+date: "2026-05-21"
+author: Transitrix
 
-  factors:
-    - id: FACTOR-1
-      name: "Competitive market pressure"
-      type: external          # external | internal
+factors:
+  - id: FACTOR-1
+    name: "Competitive market pressure"
+    type: external          # external | internal
 
-  goals:
-    - id: GOAL-1
-      name: "Grow revenue by 20%"
-      factors: [FACTOR-1]     # id-references to factors[]
+goals:
+  - id: GOAL-1
+    name: "Grow revenue by 20%"
+    factors: [FACTOR-1]     # id-references to factors[]
 
-  changes:
-    - id: CHANGE-1
-      name: "Launch new product line"
-      goals: [GOAL-1]         # id-references to goals[]
+changes:
+  - id: CHANGE-1
+    name: "Launch new product line"
+    goals: [GOAL-1]         # id-references to goals[]
 
-  activities:
-    - id: ACTIVITY-1
-      name: "Market research"
-      changes: [CHANGE-1]     # id-references to changes[]
+activities:
+  - id: ACTIVITY-1
+    name: "Market research"
+    changes: [CHANGE-1]     # id-references to changes[]
 ```
 
 A complete example: [`examples/fgca/strategy-2026.fgca.transitrix.yaml`](examples/fgca/strategy-2026.fgca.transitrix.yaml).
@@ -159,21 +158,23 @@ A complete example: [`examples/fgca/strategy-2026.fgca.transitrix.yaml`](example
 
 ## Fields
 
-### `fgca` root
+### Document root
 
 | Field | Required | Description |
 |---|---|---|
-| `fgca.id` | yes | document ID — `FGCA-[<middle>-]<INTEGER>` per the canonical grammar |
-| `fgca.name` | yes | human-readable name |
-| `fgca.description` | no | one-paragraph context |
-| `fgca.period` | no | time period the chain covers (e.g. `"2026"`, `"2026-Q3"`) |
-| `fgca.version` | no | document version |
-| `fgca.date` | no | document date (YYYY-MM-DD) |
-| `fgca.author` | no | document author |
-| `fgca.factors` | yes | array of factor entries — see below |
-| `fgca.goals` | yes | array of goal entries — see below |
-| `fgca.changes` | yes | array of change entries — see below |
-| `fgca.activities` | yes | array of activity entries — see below |
+| `notation` | yes | MUST equal `fgca` (per [CONTRACT.md](CONTRACT.md)) |
+| `spec_version` | no | reserved field per the shared contract |
+| `id` | yes | document ID — `FGCA-[<middle>-]<INTEGER>` per the canonical grammar |
+| `name` | yes | human-readable name |
+| `description` | no | one-paragraph context |
+| `period` | no | time period the chain covers (e.g. `"2026"`, `"2026-Q3"`) |
+| `version` | no | document version |
+| `date` | no | document date (YYYY-MM-DD) |
+| `author` | no | document author |
+| `factors` | yes | array of factor entries — see below |
+| `goals` | yes | array of goal entries — see below |
+| `changes` | yes | array of change entries — see below |
+| `activities` | yes | array of activity entries — see below |
 
 ### `factors[]`
 
@@ -212,7 +213,7 @@ A complete example: [`examples/fgca/strategy-2026.fgca.transitrix.yaml`](example
 | `goals` | no | array of `GOAL-…` IDs the activity supports directly (degenerate FGA-style link, used when the Change layer adds no information for that activity) |
 | `description` | no | one-paragraph elaboration |
 
-ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>`. Middle segments are optional and notation-specific. The terminal integer is positive (≥ 1) with no leading zeros. `ACTIVITY-` is the canonical activity prefix (replacing the older `ACT-` form); `CHANGE-` is the FGCA change-layer prefix. The full grammar and TYPE registry will live in a forthcoming `IDS_AND_REFERENCES.md` appendix.
+ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>`. Middle segments are optional and notation-specific. The terminal integer is positive (≥ 1) with no leading zeros. `ACTIVITY-` is the canonical activity prefix (replacing the older `ACT-` form); `CHANGE-` is the FGCA change-layer prefix. The full grammar and TYPE registry live in [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md).
 
 ---
 
@@ -220,10 +221,10 @@ ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>`. 
 
 | Rule | Severity | Description |
 |---|---|---|
-| `FGCA-001` | error | `fgca` root key missing. |
-| `FGCA-002` | error | `fgca.id` missing or empty. |
-| `FGCA-003` | error | `fgca.name` missing or empty. |
-| `FGCA-004` | error | any of `fgca.factors` / `fgca.goals` / `fgca.changes` / `fgca.activities` missing or empty. |
+| `FGCA-001` | error | document root is not an object, or `notation` field missing / does not equal `fgca`. |
+| `FGCA-002` | error | `id` missing or empty. |
+| `FGCA-003` | error | `name` missing or empty. |
+| `FGCA-004` | error | any of `factors` / `goals` / `changes` / `activities` missing or empty. |
 | `FGCA-005` | error | every entry in the four arrays must have a non-empty `id` and `name`. |
 | `FGCA-006` | error | IDs unique within their layer (and SHOULD be unique across all four layers within a document). |
 | `FGCA-007` | error | every ID matches the canonical grammar `<TYPE>-[<middle>-]<INTEGER>` with the right type prefix for its layer. |
@@ -239,9 +240,9 @@ ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>`. 
 
 ## References
 
-- FGA notation (3-layer simplified variant, nested form): [`03-fga.md`](03-fga.md)
+- FGA notation (3-layer simplified variant, same flat form): [`03-fga.md`](03-fga.md)
 - Goals tree notation: [`04-goals.md`](04-goals.md)
 - Activities notation: [`07-activities.md`](07-activities.md) — uses `delivers_changes:` to link into the FGCA chain
-- Canonical ID grammar and TYPE registry: forthcoming `IDS_AND_REFERENCES.md` appendix
+- Canonical ID grammar and TYPE registry: [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md)
 - Family selection across FGCA / FGA / Goals / Activities: `notations/README.md` § Family selection
 - Methodology section 6.2: `method/methodology.md`

--- a/notations/03-fga.md
+++ b/notations/03-fga.md
@@ -1,9 +1,9 @@
 ---
 notation: "FGA Strategy-to-Execution Chain"
-version: "0.1"
+version: "0.2"
 author: "Valerii Korobeinikov"
-last_updated: "2026-05-08"
-status: "draft"
+last_updated: "2026-05-26"
+status: "documented"
 file_extension: "*.fga.transitrix.yaml"
 ---
 
@@ -16,7 +16,7 @@ file_extension: "*.fga.transitrix.yaml"
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|
@@ -66,58 +66,116 @@ Examples:
 
 ---
 
-## 4. Top-level structure
+## 4. Top-level structure — flat form
+
+FGA uses the **flat form**: document metadata and the three layers (`factors`, `goals`, `activities`) live at the document root as parallel arrays. There is no wrapper key. Links between layers are id-references on each item, not nesting.
+
+The same flat-with-references shape applies family-wide across all four strategy-chain notations (FGCA, FGA, Goals, Activities) — see [`README.md`](README.md) § Family selection for the family-wide rule (decided 2026-05-26).
 
 ```yaml
-fga:
-  id: "FGA-OPS-001"
-  name: "Q3 Operational Initiatives"
-  description: "Direct mapping of Q3 activities to strategic goals"
-  period: "2026-Q3"
+notation: fga
+spec_version: "0.1"
 
-  factors:
-    - id: "FACTOR-CHURN-001"
-      name: "Rising customer churn in SMB segment"
-      type: "external"               # external | internal
-      goals:
-        - id: "GOAL-RET-001"
-          name: "Improve SMB retention to 90%"
-          activities:
-            - id: "ACT-ONBOARD-001"
-              name: "Redesign onboarding flow"
-              owner: "ROLE-PRODUCT-001"
-              status: "In Progress"
-              due_date: "2026-09-30"
-            - id: "ACT-SUPPORT-001"
-              name: "Launch dedicated SMB support tier"
-              owner: "ROLE-CS-001"
-              status: "Planned"
-              due_date: "2026-08-31"
+id: FGA-STRAT-1
+name: "Strategy 2026 — FGA chain"
+description: "Factor → Goal → Activity decomposition for the 2026 plan."
+period: "2026"
+version: "0.1"
+date: "2026-05-26"
+author: Transitrix
+
+factors:
+  - id: FACTOR-1
+    name: "Competitive market pressure"
+    type: external          # external | internal
+
+goals:
+  - id: GOAL-1
+    name: "Grow revenue by 20%"
+    factors: [FACTOR-1]     # id-references to factors[]
+
+activities:
+  - id: ACTIVITY-1
+    name: "Launch new product line"
+    goals: [GOAL-1]         # id-references to goals[]
 ```
+
+A complete example: [`examples/fga/strategy-2026.fga.transitrix.yaml`](examples/fga/strategy-2026.fga.transitrix.yaml).
 
 ---
 
 ## 5. Fields
 
+### Document root
+
 | Field | Required | Description |
-|-------|----------|-------------|
-| `fga.id` | Yes | Unique ID for this view (`FGA-DOMAIN-SEQ`) |
-| `fga.name` | Yes | Human-readable name |
-| `fga.period` | No | Time period this FGA covers |
-| `factors[].id` | Yes | Unique factor ID |
-| `factors[].name` | Yes | Description of the driving factor |
-| `factors[].type` | Yes | `external` or `internal` |
-| `goals[].id` | Yes | References an existing Goal element ID |
-| `goals[].name` | Yes | Goal name (should match the element) |
-| `activities[].id` | Yes | Unique activity ID |
-| `activities[].name` | Yes | Activity description |
-| `activities[].owner` | No | Reference to BusinessRole element ID |
-| `activities[].status` | No | `Planned` / `In Progress` / `Done` |
-| `activities[].due_date` | No | Target completion date (YYYY-MM-DD) |
+|---|---|---|
+| `notation` | yes | MUST equal `fga` (per [CONTRACT.md](CONTRACT.md)) |
+| `spec_version` | no | reserved field per the shared contract |
+| `id` | yes | document ID — `FGA-[<middle>-]<INTEGER>` per the canonical grammar |
+| `name` | yes | human-readable name |
+| `description` | no | one-paragraph context |
+| `period` | no | time period the chain covers (e.g. `"2026"`, `"2026-Q3"`) |
+| `version` | no | document version |
+| `date` | no | document date (YYYY-MM-DD) |
+| `author` | no | document author |
+| `factors` | yes | array of factor entries — see below |
+| `goals` | yes | array of goal entries — see below |
+| `activities` | yes | array of activity entries — see below |
+
+### `factors[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | `FACTOR-[<middle>-]<INTEGER>` |
+| `name` | yes | what the factor is |
+| `type` | no | `external` or `internal` |
+| `description` | no | one-paragraph elaboration |
+
+### `goals[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | `GOAL-[<middle>-]<INTEGER>` |
+| `name` | yes | what the goal is |
+| `factors` | no | array of `FACTOR-…` IDs this goal is driven by |
+| `description` | no | one-paragraph elaboration |
+
+### `activities[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | `ACTIVITY-[<middle>-]<INTEGER>` |
+| `name` | yes | what the activity is |
+| `goals` | no | array of `GOAL-…` IDs the activity supports |
+| `owner` | no | `ROLE-…` ID of the accountable role |
+| `status` | no | `Planned` / `In Progress` / `Done` |
+| `due_date` | no | target completion date (YYYY-MM-DD) |
+| `description` | no | one-paragraph elaboration |
+
+ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md).
 
 ---
 
-## 6. Difference from FGCA
+## 6. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `FGA-001` | error | document root is not an object, or `notation` field missing / does not equal `fga`. |
+| `FGA-002` | error | `id` missing or does not match `FGA-[<middle>-]<INTEGER>`. |
+| `FGA-003` | error | `name` missing or empty. |
+| `FGA-004` | error | any of `factors` / `goals` / `activities` missing or empty. |
+| `FGA-005` | error | every entry in the three arrays must have a non-empty `id` and `name`. |
+| `FGA-006` | error | IDs unique within their layer (and SHOULD be unique across all three layers within a document). |
+| `FGA-007` | error | every ID matches the canonical grammar `<TYPE>-[<middle>-]<INTEGER>` with the right type prefix for its layer. |
+| `FGA-008` | error | `goals[].factors[]` IDs must reference defined factors. |
+| `FGA-009` | error | `activities[].goals[]` IDs must reference defined goals. |
+| `FGA-010` | warn | a factor with no goal referencing it is orphan. |
+| `FGA-011` | warn | a goal with no activity referencing it is orphan. |
+
+---
+
+## 7. Difference from FGCA
 
 FGCA adds a `changes` layer between goals and activities:
 
@@ -128,13 +186,15 @@ FGA:  Factor → Goal →          Activity
 
 When converting FGA to FGCA: identify the implicit change each goal demands and make it explicit. This is the right move when a goal requires organisational transformation, not just execution.
 
+Both notations use the same flat-with-references shape — FGA is FGCA minus the `changes[]` array, with `activities[].goals` taking the place of `activities[].changes`.
+
 ---
 
-## 7. References
+## 8. References
 
-- FGCA notation: `notations/02-fgca.md`
-- Goals tree notation: `notations/04-goals.md`
+- FGCA notation: [`02-fgca.md`](02-fgca.md)
+- Goals tree notation: [`04-goals.md`](04-goals.md)
 - Goal elements: `elements/01_motivation/*.yaml` (type: Goal)
-- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
-- Family selection across FGCA / FGA / Goals / Activities: `notations/README.md` § Family selection
+- ID grammar and TYPE registry: [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md)
+- Family selection across FGCA / FGA / Goals / Activities: `README.md` § Family selection
 - Methodology section 6.2: `method/methodology.md`

--- a/notations/04-goals.md
+++ b/notations/04-goals.md
@@ -1,8 +1,8 @@
 ---
 notation: "Goals Tree"
-version: "0.2"
+version: "0.3"
 author: "Valerii Korobeinikov"
-last_updated: "2026-05-08"
+last_updated: "2026-05-26"
 status: "documented"
 file_extension: "*.goals.transitrix.yaml"
 dsm_status: "implemented — Goals & Activities section, Visual Editor (G)"
@@ -10,18 +10,14 @@ dsm_status: "implemented — Goals & Activities section, Visual Editor (G)"
 
 # Goals Tree Notation — Reference
 
-**Version:** 0.2
-**Date:** 2026-05-08
-**Status:** Implemented in Transitrix DSM
-**File extension:** `*.goals.transitrix.yaml`
-**Scope:** Hierarchy of strategic and tactical goals; mono-type tree composed entirely of Goal elements.
+**Scope:** Hierarchy of strategic and tactical goals; mono-type tree composed entirely of Goal elements. Authored as a flat document — hierarchy is expressed through `parent` references on each goal.
 **Renderer:** Transitrix DSM — Visual Editor (G), Goals table; Transitrix Studio (planned)
 
 ---
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|
@@ -34,7 +30,7 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 A goals tree is a hierarchical view that arranges Goal elements from `elements/01_motivation/` into a top-down tree — from broad strategic ambitions down to specific tactical objectives.
 
-Unlike a flat list of goals, the tree makes the logical decomposition explicit: a parent goal is achieved through the combined delivery of its child goals. The tree is a **view** over atomic Goal elements — the elements themselves remain unchanged in `elements/01_motivation/`.
+The hierarchy is expressed by `parent` references on each goal: a goal whose `parent` is omitted (or null) is a root; a goal whose `parent` is `GOAL-XYZ` is a child of that goal. The document itself is a flat list — the tree shape is derived from the `parent` references at render time.
 
 Goals trees live in `views/goals/`.
 
@@ -63,85 +59,133 @@ Examples:
 
 ---
 
-## 4. Top-level structure
+## 4. Top-level structure — flat form
+
+The document carries document metadata, a `goal_types[]` array that defines the level vocabulary, and a flat `goals[]` array at the document root. There is no wrapper key. The tree shape is derived from the `parent` field on each goal.
+
+The same flat-with-references shape applies family-wide across all four strategy-chain notations (FGCA, FGA, Goals, Activities) — see [`README.md`](README.md) § Family selection for the family-wide rule (decided 2026-05-26; supersedes the earlier "nested for trees, flat for DAGs" heuristic).
 
 ```yaml
-goals_tree:
-  id: "GT-GROWTH-001"
-  name: "Growth Strategy Goals"
-  description: "Strategic and tactical goals for the 2026 growth programme"
-  root:
-    goal_id: "GOAL-REV-001"          # References an existing Goal element
-    children:
-      - goal_id: "GOAL-MARKET-001"
-        children:
-          - goal_id: "GOAL-ACQ-001"
-          - goal_id: "GOAL-RET-001"
-      - goal_id: "GOAL-PRODUCT-001"
-        children:
-          - goal_id: "GOAL-NPS-001"
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-STRAT-1
+name: "Strategy 2026 — Goals Tree"
+description: "Goal hierarchy across Strategy → Strategic Goal → Project Goal levels for the 2026 plan."
+period: "2026"
+version: "0.1"
+date: "2026-05-26"
+author: Transitrix
+
+goal_types:
+  - { name: "Strategy",         level: 0 }
+  - { name: "Strategic Intention", level: 1 }
+  - { name: "Strategic Goal",   level: 2 }
+  - { name: "Business Goal",    level: 3 }
+  - { name: "Project Goal",     level: 4 }
+
+goals:
+  - id: GOAL-REVENUE-1
+    name: "Triple revenue in 3 years"
+    type: "Strategy"
+    level: 0
+    # No parent — root.
+
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 2
+    parent: GOAL-REVENUE-1
+
+  - id: GOAL-BERLIN-1
+    name: "Open Berlin office"
+    type: "Project Goal"
+    level: 4
+    parent: GOAL-EU-1
 ```
+
+A complete example: [`examples/goals/strategy-2026.goals.transitrix.yaml`](examples/goals/strategy-2026.goals.transitrix.yaml).
 
 ---
 
 ## 5. Fields
 
+### Document root
+
 | Field | Required | Description |
-|-------|----------|-------------|
-| `goals_tree.id` | Yes | Unique identifier for this view (`GT-DOMAIN-SEQ`) |
-| `goals_tree.name` | Yes | Human-readable name of the goals tree |
-| `goals_tree.description` | No | What this goals tree represents |
-| `root` | Yes | The top-most goal in the hierarchy |
-| `goal_id` | Yes | Reference to an existing Goal element ID |
-| `children` | No | List of child goals; omit for leaf goals |
+|---|---|---|
+| `notation` | yes | MUST equal `goals` (per [CONTRACT.md](CONTRACT.md)) |
+| `spec_version` | no | reserved field per the shared contract |
+| `id` | yes | document ID — `GOALS-[<middle>-]<INTEGER>` per the canonical grammar (the document-level TYPE `GOALS_TREE` in [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §3.2 is the historical label; document IDs use the short `GOALS-…` form for filenames and references) |
+| `name` | yes | human-readable name |
+| `description` | no | one-paragraph context |
+| `period` | no | time period the tree covers |
+| `version` | no | document version |
+| `date` | no | document date (YYYY-MM-DD) |
+| `author` | no | document author |
+| `goal_types` | yes | array of `{name, level}` entries defining the level vocabulary — see §5.1 |
+| `goals` | yes | flat array of goal entries — see §5.2 |
+
+### 5.1 `goal_types[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | human-readable level name (`"Strategy"`, `"Strategic Goal"`, …) |
+| `level` | yes | non-negative integer; `0` is the root level |
+
+Organisations choose their own level vocabulary; the canonical 8-level default is listed in §9.1.
+
+### 5.2 `goals[]`
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | `GOAL-[<middle>-]<INTEGER>` per the canonical grammar |
+| `name` | yes | what the goal is |
+| `type` | yes | one of the `name` values from `goal_types[]` |
+| `level` | yes | non-negative integer matching the `level` of the named `type` |
+| `parent` | no | `GOAL-…` ID of the parent goal. Omit for a root (`level = 0`). |
+| `description` | no | one-paragraph elaboration |
+| `link` | no | URL pointing at supplementary documentation |
+| `tag` | no | free-form classifier string |
+
+ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md).
 
 ---
 
-## 6. Constraints
+## 6. Validation rules
 
-- Every `goal_id` must reference an existing element of `type: Goal` in `elements/01_motivation/`
-- A Goal element may appear in multiple trees but only once per tree
-- Cycles are not allowed
-- Maximum recommended depth: 4 levels
-
----
-
-## 7. Example
-
-```yaml
-goals_tree:
-  id: "GT-OPS-001"
-  name: "Operational Excellence Goals"
-  description: "Delivery reliability and quality goals for 2026"
-  root:
-    goal_id: "GOAL-RELIABILITY-001"
-    children:
-      - goal_id: "GOAL-UPTIME-001"
-      - goal_id: "GOAL-INCIDENT-001"
-        children:
-          - goal_id: "GOAL-MTTR-001"
-          - goal_id: "GOAL-MTTA-001"
-      - goal_id: "GOAL-QUALITY-001"
-```
+| Rule | Severity | Description |
+|---|---|---|
+| `GOALS-001` | error | document root is not an object, or `notation` field missing / does not equal `goals`. |
+| `GOALS-002` | error | `id` missing or does not match `GOALS-[<middle>-]<INTEGER>`. |
+| `GOALS-003` | error | `name` missing or empty. |
+| `GOALS-004` | error | `goal_types` missing or empty; `goals` missing or empty. |
+| `GOALS-005` | error | every entry in `goal_types[]` must have a non-empty `name` and a non-negative integer `level`. |
+| `GOALS-006` | error | every entry in `goals[]` must have a non-empty `id`, `name`, `type`, and a non-negative integer `level`. |
+| `GOALS-007` | error | every `goals[].id` matches the canonical grammar and is unique within the document. |
+| `GOALS-008` | error | `goals[].type` references a `name` defined in `goal_types[]`; `goals[].level` equals the level associated with that type. |
+| `GOALS-009` | warn | `goals[].parent` references an `id` not defined in `goals[]` — the goal is treated as an orphan / backlog item. |
+| `GOALS-010` | error | the `parent` chain contains a cycle (a goal is its own ancestor). |
+| `GOALS-011` | warn | a non-root goal (`level ≥ 1`) has no `parent` set; either declare it as a root by promoting it to `level: 0`, or attach it to a parent. |
 
 ---
 
-## 8. References
+## 7. References
 
 - Goal elements: `elements/01_motivation/*.yaml` (type: Goal)
-- FGCA notation: `notations/02-fgca.md`
-- FGA notation: `notations/03-fga.md`
-- ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
-- Family selection across FGCA / FGA / Goals / Activities: `notations/README.md` § Family selection
+- FGCA notation: [`02-fgca.md`](02-fgca.md)
+- FGA notation: [`03-fga.md`](03-fga.md)
+- ID grammar and TYPE registry: [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md)
+- Family selection across FGCA / FGA / Goals / Activities: [`README.md`](README.md) § Family selection
 - Methodology section 6.1: `method/methodology.md`
 
 ---
 
-## 9. DSM Implementation Rules
+## 8. DSM Implementation Rules
 
 This section describes how Transitrix DSM implements the Goals Tree. These rules govern the API, Visual Editor (G), and table view.
 
-### 9.1 Hierarchy depth
+### 8.1 Hierarchy depth
 
 The hierarchy depth is **not hardcoded** — it is configured in the `goal_types` table per organisation. The default configuration uses **8 levels**:
 
@@ -158,7 +202,7 @@ The hierarchy depth is **not hardcoded** — it is configured in the `goal_types
 
 All validation and visualisation logic adapts dynamically to the currently active `goal_types` configuration — organisations can rename or resize the hierarchy.
 
-### 9.2 Structural constraints
+### 8.2 Structural constraints
 
 **Rule 1 — Strict N+1 hierarchy:** A child goal must always be exactly one level deeper than its parent.
 
@@ -168,11 +212,11 @@ Constraint: child.level = parent.level + 1
 
 Attaching a Level 4 goal directly to a Level 2 parent is rejected.
 
-**Rule 2 — Single parent:** Every goal (except the root) must have exactly one parent. Goals with a missing or invalid `parent_id` are treated as **Orphans** (backlog) and are not shown in the main tree until attached.
+**Rule 2 — Single parent:** Every goal (except the root) must have exactly one parent. Goals with a missing or invalid `parent` are treated as **Orphans** (backlog) and are not shown in the main tree until attached.
 
 **Rule 3 — Single root:** Only one goal with `level = 0` (type = Strategy) may exist. The API rejects creation of a second root.
 
-### 9.3 Editing and cascade updates
+### 8.3 Editing and cascade updates
 
 When a goal is moved to a new parent:
 
@@ -181,10 +225,10 @@ When a goal is moved to a new parent:
 
 **Max-depth protection:** if moving a branch would push its deepest descendant beyond the configured maximum level, the operation is blocked.
 
-### 9.4 Backlog
+### 8.4 Backlog
 
 Goals without a valid parent (orphans) live in the **backlog**. They are visible in the Goals table but not rendered in the Visual Editor (G) tree. Dragging a backlog goal onto a tree node attaches it and triggers the cascade level update.
 
-### 9.5 Relationship to FGCA
+### 8.5 Relationship to FGCA
 
-In DSM the Goals Tree is the G layer of FGCA. Goals are linked to Activities via the `goal_id` field on Activity records. The FGCA diagram (Strategy-to-Action) visualises this cross-layer chain. See `notations/02-fgca.md`.
+In DSM the Goals Tree is the G layer of FGCA. Goals are linked to Activities via the `goals: [GOAL-…]` field on Activity records. The FGCA diagram (Strategy-to-Action) visualises this cross-layer chain. See [`02-fgca.md`](02-fgca.md).

--- a/notations/08-blocks.md
+++ b/notations/08-blocks.md
@@ -71,7 +71,7 @@ Examples:
 
 ## 4. Top-level structure — nested form
 
-The blocks notation is a tree: every child has exactly one parent. Per the family rule "nested for trees, flat for DAGs" (see [README.md](README.md) § Family selection), nesting is expressed directly by YAML structure — no id-references between blocks.
+The blocks notation is a tree: every child has exactly one parent. Hierarchy is expressed directly by YAML structure — no id-references between blocks. (The strategy-chain notations FGCA / FGA / Goals / Activities use a different shape — flat top-level arrays with `parent`/cross-reference fields — per the family-wide rule in [README.md](README.md) § Family selection. Blocks pre-dates that family and is not part of it; the YAML-nested form is canonical here.)
 
 A document carries a single `nested_blocks:` root key with the document's identifying fields and a `blocks: [...]` array of top-level blocks. A file MAY contain several top-level blocks; they are rendered as independent diagram sections in array order.
 

--- a/notations/README.md
+++ b/notations/README.md
@@ -58,14 +58,18 @@ Four notations — FGCA, FGA, the Goals tree, and the Activities network — sit
 | You need a quarterly goals review with no factor or activity context. | **Goals tree** |
 | You're explaining why a goal-action gap exists and what transformation closes it. | **FGCA** |
 
-### Form rule — nested for trees, flat for DAGs
+### Form rule — flat top-level arrays with reference-based hierarchy
 
-The four notations split into two structural shapes:
+**All four strategy-chain notations — FGCA, FGA, Goals, Activities — use the flat form.** Document metadata and the layer arrays live at the document root as parallel top-level arrays. There is no wrapper root key. Where a notation is tree-shaped (Goals, Activities), hierarchy is expressed by `parent` references on each element inside the flat array. Where a notation is DAG-shaped (FGCA, FGA), cross-layer links are id-references on each element in the canonical downstream direction.
 
-- **Tree-shaped, nested form.** FGA and the Goals tree are trees — each child has exactly one parent. The document nests children under parents directly; the YAML structure carries the hierarchy and no id-references are needed inside the document.
-- **DAG-shaped, flat form.** FGCA and the Activities network are DAGs — one Change can deliver many Goals; one Activity can deliver many Changes; activity predecessors fan out the same way. Nesting would require duplicating nodes for every cross-layer link. These notations use a single root key (`fgca:` for FGCA, the top-level `activities:` array for Activities) with parallel layer arrays and id-references between layers.
+| Notation | Top-level arrays | Hierarchy / cross-link |
+|---|---|---|
+| **Goals** | `goal_types[]`, `goals[]` | `goal.parent: GOAL-…` (omitted at root) |
+| **FGA** | `factors[]`, `goals[]`, `activities[]` | `goal.factors: [FACTOR-…]`; `activity.goals: [GOAL-…]` |
+| **FGCA** | `factors[]`, `goals[]`, `changes[]`, `activities[]` | `goal.factors: [FACTOR-…]`; `change.goals: [GOAL-…]`; `activity.changes: [CHANGE-…]` |
+| **Activities** | `activities[]` | `activity.predecessors: [ACTIVITY-…]`; optional `parent: ACTIVITY-…` for WBS groupings |
 
-**Rule of thumb:** if a child element can have multiple parents in the semantic graph, the notation uses the flat form. The rule was set on 2026-05-20 alongside the FGCA schema; see [02-fgca.md](02-fgca.md) "Top-level structure — flat form" for the worked-out FGCA shape and [07-activities.md](07-activities.md) §4 for the Activities shape.
+**Decision (2026-05-26)** — this supersedes the earlier "nested for trees, flat for DAGs" heuristic. Reasoning: a single shape across the family removes the spec-vs-implementation gap that the heuristic produced (downstream tools have to handle both forms), and tree-shape semantics survive perfectly well as `parent`-references inside a flat array. The earlier rule was a 2026-05-20 working position alongside the original FGCA schema decision; this entry replaces it.
 
 ## Examples
 

--- a/notations/examples/fga/README.md
+++ b/notations/examples/fga/README.md
@@ -5,49 +5,56 @@ Use this format when you want a direct mapping from goals to activities without 
 
 **File extension:** `*.fga.transitrix.yaml`
 
+See the canonical spec: [`../../03-fga.md`](../../03-fga.md).
+
 ## Minimal structure
 
 ```yaml
 notation: fga
+spec_version: "0.1"
+
+id: FGA-SAMPLE-1
+name: "Sample FGA chain"
 
 factors:
-  - id: 1
-    name: "Market growth"
+  - id: FACTOR-MARKET-1
+    name: "Market growth opportunity"
+    type: external
 
 goals:
-  - id: 1
+  - id: GOAL-EXPAND-1
     name: "Expand market share"
-    factor: [{ id: 1 }]      # one or more factor IDs
+    factors: [FACTOR-MARKET-1]   # one or more FACTOR-… IDs
 
 activities:
-  - id: 1
+  - id: ACTIVITY-LAUNCH-1
     name: "Launch in two new regions"
-    goal_id: 1               # which goal this activity delivers
+    goals: [GOAL-EXPAND-1]       # one or more GOAL-… IDs the activity supports
 ```
 
-## Optional header fields
+## Optional document-root fields
 
 ```yaml
-title: "My FGA"
 description: "Short description"
+period: "2026"
 version: "0.1"
-date: "2026-05-12"
+date: "2026-05-26"
 author: "Your Name"
 ```
 
 ## Difference from FGCA
 
-FGA omits the `changes` section entirely. Activities link directly to goals via `goal_id`.
+FGA omits the `changes` section entirely. Activities link directly to goals via `activity.goals: [GOAL-…]`.
 Use FGCA (`.fgca.transitrix.yaml`) when you need to track discrete change packages between goals and activities.
 
 ## Rules
 
-- All IDs must be unique integers within their section.
-- A goal can reference multiple factors: `factor: [{ id: 1 }, { id: 2 }]`.
-- Each activity belongs to exactly one goal.
+- All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar per [`../../IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md). IDs are unique within their layer.
+- A goal MAY reference multiple factors via `factors: [FACTOR-…, FACTOR-…]`.
+- An activity MAY reference multiple goals via `goals: [GOAL-…, GOAL-…]`.
 
 ## Examples in this folder
 
 | File | Description |
 |---|---|
-| `strategy-2026.fga.transitrix.yaml` | FGA chain (3 factors, 3 goals, 6 activities) |
+| `strategy-2026.fga.transitrix.yaml` | FGA chain (3 factors, 3 goals, 7 activities) |

--- a/notations/examples/fga/strategy-2026.fga.transitrix.yaml
+++ b/notations/examples/fga/strategy-2026.fga.transitrix.yaml
@@ -1,71 +1,76 @@
 notation: fga
 spec_version: "0.1"
 
-fga:
-  id: "FGA-STRATEGY-2026"
-  name: "Strategy 2026"
-  description: "Factor–Goal–Activity view for the 2026 strategic plan. Changes layer omitted — activities map directly to goals."
-  period: "2026"
+id: FGA-STRATEGY-2026
+name: "Strategy 2026"
+description: "Factor–Goal–Activity view for the 2026 strategic plan. Changes layer omitted — activities map directly to goals."
+period: "2026"
+version: "0.1"
+date: "2026-05-26"
+author: Transitrix
 
-  factors:
-    - id: "FACTOR-MARKET-001"
-      name: "Market growth opportunity in new geographies"
-      type: "external"
-      goals:
-        - id: "GOAL-MARKET-001"
-          name: "Expand market share"
-          activities:
-            - id: "ACT-MARKET-001"
-              name: "Launch in two new regions"
-              owner: "ROLE-BIZ-001"
-              status: "In Progress"
-              due_date: "2026-09-30"
-            - id: "ACT-MARKET-002"
-              name: "Partner channel programme"
-              owner: "ROLE-SALES-001"
-              status: "Planned"
-              due_date: "2026-12-31"
+factors:
+  - id: FACTOR-MARKET-1
+    name: "Market growth opportunity in new geographies"
+    type: external
+  - id: FACTOR-REG-1
+    name: "Increasing regulatory pressure (GDPR, data residency)"
+    type: external
+  - id: FACTOR-TECH-1
+    name: "Internal shift to cloud-native architecture"
+    type: internal
 
-    - id: "FACTOR-REG-001"
-      name: "Increasing regulatory pressure (GDPR, data residency)"
-      type: "external"
-      goals:
-        - id: "GOAL-COMPLIANCE-001"
-          name: "Achieve full regulatory compliance"
-          activities:
-            - id: "ACT-COMPLIANCE-001"
-              name: "GDPR gap assessment"
-              owner: "ROLE-LEGAL-001"
-              status: "Done"
-              due_date: "2026-03-31"
-            - id: "ACT-COMPLIANCE-002"
-              name: "Policy and training rollout"
-              owner: "ROLE-HR-001"
-              status: "In Progress"
-              due_date: "2026-06-30"
+goals:
+  - id: GOAL-MARKET-1
+    name: "Expand market share"
+    factors: [FACTOR-MARKET-1, FACTOR-TECH-1]
+  - id: GOAL-COMPLIANCE-1
+    name: "Achieve full regulatory compliance"
+    factors: [FACTOR-REG-1]
+  - id: GOAL-PLATFORM-1
+    name: "Modernise platform"
+    factors: [FACTOR-TECH-1]
 
-    - id: "FACTOR-TECH-001"
-      name: "Internal shift to cloud-native architecture"
-      type: "internal"
-      goals:
-        - id: "GOAL-PLATFORM-001"
-          name: "Modernise platform"
-          activities:
-            - id: "ACT-PLATFORM-001"
-              name: "Migrate to cloud-native stack"
-              owner: "ROLE-ENG-001"
-              status: "In Progress"
-              due_date: "2026-10-31"
-            - id: "ACT-PLATFORM-002"
-              name: "API gateway rollout"
-              owner: "ROLE-ENG-001"
-              status: "Planned"
-              due_date: "2026-12-31"
-        - id: "GOAL-MARKET-001"
-          name: "Expand market share"
-          activities:
-            - id: "ACT-MARKET-003"
-              name: "Launch self-serve onboarding"
-              owner: "ROLE-PRODUCT-001"
-              status: "Planned"
-              due_date: "2026-11-30"
+activities:
+  - id: ACTIVITY-MARKET-1
+    name: "Launch in two new regions"
+    goals: [GOAL-MARKET-1]
+    owner: ROLE-BIZ-1
+    status: "In Progress"
+    due_date: "2026-09-30"
+  - id: ACTIVITY-MARKET-2
+    name: "Partner channel programme"
+    goals: [GOAL-MARKET-1]
+    owner: ROLE-SALES-1
+    status: "Planned"
+    due_date: "2026-12-31"
+  - id: ACTIVITY-MARKET-3
+    name: "Launch self-serve onboarding"
+    goals: [GOAL-MARKET-1]
+    owner: ROLE-PRODUCT-1
+    status: "Planned"
+    due_date: "2026-11-30"
+  - id: ACTIVITY-COMPLIANCE-1
+    name: "GDPR gap assessment"
+    goals: [GOAL-COMPLIANCE-1]
+    owner: ROLE-LEGAL-1
+    status: "Done"
+    due_date: "2026-03-31"
+  - id: ACTIVITY-COMPLIANCE-2
+    name: "Policy and training rollout"
+    goals: [GOAL-COMPLIANCE-1]
+    owner: ROLE-HR-1
+    status: "In Progress"
+    due_date: "2026-06-30"
+  - id: ACTIVITY-PLATFORM-1
+    name: "Migrate to cloud-native stack"
+    goals: [GOAL-PLATFORM-1]
+    owner: ROLE-ENG-1
+    status: "In Progress"
+    due_date: "2026-10-31"
+  - id: ACTIVITY-PLATFORM-2
+    name: "API gateway rollout"
+    goals: [GOAL-PLATFORM-1]
+    owner: ROLE-ENG-1
+    status: "Planned"
+    due_date: "2026-12-31"

--- a/notations/examples/fgca/README.md
+++ b/notations/examples/fgca/README.md
@@ -5,52 +5,58 @@ Shows how external factors drive goals, which require changes, which are deliver
 
 **File extension:** `*.fgca.transitrix.yaml`
 
+See the canonical spec: [`../../02-fgca.md`](../../02-fgca.md).
+
 ## Minimal structure
 
 ```yaml
 notation: fgca
 spec_version: "0.1"
 
+id: FGCA-SAMPLE-1
+name: "Sample FGCA chain"
+
 factors:
-  - id: 1
+  - id: FACTOR-1
     name: "External factor driving change"
+    type: external
 
 goals:
-  - id: 1
+  - id: GOAL-1
     name: "Strategic goal"
-    factor: [{ id: 1 }]      # one or more factor IDs
+    factors: [FACTOR-1]            # one or more FACTOR-… IDs
 
 changes:
-  - id: 1
+  - id: CHANGE-1
     name: "Transformation programme"
-    goal_id: 1               # which goal this change addresses
-    activity_ids: [1, 2]     # activities that deliver this change
+    goals: [GOAL-1]                # one or more GOAL-… IDs this change delivers
 
 activities:
-  - id: 1
+  - id: ACTIVITY-1
     name: "Research phase"
-    goal_id: 1
-  - id: 2
+    changes: [CHANGE-1]            # one or more CHANGE-… IDs this activity delivers
+  - id: ACTIVITY-2
     name: "Rollout phase"
-    goal_id: 1
+    changes: [CHANGE-1]
 ```
 
-## Optional header fields
+## Optional document-root fields
 
 ```yaml
-title: "My FGCA Chain"
 description: "Short description"
+period: "2026"
 version: "0.1"
-date: "2026-05-12"
+date: "2026-05-26"
 author: "Your Name"
 ```
 
 ## Rules
 
-- All IDs (`factors`, `goals`, `changes`, `activities`) must be unique integers within their section.
-- A goal can reference multiple factors: `factor: [{ id: 1 }, { id: 2 }]`.
-- A change belongs to exactly one goal (`goal_id`) but can list multiple delivering activities.
-- An activity belongs to exactly one goal (`goal_id`).
+- All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar per [`../../IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md). IDs are unique within their layer.
+- A goal MAY reference multiple factors via `factors: [FACTOR-…, FACTOR-…]`.
+- A change MAY reference multiple goals via `goals: [GOAL-…, GOAL-…]`.
+- An activity MAY reference multiple changes via `changes: [CHANGE-…, CHANGE-…]`.
+- For degenerate paths where a change layer adds no information, an activity MAY link directly via `goals: [GOAL-…]` — see [`../../02-fgca.md`](../../02-fgca.md) §Fields.
 
 ## Examples in this folder
 

--- a/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
+++ b/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
@@ -1,58 +1,57 @@
 notation: fgca
 spec_version: "0.1"
 
-fgca:
-  id: FGCA-STRAT-1
-  name: "Strategy 2026 — FGCA chain"
-  description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
-  period: "2026"
-  version: "0.1"
-  date: "2026-05-21"
-  author: Transitrix
+id: FGCA-STRAT-1
+name: "Strategy 2026 — FGCA chain"
+description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
+period: "2026"
+version: "0.1"
+date: "2026-05-26"
+author: Transitrix
 
-  factors:
-    - id: FACTOR-1
-      name: "Competitive market pressure"
-      type: external
-    - id: FACTOR-2
-      name: "Digital adoption acceleration"
-      type: external
+factors:
+  - id: FACTOR-1
+    name: "Competitive market pressure"
+    type: external
+  - id: FACTOR-2
+    name: "Digital adoption acceleration"
+    type: external
 
-  goals:
-    - id: GOAL-1
-      name: "Grow revenue by 20%"
-      factors: [FACTOR-1, FACTOR-2]
-    - id: GOAL-2
-      name: "Reduce operational costs"
-      factors: [FACTOR-2]
-    - id: GOAL-3
-      name: "Improve customer retention"
-      factors: [FACTOR-1]
+goals:
+  - id: GOAL-1
+    name: "Grow revenue by 20%"
+    factors: [FACTOR-1, FACTOR-2]
+  - id: GOAL-2
+    name: "Reduce operational costs"
+    factors: [FACTOR-2]
+  - id: GOAL-3
+    name: "Improve customer retention"
+    factors: [FACTOR-1]
 
-  changes:
-    - id: CHANGE-1
-      name: "Launch new product line"
-      goals: [GOAL-1]
-    - id: CHANGE-2
-      name: "Automate manual processes"
-      goals: [GOAL-2]
-    - id: CHANGE-3
-      name: "Enhance support platform"
-      goals: [GOAL-3]
+changes:
+  - id: CHANGE-1
+    name: "Launch new product line"
+    goals: [GOAL-1]
+  - id: CHANGE-2
+    name: "Automate manual processes"
+    goals: [GOAL-2]
+  - id: CHANGE-3
+    name: "Enhance support platform"
+    goals: [GOAL-3]
 
-  activities:
-    - id: ACTIVITY-1
-      name: "Market research"
-      changes: [CHANGE-1]
-    - id: ACTIVITY-2
-      name: "MVP development"
-      changes: [CHANGE-1]
-    - id: ACTIVITY-3
-      name: "Process audit"
-      changes: [CHANGE-2]
-    - id: ACTIVITY-4
-      name: "RPA tooling rollout"
-      changes: [CHANGE-2]
-    - id: ACTIVITY-5
-      name: "CRM implementation"
-      changes: [CHANGE-3]
+activities:
+  - id: ACTIVITY-1
+    name: "Market research"
+    changes: [CHANGE-1]
+  - id: ACTIVITY-2
+    name: "MVP development"
+    changes: [CHANGE-1]
+  - id: ACTIVITY-3
+    name: "Process audit"
+    changes: [CHANGE-2]
+  - id: ACTIVITY-4
+    name: "RPA tooling rollout"
+    changes: [CHANGE-2]
+  - id: ACTIVITY-5
+    name: "CRM implementation"
+    changes: [CHANGE-3]

--- a/notations/examples/goals/strategy-2026.goals.transitrix.yaml
+++ b/notations/examples/goals/strategy-2026.goals.transitrix.yaml
@@ -1,17 +1,53 @@
 notation: goals
 spec_version: "0.1"
 
-goals_tree:
-  id: "GT-STRATEGY-2026"
-  name: "Strategy 2026 — Goals Tree"
-  description: "Goal hierarchy across Strategy → Business Goal → Project levels for the 2026 plan."
-  root:
-    goal_id: "GOAL-REVENUE-001"       # "Triple revenue in 3 years"
-    children:
-      - goal_id: "GOAL-EU-001"        # "Launch in 3 EU markets"
-        children:
-          - goal_id: "GOAL-BERLIN-001"    # "Open Berlin office"
-          - goal_id: "GOAL-EU-REG-001"   # "Obtain EU regulatory approval"
-      - goal_id: "GOAL-MENA-001"      # "Launch in MENA"
-        children:
-          - goal_id: "GOAL-DUBAI-001"    # "Partner with Dubai distributor"
+id: GOALS-STRATEGY-2026
+name: "Strategy 2026 — Goals Tree"
+description: "Goal hierarchy across Strategy → Strategic Goal → Project Goal levels for the 2026 plan."
+period: "2026"
+version: "0.1"
+date: "2026-05-26"
+author: Transitrix
+
+goal_types:
+  - { name: "Strategy",         level: 0 }
+  - { name: "Strategic Intention", level: 1 }
+  - { name: "Strategic Goal",   level: 2 }
+  - { name: "Project Goal",     level: 4 }
+
+goals:
+  - id: GOAL-REVENUE-1
+    name: "Triple revenue in 3 years"
+    type: "Strategy"
+    level: 0
+    # No parent — single root.
+
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 2
+    parent: GOAL-REVENUE-1
+
+  - id: GOAL-BERLIN-1
+    name: "Open Berlin office"
+    type: "Project Goal"
+    level: 4
+    parent: GOAL-EU-1
+
+  - id: GOAL-EU-REG-1
+    name: "Obtain EU regulatory approval"
+    type: "Project Goal"
+    level: 4
+    parent: GOAL-EU-1
+
+  - id: GOAL-MENA-1
+    name: "Launch in MENA"
+    type: "Strategic Goal"
+    level: 2
+    parent: GOAL-REVENUE-1
+
+  - id: GOAL-DUBAI-1
+    name: "Partner with Dubai distributor"
+    type: "Project Goal"
+    level: 4
+    parent: GOAL-MENA-1


### PR DESCRIPTION
## Summary

Per the **Reading B** clarification on strategy/#60 (2026-05-26): scope = shape only, not lexicon. All four strategy-chain notations (FGCA, FGA, Goals, Activities) move to the flat form. The earlier "nested for trees, flat for DAGs" heuristic is superseded.

What stays canonical (NOT changed to match the library):
- Typed string IDs per `IDS_AND_REFERENCES.md` (`FACTOR-1`, `GOAL-RET-1`, `CHANGE-1`, `ACTIVITY-ONBOARD-1`).
- Plural canonical-direction cross-references (`goal.factors: [FACTOR-…]`, `change.goals: [GOAL-…]`, `activity.changes: [CHANGE-…]`).
- Methodology validation-code namespaces (`FGCA-…`, `FGA-…`, `GOALS-…`).

What changes (matches the library shape):
- Flat top-level arrays — no `fgca:` / `fga:` / `goals_tree:` wrapper.
- Hierarchy in tree-shaped notations expressed via `parent: …` references inside the flat array, not YAML nesting.

## Files (10)

- **`notations/02-fgca.md`** — `fgca:` wrapper dropped; field table renamed `fgca.X` → `X`; FGCA-001 reworded for the no-wrapper world.
- **`notations/03-fga.md`** — schema fully rewritten: three top-level arrays (`factors[]`, `goals[]`, `activities[]`), canonical downstream cross-refs (`goal.factors: [FACTOR-…]`, `activity.goals: [GOAL-…]`). New §6 Validation rules `FGA-001 … 011`. Bumped to v0.2 / `documented`.
- **`notations/04-goals.md`** — schema fully rewritten: flat `goal_types[]` + `goals[]` with `parent: GOAL-…` references. New §6 Validation rules `GOALS-001 … 011`. DSM Implementation Rules moved §9 → §8 to seat the new §6 cleanly. Bumped to v0.3.
- **`notations/README.md`** — §Form rule rewritten; old heuristic marked superseded; per-notation arrays + reference fields tabulated.
- **`notations/08-blocks.md`** — one cross-reference to the old form rule reworded (blocks pre-dates the strategy-chain family and is not part of it).
- **`notations/examples/fga/`** + **`fgca/`** + **`goals/`** — three example YAMLs and two explainer READMEs brought to canonical form (typed string IDs, plural cross-refs, flat top-level arrays).

## Verification

- `git diff` shows no stale `goals_tree:` / `fgca.X` / `fga:` wrapper / `root.goal_id` references remaining in `notations/`.
- All example IDs follow `<TYPE>-[<middle>-]<INTEGER>` with no leading zeros.
- Family rule in `notations/README.md` matches the per-notation §Top-level-structure intros in 02 / 03 / 04.

## Out of scope (called out in the commit message)

- **`@transitrix/diagrams` validators are not patched.** Per the orchestrator instruction on #60: flag back, do not patch from this side. Follow-up task lives in `transitrix-studio` to teach the library's input layer the canonical form (or define a canonical-form ↔ DSM-API mapping explicitly).
- **Other notations that carry their own `goal_id`-style cross-refs** (Scenarios, Capability Map, Process Blueprint) are not in the strategy-chain family addressed here; their drift is separate.

## Test plan

- [ ] Visual review of `notations/02-fgca.md`, `notations/03-fga.md`, `notations/04-goals.md` — schema sections read cleanly without wrapper references; validation tables internally consistent; cross-refs between specs land on the right anchors.
- [ ] `git grep -nE "goals_tree:|fgca\.id|root\.goal_id"` returns nothing in `notations/`.
- [ ] Example YAMLs parse mentally against the new spec wording (no `notation:` mismatch, IDs follow canonical grammar, cross-refs resolve to defined elements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
