### PR TITLE
docs(notations): adopter manifest spec — transitrix.yaml (three-zone model, phase 3)

### DIFF
--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -1,0 +1,52 @@
+---
+title: "Adopter manifest — transitrix.yaml"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-05-27"
+status: "draft"
+---
+
+# Adopter Manifest — `transitrix.yaml`
+
+**Scope:** The top-level manifest an adopting repository carries to declare which methodology release it conforms to, which notations it uses, and which zones it maintains. One file per adopter repository, at the repository root.
+
+Adopters do **not** vendor a copy of `notations/` into their repo — they pin a methodology version here and follow the published specs at that version. The zone model the `zones:` field refers to is defined in [CONTRACT.md](CONTRACT.md) §5.
+
+---
+
+## 1. Location
+
+| Adopter case | Repo root | Manifest path |
+|---|---|---|
+| Single legal entity | `[org]/` | `[org]/transitrix.yaml` |
+| Holding (multiple entities) | `organizations/` | `organizations/transitrix.yaml`, with `_shared/` for group-level codex / field |
+
+In this methodology repo the worked example lives at `organizations/acme_corp/transitrix.yaml`.
+
+---
+
+## 2. Structure
+
+```yaml
+transitrix: 1                       # manifest schema version (integer)
+methodology_version: "0.4.x"        # the methodology release this repo conforms to
+notations: [fgca, goals, activities, issues, capability-map, codex]
+zones: [canon, field, codex]
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `transitrix` | yes | integer | Manifest schema version. `1` today. Identifies the file as a Transitrix adopter manifest. |
+| `methodology_version` | yes | string | The methodology release this repository pins to. Adopters follow the published specs at this version rather than vendoring `notations/`. |
+| `notations` | yes | list | Short names of the notations the repository uses, from the catalogue in [README.md](README.md) — plus `codex` for the codex zone (see [14-codex.md](14-codex.md)). |
+| `zones` | yes | list | Which zones the repository maintains — any subset of `canon`, `field`, `codex`. A repo MAY start canon-only and add `field` / `codex` later. |
+
+No validator enforces the manifest yet; it is declarative. Tooling MAY read it to discover the pinned methodology version and the active notations and zones.
+
+---
+
+## 3. References
+
+- Zone model and admission record: [CONTRACT.md](CONTRACT.md) §5–6.
+- Notation catalogue (short names): [README.md](README.md).
+- Codex zone: [14-codex.md](14-codex.md).


### PR DESCRIPTION
## What

Phase 3 of the **three-zone model**: the adopter manifest. Spec + one example; **no validator** (declarative). Independent of Phases 1/2.

## Changes

**`notations/MANIFEST.md`** (new) — defines the top-level `transitrix.yaml` an adopting repo carries:

```yaml
transitrix: 1
methodology_version: "0.4.x"
notations: [fgca, goals, activities, issues, capability-map, codex]
zones: [canon, field, codex]
```

- `transitrix` — manifest schema version (integer).
- `methodology_version` — the methodology release the repo pins to; adopters follow the published specs at that version rather than vendoring `notations/`.
- `notations` — short names in use (catalogue in README.md, plus `codex`).
- `zones` — subset of `canon` / `field` / `codex` the repo maintains.

Includes the location table for the two adopter cases — single legal entity (root = `[org]/`) vs holding (root = `organizations/`, with `_shared/` for group-level codex/field).

Example block parses.

## Scope

The worked `organizations/acme_corp/transitrix.yaml` file lands in **Phase 4** (layout migration); this PR is the spec only. Phase 4 needs Phases 1+2 merged (both are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
