### PR TITLE
Canonical CAPABILITY-V/H + CAPABILITY_MAP- forms across canon (Option A)

### DIFF
--- a/notations/05-capability-map.md
+++ b/notations/05-capability-map.md
@@ -78,12 +78,14 @@ Transitrix applies the **CMMI V2.0** standard to measure capability maturity.
 
 ## 4. Capability ID conventions (Transitrix Studio — YAML files)
 
+Capability IDs follow the canonical `CAPABILITY-<V/H sub-grammar>` form defined in [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §2.
+
 | Axis | Format | Examples |
 |------|--------|---------|
-| Vertical (domain) | `V[N]`, `V[N].[N]`, `V[N].[N].[N]` | `V1`, `V1.1`, `V1.1.2` |
-| Horizontal (cross-cutting) | `H[N]`, `H[N].[N]` | `H1`, `H1.2` |
+| Vertical (domain) | `CAPABILITY-V[N]`, `CAPABILITY-V[N].[N]`, `CAPABILITY-V[N].[N].[N]` | `CAPABILITY-V1`, `CAPABILITY-V1.1`, `CAPABILITY-V1.1.2` |
+| Horizontal (cross-cutting) | `CAPABILITY-H[N]`, `CAPABILITY-H[N].[N]` | `CAPABILITY-H1`, `CAPABILITY-H1.2` |
 
-Vertical capabilities are primary business domains. Horizontal capabilities cut across domains (security, compliance, data governance).
+Vertical capabilities are primary business domains. Horizontal capabilities cut across domains (security, compliance, data governance). The bare V/H component (`V1`, `H1.2`) without the `CAPABILITY-` prefix still appears as the address inside the DSM addressing system in §5 (`set_name.b.o.L1.L2.L3`) — the canonical ID prefixes that address with `CAPABILITY-`.
 
 ---
 
@@ -202,13 +204,13 @@ Examples:
 
 ```yaml
 capability_map:
-  id: "CM-BUSINESS-001"
+  id: "CAPABILITY_MAP-BUSINESS-1"
   name: "Business Capabilities Map"
   description: "Core business capabilities with current and target maturity"
   assessment_date: "2026-05-08"
 
   capabilities:
-    - id: "V1"
+    - id: "CAPABILITY-V1"
       name: "Order Management"
       type: "domain"                       # domain | supporting
       current_maturity: 2
@@ -220,11 +222,11 @@ capability_map:
         - "APP-OMS-001"
         - "APP-CRM-001"
       children:
-        - id: "V1.1"
+        - id: "CAPABILITY-V1.1"
           name: "Order Intake"
           current_maturity: 3
           target_maturity: 3
-        - id: "V1.2"
+        - id: "CAPABILITY-V1.2"
           name: "Order Fulfilment"
           current_maturity: 2
           target_maturity: 3
@@ -237,10 +239,10 @@ capability_map:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `capability_map.id` | Yes | Unique ID for this map view (`CM-DOMAIN-SEQ`) |
+| `capability_map.id` | Yes | Unique ID for this map view, canonical TYPE `CAPABILITY_MAP` (`CAPABILITY_MAP-<DOMAIN>-<SEQ>`) |
 | `capability_map.name` | Yes | Human-readable name |
 | `capability_map.assessment_date` | Yes | Date of the maturity assessment (YYYY-MM-DD) |
-| `id` | Yes | Capability ID (V1, V1.1, H1 format) |
+| `id` | Yes | Capability ID — canonical form `CAPABILITY-V1`, `CAPABILITY-V1.1`, `CAPABILITY-H1` (see [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §2) |
 | `name` | Yes | Capability name |
 | `type` | Yes | `domain` or `supporting` |
 | `current_maturity` | Yes | Current CMM level (1–5) |
@@ -258,7 +260,7 @@ capability_map:
 Individual capability elements in `elements/02_business/` carry the full maturity history:
 
 ```yaml
-id: "CAP-ORD-001"
+id: "CAPABILITY-V1"
 name: "Order Management"
 type: "Capability"
 layer: "Business"
@@ -267,7 +269,7 @@ metadata:
   owner: "firstname.lastname"
   updated_at: "2026-05-08"
 properties:
-  capability_id: "V1"
+  capability_id: "CAPABILITY-V1"
   maturity_levels:
     - level: 1
       effective_from: "2024-01-01"

--- a/notations/06-process-map.md
+++ b/notations/06-process-map.md
@@ -82,7 +82,7 @@ process_map:
         - process_id: "PROC-ORD-FULFILL-001"
           name: "Order Fulfilment"
           owner_role: "ROLE-OPS-001"
-          capability: "V1"
+          capability: "CAPABILITY-V1"
           maturity: 2
           status: "Active"
           bpmn_file: "views/bpmn/ORDER_FULFILLMENT_process.bpmn.transitrix.yaml"
@@ -90,7 +90,7 @@ process_map:
         - process_id: "PROC-CUST-ONBOARD-001"
           name: "Customer Onboarding"
           owner_role: "ROLE-SALES-001"
-          capability: "V2"
+          capability: "CAPABILITY-V2"
           maturity: 1
           status: "Draft"
 

--- a/notations/09-products.md
+++ b/notations/09-products.md
@@ -77,8 +77,8 @@ products_catalogue:
       maturity: 3                      # CMM level 1–5
       description: "Online storefront and order management for end customers"
       capabilities:
-        - "V1"
-        - "V2"
+        - "CAPABILITY-V1"
+        - "CAPABILITY-V2"
       processes:
         - "PROC-ORD-FULFILL-001"
       supporting_apps:

--- a/notations/10-applications.md
+++ b/notations/10-applications.md
@@ -80,7 +80,7 @@ applications_catalogue:
       maturity: 3                      # CMM level 1–5
       description: "Core system for order lifecycle management"
       capabilities:
-        - "V1"
+        - "CAPABILITY-V1"
       products:
         - "PROD-ECOMM-001"
       integrations:

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -180,10 +180,10 @@ The TYPE registry above was confirmed 2026-05-20. Several notations and example 
 | `ACT-…` | `ACTIVITY-…` | examples under `examples/fga/`, `examples/fgca/`, `examples/activities/`; spec example in `03-fga.md` §4; `07-activities.md` §4 (`delivers_changes: [CHG-001]`). | follow-up |
 | `CHG-…` | `CHANGE-…` | spec example in `07-activities.md` §4; FGCA when its schema lands | follow-up |
 | `FAC-…` | `FACTOR-…` | scenarios examples (`FAC-MARKET-001`, etc.); some FGA references | follow-up |
-| `CAP-…` | `CAPABILITY-V…` / `CAPABILITY-H…` | products and applications examples (cross-refs into capabilities); process-map examples | follow-up |
+| `CAP-…` | `CAPABILITY-V…` / `CAPABILITY-H…` | residual: `11-scenarios.md` spec example + `examples/scenarios/optimistic-2027.scenarios.transitrix.yaml` | capability-map / products / applications / process-map portion **executed 2026-05-28**; scenarios remains as a follow-up |
 | `SCN-…` / `SCEN-…` | `SCENARIO-…` | `11-scenarios.md`; scenarios examples; `07-activities.md` (`scenario: SCEN-2026-OPT`) | follow-up — variant `SCEN` vs `SCN` also needs unifying |
 | Integer-only IDs (`1`, `2`, …) | typed string IDs (`GOAL-1`, `FACTOR-1`, …) | originally the FGCA example | covered in the in-flight FGCA schema PR — see [transitrix/methodology#7](https://github.com/transitrix/methodology/pull/7) |
-| `V1`, `V1.2`, `H1.2` (no `CAPABILITY-` prefix) | `CAPABILITY-V1`, `CAPABILITY-V1.2`, `CAPABILITY-H1.2` | capability-map examples (own IDs); products / applications / process-map examples (cross-refs into capabilities) | follow-up |
+| `V1`, `V1.2`, `H1.2` (no `CAPABILITY-` prefix) | `CAPABILITY-V1`, `CAPABILITY-V1.2`, `CAPABILITY-H1.2` | residual: `examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml`; prose mentions in `method/methodology.md`; `integration/studio.md` | capability-map / products / applications / process-map portion **executed 2026-05-28** (capability-map examples + cross-refs in products / applications / process-map specs, examples, and `acme_corp` views); scenarios + supporting docs remain |
 | Zero-padded sequences (`001`, `002`, …) | no-leading-zero integers (`1`, `2`, …) | most example files | follow-up — purely a string-form change; sort order is unaffected because comparison is numeric |
 
 **Migration policy:** one follow-up issue per notation (spec + its examples). Do not bundle migrations into a single mega-PR — they touch different files and benefit from independent review.

--- a/notations/examples/applications/portfolio-2026.applications.transitrix.yaml
+++ b/notations/examples/applications/portfolio-2026.applications.transitrix.yaml
@@ -21,9 +21,9 @@ applications_catalogue:
       maturity: 4
       description: Core system for end-to-end order lifecycle management.
       capabilities:
-        - V1.2      # Order Fulfilment — order processing
-        - V2.2      # Inventory Management — inventory tracking
-        - V1.2.1    # Pick & Pack — fulfilment orchestration
+        - CAPABILITY-V1.2      # Order Fulfilment — order processing
+        - CAPABILITY-V2.2      # Inventory Management — inventory tracking
+        - CAPABILITY-V1.2.1    # Pick & Pack — fulfilment orchestration
       products:
         - prod-mobile-app
         - prod-partner-bundle
@@ -47,8 +47,8 @@ applications_catalogue:
       maturity: 3
       description: Customer relationship and sales pipeline management.
       capabilities:
-        - V2.1    # Customer Acquisition — lead management, opportunity tracking
-        - V2      # CRM — customer 360 view
+        - CAPABILITY-V2.1    # Customer Acquisition — lead management, opportunity tracking
+        - CAPABILITY-V2      # CRM — customer 360 view
 
     - app_id: APP-EBS-001
       name: Enterprise Event Bus
@@ -75,9 +75,9 @@ applications_catalogue:
       maturity: 4
       description: Central analytical data store for BI and reporting.
       capabilities:
-        - V4.1    # Analytics — real-time reporting
-        - V4.2    # Analytics — historical analysis
-        - H1      # Master Data Management — data cataloguing
+        - CAPABILITY-V4.1    # Analytics — real-time reporting
+        - CAPABILITY-V4.2    # Analytics — historical analysis
+        - CAPABILITY-H1      # Master Data Management — data cataloguing
 
     - app_id: APP-LEGACY-PORTAL-001
       name: Legacy Customer Portal

--- a/notations/examples/capability-map/README.md
+++ b/notations/examples/capability-map/README.md
@@ -4,7 +4,7 @@ File extension: **`.capability-map.transitrix.yaml`**
 
 ## Format overview
 
-A capability map is a hierarchical view of what an organisation can do (its capabilities) and how mature each capability is on the CMMI V2.0 1–5 scale. Vertical capabilities (`V1`, `V1.1`, …) are core business domains; horizontal capabilities (`H1`, `H1.2`, …) cut across domains (master data management, compliance, ESG).
+A capability map is a hierarchical view of what an organisation can do (its capabilities) and how mature each capability is on the CMMI V2.0 1–5 scale. Vertical capabilities (`CAPABILITY-V1`, `CAPABILITY-V1.1`, …) are core business domains; horizontal capabilities (`CAPABILITY-H1`, `CAPABILITY-H1.2`, …) cut across domains (master data management, compliance, ESG).
 
 ## Files in this folder
 
@@ -28,7 +28,7 @@ notation: capability-map
 | `capability_map.id` | Unique identifier for this map |
 | `capability_map.name` | Display name |
 | `capability_map.assessment_date` | Date in `YYYY-MM-DD` format |
-| `capabilities[].id` | Pattern `V[n]` or `H[n]` with optional `.n` segments — unique across the tree |
+| `capabilities[].id` | Canonical form `CAPABILITY-V[n]` or `CAPABILITY-H[n]` with optional `.n` segments — unique across the tree (see [`IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md) §2) |
 | `capabilities[].name` | Capability name |
 | `capabilities[].current_maturity` | Integer 1–5 (CMMI level) |
 

--- a/notations/examples/capability-map/business.capability-map.transitrix.yaml
+++ b/notations/examples/capability-map/business.capability-map.transitrix.yaml
@@ -6,13 +6,13 @@ version: "1.0"
 date: "2026-05-08"
 
 capability_map:
-  id: CM-BUSINESS-001
+  id: CAPABILITY_MAP-BUSINESS-1
   name: Business Capabilities Map
   description: Core business capabilities with current and target maturity.
   assessment_date: "2026-05-08"
 
   capabilities:
-    - id: V1
+    - id: CAPABILITY-V1
       name: Order Management
       type: domain
       current_maturity: 2
@@ -24,30 +24,30 @@ capability_map:
         - APP-OMS-001
         - APP-CRM-001
       children:
-        - id: V1.1
+        - id: CAPABILITY-V1.1
           name: Order Intake
           type: domain
           current_maturity: 3
           target_maturity: 3
-        - id: V1.2
+        - id: CAPABILITY-V1.2
           name: Order Fulfilment
           type: domain
           current_maturity: 2
           target_maturity: 3
           target_date: "2026-09-30"
           children:
-            - id: V1.2.1
+            - id: CAPABILITY-V1.2.1
               name: Pick & Pack
               type: domain
               current_maturity: 2
               target_maturity: 3
-            - id: V1.2.2
+            - id: CAPABILITY-V1.2.2
               name: Last-mile Delivery
               type: domain
               current_maturity: 1
               target_maturity: 3
 
-    - id: V2
+    - id: CAPABILITY-V2
       name: Customer Relationship Management
       type: domain
       current_maturity: 3
@@ -57,25 +57,25 @@ capability_map:
       applications:
         - APP-CRM-001
       children:
-        - id: V2.1
+        - id: CAPABILITY-V2.1
           name: Customer Acquisition
           type: domain
           current_maturity: 2
           target_maturity: 4
-        - id: V2.2
+        - id: CAPABILITY-V2.2
           name: Customer Service
           type: domain
           current_maturity: 3
           target_maturity: 4
 
-    - id: V3
+    - id: CAPABILITY-V3
       name: Financial Management
       type: domain
       current_maturity: 4
       target_maturity: 5
       owner_role: ROLE-FIN-001
 
-    - id: H1
+    - id: CAPABILITY-H1
       name: Master Data Management
       type: supporting
       description: Cross-cutting capability ensuring data quality across domains.
@@ -83,7 +83,7 @@ capability_map:
       target_maturity: 3
       target_date: "2027-12-31"
 
-    - id: H2
+    - id: CAPABILITY-H2
       name: ESG & Compliance
       type: supporting
       description: Environmental, social, governance, and regulatory compliance.

--- a/notations/examples/capability-map/northbay-retail.capability-map.transitrix.yaml
+++ b/notations/examples/capability-map/northbay-retail.capability-map.transitrix.yaml
@@ -6,13 +6,13 @@ version: "2.0"
 date: "2026-05-12"
 
 capability_map:
-  id: CM-NB-RETAIL-001
+  id: CAPABILITY_MAP-NB-RETAIL-1
   name: NorthBay Retail — Business Capabilities Map
   description: Three core verticals (Customer Engagement, Supply Chain, Financial Management) plus three cross-cutting horizontals (MDM, Cybersecurity, ESG).
   assessment_date: "2026-05-12"
 
   capabilities:
-    - id: V1
+    - id: CAPABILITY-V1
       name: Customer Engagement
       type: domain
       description: All capabilities involved in attracting, retaining, and servicing the customer.
@@ -24,44 +24,44 @@ capability_map:
         - APP-CRM-001
         - APP-MARKETING-CLOUD-001
       children:
-        - id: V1.1
+        - id: CAPABILITY-V1.1
           name: Marketing
           type: domain
           current_maturity: 2
           target_maturity: 4
           target_date: "2027-06-30"
           children:
-            - id: V1.1.1
+            - id: CAPABILITY-V1.1.1
               name: Campaign Management
               type: domain
               current_maturity: 2
               target_maturity: 4
               owner_role: ROLE-MKTG-001
-            - id: V1.1.2
+            - id: CAPABILITY-V1.1.2
               name: Loyalty Programmes
               type: domain
               current_maturity: 3
               target_maturity: 4
               owner_role: ROLE-LOYALTY-001
-            - id: V1.1.3
+            - id: CAPABILITY-V1.1.3
               name: Brand & Content
               type: domain
               current_maturity: 2
               target_maturity: 3
-        - id: V1.2
+        - id: CAPABILITY-V1.2
           name: Sales Channels
           type: domain
           current_maturity: 2
           target_maturity: 4
           target_date: "2027-12-31"
           children:
-            - id: V1.2.1
+            - id: CAPABILITY-V1.2.1
               name: In-store Retail
               type: domain
               current_maturity: 3
               target_maturity: 4
               owner_role: Director of Retail Operations
-            - id: V1.2.2
+            - id: CAPABILITY-V1.2.2
               name: E-commerce
               type: domain
               current_maturity: 2
@@ -70,35 +70,35 @@ capability_map:
               applications:
                 - APP-OMS-001
                 - APP-WEB-STORE-001
-            - id: V1.2.3
+            - id: CAPABILITY-V1.2.3
               name: Mobile App Commerce
               type: domain
               current_maturity: 1
               target_maturity: 3
               target_date: "2026-12-31"
-        - id: V1.3
+        - id: CAPABILITY-V1.3
           name: Customer Service
           type: domain
           current_maturity: 2
           target_maturity: 4
           children:
-            - id: V1.3.1
+            - id: CAPABILITY-V1.3.1
               name: Pre-sale Support
               type: domain
               current_maturity: 2
               target_maturity: 3
-            - id: V1.3.2
+            - id: CAPABILITY-V1.3.2
               name: Post-sale Service
               type: domain
               current_maturity: 2
               target_maturity: 4
-            - id: V1.3.3
+            - id: CAPABILITY-V1.3.3
               name: Returns & Refunds
               type: domain
               current_maturity: 3
               target_maturity: 4
 
-    - id: V2
+    - id: CAPABILITY-V2
       name: Supply Chain Management
       type: domain
       description: From supplier selection through inbound logistics to last-mile delivery.
@@ -107,64 +107,64 @@ capability_map:
       target_date: "2027-09-30"
       owner_role: ROLE-CSCO-001
       children:
-        - id: V2.1
+        - id: CAPABILITY-V2.1
           name: Sourcing & Procurement
           type: domain
           current_maturity: 3
           target_maturity: 4
           children:
-            - id: V2.1.1
+            - id: CAPABILITY-V2.1.1
               name: Supplier Management
               type: domain
               current_maturity: 3
               target_maturity: 4
-            - id: V2.1.2
+            - id: CAPABILITY-V2.1.2
               name: Contract Negotiation
               type: domain
               current_maturity: 2
               target_maturity: 4
-        - id: V2.2
+        - id: CAPABILITY-V2.2
           name: Inventory Management
           type: domain
           current_maturity: 3
           target_maturity: 5
           target_date: "2027-12-31"
           children:
-            - id: V2.2.1
+            - id: CAPABILITY-V2.2.1
               name: Demand Forecasting
               type: domain
               current_maturity: 2
               target_maturity: 5
               target_date: "2027-06-30"
-            - id: V2.2.2
+            - id: CAPABILITY-V2.2.2
               name: Replenishment
               type: domain
               current_maturity: 3
               target_maturity: 5
-            - id: V2.2.3
+            - id: CAPABILITY-V2.2.3
               name: Allocation & Assortment
               type: domain
               current_maturity: 3
               target_maturity: 4
-        - id: V2.3
+        - id: CAPABILITY-V2.3
           name: Logistics
           type: domain
           current_maturity: 3
           target_maturity: 4
           children:
-            - id: V2.3.1
+            - id: CAPABILITY-V2.3.1
               name: Inbound Logistics
               type: domain
               current_maturity: 4
               target_maturity: 4
-            - id: V2.3.2
+            - id: CAPABILITY-V2.3.2
               name: Outbound Logistics & Last-mile
               type: domain
               current_maturity: 2
               target_maturity: 4
               target_date: "2027-09-30"
 
-    - id: V3
+    - id: CAPABILITY-V3
       name: Financial Management
       type: domain
       description: Treasury, accounting, controlling, tax.
@@ -172,24 +172,24 @@ capability_map:
       target_maturity: 5
       owner_role: ROLE-FIN-001
       children:
-        - id: V3.1
+        - id: CAPABILITY-V3.1
           name: Treasury & Cash Management
           type: domain
           current_maturity: 4
           target_maturity: 5
-        - id: V3.2
+        - id: CAPABILITY-V3.2
           name: Accounting & Reporting
           type: domain
           current_maturity: 4
           target_maturity: 5
           target_date: "2026-12-31"
-        - id: V3.3
+        - id: CAPABILITY-V3.3
           name: Controlling & Planning
           type: domain
           current_maturity: 3
           target_maturity: 5
 
-    - id: H1
+    - id: CAPABILITY-H1
       name: Master Data Management
       type: supporting
       description: Cross-cutting capability ensuring product, customer, and supplier data quality across all domains.
@@ -198,7 +198,7 @@ capability_map:
       target_date: "2027-12-31"
       owner_role: ROLE-DATAGOV-001
 
-    - id: H2
+    - id: CAPABILITY-H2
       name: Cybersecurity
       type: supporting
       description: Information security, identity & access management, incident response.
@@ -207,7 +207,7 @@ capability_map:
       target_date: "2027-06-30"
       owner_role: ROLE-CISO-001
 
-    - id: H3
+    - id: CAPABILITY-H3
       name: ESG & Compliance
       type: supporting
       description: Environmental reporting, social responsibility, regulatory compliance across all markets.

--- a/notations/examples/process-map/README.md
+++ b/notations/examples/process-map/README.md
@@ -40,7 +40,7 @@ notation: process-map
 | Field | Description |
 |---|---|
 | `owner_role` | Responsible role |
-| `capability` | Capability ID this process realises (e.g. `V1`, `H1`) |
+| `capability` | Capability ID this process realises (canonical form, e.g. `CAPABILITY-V1`, `CAPABILITY-H1`) |
 | `maturity` | Integer 1–5 |
 | `bpmn_file` | Path to the detailed BPMN diagram |
 | `description` | Short description |

--- a/notations/examples/process-map/enterprise.process-map.transitrix.yaml
+++ b/notations/examples/process-map/enterprise.process-map.transitrix.yaml
@@ -21,7 +21,7 @@ process_map:
         - process_id: PROC-ORD-FULFILL-001
           name: Order Fulfilment
           owner_role: ROLE-OPS-001
-          capability: V1
+          capability: CAPABILITY-V1
           maturity: 3
           status: Active
           bpmn_file: views/bpmn/ORDER_FULFILLMENT_process.bpmn.transitrix.yaml
@@ -29,13 +29,13 @@ process_map:
         - process_id: PROC-CUST-ONBOARD-001
           name: Customer Onboarding
           owner_role: ROLE-SALES-001
-          capability: V2
+          capability: CAPABILITY-V2
           maturity: 2
           status: Active
         - process_id: PROC-DELIV-001
           name: Last-mile Delivery
           owner_role: ROLE-LOG-001
-          capability: V1
+          capability: CAPABILITY-V1
           maturity: 1
           status: Draft
 

--- a/notations/examples/process-map/northbay-retail.process-map.transitrix.yaml
+++ b/notations/examples/process-map/northbay-retail.process-map.transitrix.yaml
@@ -21,20 +21,20 @@ process_map:
         - process_id: PROC-NB-SOURCE-001
           name: Strategic Sourcing
           owner_role: ROLE-SOURCING-001
-          capability: V2.1.1
+          capability: CAPABILITY-V2.1.1
           maturity: 3
           status: Active
           description: Identify, evaluate, and onboard strategic suppliers.
         - process_id: PROC-NB-PURCHASE-001
           name: Purchase Order Processing
           owner_role: ROLE-PROC-001
-          capability: V2.1
+          capability: CAPABILITY-V2.1
           maturity: 4
           status: Active
         - process_id: PROC-NB-INV-FORECAST-001
           name: Demand Forecasting
           owner_role: ROLE-SUPPLY-001
-          capability: V2.2.1
+          capability: CAPABILITY-V2.2.1
           maturity: 2
           status: Active
           bpmn_file: views/bpmn/DEMAND_FORECAST_process.bpmn.transitrix.yaml
@@ -42,45 +42,45 @@ process_map:
         - process_id: PROC-NB-INV-REPLEN-001
           name: Store Replenishment
           owner_role: ROLE-INV-001
-          capability: V2.2.2
+          capability: CAPABILITY-V2.2.2
           maturity: 3
           status: Active
         - process_id: PROC-NB-RECEIVE-001
           name: Inbound Receiving
           owner_role: ROLE-WH-001
-          capability: V2.3.1
+          capability: CAPABILITY-V2.3.1
           maturity: 4
           status: Active
         - process_id: PROC-NB-ORD-FULFILL-001
           name: Online Order Fulfilment
           owner_role: ROLE-FULFILL-001
-          capability: V1.2.2
+          capability: CAPABILITY-V1.2.2
           maturity: 3
           status: Active
           bpmn_file: views/bpmn/ORDER_FULFILLMENT_process.bpmn.transitrix.yaml
         - process_id: PROC-NB-DELIVERY-001
           name: Last-mile Delivery
           owner_role: ROLE-LOG-001
-          capability: V2.3.2
+          capability: CAPABILITY-V2.3.2
           maturity: 2
           status: Active
           description: Self-operated and 3PL hybrid delivery to home and pickup points.
         - process_id: PROC-NB-CUST-ONBOARD-001
           name: Customer Onboarding & Account Creation
           owner_role: ROLE-DIGITAL-001
-          capability: V1.2
+          capability: CAPABILITY-V1.2
           maturity: 2
           status: Active
         - process_id: PROC-NB-RETURNS-001
           name: Returns & Refunds Processing
           owner_role: ROLE-CS-001
-          capability: V1.3.3
+          capability: CAPABILITY-V1.3.3
           maturity: 3
           status: Active
         - process_id: PROC-NB-LOYALTY-001
           name: Loyalty Programme Operations
           owner_role: ROLE-LOYALTY-001
-          capability: V1.1.2
+          capability: CAPABILITY-V1.1.2
           maturity: 3
           status: Active
 
@@ -102,20 +102,20 @@ process_map:
         - process_id: PROC-NB-FIN-CLOSE-001
           name: Monthly Financial Close
           owner_role: ROLE-CONTROLLER-001
-          capability: V3.2
+          capability: CAPABILITY-V3.2
           maturity: 4
           status: Active
         - process_id: PROC-NB-IT-INCIDENT-001
           name: IT Incident Response
           owner_role: ROLE-IT-001
-          capability: H2
+          capability: CAPABILITY-H2
           maturity: 2
           status: Active
           description: 24/7 incident response with severity-based escalation.
         - process_id: PROC-NB-MKT-CAMPAIGN-001
           name: Marketing Campaign Management
           owner_role: ROLE-MKTG-001
-          capability: V1.1.1
+          capability: CAPABILITY-V1.1.1
           maturity: 2
           status: Active
         - process_id: PROC-NB-LEGAL-REVIEW-001
@@ -126,13 +126,13 @@ process_map:
         - process_id: PROC-NB-VENDOR-MGT-001
           name: Vendor Management
           owner_role: ROLE-VENDOR-001
-          capability: V2.1.1
+          capability: CAPABILITY-V2.1.1
           maturity: 3
           status: Active
         - process_id: PROC-NB-DATA-QUALITY-001
           name: Master Data Quality Reviews
           owner_role: ROLE-DATAGOV-001
-          capability: H1
+          capability: CAPABILITY-H1
           maturity: 1
           status: Draft
           description: Quarterly product, customer, and supplier MDM audits.
@@ -150,7 +150,7 @@ process_map:
         - process_id: PROC-NB-BUDGET-001
           name: Annual Budget Cycle
           owner_role: ROLE-FIN-001
-          capability: V3.3
+          capability: CAPABILITY-V3.3
           maturity: 4
           status: Active
         - process_id: PROC-NB-RISK-001
@@ -161,7 +161,7 @@ process_map:
         - process_id: PROC-NB-COMPLIANCE-001
           name: Compliance Audit
           owner_role: ROLE-LEGAL-001
-          capability: H3
+          capability: CAPABILITY-H3
           maturity: 2
           status: Active
         - process_id: PROC-NB-PERF-REVIEW-001

--- a/notations/examples/products/portfolio-2026.products.transitrix.yaml
+++ b/notations/examples/products/portfolio-2026.products.transitrix.yaml
@@ -20,9 +20,9 @@ products_catalogue:
       maturity: 4
       description: Self-service analytics and reporting platform for business teams.
       capabilities:
-        - V4.1    # Analytics & Reporting — real-time dashboards
-        - V4.2    # Analytics & Reporting — predictive analytics
-        - H1      # Master Data Management — data cataloguing
+        - CAPABILITY-V4.1    # Analytics & Reporting — real-time dashboards
+        - CAPABILITY-V4.2    # Analytics & Reporting — predictive analytics
+        - CAPABILITY-H1      # Master Data Management — data cataloguing
       processes:
         - PROC-RPT-001        # Reporting
         - PROC-DATGOV-001     # Data governance
@@ -39,9 +39,9 @@ products_catalogue:
       maturity: 3
       description: End-to-end digital onboarding for new hires.
       capabilities:
-        - V5.1    # HR — document collection
-        - V5.2    # HR — IT provisioning
-        - V5.3    # HR — training assignment
+        - CAPABILITY-V5.1    # HR — document collection
+        - CAPABILITY-V5.2    # HR — IT provisioning
+        - CAPABILITY-V5.3    # HR — training assignment
       processes:
         - PROC-HR-ONBOARD-001     # Employee onboarding
         - PROC-HR-OFFBOARD-001    # Employee offboarding
@@ -67,9 +67,9 @@ products_catalogue:
       maturity: 3
       description: iOS and Android app for customer self-service and account management.
       capabilities:
-        - V2.1    # Customer Acquisition — account management
-        - V1.2    # Order Fulfilment — order tracking
-        - V6.1    # Digital — push notifications
+        - CAPABILITY-V2.1    # Customer Acquisition — account management
+        - CAPABILITY-V1.2    # Order Fulfilment — order tracking
+        - CAPABILITY-V6.1    # Digital — push notifications
 
     - product_id: prod-partner-bundle
       name: Partner Integration Bundle
@@ -80,8 +80,8 @@ products_catalogue:
       maturity: 1
       description: Bundled APIs and support package for strategic partners.
       capabilities:
-        - V6.2    # Digital — partner API access
-        - V6.3    # Digital — co-branded portal
+        - CAPABILITY-V6.2    # Digital — partner API access
+        - CAPABILITY-V6.3    # Digital — co-branded portal
       processes:
         - PROC-PARTNER-ONBOARD-001    # Partner onboarding
 

--- a/organizations/acme_corp/.templates/capability-map_template.yaml
+++ b/organizations/acme_corp/.templates/capability-map_template.yaml
@@ -12,13 +12,13 @@ notation: capability-map
 spec_version: "0.1"
 
 capability_map:
-  id: "CM-DOMAIN-1"                    # CM-<DOMAIN>-<SEQ>
+  id: "CAPABILITY_MAP-DOMAIN-1"        # CAPABILITY_MAP-<DOMAIN>-<SEQ>
   name: "<Domain> Capabilities"
   description: "Capabilities with current and target maturity"
   assessment_date: "2026-01-01"        # YYYY-MM-DD, quoted (CONTRACT.md §4)
 
   capabilities:
-    - id: "V1"                         # vertical address: V1, V1.1, V1.1.1, or H1 …
+    - id: "CAPABILITY-V1"              # canonical capability ID, V/H sub-grammar (see IDS §2)
       name: "<Capability name>"
       type: "domain"                   # domain | supporting   (REQUIRED — also on children)
       current_maturity: 2              # CMM level 1–5 (REQUIRED)
@@ -29,13 +29,13 @@ capability_map:
       applications:                    # optional — ApplicationComponent element IDs
         - "APP-XXX-1"
       children:                        # optional — nested capabilities (same fields)
-        - id: "V1.1"
+        - id: "CAPABILITY-V1.1"
           name: "<Child capability>"
           type: "domain"
           current_maturity: 3
           target_maturity: 3
 
-    - id: "H1"                         # horizontal (cross-cutting) capability
+    - id: "CAPABILITY-H1"              # horizontal (cross-cutting) capability
       name: "<Shared capability>"
       type: "supporting"
       current_maturity: 2

--- a/organizations/acme_corp/canon/views/applications/README.md
+++ b/organizations/acme_corp/canon/views/applications/README.md
@@ -29,7 +29,7 @@ applications_catalogue:
       status: "Active"                  # Draft | Active | Deprecated | Decommissioning
       maturity: 3
       description: "Core system for order lifecycle management"
-      capabilities: ["V1"]
+      capabilities: ["CAPABILITY-V1"]
       products: ["PROD-ECOMM-1"]
       integrations:
         - target: "APP-CRM-1"

--- a/organizations/acme_corp/canon/views/capabilities/README.md
+++ b/organizations/acme_corp/canon/views/capabilities/README.md
@@ -13,13 +13,13 @@ notation: capability-map
 spec_version: "0.1"
 
 capability_map:
-  id: "CM-CUSTOMER-1"
+  id: "CAPABILITY_MAP-CUSTOMER-1"
   name: "Customer-Domain Capabilities"
   description: "Customer-facing capabilities with current and target maturity"
   assessment_date: "2026-05-26"
 
   capabilities:
-    - id: "V1"                          # → canon/elements/02_business/capabilities/V1.yaml
+    - id: "CAPABILITY-V1"               # → canon/elements/02_business/capabilities/CAPABILITY-V1.yaml
       name: "Order Management"
       type: "domain"                    # domain | supporting
       current_maturity: 2
@@ -31,18 +31,18 @@ capability_map:
         - "APP-OMS-1"
         - "APP-CRM-1"
       children:
-        - id: "V1.1"
+        - id: "CAPABILITY-V1.1"
           name: "Order Intake"
           type: "domain"
           current_maturity: 3
           target_maturity: 3
-        - id: "V1.2"
+        - id: "CAPABILITY-V1.2"
           name: "Order Fulfilment"
           type: "domain"
           current_maturity: 2
           target_maturity: 3
           target_date: "2026-09-30"
-    - id: "V2"
+    - id: "CAPABILITY-V2"
       name: "Customer Relationship"
       type: "domain"
       current_maturity: 2
@@ -52,7 +52,7 @@ capability_map:
         - "APP-CRM-1"
 ```
 
-`V1` / `V1.1` are vertical-capability addresses; **every** capability, including children, carries `type` (required). The maturity history of an individual capability lives on its element file, not here.
+`CAPABILITY-V1` / `CAPABILITY-V1.1` are canonical capability IDs (V/H sub-grammar per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §2); **every** capability, including children, carries `type` (required). The maturity history of an individual capability lives on its element file, not here.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/processmap/README.md
+++ b/organizations/acme_corp/canon/views/processmap/README.md
@@ -27,14 +27,14 @@ process_map:
         - process_id: "PROC-ORD-FULFILL-1"   # → canon/elements/02_business/processes/PROC-ORD-FULFILL-1.yaml
           name: "Order Fulfilment"
           owner_role: "ROLE-OPS-1"
-          capability: "V1"
+          capability: "CAPABILITY-V1"
           maturity: 2
           status: "Active"                    # Draft | Active | Deprecated
           bpmn_file: "canon/views/bpmn/order-fulfilment.bpmn.transitrix.yaml"
         - process_id: "PROC-CUST-ONBOARD-1"
           name: "Customer Onboarding"
           owner_role: "ROLE-SALES-1"
-          capability: "V2"
+          capability: "CAPABILITY-V2"
           maturity: 1
           status: "Draft"
 

--- a/organizations/acme_corp/canon/views/products/README.md
+++ b/organizations/acme_corp/canon/views/products/README.md
@@ -28,7 +28,7 @@ products_catalogue:
       status: "Active"                  # Draft | Active | Deprecated
       maturity: 3
       description: "Online storefront and order management for end customers"
-      capabilities: ["V1", "V2"]
+      capabilities: ["CAPABILITY-V1", "CAPABILITY-V2"]
       processes: ["PROC-ORD-FULFILL-1"]
       supporting_apps: ["APP-OMS-1", "APP-CRM-1"]
 
@@ -41,7 +41,7 @@ products_catalogue:
       description: "Tier-1 and Tier-2 support for customers via chat, email, and phone"
 ```
 
-`capabilities`, `processes`, and `supporting_apps` hold **element IDs** (`V1`, `PROC-…`, `APP-…`), not display names — the catalogue references the elements, it does not duplicate them.
+`capabilities`, `processes`, and `supporting_apps` hold **element IDs** (`CAPABILITY-V1`, `PROC-…`, `APP-…`), not display names — the catalogue references the elements, it does not duplicate them.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Resolves the long-standing conflict between `notations/IDS_AND_REFERENCES.md` (§2/§3.2: canonical `CAPABILITY-V1`, doc-id `CAPABILITY_MAP-…`) and `notations/05-capability-map.md` (which had been documenting the bare `V1` / `CM-…` legacy forms). **Option A: IDS wins.**

- `05-capability-map.md` §4 conventions, §12 example, §13 field table, §14 element example → canonical
- Inline spec examples in `06-process-map.md`, `09-products.md`, `10-applications.md` → canonical
- All in-scope `notations/examples/*` (capability-map / process-map / products / applications) → canonical, including the two capability-map example yamls and both process-map example yamls
- `organizations/acme_corp/.templates/capability-map_template.yaml` + `canon/views/{capabilities,applications,products,processmap}/README.md` → canonical
- `notations/IDS_AND_REFERENCES.md` §6 migration rows for `CAP-…` and bare `V1`/`H1` marked **executed 2026-05-28** for the capability-map portion; residual narrowed to scenarios + supporting docs

## What stayed out of scope (deliberately, per task#81 Outcome list)

These still use legacy forms and remain follow-up §6 work (now explicitly enumerated in the §6 Notes column):

- `notations/11-scenarios.md` + `notations/examples/scenarios/*` (CAP-…, bare V/H)
- `method/methodology.md` prose mentions of V1/H1
- `integration/studio.md` DSM integration doc

Scenarios is a separate family-shape question (see working-rules #1 + #5); not bundled here.

The document-id zero-pad (`CM-BUSINESS-001` → `CAPABILITY_MAP-BUSINESS-1`) is incidental — the new ID has to satisfy IDS §1 "no leading zeros," so dropping `001` → `1` was unavoidable. Not an attempt to execute the zero-padding §6 row.

## Test plan

- [x] All 7 touched `.yaml` files parse cleanly via `python -m yaml safe_load`
- [x] All 11 touched `.md` files end with newline + a complete final line (per working rule #2 — no mid-word truncation)
- [x] No bare `V1` / `H1` / `CM-` / `CAP-…` capability references remain in `notations/{05-capability-map.md,06-process-map.md,09-products.md,10-applications.md}`, `notations/examples/{capability-map,process-map,products,applications}/`, or `organizations/acme_corp/`
- [x] IDS §6 still has both affected rows, with executed/residual annotations
- [ ] (gated by Valerii) merge

Task: `vkgeorgia/strategy#81`. One PR per working rule #1; gated per task acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)