### PR TITLE
Cheat-sheet conformance CI (Skill embedded summary vs canon catalogue)

### DIFF
--- a/.github/workflows/skill-cheatsheet-conformance.yml
+++ b/.github/workflows/skill-cheatsheet-conformance.yml
@@ -1,0 +1,31 @@
+name: Skill cheat-sheet conformance
+
+# Catches drift between the onboarding Skill's embedded cheat sheet
+# (skills/onboarding/SKILL.md) and the canonical notation catalogue
+# (notations/README.md). Implementation: scripts/check-skill-cheatsheet.mjs.
+#
+# CI is red on drift — the script exits non-zero and the job fails. Fix the
+# Skill, or — if the canon is wrong — update both together in the same PR.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Mondays 09:00 UTC — weekly safety net for drift introduced via
+    # direct-commit changes to main that bypass PR review.
+    - cron: '0 9 * * 1'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run cheat-sheet conformance check
+        run: node scripts/check-skill-cheatsheet.mjs

--- a/scripts/check-skill-cheatsheet.mjs
+++ b/scripts/check-skill-cheatsheet.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+// Cheat-sheet conformance check — diffs the onboarding Skill's embedded
+// cheat sheet against the canonical notation catalogue.
+//
+// Ground truth: notations/README.md §"Catalogue" — the canonical index of the
+// 13 view notations (short name + file extension + status).
+//
+// What we check:
+//   A. Every notation in the canon catalogue has a row in the Skill's
+//      family-selection matrix carrying the canonical file extension.
+//   B. Every notation in the canon catalogue has a view-template at the
+//      canonical path `templates/<short>.<short>.transitrix.yaml`.
+//   C. Every file extension that appears in the Skill's family-selection
+//      matrix corresponds to a notation in the canon (no Skill-only rows).
+//   D. Every view-template path in the Skill's templates table corresponds
+//      to a notation in the canon (no Skill-only templates).
+//
+// What we do NOT check (out of scope for v1):
+//   - The codex zone-primitives section in the cheat sheet (codex is not in
+//     the catalogue table; it is a parallel zone-primitive notation).
+//   - Root-scaffolding templates (transitrix.yaml, AGENTS.md, copilot-
+//     instructions.md) — adopter-shape concerns, not notation-shape concerns.
+//   - Intra-spec drift (each spec's front-matter `file_extension` vs its
+//     "File header" section) — a separate known issue, not the Skill's fault.
+//   - The free-text "Situation" prose in the family-selection matrix.
+//
+// Exit codes:
+//   0 — no drift
+//   1 — drift found (one or more checks failed)
+//   2 — script-internal error (file missing, parse failure)
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = join(dirname(__filename), '..');
+const CATALOGUE_PATH = join(REPO_ROOT, 'notations', 'README.md');
+const SKILL_PATH = join(REPO_ROOT, 'skills', 'onboarding', 'SKILL.md');
+
+// --- Parsers ---------------------------------------------------------------
+
+// Pull the catalogue table from notations/README.md.
+// Returns: Map<short_name, { extension, status }>.
+async function parseCatalogue() {
+  const text = await readFile(CATALOGUE_PATH, 'utf8');
+  const lines = text.split('\n');
+
+  // Locate the section heading then the first markdown table after it.
+  const headingIdx = lines.findIndex(l => /^##\s+Catalogue\s*$/.test(l));
+  if (headingIdx < 0) {
+    throw new Error(`notations/README.md: "## Catalogue" section not found`);
+  }
+
+  // Find the table header row after the heading.
+  let headerIdx = -1;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('| Spec ')) {
+      headerIdx = i;
+      break;
+    }
+    if (/^##\s/.test(lines[i])) break; // hit the next section
+  }
+  if (headerIdx < 0) {
+    throw new Error(`notations/README.md: catalogue table header not found`);
+  }
+
+  // Data rows start two lines after the header (skip header + separator).
+  const out = new Map();
+  for (let i = headerIdx + 2; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) break;
+    const cells = line.split('|').map(c => c.trim());
+    // cells: ['', Spec, ShortName, Purpose, FileExtension, Status, '']
+    if (cells.length < 7) continue;
+    const shortNameCell = cells[2];
+    const extCell = cells[4];
+    const statusCell = cells[5];
+    const shortMatch = shortNameCell.match(/`([^`]+)`/);
+    const extMatch = extCell.match(/`([^`]+)`/);
+    if (!shortMatch || !extMatch) {
+      throw new Error(`notations/README.md: cannot parse catalogue row: ${line}`);
+    }
+    out.set(shortMatch[1], { extension: extMatch[1], status: statusCell });
+  }
+
+  if (out.size === 0) {
+    throw new Error(`notations/README.md: catalogue table parsed empty`);
+  }
+  return out;
+}
+
+// Pull the family-selection matrix from skills/onboarding/SKILL.md.
+// Returns: Set<file_extension>. The matrix has one row per notation; we use
+// the file-extension column as the join key against the canon catalogue.
+async function parseSkillMatrix() {
+  const text = await readFile(SKILL_PATH, 'utf8');
+  const lines = text.split('\n');
+
+  const headingIdx = lines.findIndex(l => /^###\s+Family selection\s*$/.test(l));
+  if (headingIdx < 0) {
+    throw new Error(`SKILL.md: "### Family selection" section not found`);
+  }
+
+  // The first markdown table after the heading is the matrix.
+  let headerIdx = -1;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('| Situation ')) {
+      headerIdx = i;
+      break;
+    }
+    if (/^##\s|^###\s/.test(lines[i])) break;
+  }
+  if (headerIdx < 0) {
+    throw new Error(`SKILL.md: family-selection matrix header not found`);
+  }
+
+  const out = new Set();
+  for (let i = headerIdx + 2; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) break;
+    const cells = line.split('|').map(c => c.trim());
+    if (cells.length < 5) continue;
+    const extCell = cells[3];
+    const extMatch = extCell.match(/`([^`]+)`/);
+    if (!extMatch) {
+      throw new Error(`SKILL.md: cannot parse matrix row: ${line}`);
+    }
+    out.add(extMatch[1]);
+  }
+
+  if (out.size === 0) {
+    throw new Error(`SKILL.md: family-selection matrix parsed empty`);
+  }
+  return out;
+}
+
+// Pull the view-notation template paths from skills/onboarding/SKILL.md.
+// Returns: Set<short_name>, extracted from `templates/<short>.<short>.transitrix.yaml`.
+// Other template categories (root scaffolding, codex) do not match the
+// `<short>.<short>.transitrix.yaml` shape and are naturally filtered out.
+async function parseSkillTemplates() {
+  const text = await readFile(SKILL_PATH, 'utf8');
+  // Match every `templates/<x>.<y>.transitrix.yaml` mention; we collect the
+  // short name when x === y.
+  const re = /`templates\/([a-z][a-z0-9-]*)\.([a-z][a-z0-9-]*)\.transitrix\.yaml`/g;
+  const out = new Set();
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    if (m[1] === m[2]) out.add(m[1]);
+  }
+  if (out.size === 0) {
+    throw new Error(`SKILL.md: no view-notation template paths found`);
+  }
+  return out;
+}
+
+// --- Reporter --------------------------------------------------------------
+
+function reportFailure(failures) {
+  console.error(`\nSkill cheat-sheet drifted from the canon — ${failures.length} finding(s):\n`);
+  for (const f of failures) {
+    console.error(`  - [${f.check}] ${f.message}`);
+  }
+  console.error(
+    `\nFix the Skill (skills/onboarding/SKILL.md) to match the canon ` +
+    `(notations/README.md), or — if the canon is wrong — update both ` +
+    `together in the same PR.\n`
+  );
+}
+
+// --- Main ------------------------------------------------------------------
+
+async function main() {
+  let catalogue, skillMatrixExts, skillTemplateShorts;
+  try {
+    [catalogue, skillMatrixExts, skillTemplateShorts] = await Promise.all([
+      parseCatalogue(),
+      parseSkillMatrix(),
+      parseSkillTemplates(),
+    ]);
+  } catch (e) {
+    console.error(`error: ${e.message}`);
+    process.exit(2);
+  }
+
+  const failures = [];
+
+  // Build the canonical extension set + per-extension short-name lookup.
+  const canonExts = new Set();
+  const extToShort = new Map();
+  for (const [shortName, { extension }] of catalogue) {
+    canonExts.add(extension);
+    extToShort.set(extension, shortName);
+  }
+
+  // Check A: every catalogue notation has a matching row in the matrix.
+  for (const [shortName, { extension }] of catalogue) {
+    if (!skillMatrixExts.has(extension)) {
+      failures.push({
+        check: 'A',
+        message:
+          `notation "${shortName}" (extension \`${extension}\`) is in the canon catalogue ` +
+          `(notations/README.md) but has no row in the Skill's family-selection matrix ` +
+          `(SKILL.md §"Family selection") carrying that extension.`,
+      });
+    }
+  }
+
+  // Check B: every catalogue notation has a matching template at the canonical path.
+  for (const [shortName] of catalogue) {
+    if (!skillTemplateShorts.has(shortName)) {
+      failures.push({
+        check: 'B',
+        message:
+          `notation "${shortName}" is in the canon catalogue but has no view-template ` +
+          `entry at \`templates/${shortName}.${shortName}.transitrix.yaml\` in the ` +
+          `Skill's templates table.`,
+      });
+    }
+  }
+
+  // Check C: every extension in the matrix is in the canon catalogue.
+  for (const ext of skillMatrixExts) {
+    if (!canonExts.has(ext)) {
+      failures.push({
+        check: 'C',
+        message:
+          `extension \`${ext}\` appears in the Skill's family-selection matrix but is ` +
+          `not in the canon catalogue (notations/README.md). Either the cheat-sheet has ` +
+          `a stray row or the catalogue is missing the notation.`,
+      });
+    }
+  }
+
+  // Check D: every view-template short name in the Skill is in the catalogue.
+  for (const shortName of skillTemplateShorts) {
+    if (!catalogue.has(shortName)) {
+      failures.push({
+        check: 'D',
+        message:
+          `view-template \`templates/${shortName}.${shortName}.transitrix.yaml\` is ` +
+          `listed in the Skill's templates table but "${shortName}" is not a notation ` +
+          `in the canon catalogue (notations/README.md).`,
+      });
+    }
+  }
+
+  if (failures.length > 0) {
+    reportFailure(failures);
+    process.exit(1);
+  }
+
+  console.log(
+    `Skill cheat-sheet conforms to the canon — ${catalogue.size} notations ` +
+    `checked across the family-selection matrix and the view-templates table.`
+  );
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error(`error: ${e.message}`);
+  process.exit(2);
+});

--- a/skills/onboarding/README.md
+++ b/skills/onboarding/README.md
@@ -132,3 +132,41 @@ The bundle is part of the methodology repo (`github.com/transitrix/methodology`,
 - There is no auto-update — the bundle is plain files.
 
 If a notation's canonical shape changes, the template under `templates/` and the corresponding row in `SKILL.md`'s cheat sheet must be updated in the same commit.
+
+---
+
+## Cheat-sheet conformance check
+
+The embedded cheat sheet in [`SKILL.md`](SKILL.md) is downstream of [`notations/README.md`](../../notations/README.md). When the canon catalogue changes — a notation added, renamed, retired, or its file extension changed — the Skill must follow. CI guards this:
+
+- **Script:** [`scripts/check-skill-cheatsheet.mjs`](../../scripts/check-skill-cheatsheet.mjs) — pure Node, no dependencies.
+- **Workflow:** [`.github/workflows/skill-cheatsheet-conformance.yml`](../../.github/workflows/skill-cheatsheet-conformance.yml) — runs on every PR and weekly Monday 09:00 UTC.
+
+### What the script checks
+
+Ground truth = the catalogue table in [`notations/README.md`](../../notations/README.md). The script verifies:
+
+| Check | Rule |
+|---|---|
+| A | Every notation in the canon catalogue has a row in `SKILL.md` §"Family selection" carrying its canonical file extension. |
+| B | Every notation in the canon catalogue has a view-template at `templates/<short>.<short>.transitrix.yaml` in the Skill's templates table. |
+| C | Every file extension in the family-selection matrix corresponds to a notation in the canon. |
+| D | Every view-template path in the templates table corresponds to a notation in the canon. |
+
+The script exits `1` on drift (CI red) with a per-finding list naming the specific notation and where to fix it. Exit `2` is a script-internal error (file missing, parser broke).
+
+### What the script does NOT check
+
+- The codex zone-primitives section in the cheat sheet — codex isn't in the catalogue table; it's a parallel zone-primitive notation with a separate spec ([`notations/14-codex.md`](../../notations/14-codex.md)).
+- Root-scaffolding templates (`transitrix.yaml`, `AGENTS.md`, `copilot-instructions.md`) — adopter-shape concerns, not notation-shape concerns.
+- Intra-spec drift (each spec's front-matter `file_extension` vs its "File header" section) — a separate known issue, not the Skill's fault.
+- The free-text "Situation" prose in the family-selection matrix.
+
+### When CI fails
+
+Read the per-finding output. For each finding:
+
+- **Check A / B failure** — the canon added or renamed a notation; update the Skill cheat sheet and add/rename the view-template under `skills/onboarding/templates/` in the same PR.
+- **Check C / D failure** — the Skill has a stray row or template that doesn't match the canon; either the catalogue is missing the notation (update the catalogue) or the Skill has a typo (fix the Skill).
+
+The script runs on every PR, so a drift introduced anywhere — Skill side or canon side — surfaces in the PR conversation, not in the Actions tab as a warning.


### PR DESCRIPTION
## Summary

A GitHub Actions check that catches drift between the onboarding Skill's embedded cheat sheet (`skills/onboarding/SKILL.md`) and the canonical notation catalogue (`notations/README.md`).

- **Script** — `scripts/check-skill-cheatsheet.mjs`, pure-Node (no `package.json`, no dependencies). Ground truth = the catalogue table in `notations/README.md`. Verifies four invariants:
  - **A** — every catalogue notation has a row in the Skill's family-selection matrix carrying its canonical file extension
  - **B** — every catalogue notation has a view-template at `templates/<short>.<short>.transitrix.yaml`
  - **C** — every extension in the matrix corresponds to a notation in the canon (no Skill-only stray rows)
  - **D** — every view-template path corresponds to a notation in the canon (no Skill-only stray templates)
- **Workflow** — `.github/workflows/skill-cheatsheet-conformance.yml`, runs on every PR + `workflow_dispatch` + weekly Monday 09:00 UTC cron. CI red on drift (script exits `1`); no warning-only mode. Exit `2` is script-internal error.
- **Docs** — new "Cheat-sheet conformance check" section in `skills/onboarding/README.md`: what's checked, what's deliberately not, how to react to a red CI.

## Sanity run on current main

```
$ node scripts/check-skill-cheatsheet.mjs
Skill cheat-sheet conforms to the canon — 13 notations checked across the family-selection matrix and the view-templates table.
exit=0
```

## What's out of scope (deliberately)

- **Codex zone-primitives section** in the cheat sheet — codex isn't in the catalogue table; it's a parallel zone-primitive notation with a separate spec (`notations/14-codex.md`). The script naturally scopes to view notations only via the `<short>.<short>.transitrix.yaml` shape regex.
- **Root-scaffolding templates** (`transitrix.yaml`, `AGENTS.md`, `copilot-instructions.md`) — adopter-shape concerns, not notation-shape concerns.
- **Intra-spec drift** (each spec's front-matter `file_extension` vs its "File header" section value) — a separate known issue per `CLAUDE.md`, not the Skill's fault.
- **Free-text "Situation" prose** in the family-selection matrix.

## Test plan

- [x] Script passes on current main with zero drift (13 notations parsed)
- [x] Workflow YAML parses cleanly
- [x] Script handles missing files / parse failures with exit code `2` (separate from drift exit code `1`)
- [ ] Once merged, the workflow runs on this PR's own branch verifying the green-path
- [ ] (gated by Valerii) merge

Task: `vkgeorgia/strategy#55`. One PR per working rule #1; gated per task acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)