### PR TITLE
docs(notations): require quoted ISO 8601 dates (CONTRACT §4)

### DIFF
--- a/notations/07-activities.md
+++ b/notations/07-activities.md
@@ -82,7 +82,7 @@ date: "2026-05-11"
 author: "Valerii Korobeinikov"
 
 project:                              # optional; enables Gantt rendering
-  start_date: 2026-06-01              # optional; project zero-time for computed Gantt
+  start_date: "2026-06-01"            # optional; project zero-time for computed Gantt
   calendar:                           # optional; working calendar (see §5.8)
     working_days: [mon, tue, wed, thu, fri]
     hours_per_day: 8
@@ -110,8 +110,8 @@ activities:
     score: 5                          # optional, integer — local prioritisation signal
     sort: 10                          # optional, integer — manual display ordering
     tags: [q3-priority, customer]     # optional, array of free-text tags
-    start_date: 2026-06-01            # optional, planned start (ISO 8601 date)
-    end_date: 2026-06-15              # optional, planned end (ISO 8601 date)
+    start_date: "2026-06-01"          # optional, planned start (ISO 8601 date)
+    end_date: "2026-06-15"            # optional, planned end (ISO 8601 date)
     labor_cost: 5000.00               # optional, decimal — labour cost (currency in metadata or implicit org-default)
     resources_cost: 2000.00           # optional, decimal — non-labour resource cost
     effort: 80                        # optional, decimal — effort in person-hours (or org-defined unit)
@@ -238,7 +238,7 @@ The optional `project:` block anchors the schedule on a calendar for Gantt rende
 
 ```yaml
 project:
-  start_date: 2026-06-01              # optional; project zero-time
+  start_date: "2026-06-01"            # optional; project zero-time
   calendar:                           # optional; defaults: 7-day week, 24-h day, no holidays
     working_days: [mon, tue, wed, thu, fri]
     hours_per_day: 8

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -45,3 +45,11 @@ Additional notation-specific rules (per-field, semantic, structural) live in the
 Each notation has exactly one canonical file extension, of the form `.<short-name>.transitrix.yaml`. The validator rejects any file whose extension and `notation:` value disagree (rule `HDR-003`).
 
 No aliases are accepted: one notation has exactly one extension. The full per-notation mapping lives in [README.md](README.md).
+
+---
+
+## 4. Date format
+
+All date-typed fields across the Transitrix notations MUST be quoted ISO 8601 strings in `YYYY-MM-DD` form (e.g., `"2026-06-01"`). Unquoted `2026-06-01` is parsed by YAML 1.1 loaders as a native date type and is **not** accepted as the canonical form. Quote dates explicitly.
+
+Which fields are date-typed is defined per notation — the shared header `date:`, plus fields such as activity `start_date` / `end_date` and `project.start_date` / `project.calendar.holidays[]`, capability `assessment_date` / `target_date`, issue `created_at` / `resolved_at` / `updated_at`, and application / product `updated_at`. The quoting rule above applies to every one of them; specs reference this section rather than restating it.


### PR DESCRIPTION
## What

Establishes **quoted ISO 8601 strings** (`"2026-06-01"`) as the canonical form for every date-typed field across the Transitrix notations.

Bare `YYYY-MM-DD` parses under YAML 1.1 as a native `Date` type, which downstream loaders stringify in non-ISO form and date validators then reject. Quoting fixes this at the source.

## Changes

- **`notations/CONTRACT.md`** — new `§4 Date format` documenting the rule for all date-typed fields (shared header `date:`, activity `start_date`/`end_date`/`project.*`, capability `target_date`/`assessment_date`, issue `created_at`/`resolved_at`/`updated_at`, application/product `updated_at`). Per-notation specs reference this section rather than restating it.
- **`notations/07-activities.md`** — quoted the four `start_date`/`end_date` values in the example snippets so the spec conforms to its own rule (the only unquoted date-shaped values remaining in the tree).

## Scope notes

- **Examples already conform.** Every `notations/examples/**/*.yaml` already uses quoted dates, so no example files needed changes.
- **Skill templates already conform.** The onboarding Skill templates live on a separate, not-yet-merged branch; verified their date fields are already quoted, so no work is required there.
- **Out of scope here:** one Gantt snippet in `notations/examples/activities/README.md` carries an unquoted `start_date`, but that line exists only on the in-flight office-relocation branch (not `main`) — it should be quoted there to avoid reintroducing the trap.

## Verification

```
git grep -nE '(date|start_date|end_date|updated_at|created_at|resolved_at|target_date|assessment_date):\s*[0-9]' -- '*.yaml' '*.md'
```
returns empty across the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
