### PR TITLE
docs(acme_corp): wave-3 refresh — view skeletons, capability-map template, surface docs

### DIFF
--- a/organizations/acme_corp/.templates/capability-map_template.yaml
+++ b/organizations/acme_corp/.templates/capability-map_template.yaml
@@ -1,200 +1,42 @@
-# Transitrix Capability Map Template
-# Purpose: Model enterprise capabilities with maturity levels
-# Complements: Business Layer elements with capability assessment
-# Location: elements/02_business/ (as capability-map.yaml)
+# Transitrix Capability Map — copy-and-fill template
+# Spec:      notations/05-capability-map.md
+# Extension: *.capability-map.transitrix.yaml
+# Location:  views/capabilities/   (the map references Capability elements in
+#            elements/02_business/capabilities/)
+#
+# CMM maturity is 1–5 (Initial / Repeatable / Defined / Managed / Optimized) —
+# see 05-capability-map.md §3. Capability addresses are V<L1[.L2[.L3]]> for
+# vertical (domain) capabilities and H<…> for horizontal (cross-cutting) ones.
 
-enterprise: "Organization Name"
-business_domain: "Business Domain"
-capability_set: "baseline"  # Values: baseline, target, current, roadmap, etc.
+notation: capability-map
+spec_version: "0.1"
 
-capabilities:
-  # ROOT CAPABILITY LEVEL (V1)
-  - id: "V1"
-    name: "Strategic Business Area Name"
-    type: "domain"  # Values: domain, function, capability
-    category: "Strategic"  # Values: Strategic, Planning, Execution, Support, Learning
-    description: "Clear description of what this capability area covers"
-    start_date: "2026-05-03"
+capability_map:
+  id: "CM-DOMAIN-1"                    # CM-<DOMAIN>-<SEQ>
+  name: "<Domain> Capabilities"
+  description: "Capabilities with current and target maturity"
+  assessment_date: "2026-01-01"        # YYYY-MM-DD, quoted (CONTRACT.md §4)
 
-    # Maturity assessment
-    maturity_levels:
-      - level: 1  # Initial: ad hoc, unstructured
-        effective_from: "2026-05-03"
-        status: "Current"  # Indicates if this is the current maturity
+  capabilities:
+    - id: "V1"                         # vertical address: V1, V1.1, V1.1.1, or H1 …
+      name: "<Capability name>"
+      type: "domain"                   # domain | supporting   (REQUIRED — also on children)
+      current_maturity: 2              # CMM level 1–5 (REQUIRED)
+      target_maturity: 3               # optional
+      target_date: "2026-12-31"        # optional, YYYY-MM-DD
+      owner_role: "ROLE-XXX-1"         # optional — BusinessRole element ID
+      business_process: "PROC-XXX-1"   # optional — BusinessProcess element ID
+      applications:                    # optional — ApplicationComponent element IDs
+        - "APP-XXX-1"
+      children:                        # optional — nested capabilities (same fields)
+        - id: "V1.1"
+          name: "<Child capability>"
+          type: "domain"
+          current_maturity: 3
+          target_maturity: 3
 
-    # Optional metadata
-    owner: "firstname.lastname"  # Person responsible for this capability
-    owner_role: "ROLE-DIRECTOR-001"  # Reference to BusinessRole element
-    business_process: "PROC-STRATEGY-001"  # Reference to BusinessProcess
-    applications: []  # References to ApplicationComponent elements
-    notes: "Additional context or strategic importance"
-
-  # CHILD CAPABILITY (V1.1)
-  - id: "V1.1"
-    name: "Sub-capability Within V1"
-    type: "domain"
-    category: "Strategic"
-    description: "Describes this sub-domain"
-    start_date: "2026-05-03"
-
-    maturity_levels:
-      - level: 1
-        effective_from: "2026-05-03"
-        status: "Current"
-      - level: 2  # Historical maturity level
-        effective_from: "2027-01-01"
-        status: null
-
-    owner: "firstname.lastname"
-    parent_capability: "V1"  # Links to parent capability
-
-  # GRANULAR FUNCTION (V1.1.1)
-  - id: "V1.1.1"
-    name: "Specific Function or Process"
-    type: "function"
-    category: "Planning"
-    description: "Very specific capability or function"
-    start_date: "2026-05-03"
-
-    maturity_levels:
-      - level: 2
-        effective_from: "2026-05-03"
-        status: "Current"
-
-    owner: "firstname.lastname"
-    owner_role: "ROLE-MANAGER-001"
-    business_process: "PROC-DETAIL-001"
-    parent_capability: "V1.1"
-
-    # Target maturity for roadmap
-    target_maturity: 3
-    target_date: "2026-12-31"
-
-  # HORIZONTAL CAPABILITY (H1)
-  # Cross-cutting capabilities that support multiple domains
-  - id: "H1"
-    name: "Horizontal Capability (Cross-cutting)"
-    type: "domain"
-    category: "Support"  # Usually Support or Learning for horizontal
-    description: "Capability that supports multiple business domains"
-    start_date: "2026-05-03"
-
-    maturity_levels:
-      - level: 2
-        effective_from: "2026-05-03"
-        status: "Current"
-
-    owner: "firstname.lastname"
-    applications: ["APP-SHARED-PLATFORM-001"]  # Often supports shared platforms
-
-# Metadata about the capability map
-metadata:
-  version: "1.0.0"
-  created_at: "2026-05-03"
-  updated_at: "2026-05-03"
-  created_by: "firstname.lastname"
-  review_date: "2026-08-03"
-  status: "Draft"  # Values: Draft, Active, Deprecated
-
-# Maturity Level Definitions (customize as needed)
-maturity_scale:
-  1:
-    name: "Initial"
-    description: "Processes are unstructured, ad hoc, and often chaotic"
-    characteristics:
-      - "Ad hoc processes"
-      - "No formal documentation"
-      - "Depends on individuals"
-      - "Success unpredictable"
-
-  2:
-    name: "Repeatable"
-    description: "Basic processes exist; may be informal but repeatable"
-    characteristics:
-      - "Some documented processes"
-      - "Similar tasks performed by different people"
-      - "Still individual-dependent"
-      - "Some discipline in process execution"
-
-  3:
-    name: "Defined"
-    description: "Processes are documented, standardized, and communicated"
-    characteristics:
-      - "Documented and communicated processes"
-      - "Tailored from standard templates"
-      - "Institutionalized best practices"
-      - "Process training exists"
-
-  4:
-    name: "Managed"
-    description: "Processes are measured, controlled, and monitored"
-    characteristics:
-      - "Quantitative targets and goals"
-      - "Processes measured and monitored"
-      - "Statistical techniques used"
-      - "Corrective actions when needed"
-
-  5:
-    name: "Optimized"
-    description: "Continuous improvement and optimization of processes"
-    characteristics:
-      - "Continuous optimization"
-      - "Automation where applicable"
-      - "Lessons learned captured"
-      - "Proactive process improvement"
-
----
-
-## Usage Notes
-
-### ID Conventions
-
-**Vertical Capabilities** - Primary business domains:
-- `V1`, `V2`, `V3` - Root level domains
-- `V1.1`, `V1.2` - Sub-domains of V1
-- `V1.1.1`, `V1.1.2` - Specific functions within sub-domain
-
-**Horizontal Capabilities** - Cross-cutting, enterprise-wide:
-- `H1`, `H2` - Root level horizontal capabilities
-- `H1.1`, `H1.2` - Sub-components
-
-**Backlog** - Capabilities under evaluation or postponed:
-- `V0.1`, `V0.2` - Vertical backlog
-- `H0.1`, `H0.2` - Horizontal backlog
-
-### Maturity Progression
-
-Track capability maturity over time:
-```yaml
-maturity_levels:
-  - level: 1
-    effective_from: "2026-05-03"
-    status: "Current"
-  - level: 2
-    effective_from: "2026-08-01"
-    status: null
-  - level: 3
-    effective_from: "2027-01-01"
-    status: null
-```
-
-### Linking to Architecture
-
-- **owner_role**: Reference to `ROLE-XXX-001` element
-- **business_process**: Reference to `PROC-XXX-001` element
-- **applications**: Array of `APP-XXX-001` element IDs
-
-### Roadmap Integration
-
-Include target maturity for roadmap planning:
-```yaml
-target_maturity: 4
-target_date: "2027-06-30"
-improvement_initiative: "Digital transformation project"
-```
-
----
-
-**Version:** 1.0.0
-**Created:** May 3, 2026
-**Based on:** Segments project Capability Map concept + Transitrix methodology
+    - id: "H1"                         # horizontal (cross-cutting) capability
+      name: "<Shared capability>"
+      type: "supporting"
+      current_maturity: 2
+      target_maturity: 3

--- a/organizations/acme_corp/CONVENTIONS.md
+++ b/organizations/acme_corp/CONVENTIONS.md
@@ -6,31 +6,53 @@
 
 Element IDs uniquely identify architecture elements and must follow a strict format for consistency and searchability.
 
-**Format:** `[TYPE]-[DOMAIN]-[SEQUENCE]`
+**Format:** `<TYPE>-[<middle segment(s)>-]<INTEGER>` — the canonical ID grammar defined in [`notations/IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md). The terminal integer is a positive number ≥ 1 with **no leading zeros**; middle segments (a domain code, period, or programme name) are optional.
 
-#### Type Prefixes
+#### Type prefixes (canonical registry)
 
-| Layer | Type | Prefix |
-|-------|------|--------|
-| **Motivation** | Goal | `GOAL` |
-| | Principle | `PRIN` |
-| | Constraint | `CONS` |
-| | Driver | `DRIV` |
-| | Outcome | `OUTC` |
-| **Business** | Role | `ROLE` |
-| | Actor | `ACTR` |
-| | Process | `PROC` |
-| | Function | `FUNC` |
-| | Service | `SRVC` |
-| **Application** | Component | `APP` |
-| | Service | `SRVC` |
-| | Data Object | `DATA` |
-| | Interface | `INTF` |
-| **Technology** | Node | `NODE` |
-| | System Software | `SYS` |
-| | Artifact | `ARTF` |
-| | Device | `DEV` |
-| | Network Path | `NET` |
+Use exactly these prefixes; the abbreviated forms `ACT`, `CHG`, `FAC`, `CAP`, `SCN` are deprecated. The authoritative list lives in `IDS_AND_REFERENCES.md` §3.
+
+**Element types**
+
+| TYPE | What it is |
+|---|---|
+| `FACTOR` | strategic driver (external / internal) |
+| `GOAL` | strategic or tactical goal |
+| `CHANGE` | business transformation (BDN change layer) |
+| `ACTIVITY` | initiative / workstream |
+| `CAPABILITY` | capability — V/H address, e.g. `CAPABILITY-V1.2` (see appendix §2) |
+| `PROCESS` | business process |
+| `PRODUCT` | product or service |
+| `APPLICATION` | application |
+| `INTEGRATION` | integration between applications |
+| `ROLE` | business role |
+| `UNIT` | organisational unit |
+| `EMPLOYEE` | named employee |
+| `SCENARIO` | strategic scenario |
+| `ISSUE` | issue — problem, defect, or open question |
+| `EQUIPMENT` | physical instrument / device / facility a process stage depends on |
+| `INFORMATION_ENTITY` | data / document / record produced or consumed by a process stage |
+| `RULE` | business rule (`elements/02_business/rules/`) |
+| `CONSTRAINT` | design / operating constraint (`elements/01_motivation/constraints/`) |
+
+**Document-level types** — the file's own ID; the TYPE names the notation
+
+| TYPE | Notation file |
+|---|---|
+| `FGCA` | `*.fgca.transitrix.yaml` |
+| `FGA` | `*.fga.transitrix.yaml` |
+| `GOALS_TREE` | `*.goals.transitrix.yaml` |
+| `CAPABILITY_MAP` | `*.capability-map.transitrix.yaml` |
+| `PROCESS_MAP` | `*.process-map.transitrix.yaml` |
+| `ACTIVITIES_NET` | `*.activities.transitrix.yaml` |
+| `PRODUCTS_CAT` | `*.products.transitrix.yaml` |
+| `APPLICATIONS_CAT` | `*.applications.transitrix.yaml` |
+| `SCENARIOS` | `*.scenarios.transitrix.yaml` |
+| `BLOCKS` | `*.blocks.transitrix.yaml` |
+| `ISSUES_CAT` | `*.issues.transitrix.yaml` |
+| `PROCESS_BLUEPRINT` | `*.process-blueprint.transitrix.yaml` |
+
+> **Drift note.** Some current catalogue specs and example files still use abbreviated cross-reference prefixes (`APP-`, `PROC-`, `PROD-`) and zero-padded sequences (`-001`). These are tracked migrations (IDS_AND_REFERENCES.md §6) and will converge on the canonical forms above; follow each notation spec's own examples until its migration lands.
 
 #### Domain Codes
 
@@ -49,15 +71,15 @@ AUT   = Authentication
 BIL   = Billing
 ```
 
-#### Sequence Numbers
+#### Sequence numbers
 
-Use zero-padded numbers starting from 001:
+Use plain positive integers starting from `1` — **no leading zeros** (sorting and comparison are numeric, not lexical):
 
 ```
-GOAL-REV-001      (First revenue goal)
-GOAL-REV-002      (Second revenue goal)
-ROLE-SALES-001    (First sales role)
-APP-ORD-API-001   (First order API component)
+GOAL-REV-1        (First revenue goal)
+GOAL-REV-2        (Second revenue goal)
+ROLE-SALES-1      (First sales role)
+APPLICATION-ORD-API-1  (First order API component)
 ```
 
 ### Element ID Examples

--- a/organizations/acme_corp/GETTING_STARTED.md
+++ b/organizations/acme_corp/GETTING_STARTED.md
@@ -5,9 +5,9 @@ Welcome to the Transitrix Architecture-as-Code methodology! This guide will walk
 ## Prerequisites
 
 - Git client
-- Text editor (VS Code recommended)
-- Python 3.9+ (for running validators)
+- VS Code with the Transitrix extension — live diagram preview and inline validation as you edit (recommended)
 - Basic understanding of YAML format
+- *Optional:* Python 3.9+ — only if you want to run the local linter (`.validators/lint.py`) outside the editor
 
 ## Step 1: Clone and Setup
 
@@ -25,7 +25,7 @@ Review the main directories:
 - **.templates/** - Templates to copy when creating new elements
 - **.validators/** - Linting tools to ensure consistency
 
-Read `method/Transitrix Методология управления архитектурой предприятия.md` for complete methodology details.
+Read `method/methodology.md` for complete methodology details.
 
 ## Step 3: Create Your First Element
 
@@ -115,6 +115,8 @@ properties:
 **Note:** Make sure the target ID (`PROC-ORD-001`) exists in `elements/02_business/`. For now, you can reference a process you'll create next, or use an existing element ID.
 
 ## Step 5: Validate Your Changes
+
+The Transitrix VS Code extension validates and previews as you edit. To run the local linter as an optional extra check:
 
 ```bash
 python3 .validators/lint.py
@@ -338,7 +340,7 @@ Edit `.validators/lint.py` and add your custom validation rule. See the Developm
 
 ## Getting Help
 
-- Read the full methodology: `method/Transitrix Методология управления архитектурой предприятия.md`
+- Read the full methodology: `method/methodology.md`
 - Review templates in `.templates/` for detailed examples
 - Check the linter output for specific validation issues
 - Ask your architecture team - they can help you understand your organization's structure

--- a/organizations/acme_corp/views/applications/README.md
+++ b/organizations/acme_corp/views/applications/README.md
@@ -1,6 +1,6 @@
 # `views/applications/`
 
-Filtered views over Application elements (ArchiMate `ApplicationComponent`, `ApplicationService`). Each application is stored atomically as one file under `elements/03_application/<APP_ID>.yaml`. A view here defines how to filter, group, and present a subset.
+Applications catalogue — a curated catalogue of the applications and integrations in operation. Each entry references an Application element under `elements/03_application/applications/` and carries the display attributes used to render the catalogue.
 
 ## File convention
 
@@ -9,28 +9,47 @@ Filtered views over Application elements (ArchiMate `ApplicationComponent`, `App
 ## Skeleton
 
 ```yaml
-title: "Production Application Portfolio"
-description: "All Active applications, grouped by criticality"
+notation: applications
+spec_version: "0.1"
 
-filter:
-  type: ["ApplicationComponent", "ApplicationService"]
-  status: ["Active", "Production"]
+applications_catalogue:
+  id: "APP-CAT-1"
+  name: "Acme Corp Applications Catalogue"
+  description: "Applications and integrations in operation at Acme Corp"
+  version: "1.0"
+  updated_at: "2026-05-26"
 
-group_by: "properties.criticality"
+  applications:
+    - app_id: "APP-OMS-1"               # → elements/03_application/applications/APP-OMS-1.yaml
+      name: "Order Management System"
+      type: "application"               # application | integration | platform | data_store
+      domain: "Operations"
+      owner_role: "ROLE-TECH-1"
+      vendor: "Internal"
+      status: "Active"                  # Draft | Active | Deprecated | Decommissioning
+      maturity: 3
+      description: "Core system for order lifecycle management"
+      capabilities: ["V1"]
+      products: ["PROD-ECOMM-1"]
+      integrations:
+        - target: "APP-CRM-1"
+          direction: "outbound"
+          protocol: "REST"
+          description: "Sends order events to CRM"
 
-columns:
-  - "name"
-  - "owner"
-  - "tech_stack"
-  - "criticality"
-  - "updated_at"
+    - app_id: "APP-CRM-1"
+      name: "CRM System"
+      type: "application"
+      domain: "Sales"
+      owner_role: "ROLE-SALES-1"
+      vendor: "Salesforce"
+      status: "Active"
+      description: "Customer relationship and sales pipeline management"
 ```
 
-## What the view does NOT do
-
-It does not store application data. The application elements live in `elements/03_application/`. A view describes how to render a slice of them — the data stays in the elements.
+`capabilities` and `products` hold **element IDs**, not display names. Integrations may be inlined (as above) or modelled as their own `type: integration` entries.
 
 ## See also
 
-- `method/methodology.md` §4 — elements vs views
-- `elements/03_application/` — individual Application element files
+- `notations/10-applications.md` — applications-catalogue notation reference (full field table)
+- `elements/03_application/applications/` — where individual Application elements live

--- a/organizations/acme_corp/views/capabilities/README.md
+++ b/organizations/acme_corp/views/capabilities/README.md
@@ -1,6 +1,6 @@
 # `views/capabilities/`
 
-Capability maps — hierarchical view of capabilities with CMM maturity overlay. Each capability referenced here is a Capability element under `elements/02_business/`.
+Capability maps — a hierarchical view of business capabilities with a CMM maturity overlay. Each capability addressed here resolves to a Capability element under `elements/02_business/capabilities/`.
 
 ## File convention
 
@@ -9,22 +9,53 @@ Capability maps — hierarchical view of capabilities with CMM maturity overlay.
 ## Skeleton
 
 ```yaml
-title: "Customer-Domain Capabilities"
-set_id: "v1.0"
-organisation: "Acme Corp"
+notation: capability-map
+spec_version: "0.1"
 
-capabilities:
-  - id: "CAP-CRM-001"             # references elements/02_business/CAP-CRM-001.yaml
-    address: "1.0.0"              # L1
-    maturity:
-      - { date: "2026-01-01", level: 2 }
-      - { date: "2026-04-01", level: 3 }
-  - id: "CAP-CRM-002"
-    address: "1.1.0"              # L2 under L1=1
+capability_map:
+  id: "CM-CUSTOMER-1"
+  name: "Customer-Domain Capabilities"
+  description: "Customer-facing capabilities with current and target maturity"
+  assessment_date: "2026-05-26"
+
+  capabilities:
+    - id: "V1"                          # → elements/02_business/capabilities/V1.yaml
+      name: "Order Management"
+      type: "domain"                    # domain | supporting
+      current_maturity: 2
+      target_maturity: 3
+      target_date: "2026-12-31"
+      owner_role: "ROLE-OPS-1"
+      business_process: "PROC-ORD-FULFILL-1"
+      applications:
+        - "APP-OMS-1"
+        - "APP-CRM-1"
+      children:
+        - id: "V1.1"
+          name: "Order Intake"
+          type: "domain"
+          current_maturity: 3
+          target_maturity: 3
+        - id: "V1.2"
+          name: "Order Fulfilment"
+          type: "domain"
+          current_maturity: 2
+          target_maturity: 3
+          target_date: "2026-09-30"
+    - id: "V2"
+      name: "Customer Relationship"
+      type: "domain"
+      current_maturity: 2
+      target_maturity: 3
+      owner_role: "ROLE-SALES-1"
+      applications:
+        - "APP-CRM-1"
 ```
+
+`V1` / `V1.1` are vertical-capability addresses; **every** capability, including children, carries `type` (required). The maturity history of an individual capability lives on its element file, not here.
 
 ## See also
 
-- `method/methodology.md` §6.2 / §6.3 — capabilities and maturity model
+- `notations/05-capability-map.md` — capability-map notation reference (CMM maturity, V/H addressing, full field table)
 - `.templates/capability-map_template.yaml` — copy-and-fill template
-- `elements/02_business/` — where individual Capability elements live
+- `elements/02_business/capabilities/` — where individual Capability elements live

--- a/organizations/acme_corp/views/fga/README.md
+++ b/organizations/acme_corp/views/fga/README.md
@@ -9,21 +9,30 @@ Factor → Goal → Activity chains. Simplified 3-layer variant of FGCA — used
 ## Skeleton
 
 ```yaml
-title: "Q2 Operational Improvements"
+notation: fga
+spec_version: "0.1"
+
+id: FGA-OPS-1
+name: "Q2 Operational Improvements"
+description: "Factor → Goal → Activity chain for support operations."
+period: "2026-Q2"
+date: "2026-05-26"
+author: "Acme Ops"
 
 factors:
-  - id: "FACTOR-OPS-001"
-    description: "Customer-support response time degraded over Q1"
+  - id: FACTOR-COMP-1              # → elements/01_motivation/factors/FACTOR-COMP-1.yaml
+    name: "Support response time degraded over Q1"
+    type: internal
 
 goals:
-  - id: "GOAL-OPS-001"
-    factors: ["FACTOR-OPS-001"]
-    description: "Restore P50 response time to under 2 hours by end of Q2"
+  - id: GOAL-OPS-1
+    name: "Restore P50 response time to under 2 hours by end of Q2"
+    factors: [FACTOR-COMP-1]
 
 activities:
-  - id: "ACT-OPS-001"
-    goals: ["GOAL-OPS-001"]
-    description: "Add second-shift coverage in EU timezone"
+  - id: ACTIVITY-SUPPORT-1
+    name: "Add second-shift coverage in EU timezone"
+    goals: [GOAL-OPS-1]
 ```
 
 ## See also

--- a/organizations/acme_corp/views/fgca/README.md
+++ b/organizations/acme_corp/views/fgca/README.md
@@ -9,26 +9,36 @@ Factor → Goal → Change → Activity chains. Strategy-to-execution scaffold: 
 ## Skeleton
 
 ```yaml
-title: "EU Expansion 2026"
+notation: fgca
+spec_version: "0.1"
+
+id: FGCA-EU-1
+name: "EU Expansion 2026"
+description: "Factor → Goal → Change → Activity chain for EU market entry."
+period: "2026"
+date: "2026-05-26"
+author: "Acme Strategy Office"
 
 factors:
-  - id: "FACTOR-EU-001"
-    description: "EU regulatory window closing in Q3"
+  - id: FACTOR-EU-REG-1           # → elements/01_motivation/factors/FACTOR-EU-REG-1.yaml
+    name: "EU regulatory window closing in Q3"
+    type: external
+    references_constraint: [CONSTRAINT-GDPR-RESIDENCY-1]   # → elements/01_motivation/constraints/
 
 goals:
-  - id: "GOAL-EU-001"
-    factors: ["FACTOR-EU-001"]
-    description: "Operational presence in 3 EU markets by Q4"
+  - id: GOAL-EU-1
+    name: "Operational presence in 3 EU markets by Q4"
+    factors: [FACTOR-EU-REG-1]
 
 changes:
-  - id: "CHANGE-EU-001"
-    goals: ["GOAL-EU-001"]
-    description: "Stand up EU-localised CRM and payment processing"
+  - id: CHANGE-EU-CRM-1
+    name: "Stand up EU-localised CRM and payment processing"
+    goals: [GOAL-EU-1]
 
 activities:
-  - id: "ACT-CRM-EU-001"
-    changes: ["CHANGE-EU-001"]
-    description: "Implement EU-localised CRM rollout"
+  - id: ACTIVITY-CRM-EU-1
+    name: "Implement EU-localised CRM rollout"
+    changes: [CHANGE-EU-CRM-1]
 ```
 
 ## See also

--- a/organizations/acme_corp/views/goals/README.md
+++ b/organizations/acme_corp/views/goals/README.md
@@ -9,19 +9,36 @@ Hierarchical goals trees. Each tree references Goal elements stored atomically u
 ## Skeleton
 
 ```yaml
-title: "Strategy 2026"
-description: "Top-level strategic goals for FY2026"
+notation: goals
+spec_version: "0.1"
 
-goal_types:
-  - { name: "Strategy", level: 0 }
-  - { name: "Business Goal", level: 1 }
-  - { name: "Project", level: 2 }
+id: GOALS-STRATEGY-2026
+name: "Acme Corp — Strategy 2026 Goals Tree"
+description: "Goal hierarchy for the 2026 EU-expansion plan."
+period: "2026"
+date: "2026-05-26"
+author: "Acme Strategy Office"
+
+goal_types:                       # contiguous levels from 0 (GOALS-013)
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
 
 goals:
-  - id: "GOAL-FIN-001"           # references elements/01_motivation/GOAL-FIN-001.yaml
-    parent_id: 0
-  - id: "GOAL-MKT-002"
-    parent_id: "GOAL-FIN-001"
+  - id: GOAL-REVENUE-1            # → elements/01_motivation/goals/GOAL-REVENUE-1.yaml
+    name: "Triple revenue in 3 years"
+    type: "Strategy"
+    level: 0
+    # root — no parent
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 1                       # parent is level 0 → strict N+1 (GOALS-012)
+    parent: GOAL-REVENUE-1
+  - id: GOAL-OPS-1
+    name: "Cut support response time by half"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
 ```
 
 ## See also

--- a/organizations/acme_corp/views/processmap/README.md
+++ b/organizations/acme_corp/views/processmap/README.md
@@ -1,6 +1,6 @@
 # `views/processmap/`
 
-Process landscape maps — top-level catalogues of an organisation's processes, grouped by Operating / Supporting / Management. Each process referenced here is a BusinessProcess element under `elements/02_business/`. Detailed flow diagrams (BPMN) live in `views/bpmn/`.
+Process landscape maps — a top-level catalogue of the organisation's processes, grouped by Operating / Supporting / Management. Each process referenced here resolves to a BusinessProcess element under `elements/02_business/processes/`. Detailed flow diagrams (BPMN) live in `views/bpmn/`.
 
 ## File convention
 
@@ -9,20 +9,58 @@ Process landscape maps — top-level catalogues of an organisation's processes, 
 ## Skeleton
 
 ```yaml
-title: "Acme Corp — Process Landscape"
+notation: process-map
+spec_version: "0.1"
 
-groups:
-  operating:
-    - id: "PROC-ORD-FULFILL-001"   # references elements/02_business/<file>.yaml
-    - id: "PROC-ORD-PLACE-001"
-  supporting:
-    - id: "PROC-HR-ONBOARD-001"
-  management:
-    - id: "PROC-FIN-CLOSE-001"
+process_map:
+  id: "PM-ACME-1"
+  name: "Acme Corp — Process Landscape"
+  description: "Top-level catalogue of operating, supporting, and management processes"
+  version: "1.0"
+  updated_at: "2026-05-26"
+
+  groups:
+    - id: "GRP-OPERATING"
+      name: "Operating Processes"
+      type: "operating"                 # operating | supporting | management
+      processes:
+        - process_id: "PROC-ORD-FULFILL-1"   # → elements/02_business/processes/PROC-ORD-FULFILL-1.yaml
+          name: "Order Fulfilment"
+          owner_role: "ROLE-OPS-1"
+          capability: "V1"
+          maturity: 2
+          status: "Active"                    # Draft | Active | Deprecated
+          bpmn_file: "views/bpmn/order-fulfilment.bpmn.transitrix.yaml"
+        - process_id: "PROC-CUST-ONBOARD-1"
+          name: "Customer Onboarding"
+          owner_role: "ROLE-SALES-1"
+          capability: "V2"
+          maturity: 1
+          status: "Draft"
+
+    - id: "GRP-SUPPORTING"
+      name: "Supporting Processes"
+      type: "supporting"
+      processes:
+        - process_id: "PROC-CS-RESOLVE-1"
+          name: "Customer Support Resolution"
+          owner_role: "ROLE-CS-1"
+          status: "Active"
+
+    - id: "GRP-MANAGEMENT"
+      name: "Management Processes"
+      type: "management"
+      processes:
+        - process_id: "PROC-STRAT-PLAN-1"
+          name: "Annual Strategy Planning"
+          owner_role: "ROLE-EXEC-1"
+          status: "Active"
 ```
+
+`process_id`, `owner_role`, and `capability` hold **element / capability IDs**, not display names.
 
 ## See also
 
-- `method/methodology.md` §6.4 — process diagrams vs landscape maps
+- `notations/06-process-map.md` — process-map notation reference (full field table)
 - `views/bpmn/` — detailed flow diagrams for individual processes
-- `elements/02_business/` — where individual BusinessProcess elements live
+- `elements/02_business/processes/` — where individual BusinessProcess elements live

--- a/organizations/acme_corp/views/products/README.md
+++ b/organizations/acme_corp/views/products/README.md
@@ -1,6 +1,6 @@
 # `views/products/`
 
-Filtered views over Product elements. Each Product is stored atomically as one file under `elements/02_business/<PRODUCT_ID>.yaml` (with `type: Product`). A view here defines how to filter, group, and present a subset of those products — for example, "active retail products grouped by category" or "products by maturity stage".
+Products catalogue — a curated catalogue of the products and services the organisation offers. Each entry references a Product element under `elements/02_business/products/` and carries the display attributes used to render the catalogue.
 
 ## File convention
 
@@ -9,28 +9,41 @@ Filtered views over Product elements. Each Product is stored atomically as one f
 ## Skeleton
 
 ```yaml
-title: "Active Retail Portfolio"
-description: "Products currently in market, grouped by category"
+notation: products
+spec_version: "0.1"
 
-filter:
-  type: "Product"
-  status: ["Active", "Production"]
-  tags: ["retail"]
+products_catalogue:
+  id: "PROD-CAT-1"
+  name: "Acme Corp Products Catalogue"
+  description: "Products and services offered by Acme Corp"
+  version: "1.0"
+  updated_at: "2026-05-26"
 
-group_by: "category"               # field on the Product element
+  products:
+    - product_id: "PROD-ECOMM-1"        # → elements/02_business/products/PROD-ECOMM-1.yaml
+      name: "E-Commerce Platform"
+      type: "digital_product"           # digital_product | service | platform | bundle
+      domain: "Digital"
+      owner_role: "ROLE-PROD-1"
+      status: "Active"                  # Draft | Active | Deprecated
+      maturity: 3
+      description: "Online storefront and order management for end customers"
+      capabilities: ["V1", "V2"]
+      processes: ["PROC-ORD-FULFILL-1"]
+      supporting_apps: ["APP-OMS-1", "APP-CRM-1"]
 
-columns:
-  - "name"
-  - "owner"
-  - "launched_at"
-  - "stage"
+    - product_id: "SVC-SUPPORT-1"
+      name: "Customer Support Service"
+      type: "service"
+      domain: "Operations"
+      owner_role: "ROLE-CS-1"
+      status: "Active"
+      description: "Tier-1 and Tier-2 support for customers via chat, email, and phone"
 ```
 
-## What the view does NOT do
-
-It does not store product data. The Product elements live in `elements/02_business/`. A view describes how to render a slice of them — the data stays in the elements.
+`capabilities`, `processes`, and `supporting_apps` hold **element IDs** (`V1`, `PROC-…`, `APP-…`), not display names — the catalogue references the elements, it does not duplicate them.
 
 ## See also
 
-- `method/methodology.md` §4 — elements vs views
-- `elements/02_business/` — individual Product element files
+- `notations/09-products.md` — products-catalogue notation reference (full field table)
+- `elements/02_business/products/` — where individual Product elements live


### PR DESCRIPTION
## What

Refreshes the `organizations/acme_corp` template org against the current notation specs. Three scoped commits:

1. **View-README skeletons** (`views/{fga,fgca,goals,products,applications,capabilities,processmap}/README.md`) rewritten to conform to the current specs:
   - `fga` / `fgca` / `goals` → **flat, no-wrapper** form (notation header, `id`, `name`, typed+leveled goals with strict N+1, `ACTIVITY-` prefix). The nested `goals_tree:`/`fga:` shapes some of us remember are pre-2026-05-26 and no longer in the specs.
   - `capabilities` / `products` / `applications` / `processmap` → wrapper roots (`capability_map` / `products_catalogue` / `applications_catalogue` / `process_map`); cross-references hold **element IDs**, not display names; every capability incl. children carries `type`.
   - All skeletons share one coherent Acme Corp model with canonical `-1` IDs so cross-references line up.
2. **`.templates/capability-map_template.yaml`** rewritten to the current `capability_map:` schema (the old one used a divergent structure + a YAML/markdown mix). Element-layer and bpmn templates sanity-checked — valid and current.
3. **Surface docs:** `GETTING_STARTED.md` demotes Python to an optional local-linter tool (VS Code extension / Studio lead for preview + validation) and fixes a stale `method/…` reference; `CONVENTIONS.md` replaces the stale Type-Prefix table with the canonical registry from `IDS_AND_REFERENCES.md` §3 and the no-leading-zeros grammar. `NEW_ORGANIZATION_TEMPLATE.md` re-read — copies the now-refreshed acme_corp, no change needed.

All YAML skeleton blocks parse; the goals example satisfies the N+1 / contiguity rules.

## Deferred to a follow-up (not in this PR)

The **elements/ population** (example primitives for every referenced ID + per-folder READMEs + traceability) is intentionally **not** included. Two blockers surfaced:

- `acme_corp/views/` holds only README *skeletons*, not populated view files — so there are no "referenced IDs in example views" beyond the skeletons themselves.
- `FACTOR` / `CHANGE` / `ACTIVITY` (and the capability/product element shapes) have **no formal element-primitive schema** in the methodology — the flat view docs define them inline. Populating them means choosing a shape, which is a canon decision.

Recommend doing the population once those element-primitive schemas are settled. The `CONSTRAINT`/`RULE` example primitives created in transitrix/methodology#25 already establish the pattern.

## Drift flagged (not fixed here — out of scope)

- Catalogue specs use abbreviated cross-ref prefixes (`APP-`, `PROC-`, `PROD-`) while the canonical registry uses full TYPE names (`APPLICATION`, `PROCESS`, `PRODUCT`). Skeletons match their own notation spec; `CONVENTIONS.md` carries a drift note. Convergence belongs to the per-notation migrations in `IDS_AND_REFERENCES.md` §6.
- Zero-padded IDs (`-001`) remain in the element/bpmn templates and scattered doc examples — same §6 migration, explicitly "not bundled."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
