### PR TITLE
docs(notations): codex spec (14-codex.md) + Field/Codex TYPEs (three-zone model, phase 2)

### DIFF
--- a/notations/14-codex.md
+++ b/notations/14-codex.md
@@ -1,0 +1,146 @@
+---
+title: "Codex — external & internal authority artefacts"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-05-27"
+status: "draft"
+---
+
+# Codex Notation — Reference
+
+**Scope:** The **Codex** zone — external constraints (laws, regulations) and internal authority documents (policies, standards) that are *given to* the organisation rather than authored by it. The three-zone model and the shared admission record are defined in [CONTRACT.md](CONTRACT.md) §5–6.
+
+Codex artefacts are **zone primitives**, not view documents: each artefact is a single YAML file named by its ID (`<TYPE>-…-<INTEGER>.yaml`, per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md)). They are not `.transitrix.yaml` notation files and carry no `notation:` header; instead they carry the shared admission record ([CONTRACT.md](CONTRACT.md) §6, with `zone: codex`) plus the codex-specific frontmatter below.
+
+---
+
+## 1. Structure: external vs internal
+
+The codex zone is split at the folder level:
+
+```
+codex/
+  external/          # given to the org by outside authorities
+    <jurisdiction>/  # ISO 3166-1 alpha-2, or `eu` / `intl`
+  internal/          # issued by the org itself
+```
+
+- **`external/`** — laws and regulations, sub-foldered by **jurisdiction** because a distributed organisation operates under multiple legal regimes that bind different processes differently.
+- **`internal/`** — policies and internal standards the organisation issues to itself. Not foldered by country.
+
+### 1.1 Jurisdiction codes
+
+External codex artefacts live under a jurisdiction folder:
+
+| Code | Meaning |
+|---|---|
+| ISO 3166-1 alpha-2 (`ge`, `de`, `ru`, …) | a single country's legal regime |
+| `eu` | EU-wide law applying across member states |
+| `intl` | supranational bodies (UN, etc.) — **reserved; no content in v1** |
+
+The folder an external artefact sits in MUST match its `jurisdiction:` frontmatter (rule `CODEX-001`).
+
+---
+
+## 2. Codex TYPEs
+
+| TYPE | Sub-zone | What it is |
+|---|---|---|
+| `LAW` | external | a statute or act binding the organisation |
+| `REGULATION` | external | a regulation issued under a law |
+| `POLICY` | internal | an internal policy the organisation issues |
+| `INTERNAL_STANDARD` | internal | an internal standard or convention |
+
+Registered in [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.5; IDs follow the canonical grammar (`LAW-PERSONAL-DATA-2017-1`, `INTERNAL_STANDARD-coding-conventions-1`, …).
+
+---
+
+## 3. Frontmatter — external codex artefacts
+
+Carries the admission record ([CONTRACT.md](CONTRACT.md) §6, `zone: codex`, `gate_checks.source_authority`) plus:
+
+```yaml
+id: LAW-PERSONAL-DATA-2017-1
+name: "Law of Georgia on Personal Data Protection"
+type: LAW                       # LAW | REGULATION
+zone: codex
+admitted_at: "2026-05-27"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  source_authority: "Legislative Herald of Georgia"
+jurisdiction: ge                # MUST match the parent folder (CODEX-001)
+effective_date: "2017-05-01"
+applies_to:
+  entities:                     # typed IDs of org entities the artefact binds
+    - APPLICATION-CRM-1
+  processes:                    # typed IDs of processes the artefact binds
+    - PROCESS-CUST-ONBOARD-1
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `jurisdiction` | yes | string | ISO 3166-1 alpha-2, `eu`, or `intl`. MUST equal the parent folder name. |
+| `effective_date` | yes | string | Date the artefact takes effect — quoted ISO 8601 ([CONTRACT.md](CONTRACT.md) §4). |
+| `applies_to` | yes | map | Sub-map with `entities:` and `processes:` — lists of typed IDs the artefact binds. A single artefact MAY apply to many entities and many processes; that is how one law's effect across different processes (and, via several artefacts, different countries) is encoded. |
+
+---
+
+## 4. Frontmatter — internal codex artefacts
+
+```yaml
+id: INTERNAL_STANDARD-coding-conventions-1
+name: "Engineering Coding Conventions"
+type: INTERNAL_STANDARD         # POLICY | INTERNAL_STANDARD
+zone: codex
+admitted_at: "2026-05-27"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  source_authority: "VP Engineering"
+issuing_authority: "VP Engineering"
+effective_date: "2026-01-01"
+applies_to:
+  entities:
+    - APPLICATION-CRM-1
+  processes: []
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `issuing_authority` | yes | string | The internal body or role that issued the artefact. |
+| `effective_date` | yes | string | Date the artefact takes effect — quoted ISO 8601. |
+| `applies_to` | yes | map | `entities:` and `processes:` lists of typed IDs the artefact binds. |
+
+Internal artefacts have no `jurisdiction` and are not foldered by country.
+
+---
+
+## 5. File location and naming
+
+```
+codex/external/<jurisdiction>/<ID>.yaml
+codex/internal/<ID>.yaml
+```
+
+One artefact per file, named by its canonical ID. Examples:
+
+- `codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml`
+- `codex/external/eu/REGULATION-GDPR-2016-1.yaml`
+- `codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml`
+
+---
+
+## 6. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `CODEX-001` | error | An external artefact's `jurisdiction:` does not match its parent folder name under `codex/external/<jurisdiction>/`. |
+| `CODEX-002` | error | Required frontmatter missing. External needs `jurisdiction` + `effective_date` + `applies_to`; internal needs `issuing_authority` + `effective_date` + `applies_to`. All codex artefacts also carry the admission record ([CONTRACT.md](CONTRACT.md) §6). |
+| `CODEX-003` | error | An `applies_to.entities[]` or `applies_to.processes[]` value is not a well-formed typed ID, or — when the validator has the canon catalogue loaded — does not resolve to a defined element. Codex binds canon, so resolution against canon is in scope here (unlike the strategy-chain notations, which defer cross-document existence checks). |
+
+---
+
+## 7. References
+
+- Zone model and admission record: [CONTRACT.md](CONTRACT.md) §5–6.
+- Codex TYPE registry and uniqueness scope: [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.5, §4.
+- Which zones and notations an adopter uses is declared in the `transitrix.yaml` manifest.

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -111,6 +111,28 @@ BPMN diagrams use their `process.id` as the document identifier; that field is a
 
 BPMN element IDs inside a single file (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) are local labels, not cross-document references. They identify nodes within one BPMN document and are not part of the TYPE registry above. Each BPMN file may use its own labelling convention.
 
+### 3.4 Field artefact types
+
+Raw, unprocessed material in the **Field** zone (see [CONTRACT.md](CONTRACT.md) §5). Field artefacts are not authoritative; their value is provenance. A Canon record cites the Field material behind it via `derived_from:` ([CONTRACT.md](CONTRACT.md) §6).
+
+| TYPE | What it is |
+|---|---|
+| `INTERVIEW` | a recorded interview or its notes |
+| `SURVEY` | a survey instrument and/or its responses |
+| `OBSERVATION` | a direct observation of work, a system, or an event |
+| `DRAFT` | a working draft not yet admitted to canon |
+
+### 3.5 Codex artefact types
+
+External constraints and internal authority documents in the **Codex** zone — *given to* the organisation, not authored by it. See [CONTRACT.md](CONTRACT.md) §5 and [14-codex.md](14-codex.md).
+
+| TYPE | Sub-zone | What it is |
+|---|---|---|
+| `LAW` | codex / external | a statute or act binding the organisation |
+| `REGULATION` | codex / external | a regulation issued under a law |
+| `POLICY` | codex / internal | an internal policy the organisation issues |
+| `INTERNAL_STANDARD` | codex / internal | an internal standard or convention |
+
 ---
 
 ## 4. Uniqueness scope
@@ -129,6 +151,9 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | `EQUIPMENT`, `INFORMATION_ENTITY` | within the notation document that defines them (today: a Process Blueprint). No organisation-wide catalogue is mandated yet; the TYPEs are registered so the IDs already conform to the canonical grammar and can be promoted to a future catalogue without renaming. |
 | `RULE` | within the organisation's element catalogue (`elements/02_business/rules/`), one file per RULE. |
 | `CONSTRAINT` | within the organisation's element catalogue (`elements/01_motivation/constraints/`), one file per CONSTRAINT. |
+| `INTERVIEW`, `SURVEY`, `OBSERVATION`, `DRAFT` | within the organisation's `field/` zone. Contradictions between Field artefacts are allowed; only the IDs must be unique. |
+| `LAW`, `REGULATION` | within the organisation's `codex/external/` zone. |
+| `POLICY`, `INTERNAL_STANDARD` | within the organisation's `codex/internal/` zone. |
 
 Document-level IDs (`FGCA-…`, `FGA-…`, etc.) are unique within the organisation.
 


### PR DESCRIPTION
## What

Phase 2 of the **three-zone model**: the ID grammar and the codex spec. Builds on Phase 1 (CONTRACT.md §5–6, merged). Pure spec.

## Changes

**`notations/IDS_AND_REFERENCES.md`**
- **§3.4 Field artefact types** — `INTERVIEW`, `SURVEY`, `OBSERVATION`, `DRAFT`.
- **§3.5 Codex artefact types** — `LAW`, `REGULATION` (external); `POLICY`, `INTERNAL_STANDARD` (internal).
- **§4** — uniqueness scopes for the `field/` and `codex/` zones (Field allows contradictions; only IDs must be unique).

**`notations/14-codex.md`** (new)
- External / internal split; `external/` sub-foldered by **jurisdiction** — ISO 3166-1 alpha-2 (`ge`, `de`, …) plus `eu` for EU-wide; `intl` reserved with no v1 content.
- Required frontmatter — external: `jurisdiction` (must match parent folder), `effective_date`, `applies_to` (`entities:` + `processes:` lists of typed IDs; one artefact may bind many of each → multi-process / multi-country effect); internal: `issuing_authority`, `effective_date`, `applies_to`.
- Validation rules `CODEX-001` (path/jurisdiction match), `CODEX-002` (required frontmatter present), `CODEX-003` (`applies_to` IDs resolve — codex binds canon, so resolution against canon is in scope).

Both embedded YAML examples parse; all sections present.

## Design note

Codex artefacts are **zone primitives** — one ID-named `.yaml` per artefact under `codex/…`, carrying the Phase-1 admission record plus the codex frontmatter. They are **not** `.transitrix.yaml` view-notation files and carry no `notation:` header, so codex is intentionally **not** added to the view-notation catalogue in `notations/README.md`. This matches the epic's Phase 5 file-naming (`LAW-…-1.yaml`).

## Scope

Independent of Phase 1's merge file-wise (different files). Together, Phases 1+2 are the prerequisite for Phase 4 (zoned `acme_corp` layout migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
