### PR TITLE
docs(acme_corp): worked Field + Codex examples (three-zone model, phase 5)

### DIFF
--- a/organizations/acme_corp/codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml
+++ b/organizations/acme_corp/codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml
@@ -1,0 +1,22 @@
+# Codex external artefact — given to the org by an outside authority; faithful to source.
+# Schema: notations/14-codex.md §3 + admission record (CONTRACT.md §6). Worked example.
+id: LAW-PERSONAL-DATA-2017-1
+name: "Law of Georgia on Personal Data Protection"
+type: LAW
+description: "Governs the processing of personal data of individuals in Georgia."
+
+# Admission record (CONTRACT.md §6)
+zone: codex
+admitted_at: "2026-05-27"
+admitted_by: "legal.counsel"
+gate_checks:
+  source_authority: "Legislative Herald of Georgia (matsne.gov.ge)"
+
+# External-codex frontmatter (14-codex.md §3)
+jurisdiction: ge                 # MUST match the parent folder codex/external/ge/ (CODEX-001)
+effective_date: "2017-05-01"
+applies_to:
+  entities:
+    - APP-CRM-1                  # CRM stores customer personal data
+  processes:
+    - PROC-CUST-ONBOARD-1        # onboarding collects personal data

--- a/organizations/acme_corp/codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml
+++ b/organizations/acme_corp/codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml
@@ -1,0 +1,22 @@
+# Codex internal artefact — issued by the org to itself. Schema: notations/14-codex.md §4
+# + admission record (CONTRACT.md §6). Worked example.
+id: INTERNAL_STANDARD-coding-conventions-1
+name: "Engineering Coding Conventions"
+type: INTERNAL_STANDARD
+description: "Internal coding standards applied to in-house application development."
+
+# Admission record (CONTRACT.md §6)
+zone: codex
+admitted_at: "2026-05-27"
+admitted_by: "vp.engineering"
+gate_checks:
+  source_authority: "VP Engineering (internal standards board)"
+
+# Internal-codex frontmatter (14-codex.md §4)
+issuing_authority: "VP Engineering"
+effective_date: "2026-01-01"
+applies_to:
+  entities:
+    - APP-OMS-1
+    - APP-CRM-1
+  processes: []

--- a/organizations/acme_corp/field/interviews/INTERVIEW-cfo-onboarding-2026-04-15-1.yaml
+++ b/organizations/acme_corp/field/interviews/INTERVIEW-cfo-onboarding-2026-04-15-1.yaml
@@ -1,0 +1,26 @@
+# Field artefact — raw, unprocessed input. Not authoritative; provenance is the point.
+# Schema: admission record per the methodology's CONTRACT.md §6; TYPE per IDS_AND_REFERENCES.md §3.4.
+id: INTERVIEW-cfo-onboarding-2026-04-15-1
+name: "CFO onboarding interview — finance operations"
+type: INTERVIEW
+
+# Admission record (CONTRACT.md §6)
+zone: field
+admitted_at: "2026-04-16"
+admitted_by: "a.analyst"
+gate_checks:
+  provenance: "recorded with consent; notes transcribed same day"
+
+# Provenance — who/when/in what setting (the point of a Field artefact)
+interviewer: "a.analyst"
+interviewee_role: "Chief Financial Officer"   # descriptive role, not a named person (no PII)
+interview_date: "2026-04-15"
+setting: "onboarding session, video call, ~45 min"
+
+# Raw notes — contradictions allowed; nothing here is canon until separately admitted.
+notes: |
+  The CFO called the monthly close "about three days too slow" and put it down to manual
+  reconciliation between the CRM and the order system. Wants to halve close time within the
+  year, and worries EU expansion will add a second ledger. Unverified — to be corroborated
+  before any of it informs a Canon record (which would then cite this artefact via
+  `derived_from: [INTERVIEW-cfo-onboarding-2026-04-15-1]`).


### PR DESCRIPTION
## What

Phase 5 of the **three-zone model**: three worked example artefacts in `acme_corp`, so adopters see exactly what a Field and a Codex artefact look like. Builds on Phases 2+4 (merged).

Each carries the **admission record** from Phase 1 (`CONTRACT.md` §6) plus its zone-specific frontmatter.

## Artefacts

- **`field/interviews/INTERVIEW-cfo-onboarding-2026-04-15-1.yaml`** — Field artefact. Provenance (interviewer, interviewee role, date, setting) + raw, unverified notes; `gate_checks.provenance`. No real PII — descriptive role and fake content. Shows how a Canon record would later cite it via `derived_from:`.
- **`codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml`** — external Codex (`LAW`). `jurisdiction: ge` matches the parent folder (`CODEX-001`), `effective_date`, `applies_to` one entity (`APP-CRM-1`) + one process (`PROC-CUST-ONBOARD-1`); `gate_checks.source_authority`.
- **`codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml`** — internal Codex. `issuing_authority`, `effective_date`, `applies_to`; `gate_checks.source_authority`.

## Verification

15/15 conformance checks pass (parse, admission record present, per-zone `gate_checks`, `CODEX-001` jurisdiction/folder match, required codex frontmatter).

**Note on `CODEX-003`:** the `applies_to` IDs (`APP-CRM-1`, `PROC-CUST-ONBOARD-1`, `APP-OMS-1`) are the acme_corp model's entities/processes as referenced in the `canon/views/` skeletons. Their `canon/elements/` files are produced by the deferred elements-population task — once that lands, `CODEX-003` (applies_to resolves to a defined element) is fully satisfied. The examples are correct in shape today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
