### PR TITLE
docs(acme_corp): fix stale GOALS validation-code range in CLAUDE.md

### DIFF
--- a/organizations/acme_corp/CLAUDE.md
+++ b/organizations/acme_corp/CLAUDE.md
@@ -130,7 +130,7 @@ Every notation file is validated before commit. Two sanctioned paths:
 
 The agent does **not** commit files with `error`-level validation findings. `warning`-level findings are surfaced to the adopter and committed only with explicit acknowledgement. The agent does not auto-suppress validation rules.
 
-Every notation spec carries its own validation-codes table (e.g. `FGCA-001..015`, `GOALS-001..011`, `BL-001..009`, `ISS-001..006`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.
+Every notation spec carries its own validation-codes table (e.g. `FGCA-001..015`, `GOALS-001..013`, `BL-001..009`, `ISS-001..006`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.
 
 ---
 


### PR DESCRIPTION
## What

Post-merge cleanup of a review nit from PR #27. `organizations/acme_corp/CLAUDE.md` §6 cited the goals validation-code range as `GOALS-001..011`, but PR #30 added `GOALS-012` / `GOALS-013` (normative N+1 hierarchy + contiguous level vocabulary). Updated the illustrative range to `GOALS-001..013`.

Verified the other ranges in the same line against the specs — `FGCA-001..015`, `BL-001..009`, `ISS-001..006` are all current — so only the GOALS range needed the bump.

One-line doc fix; no behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
