### PR TITLE
docs(notations): 01-bpmn — canonical extension is `.bpmn.transitrix.yaml` (#61)

### DIFF
--- a/notations/01-bpmn.md
+++ b/notations/01-bpmn.md
@@ -1,16 +1,16 @@
 ---
 notation: "BPMN Process Diagram"
-version: "1.1"
+version: "1.2"
 author: "Valerii Korobeinikov"
-last_updated: "2026-05-19"
+last_updated: "2026-05-26"
 status: "documented"
 file_extension: "*.bpmn.transitrix.yaml"
 ---
 
 # BPMN Process YAML Notation — Reference
 
-**Version:** 1.1
-**Date:** 2026-05-19
+**Version:** 1.2
+**Date:** 2026-05-26
 **Scope:** Reference for the YAML notation used to describe BPMN 2.0 processes. Covers structure, allowed elements, sequence flows, identifiers, validation rules, examples, and glossary.
 
 ---
@@ -39,6 +39,8 @@ The compiled output is consumable by any BPMN 2.0–conformant tool (Camunda Mod
 ## 2. File extension
 
 The file extension is **`.bpmn.transitrix.yaml`**. Files outside this extension are rejected by the compiler with an explicit error.
+
+Until 2026-05-20 the short form `.bpmn.yaml` was also accepted as an alias. Per the family-consistency decision recorded that day, the long form is now the sole canonical extension — every Transitrix notation uses the `*.<short-name>.transitrix.<ext>` form per [`CONTRACT.md`](CONTRACT.md), and BPMN is no longer an exception.
 
 ---
 

--- a/notations/examples/bpmn/README.md
+++ b/notations/examples/bpmn/README.md
@@ -1,12 +1,17 @@
 # BPMN diagrams
 
-Business Process Model and Notation diagrams defined in a compact YAML DSL.
+Business Process Model and Notation 2.0 diagrams defined as compact YAML — one pool, lanes, typed elements, named sequence flows. Layout is computed by the compiler; coordinates are not part of the notation.
 
-**File extensions:** `*.bpmn.yaml`
+**File extension:** `*.bpmn.transitrix.yaml`
+
+See the canonical spec: [`../../01-bpmn.md`](../../01-bpmn.md).
 
 ## Minimal structure
 
 ```yaml
+notation: bpmn
+spec_version: "0.1"
+
 process:
   id: my-process
   name: My Process
@@ -26,7 +31,6 @@ process:
             - id: end-1
               type: endEvent
               name: End
-
   flows:
     - id: f1
       from: start-1
@@ -47,6 +51,8 @@ process:
 | `parallelGateway` | AND gateway (diamond, + mark) |
 | `inclusiveGateway` | OR gateway (diamond, O mark) |
 
+See the spec for the full element catalogue, validation rules, and flow conditions.
+
 ## Flow conditions
 
 Add a `condition` field to a flow from a gateway:
@@ -66,28 +72,15 @@ flows:
 - Elements belong to a lane; flows connect elements across any lanes.
 - Multiple pools and multiple lanes per pool are supported.
 
----
+## Examples in this folder
 
-# Test Corpus Catalog
-
-**Version:** 0.4  
-**Updated:** 2026-05-12  
-**Count:** 6 diagrams
-
-This table lists all diagrams in `examples/bpmn/corpus/` with their structural properties and coverage matrix cell.
-
-| Filename | Elements | Flows | Cross-lane % | Cycles | Gateways | Lanes | Cell | Purpose |
-|----------|----------|-------|--------------|--------|----------|-------|------|---------|
-| `simple-linear.cervin.yaml` | 6 | 5 | 0% | No | 0 | 1 | S-Lo-A-Lo-1 | Minimal baseline; pure same-lane, no gates |
-| `simple-approval.cervin.yaml` | 8 | 7 | 29% | No | 1 (XOR) | 2 | S-Mi-A-Lo-2 | Basic cross-lane routing; horizontal port rule |
-| `small-dense-approval.cervin.yaml` | 9 | 11 | 75% | No | 4 (2 AND, 1 XOR) | 2 | S-Hi-A-Hi-2 | Dense gates, high cross-lane; parallel paths |
-| `order-processing.cervin.yaml` | 14 | 13 | 46% | Yes | 4 (1 XOR, 2 AND) | 3 | M-Mi-C-Hi-3 | Multi-lane; gateway distribution; backward edge |
-| `large-cyclic-workflow.cervin.yaml` | 22 | 25 | 76% | Yes (rework loop) | 10 (4 AND, 6 XOR) | 4 | L-Hi-C-Hi-4 | Dense gates, cyclic; backward routing test |
-| `xlarge-stress-test.cervin.yaml` | 52 | 54 | 82% | No | 20 (8 AND, 12 XOR) | 5 | XL-Hi-A-Hi-4+ | Stress test: 50+ elements, extreme complexity |
-
-## Notes
-
-- **Acyclic** diagrams are preferred for baseline (simpler to reason about); cyclic examples test backward routing and cycle-breaking heuristics.
-- **Gateway density** ranges from 0% (only tasks/events) to 100% (only gateways). Most real processes cluster around 10–30%.
-- **Cross-lane share** measures flows connecting different lanes; 0% is pure same-lane, 100% is every flow goes cross-lane.
-- Each file is validated via `BpmnModdle.fromXML` during test runs to ensure valid BPMN 2.0 output.
+| File | Description |
+|---|---|
+| `simple-linear.bpmn.transitrix.yaml` | Minimal baseline — pure same-lane, no gateways |
+| `simple-approval.bpmn.transitrix.yaml` | Basic cross-lane routing with one XOR gateway |
+| `small-dense-approval.bpmn.transitrix.yaml` | Dense gateways, high cross-lane share |
+| `order-fulfillment.bpmn.transitrix.yaml` | Multi-lane order-fulfilment flow |
+| `feature-release.bpmn.transitrix.yaml` | Feature-release pipeline with approval gates |
+| `ai-expense-approval.bpmn.transitrix.yaml` | AI-assisted expense approval with multi-step routing |
+| `large-cyclic-workflow.bpmn.transitrix.yaml` | Dense gates, rework loop — backward-routing test |
+| `xlarge-stress-test.bpmn.transitrix.yaml` | 50+ element stress test |


### PR DESCRIPTION
## Summary

Closes strategy/#61 — propagates the 2026-05-20 BPMN-canonical-extension decision (reconfirmed by Valerii 2026-05-26) into the methodology repo. The decision had only been recorded on a closed hub issue; the methodology canon now states it explicitly.

### Files

- **`notations/01-bpmn.md`** — §2 File extension picks up a one-sentence historical note ("Until 2026-05-20 the short form `.bpmn.yaml` was also accepted as an alias …"); front-matter and body header bumped to version 1.2 / 2026-05-26. No other body changes needed — the spec already lists `*.bpmn.transitrix.yaml` as the sole canonical form in the per-notation table.
- **`notations/examples/bpmn/README.md`** — rewritten end-to-end. The previous version advertised `*.bpmn.yaml` as the extension, carried a stale "Test Corpus Catalog" section pointing at `*.cervin.yaml` filenames and an `examples/bpmn/corpus/` path that doesn't exist in this repo, and listed `order-processing.cervin.yaml` (deleted on the studio side). New README matches the pattern of sibling example READMEs (`fga/`, `fgca/`) with the canonical extension, a minimal-structure snippet that carries the `notation: bpmn` header, and a per-file index of the eight examples actually in the folder.

### Why no file renames

The 8 BPMN examples in `notations/examples/bpmn/` already use the canonical `.bpmn.transitrix.yaml` extension and already carry the `notation: bpmn` header, so the "rename `*.bpmn.yaml` → `*.bpmn.transitrix.yaml`" acceptance criterion is already satisfied. (`order-processing` was the only `.bpmn.yaml` left in the studio examples; it was a duplicate of `order-fulfillment` and was deleted in transitrix-studio#57.)

### Cross-spec sweep

`git grep -nE '\.bpmn\.yaml'` in `methodology/` returns one remaining match — the new historical note in `01-bpmn.md` itself. Every other reference is already on the canonical form. No incidental short-form mentions in other specs / READMEs.

### Coordination

The matching `transitrix-studio` task (separate) updates `activationEvents`, the BPMN file detector, and `DEFAULT_CERVIN_EXTENSIONS` so Studio's preview button picks up `.bpmn.transitrix.yaml` files. Until that lands, a new adopter following this canon would lose preview for the long-form files in old Studio installs (current Studio extension regex matches `.bpmn.yaml` / `.cervin.yaml` only). The mirror studio PR is independent; review order is your call.

### Test plan

- [x] `git grep -nE '\.bpmn\.yaml'` in the methodology repo returns only the intentional historical note in `01-bpmn.md:43`.
- [x] All 8 BPMN example filenames already match `.bpmn.transitrix.yaml`; each carries `notation: bpmn` as its first line.
- [ ] Visual review of `examples/bpmn/README.md` — terminology consistent with `fga/` / `fgca/` siblings, file-index reflects all 8 examples in the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
