### PR TITLE
Reconcile onboarding Skill to zoned canon/+field/+codex/ + AGENTS.md + transitrix.yaml + codex

### DIFF
--- a/skills/onboarding/README.md
+++ b/skills/onboarding/README.md
@@ -1,11 +1,13 @@
 # Transitrix Onboarding Skill
 
-A Claude Code [Skill](https://docs.claude.com/en/docs/claude-code/skills) that drives a newcomer from zero to a working Transitrix enterprise-as-text repo. After it is installed, the user invokes it with `/transitrix-onboard` (or by describing the goal in plain language), and the agent walks them through scaffolding a repo, picking a starter notation, and authoring their first file with inline canonical validation.
+A Claude Code [Skill](https://docs.claude.com/en/docs/claude-code/skills) that drives a newcomer from zero to a working Transitrix enterprise-as-text repo. After it is installed, the user invokes it with `/transitrix-onboard` (or by describing the goal in plain language), and the agent walks them through scaffolding the canonical zoned (`canon/` + `field/` + `codex/`) adopter shape, picking a starter notation, and authoring their first file with inline canonical validation.
 
-This directory is the **source bundle** for that skill. The bundle ships:
+The skill itself runs in Claude Code. What it **scaffolds** for the adopter is assistant-neutral: the agent guide it drops in is `AGENTS.md` (read by any tool that supports the AGENTS.md convention), plus a `.github/copilot-instructions.md` pointer for GitHub Copilot. Adopters on Cursor / Claude Code / other tools add a one-line pointer in their tool's location.
 
-- [`SKILL.md`](SKILL.md) — the agent-facing protocol (frontmatter + the six-step flow + an embedded cheat sheet for the 13 notations).
-- [`templates/`](templates/) — one starter `.transitrix.yaml` per notation. Each template carries the canonical `notation:` and `spec_version:` headers, the canonical root shape, and `FILL-ME` placeholders.
+This directory is the **source bundle** for the skill. The bundle ships:
+
+- [`SKILL.md`](SKILL.md) — the agent-facing protocol (frontmatter + the six-step flow + an embedded cheat sheet for the 13 view notations + codex zone primitives).
+- [`templates/`](templates/) — starter files in three groups: **root scaffolding** (`transitrix.yaml` manifest + assistant-neutral `AGENTS.md` + GitHub Copilot pointer), **view notations** (one `.transitrix.yaml` per view notation), and **codex zone primitives** (external + internal).
 
 The skill is **read-only** against the methodology repo. It does not ship the canon — when the user goes deeper than the embedded cheat sheet, the skill fetches the full spec from `github.com/transitrix/methodology` via `WebFetch`.
 
@@ -53,9 +55,9 @@ Once installed, invoke the skill in three ways:
 Once invoked, the agent runs the six-step flow documented in [`SKILL.md`](SKILL.md):
 
 1. **Confirm intent and surface area.** Asks which notation you want to start with (showing the family-selection matrix), and how deep an explanation you want.
-2. **Scaffold the repo.** Creates the canonical `organizations/<org>/{elements,views}/...` tree plus `.gitignore` and a README stub.
-3. **Create the starter notation file from a template.** Copies the right template from [`templates/`](templates/) into the matching `views/<notation>/` subfolder. Renames it to `<DOMAIN>.<short-name>.transitrix.yaml`.
-4. **Interactive authoring with inline validation.** Walks the user through the placeholders one at a time and validates after each meaningful edit. Validation errors are surfaced by their canonical code (e.g. `FGCA-009 — change references unknown goal`).
+2. **Scaffold the repo.** Creates the canonical zoned tree (`canon/{elements,views}`, `field/{interviews,surveys,observations,drafts}`, `codex/{external/<jurisdiction>,internal}`), drops the `transitrix.yaml` manifest at the root, drops the assistant-neutral `AGENTS.md` agent guide and the `.github/copilot-instructions.md` pointer, and initialises `.gitignore` + a README stub.
+3. **Create the starter notation file from a template.** For view notations, copies the matching template from [`templates/`](templates/) into the right `canon/views/<notation>/` subfolder and renames it to `<DOMAIN>.<short-name>.transitrix.yaml`. For codex artefacts, copies a codex-external or codex-internal template into `codex/external/<jurisdiction>/<ID>.yaml` or `codex/internal/<ID>.yaml`.
+4. **Interactive authoring with inline validation.** Walks the user through the placeholders one at a time and validates after each meaningful edit. Validation errors are surfaced by their canonical code (e.g. `FGCA-009 — change references unknown goal`, `CODEX-001 — jurisdiction folder mismatch`).
 5. **Hand off to Transitrix Studio.** Points the user at the VS Code extension for live preview, or at `npx @transitrix/cli validate` for CLI-only workflows.
 6. **Suggest next steps.** Proposes one — and only one — adjacent artefact in the family (e.g. "you built a Goals tree, the natural next step is an FGCA").
 
@@ -65,7 +67,19 @@ The agent never silently rewrites the user's content. If a validation rule fails
 
 ## What's in `templates/`
 
-One starter YAML per notation, named `<notation>.<short-name>.transitrix.yaml` so the file extension already matches the canonical Studio recogniser. The 13 templates are:
+Three groups: root scaffolding, view notations, and codex zone primitives.
+
+### Root scaffolding (dropped into repo root in Step 2)
+
+| Purpose | Template | Destination in adopter repo |
+|---|---|---|
+| Adopter manifest (methodology version + notations + zones) | [`transitrix.yaml`](templates/transitrix.yaml) | `<repo-root>/transitrix.yaml` |
+| Assistant-neutral agent guide | [`AGENTS.md`](templates/AGENTS.md) | `<repo-root>/AGENTS.md` |
+| GitHub Copilot pointer → `AGENTS.md` | [`copilot-instructions.md`](templates/copilot-instructions.md) | `<repo-root>/.github/copilot-instructions.md` |
+
+### View notations (dropped into `canon/views/<notation>/` in Step 3)
+
+One starter YAML per view notation, named `<notation>.<short-name>.transitrix.yaml` so the file extension already matches the canonical Studio recogniser. The 13 view templates are:
 
 | Notation | Template |
 |---|---|
@@ -82,6 +96,15 @@ One starter YAML per notation, named `<notation>.<short-name>.transitrix.yaml` s
 | Products | [`products.products.transitrix.yaml`](templates/products.products.transitrix.yaml) |
 | Issues | [`issues.issues.transitrix.yaml`](templates/issues.issues.transitrix.yaml) |
 | Process Blueprint | [`process-blueprint.process-blueprint.transitrix.yaml`](templates/process-blueprint.process-blueprint.transitrix.yaml) |
+
+### Codex zone primitives (dropped into `codex/external/<jurisdiction>/` or `codex/internal/` in Step 3)
+
+Codex artefacts are zone primitives, not view documents — each is a single `<ID>.yaml` named by its canonical ID, carrying no `notation:` header. Schema: `notations/14-codex.md`.
+
+| Sub-zone | Template | Destination in adopter repo |
+|---|---|---|
+| External (laws, regulations) | [`codex-external.yaml`](templates/codex-external.yaml) | `codex/external/<jurisdiction>/<ID>.yaml` |
+| Internal (policies, standards) | [`codex-internal.yaml`](templates/codex-internal.yaml) | `codex/internal/<ID>.yaml` |
 
 Each template parses cleanly under its canonical validator out of the box — the user just replaces the `FILL-ME` markers.
 

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Transitrix Onboarding
-description: Scaffold a new Transitrix architecture-as-text repository and drive a first modelling session — enterprise architecture (BPMN, FGCA / FGA / Goals, capability map, process blueprint, activities network, blocks, scenarios, issues, products, applications). Use when the user wants to start a new Transitrix repo from scratch, or has just cloned one and wants to author their first notation file with validation.
+description: Scaffold a new Transitrix architecture-as-text repository (zoned canon/ + field/ + codex/ layout with assistant-neutral AGENTS.md + transitrix.yaml manifest) and drive a first modelling session — enterprise architecture (BPMN, FGCA / FGA / Goals, capability map, process blueprint, activities network, blocks, scenarios, issues, products, applications) plus codex artefacts (laws, regulations, policies, internal standards). Use when the user wants to start a new Transitrix repo from scratch, or has just cloned one and wants to author their first notation file with validation.
 when_to_use: User says "set up Transitrix", "model my architecture as text", "create a new transitrix repo", "I want to write [FGCA / Goals / capability map / process blueprint / ...] but don't know the schema", or asks to scaffold an organisation-as-text repository following the Transitrix methodology.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
@@ -32,40 +32,61 @@ Do not assume. If the user picks a notation outside the family-selection table, 
 
 ## Step 2 — Scaffold the repo
 
-Create the canonical Transitrix directory tree in the user's chosen target directory:
+Scaffold the canonical **zoned** Transitrix adopter shape in the user's chosen target directory. The shape mirrors the worked example at [`organizations/acme_corp/`](https://github.com/transitrix/methodology/tree/main/organizations/acme_corp) in the methodology repo and is defined for adopters in [`organizations/acme_corp/AGENTS.md`](https://github.com/transitrix/methodology/blob/main/organizations/acme_corp/AGENTS.md) §3.
 
 ```
 <repo-root>/
-├── organizations/
-│   └── <org_name>/
-│       ├── README.md
-│       ├── elements/
-│       │   ├── 01_motivation/
-│       │   │   └── constraints/       # CONSTRAINT-... yaml files (one per file)
-│       │   ├── 02_business/
-│       │   │   └── rules/             # RULE-... yaml files (one per file)
-│       │   ├── 03_application/
-│       │   └── 04_technology/
-│       └── views/
-│           ├── bpmn/
-│           ├── fgca/                  # Factor → Goal → Change → Activity
-│           ├── fga/                   # Factor → Goal → Activity (no Changes)
-│           ├── goals/
-│           ├── capabilities/          # capability-map files
-│           ├── processmap/            # process-map files
-│           ├── activities/
-│           ├── blocks/
-│           ├── scenarios/
-│           ├── issues/
-│           ├── process-blueprint/
-│           ├── products/
-│           └── applications/
-└── .gitignore
+├── transitrix.yaml                 # adopter manifest — methodology version, notations, zones
+├── AGENTS.md                       # assistant-neutral agent guide (canonical for all assistants)
+├── .github/
+│   └── copilot-instructions.md     # pointer → AGENTS.md (GitHub Copilot)
+├── README.md                       # one-paragraph org stub + pointer to the methodology canon
+├── .gitignore
+├── canon/                          # validated model — the authoritative zone
+│   ├── elements/
+│   │   ├── 01_motivation/          # GOAL, CONSTRAINT, FACTOR, …
+│   │   │   └── constraints/        # CONSTRAINT-…-N.yaml (one per file)
+│   │   ├── 02_business/            # ROLE, PROCESS, CAPABILITY, RULE, …
+│   │   │   └── rules/              # RULE-…-N.yaml (one per file)
+│   │   ├── 03_application/         # APPLICATION, INTEGRATION, …
+│   │   └── 04_technology/          # NODE, ARTIFACT, …
+│   └── views/                      # one subfolder per notation
+│       ├── bpmn/   fgca/   fga/   goals/   capabilities/   processmap/
+│       ├── activities/   blocks/   scenarios/
+│       └── applications/   products/   issues/   process-blueprint/
+├── field/                          # raw inputs — not authoritative; provenance is the point
+│   └── interviews/   surveys/   observations/   drafts/
+└── codex/                          # constraints given to the org, faithful to source
+    ├── external/                   # laws & regulations, sub-foldered by jurisdiction
+    │   └── <jurisdiction>/         # ISO 3166-1 alpha-2 (ge, de, …), or `eu` / `intl` reserved
+    └── internal/                   # policies & internal standards the org issues
 ```
 
 Use the org name from step 1 (or ask: "What's the organisation name? — lowercase, hyphens for spaces"). If the directory already exists and isn't empty, **don't overwrite** — confirm with the user before proceeding.
 
-The `views/*` subfolders correspond one-to-one with Transitrix notations. The `views/` folder name is intentionally shorter than the canonical short name in places (`capabilities/`, `processmap/`) — this is the org-side convention and matches the spec's path examples.
+The `canon/views/` folder names are intentionally shorter than the canonical short names in places (`capabilities/`, `processmap/`) — this is the adopter-side convention.
+
+### Drop in the canonical root files
+
+After the directory tree exists, copy the three canonical root files from the skill bundle's `templates/` directory into the repo root:
+
+- `templates/AGENTS.md` → `<repo-root>/AGENTS.md` — the assistant-neutral agent guide. It carries `ADOPTER-FILL-ME` placeholders the user should fill in later (language, confidentiality policy, task source — see its §7–9).
+- `templates/copilot-instructions.md` → `<repo-root>/.github/copilot-instructions.md` — the GitHub Copilot pointer that redirects to `AGENTS.md`.
+- `templates/transitrix.yaml` → `<repo-root>/transitrix.yaml` — the adopter manifest (schema: `notations/MANIFEST.md`). After copying, edit `notations:` to list only the notations the user picked in step 1 (plus `codex` if they will use the codex zone), and `zones:` to the subset of `canon, field, codex` they will maintain.
+
+**Do not scaffold a Claude-specific `CLAUDE.md` agent guide.** The canonical guide for every assistant is `AGENTS.md`. If the user is on a tool that doesn't read `AGENTS.md` natively (e.g. Claude Code looks for `CLAUDE.md`, Cursor looks for `.cursor/rules/`), drop a one-line pointer file in that tool's location that reads *"Read `AGENTS.md` in the repo root and follow it."* The guidance itself stays in `AGENTS.md` only — see `AGENTS.md` §"Using this guide with your assistant".
+
+### Three zones — what gets scaffolded
+
+The adopter manifest's `zones:` field selects which of `canon` / `field` / `codex` the repo maintains. Scaffold all three folders by default unless the user explicitly opts out — empty zones cost nothing and keep the layout consistent.
+
+- **`canon/`** — validated truth the organisation asserts. Authoritative; internally consistent. View notation files live in `canon/views/<notation>/`; reusable elements live in `canon/elements/<NN>_<layer>/`.
+- **`field/`** — raw, unprocessed material (interviews, surveys, observations, drafts). Contradictions allowed; provenance is the point. **Not** authoritative. A Canon record may *cite* a Field artefact via `derived_from:` — a citation, not a migration.
+- **`codex/`** — external constraints (laws, regulations) under `codex/external/<jurisdiction>/`, plus internal authority documents (policies, standards) under `codex/internal/`. Faithful to source; not edited to fit the model. See `notations/14-codex.md` and Step 3 below for how to seed a first codex artefact.
+
+Each artefact in any zone carries an **admission record** (`zone`, `admitted_at`, `admitted_by`, `gate_checks`, optional `derived_from`) defined in `notations/CONTRACT.md` §6. The codex and field templates ship with this record pre-filled with placeholders.
+
+### .gitignore
 
 Initialise `.gitignore`:
 
@@ -75,22 +96,33 @@ node_modules/
 .transitrix-cache/
 ```
 
-Initialise `organizations/<org>/README.md` with a one-paragraph stub naming the org and pointing at `github.com/transitrix/methodology` for the methodology canon.
-
 Don't run `git init` unless the user asked for it.
 
 ---
 
 ## Step 3 — Create the starter notation file from a template
 
-Take the user's chosen notation from step 1. Copy the matching template from `${CLAUDE_SKILL_DIR}/templates/` into the right `views/<notation>/` subfolder of the new repo. The 13 templates are listed in § Templates below.
+Take the user's chosen notation from step 1. Copy the matching template from `${CLAUDE_SKILL_DIR}/templates/` into the right zone of the new repo. The templates are listed in § Templates below.
 
-Naming convention for view files: `<DOMAIN>.<short-name>.transitrix.yaml`. Ask the user for a short domain code (e.g. `strategy-2026`, `ORDER_FULFILMENT`, `CUSTOMER_ONBOARDING`). If they give a long name, suggest a kebab-case form.
+### View notations (canon zone)
+
+For any of the 13 view notations (FGCA / FGA / Goals / Capability map / Process map / BPMN / Activities / Blocks / Scenarios / Applications / Products / Issues / Process Blueprint), the destination is `canon/views/<notation-folder>/`. Naming convention: `<DOMAIN>.<short-name>.transitrix.yaml`. Ask the user for a short domain code (e.g. `strategy-2026`, `ORDER_FULFILMENT`, `CUSTOMER_ONBOARDING`). If they give a long name, suggest a kebab-case form.
 
 After the copy:
 - Open the file and read it to the user (or summarise its structure).
 - Point at the placeholder values they need to fill in — they all carry `FILL-ME` markers.
 - The template carries the canonical `notation:` and `spec_version:` headers, the canonical root key, and one minimal placeholder element per layer. **Do not strip the headers** — the canonical header is required by `notations/CONTRACT.md`.
+
+### Codex artefacts (codex zone)
+
+Codex artefacts are **zone primitives**, not view documents — they are individual `<ID>.yaml` files, one artefact per file, named by their canonical ID. They carry **no** `notation:` header (different shape from view notations; schema in `notations/14-codex.md`).
+
+If the user wants to seed a first codex artefact:
+
+- **External** (law / regulation given to the org by outside authority) — copy `templates/codex-external.yaml` to `codex/external/<jurisdiction>/<ID>.yaml`. Rename the file to the artefact's canonical ID (e.g. `LAW-PERSONAL-DATA-2017-1.yaml`, `REGULATION-GDPR-2016-1.yaml`). The `<jurisdiction>` folder MUST match the `jurisdiction:` field inside the file (rule `CODEX-001`) — use ISO 3166-1 alpha-2 (`ge`, `de`, …), `eu` for EU-wide, or `intl` (reserved).
+- **Internal** (policy / standard the org issues to itself) — copy `templates/codex-internal.yaml` to `codex/internal/<ID>.yaml`. Internal artefacts are not foldered by jurisdiction. Rename the file to the artefact's canonical ID (e.g. `POLICY-DATA-RETENTION-1.yaml`, `INTERNAL_STANDARD-coding-conventions-1.yaml`).
+
+Update the `id:`, `name:`, `description:`, the admission record (`admitted_at`, `admitted_by`, `gate_checks.source_authority`), the codex-specific fields (`jurisdiction` + `effective_date` + `applies_to` for external; `issuing_authority` + `effective_date` + `applies_to` for internal), and the cross-references in `applies_to.entities[]` / `applies_to.processes[]` so they point at real canonical IDs in `canon/elements/`.
 
 ---
 
@@ -166,6 +198,18 @@ Use the matrix below to pick a notation. Full specs at `notations/<NN>-<name>.md
 
 **Family rule:** all four strategy-chain notations (FGCA, FGA, Goals, Activities) use the **flat form** — top-level arrays at the document root, hierarchy via `parent` / cross-references inside the flat array. No nested wrapper keys.
 
+### Zone primitives — not view documents
+
+A separate set of artefacts lives in the `field/` and `codex/` zones as one-file-per-record YAML, **not** as `.transitrix.yaml` view documents. They carry no `notation:` header. Use these when the situation is:
+
+| Situation | Zone | Location | TYPE |
+|---|---|---|---|
+| External law or regulation binding the org | **codex** | `codex/external/<jurisdiction>/<ID>.yaml` | `LAW` / `REGULATION` |
+| Internal policy or standard the org issues to itself | **codex** | `codex/internal/<ID>.yaml` | `POLICY` / `INTERNAL_STANDARD` |
+| Recorded interview / survey / observation / draft | **field** | `field/<sub>/<ID>.yaml` | `INTERVIEW` / `SURVEY` / `OBSERVATION` / `DRAFT` |
+
+Schema: `notations/14-codex.md` for codex; `notations/CONTRACT.md` §5–6 for the zone model and admission record shared across all three zones; `notations/IDS_AND_REFERENCES.md` §3.4 + §3.5 for the codex / field TYPE registry.
+
 ### One-paragraph summary per notation
 
 - **BPMN** — `notation: bpmn`. One root `process:` with `pools[].lanes[].elements[]` and `flows[]`. Elements typed (`startEvent`, `task`, `exclusiveGateway`, …); flows directed. Compiles to BPMN 2.0 XML.
@@ -181,6 +225,7 @@ Use the matrix below to pick a notation. Full specs at `notations/<NN>-<name>.md
 - **Products catalogue** — `notation: products`. Inventory of `PRODUCT-…` elements grouped by category.
 - **Issues register** — `notation: issues`. Root key `issues_catalogue:` with `issues[]`. Each issue: `issue_id`, `name`, `status` (`open` / `in_progress` / `blocked` / `resolved` / `closed`), optional `parent`, `description`, `relates_to`, `owner_role`. Hierarchy via `parent`.
 - **Process Blueprint** — `notation: process-blueprint`. Root key `process_blueprint:` with `stages[]` (each carrying `goal` and `result`) and per-aspect arrays `systems[]`, `actors[]`, `equipment[]`, `information_entities[]`. Aspect entries reference the stages they appear in via `stages: [STAGE-…]`.
+- **Codex** *(zone primitives, not a view document)* — each artefact is a single `<ID>.yaml` file under `codex/external/<jurisdiction>/` (external: `LAW` / `REGULATION`) or `codex/internal/` (internal: `POLICY` / `INTERNAL_STANDARD`). No `notation:` header; carries the admission record (`CONTRACT.md` §6, `zone: codex`, `gate_checks.source_authority`) plus codex frontmatter (external: `jurisdiction`, `effective_date`, `applies_to`; internal: `issuing_authority`, `effective_date`, `applies_to`).
 
 ### ID grammar — canon
 
@@ -197,12 +242,19 @@ When in doubt, fetch the registry: `WebFetch https://raw.githubusercontent.com/t
 
 ## Templates
 
-The `${CLAUDE_SKILL_DIR}/templates/` directory contains one starter file per notation. Each template:
+The `${CLAUDE_SKILL_DIR}/templates/` directory contains starter files in three groups: **root scaffolding** (manifest + agent guide + Copilot pointer), **view notations** (one per `.transitrix.yaml` notation, placed in `canon/views/<notation>/`), and **codex zone primitives** (placed in `codex/external/<jurisdiction>/` or `codex/internal/`).
 
-- Carries the canonical `notation:` and `spec_version:` headers (per `notations/CONTRACT.md`).
-- Uses the canonical root key (or flat top-level arrays for the strategy-chain four).
-- Has placeholder values labelled `FILL-ME` so the user can find them.
-- Includes minimal cross-references so the placeholder file parses cleanly under the canonical validator.
+Each notation template carries the canonical `notation:` and `spec_version:` headers (per `notations/CONTRACT.md`), uses the canonical root key (or flat top-level arrays for the strategy-chain four), has placeholders labelled `FILL-ME`, and parses cleanly under the canonical validator.
+
+### Root scaffolding (drop into repo root in Step 2)
+
+| File | Template | Destination |
+|---|---|---|
+| Adopter manifest | `templates/transitrix.yaml` | `<repo-root>/transitrix.yaml` |
+| Agent guide (assistant-neutral) | `templates/AGENTS.md` | `<repo-root>/AGENTS.md` |
+| GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
+
+### View notations (drop into `canon/views/<notation-folder>/` in Step 3)
 
 | Notation | Template file |
 |---|---|
@@ -220,6 +272,15 @@ The `${CLAUDE_SKILL_DIR}/templates/` directory contains one starter file per not
 | Issues | `templates/issues.issues.transitrix.yaml` |
 | Process Blueprint | `templates/process-blueprint.process-blueprint.transitrix.yaml` |
 
+### Codex zone primitives (drop into `codex/external/<jurisdiction>/` or `codex/internal/` in Step 3)
+
+| Sub-zone | Template file | Destination |
+|---|---|---|
+| External (laws, regulations) | `templates/codex-external.yaml` | `codex/external/<jurisdiction>/<ID>.yaml` |
+| Internal (policies, standards) | `templates/codex-internal.yaml` | `codex/internal/<ID>.yaml` |
+
+Codex artefacts carry no `notation:` header (they are zone primitives, not view documents). Schema: `notations/14-codex.md`.
+
 ---
 
 ## Reference reads on demand
@@ -227,9 +288,11 @@ The `${CLAUDE_SKILL_DIR}/templates/` directory contains one starter file per not
 When the user goes deeper than this cheat sheet covers, fetch the canonical spec:
 
 - ID grammar / TYPE registry: `https://raw.githubusercontent.com/transitrix/methodology/main/notations/IDS_AND_REFERENCES.md`
-- Shared file-header contract: `https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md`
+- Shared file-header contract + zone model + admission record: `https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md`
+- Adopter manifest schema (`transitrix.yaml`): `https://raw.githubusercontent.com/transitrix/methodology/main/notations/MANIFEST.md`
 - Notation index + family selection: `https://raw.githubusercontent.com/transitrix/methodology/main/notations/README.md`
-- Per-notation full specs: `https://raw.githubusercontent.com/transitrix/methodology/main/notations/<NN>-<short-name>.md`
+- Per-notation full specs: `https://raw.githubusercontent.com/transitrix/methodology/main/notations/<NN>-<short-name>.md` (including `14-codex.md` for the codex zone)
+- Worked adopter example (the shape this skill scaffolds): `https://raw.githubusercontent.com/transitrix/methodology/main/organizations/acme_corp/AGENTS.md`
 
 Read sparingly — the cheat sheet above is enough for 80% of cases. Pull the full spec only when the user hits a validation rule they want to understand, or asks for a field's semantics that the summary doesn't cover.
 

--- a/skills/onboarding/templates/AGENTS.md
+++ b/skills/onboarding/templates/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — adopter-repo agent guide
 
-> **Draft.** This file is shipped as part of the `acme_corp` template, so every adopter starts with sensible agent guidance out of the box. After you clone `acme_corp` into your own repo, edit the placeholders marked `ADOPTER-FILL-ME` to fit your situation. Treat this draft as a starting point, not a finished policy.
+> **Draft.** This file is scaffolded by the Transitrix onboarding Skill so every adopter starts with sensible agent guidance out of the box. After scaffolding, edit the placeholders marked `ADOPTER-FILL-ME` to fit your situation. Treat this draft as a starting point, not a finished policy.
 
 This file tells **any AI coding assistant** — Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or another — operating inside an **adopter's** Transitrix repository how to behave. It is intentionally tool-neutral. It does **not** apply to assistants working on the methodology canon itself — that's a different repository with its own agent guide.
 
@@ -24,8 +24,8 @@ What lives here:
 - `field/` — **raw, unprocessed inputs**: interviews, surveys, observations, drafts.
 - `codex/` — **external constraints** (laws, regulations) and **internal authority documents** (policies, standards).
 - `transitrix.yaml` — the adopter manifest: which methodology version, notations, and zones this repo uses.
-- `.templates/` — starter files the adopter copies when creating new elements / views.
-- `README.md`, `GETTING_STARTED.md`, `CONVENTIONS.md` — adopter-facing onboarding docs.
+- `.templates/` *(optional)* — starter files the adopter copies when creating new elements / views.
+- `README.md` — adopter-facing overview (purpose, layout, how to contribute).
 
 The agent's job is to **maintain the model** — validate, refactor, extend, and explain it. The agent does not invent the methodology; it consults the canon at [github.com/transitrix/methodology](https://github.com/transitrix/methodology) when in doubt.
 
@@ -38,6 +38,7 @@ The canonical Transitrix methodology lives at [github.com/transitrix/methodology
 - Notation schemas (`notations/<NN>-<name>.md`).
 - Shared header contract (`notations/CONTRACT.md`).
 - ID grammar and TYPE registry (`notations/IDS_AND_REFERENCES.md`).
+- Adopter manifest schema (`notations/MANIFEST.md`).
 - Notation index (`notations/README.md`).
 
 **Resolution order when a local file and the canon disagree:**
@@ -54,7 +55,7 @@ If the Transitrix onboarding Skill (`/transitrix-onboard`) is available, the age
 
 ## 3. Repository layout
 
-The canonical layout an adopter inherits from the `acme_corp` template:
+The canonical layout an adopter inherits when scaffolded by `/transitrix-onboard`:
 
 ```
 <repo-root>/
@@ -63,29 +64,24 @@ The canonical layout an adopter inherits from the `acme_corp` template:
 ├── .github/
 │   └── copilot-instructions.md     # pointer → AGENTS.md (GitHub Copilot)
 ├── README.md
-├── GETTING_STARTED.md
-├── CONVENTIONS.md
-├── .templates/                     # starter files to copy (not zoned)
-│   ├── elements/
-│   ├── relations/
-│   └── bpmn/
 ├── canon/                          # validated model — the authoritative zone
 │   ├── elements/                   # elements by ArchiMate layer
-│   │   ├── 01_motivation/          # GOAL, PRINCIPLE, CONSTRAINT, DRIVER, OUTCOME, VALUE
-│   │   ├── 02_business/            # ROLE, ACTOR, PROCESS, FUNCTION, SERVICE
-│   │   ├── 03_application/         # APPLICATION, SERVICE, INTERFACE, DATA_OBJECT
-│   │   └── 04_technology/          # NODE, ARTIFACT, DEVICE, …
-│   └── views/                      # one subfolder per notation (extensions in canon/views/README.md)
+│   │   ├── 01_motivation/          # GOAL, CONSTRAINT, FACTOR, …
+│   │   ├── 02_business/            # ROLE, PROCESS, CAPABILITY, RULE, …
+│   │   ├── 03_application/         # APPLICATION, INTEGRATION, …
+│   │   └── 04_technology/          # NODE, ARTIFACT, …
+│   └── views/                      # one subfolder per notation
 │       ├── bpmn/   fgca/   fga/   goals/   capabilities/   processmap/
 │       ├── activities/   blocks/   scenarios/
 │       └── applications/   products/   issues/   process-blueprint/
 ├── field/                          # raw inputs — interviews, surveys, observations, drafts
+│   ├── interviews/   surveys/   observations/   drafts/
 └── codex/                          # external laws/regulations + internal policies/standards
-    ├── external/<jurisdiction>/    # ge/  de/  eu/  …
+    ├── external/<jurisdiction>/    # ge/  de/  eu/  … (ISO 3166-1 alpha-2, or `eu` / `intl`)
     └── internal/
 ```
 
-The `canon/views/` folder names are intentionally shorter than the canonical short names in places (`capabilities/`, `processmap/`) — this is the adopter-side convention and is documented in `canon/views/README.md`.
+The `canon/views/` folder names are intentionally shorter than the canonical short names in places (`capabilities/`, `processmap/`) — this is the adopter-side convention.
 
 The agent does **not** change this layout without a deliberate decision recorded in the adopter's PR. Adopter-specific top-level additions (e.g. a `decisions/` ADR folder, a `glossary/` directory) are fine; renaming or removing the canonical folders is not.
 
@@ -101,7 +97,7 @@ Every artefact carries an **admission record** (`zone`, `admitted_at`, `admitted
 
 ### 3.2 Single-entity vs holding layout
 
-- **Single legal entity** — the repo root *is* the organisation: `canon/`, `field/`, `codex/`, and `transitrix.yaml` sit at the root (the `acme_corp` shape above).
+- **Single legal entity** — the repo root *is* the organisation: `canon/`, `field/`, `codex/`, and `transitrix.yaml` sit at the root (the shape above).
 - **Holding (multiple entities)** — the repo root holds one folder per entity, each with its own `canon/` / `field/` / `codex/`, plus a `_shared/` folder for group-level codex/field that binds several entities:
 
   ```
@@ -141,7 +137,9 @@ The file extension is always `*.<short-name>.transitrix.yaml`. The validator rej
 
 Naming convention for view files: `<DOMAIN>.<short-name>.transitrix.yaml`, where `<DOMAIN>` is a short kebab-case or upper-snake-case label for the area (e.g. `order-fulfilment.bpmn.transitrix.yaml`, `RETENTION-2026.fgca.transitrix.yaml`). One canonical instance per notation per domain.
 
-The agent never strips the `notation:` and `spec_version:` headers, and never introduces alias extensions (`*.bpmn.yaml`, `*.fgca.yml`) — they fail validation.
+Codex artefacts are an exception: they are zone primitives, not view documents. They live at `codex/external/<jurisdiction>/<ID>.yaml` or `codex/internal/<ID>.yaml`, named by their canonical ID, and carry no `notation:` header. Schema: `notations/14-codex.md`.
+
+The agent never strips the `notation:` and `spec_version:` headers from view files, and never introduces alias extensions (`*.bpmn.yaml`, `*.fgca.yml`) — they fail validation.
 
 ---
 
@@ -173,7 +171,7 @@ Every notation file is validated before commit. Two sanctioned paths:
 
 The agent does **not** commit files with `error`-level validation findings. `warning`-level findings are surfaced to the adopter and committed only with explicit acknowledgement. The agent does not auto-suppress validation rules.
 
-Every notation spec carries its own validation-codes table (e.g. `FGCA-001..015`, `GOALS-001..013`, `BL-001..009`, `ISS-001..006`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.
+Every notation spec carries its own validation-codes table (e.g. `FGCA-001..015`, `GOALS-001..013`, `BL-001..009`, `ISS-001..006`, `CODEX-001..003`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.
 
 ---
 
@@ -207,35 +205,13 @@ The agent does **not** publish externally-visible artefacts (PR descriptions, pu
 - **Linear / Jira / Asana.** Tasks live in a project management tool; the agent reads tickets via the tool's API or pasted-in URLs; PRs link back via the tool's convention.
 - **Self-hosted issues register.** Tasks live in this repo as a `.issues.transitrix.yaml` file under `canon/views/issues/` per `notations/12-issues.md`. The agent reads and updates the YAML directly.
 
-**Example — self-hosted issues register.** Place a file at `canon/views/issues/<DOMAIN>.issues.transitrix.yaml`:
-
-```yaml
-notation: issues
-spec_version: "0.1"
-
-issues_catalogue:
-  id: ISSUES_CAT-OPS-1
-  name: "Architecture issues — operations"
-  updated_at: "2026-05-26"
-
-  issues:
-    - issue_id: ISSUE-1
-      name: "Order-fulfilment SLA gap"
-      status: open                          # open | in_progress | blocked | resolved | closed
-      description: "p95 latency regressed after the new payment-routing release."
-      relates_to: [ACTIVITY-1, GOAL-1]
-      owner_role: ROLE-1
-```
-
-The agent reads, edits, and validates this file the same way as any other notation file.
-
 ---
 
 ## 10. What the agent does NOT do
 
 - Does **not** edit files under the methodology canon at `transitrix/methodology` from inside this repo.
 - Does **not** invent new notations, new TYPE prefixes, or new validation rules. Those decisions happen upstream.
-- Does **not** change the canonical repository layout — `canon/views/<notation>/`, `canon/elements/<NN>_<layer>/`, `.templates/` — without an explicit adopter decision recorded in the PR.
+- Does **not** change the canonical repository layout — `canon/views/<notation>/`, `canon/elements/<NN>_<layer>/`, `codex/external/<jurisdiction>/`, `codex/internal/`, `field/<sub>/` — without an explicit adopter decision recorded in the PR.
 - Does **not** strip the `notation:` / `spec_version:` headers, rename canonical extensions, or rewrite files into alias formats (`*.bpmn.yaml`, `*.fgca.yml`).
 - Does **not** auto-merge PRs. All PRs go through the gating in §11.
 - Does **not** push to `main` directly. Use a feature branch + PR every time.
@@ -254,11 +230,3 @@ Every non-trivial change goes through PR review by the adopter:
 5. The adopter — or a reviewer the adopter designates — merges. The agent does **not** merge its own PRs, even when permissions allow it.
 
 Trivial changes (typo fixes inside a description string, README polish) may be committed directly to `main` if the adopter has explicitly opted into a direct-commit workflow. Default: PR every time.
-
----
-
-## Reconciliation note
-
-This guide is assistant-neutral and reflects the zoned (`canon/` / `field/` / `codex/`) layout. The onboarding Skill (`/transitrix-onboard`, a Claude Code skill) scaffolds the same shape — `AGENTS.md` as the agent guide, `transitrix.yaml` as the manifest, `canon/` + `field/` + `codex/` zones — by copying templates from its bundle.
-
-The agent treats this file as **provisional**. If it conflicts with the canon, the canon wins. If it conflicts with a later adopter-supplied policy, the adopter wins.

--- a/skills/onboarding/templates/codex-external.yaml
+++ b/skills/onboarding/templates/codex-external.yaml
@@ -1,0 +1,27 @@
+# Codex external artefact — a law or regulation given to the org by an outside authority.
+# Schema: notations/14-codex.md §3 + admission record (notations/CONTRACT.md §6).
+# File location: codex/external/<jurisdiction>/<ID>.yaml
+#   <jurisdiction> = ISO 3166-1 alpha-2 (ge, de, ru, …), `eu`, or `intl` — MUST match
+#   the `jurisdiction:` field below (validator rule CODEX-001).
+# File name: the artefact's canonical ID + .yaml — one artefact per file.
+
+id: LAW-FILL-ME-1                   # canonical ID per IDS_AND_REFERENCES.md (LAW | REGULATION)
+name: "FILL-ME law or regulation name"
+type: LAW                           # LAW | REGULATION
+description: "FILL-ME — what the artefact governs"
+
+# Admission record (CONTRACT.md §6)
+zone: codex
+admitted_at: "2026-01-01"           # quoted ISO 8601 date
+admitted_by: "FILL-ME-handle"
+gate_checks:
+  source_authority: "FILL-ME — name of the issuing legislative body / official source"
+
+# External-codex frontmatter (14-codex.md §3)
+jurisdiction: ge                    # MUST match parent folder codex/external/<jurisdiction>/
+effective_date: "2017-01-01"        # quoted ISO 8601 date the artefact takes effect
+applies_to:
+  entities:                         # typed canonical IDs of org entities the artefact binds
+    - APPLICATION-FILL-ME-1
+  processes:                        # typed canonical IDs of processes the artefact binds
+    - PROCESS-FILL-ME-1

--- a/skills/onboarding/templates/codex-internal.yaml
+++ b/skills/onboarding/templates/codex-internal.yaml
@@ -1,0 +1,24 @@
+# Codex internal artefact — a policy or internal standard the org issues to itself.
+# Schema: notations/14-codex.md §4 + admission record (notations/CONTRACT.md §6).
+# File location: codex/internal/<ID>.yaml — internal artefacts are NOT foldered by jurisdiction.
+# File name: the artefact's canonical ID + .yaml — one artefact per file.
+
+id: POLICY-FILL-ME-1                # canonical ID per IDS_AND_REFERENCES.md (POLICY | INTERNAL_STANDARD)
+name: "FILL-ME policy or standard name"
+type: POLICY                        # POLICY | INTERNAL_STANDARD
+description: "FILL-ME — what the artefact governs"
+
+# Admission record (CONTRACT.md §6)
+zone: codex
+admitted_at: "2026-01-01"           # quoted ISO 8601 date
+admitted_by: "FILL-ME-handle"
+gate_checks:
+  source_authority: "FILL-ME — name of the internal issuing body or role"
+
+# Internal-codex frontmatter (14-codex.md §4)
+issuing_authority: "FILL-ME — internal body / role that issued the artefact"
+effective_date: "2026-01-01"        # quoted ISO 8601 date the artefact takes effect
+applies_to:
+  entities:                         # typed canonical IDs the artefact binds (may be empty list)
+    - APPLICATION-FILL-ME-1
+  processes: []

--- a/skills/onboarding/templates/copilot-instructions.md
+++ b/skills/onboarding/templates/copilot-instructions.md
@@ -1,0 +1,7 @@
+# GitHub Copilot — repository instructions
+
+This repository's agent guidance is maintained, assistant-neutral, in **[`AGENTS.md`](../AGENTS.md)** at the repo root.
+
+Read `AGENTS.md` and follow it. It covers the repository's purpose, the canonical Transitrix notations, the `canon/` / `field/` / `codex/` zones, ID grammar, validation, and the contribution / gating rules.
+
+This file is only a pointer — do not duplicate guidance here; keep `AGENTS.md` the single source of truth.

--- a/skills/onboarding/templates/transitrix.yaml
+++ b/skills/onboarding/templates/transitrix.yaml
@@ -1,0 +1,15 @@
+# Adopter manifest — schema defined in the methodology's notations/MANIFEST.md.
+# This file pins which methodology release this repo conforms to and what it uses.
+# Adopters do NOT vendor a copy of notations/ — they follow the published specs
+# at the pinned methodology_version.
+
+transitrix: 1                       # manifest schema version (integer; 1 today)
+methodology_version: "0.4.x"        # pin a real release once the adopter chooses one
+notations:                          # short names from notations/README.md (+ codex)
+  - fgca
+  - goals
+  - activities
+  - issues
+  - capability-map
+  - codex
+zones: [canon, field, codex]        # any subset of canon / field / codex


### PR DESCRIPTION
## Summary

Reconciles `/transitrix-onboard` (the Claude Code onboarding Skill in `skills/onboarding/`) to the canonical adopter shape that matches `organizations/acme_corp/`:

- **Step 2 — Scaffold the repo** rewritten to teach the zoned layout (`canon/{elements,views}`, `field/{interviews,surveys,observations,drafts}`, `codex/{external/<jurisdiction>,internal}`) instead of the flat `views/` + `elements/` layout. Also: drops the `transitrix.yaml` manifest at the repo root, the assistant-neutral `AGENTS.md` agent guide, and the `.github/copilot-instructions.md` pointer — explicitly **not** a Claude-specific `CLAUDE.md`. Tools that don't read `AGENTS.md` natively (Claude Code, Cursor, …) get a one-line pointer file in their tool's location.
- **Step 3 — Create the starter file** generalised to cover both **view notations** (copy into `canon/views/<notation>/`) and **codex zone primitives** (copy into `codex/external/<jurisdiction>/<ID>.yaml` or `codex/internal/<ID>.yaml`). Codex artefacts are zone primitives, not view documents; they carry no `notation:` header (`notations/14-codex.md`).
- **Cheat sheet** picks up a "Zone primitives — not view documents" section after the family-selection matrix, plus a one-paragraph codex summary alongside the 13 view-notation summaries.
- **Templates table** restructured into three groups: root scaffolding, view notations, codex zone primitives.

## New templates

- `skills/onboarding/templates/transitrix.yaml` — adopter manifest per `notations/MANIFEST.md`.
- `skills/onboarding/templates/AGENTS.md` — assistant-neutral agent guide (mirrors `organizations/acme_corp/AGENTS.md` minus the now-resolved reconciliation note).
- `skills/onboarding/templates/copilot-instructions.md` — pointer → `AGENTS.md` for GitHub Copilot.
- `skills/onboarding/templates/codex-external.yaml` — `LAW` / `REGULATION` template with admission record + `jurisdiction` + `effective_date` + `applies_to`.
- `skills/onboarding/templates/codex-internal.yaml` — `POLICY` / `INTERNAL_STANDARD` template with admission record + `issuing_authority` + `effective_date` + `applies_to`.

## acme_corp/AGENTS.md note

Its "Reconciliation note" section is rewritten — it had said the Skill still scaffolds a flat, Claude-specific layout and would be reconciled in a follow-up; after this PR that's no longer true, so the note now records that the Skill scaffolds the same zoned + assistant-neutral shape.

## Out of scope

- **Full cheat-sheet conformance to the current specs** — this is the explicit scope of `strategy#55` (Cheat-sheet conformance check). This PR adds only the codex section + the codex paragraph; it does not sweep the 13 view-notation summaries for spec drift.

## Test plan

- [x] All 3 touched / 5 new YAML files parse cleanly via `python -m yaml safe_load`
- [x] All 5 edited / new markdown files end with newline + a complete final line (per working rule #2)
- [x] No accidental `CLAUDE.md` references remain (the 2 remaining mentions in `SKILL.md` and `templates/AGENTS.md` are intentional — the explicit "don't scaffold CLAUDE.md" rule and the per-tool pointer-file convention)
- [x] Templates already use canonical `CAPABILITY-V1` / `CAPABILITY_MAP-` form (Skill bundle was built canonical per `strategy#54`; not modified here)
- [ ] (gated by Valerii) merge

Task: `vkgeorgia/strategy#82`. One PR per working rule #1; gated per task acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)