### PR TITLE
Compliance Phase 1 — REQUIREMENT element type + 15-requirement.md + REQ-001..003

### DIFF
--- a/notations/15-requirement.md
+++ b/notations/15-requirement.md
@@ -1,0 +1,137 @@
+---
+title: "Requirement — motivation-layer positive obligation"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-05-28"
+status: "draft"
+---
+
+# Requirement — Reference
+
+**Scope:** The `REQUIREMENT` element type in the motivation layer of an organisation's canon — a positive obligation the organisation must fulfil ("must submit", "must register", "must obtain approval"). The shared header / zone / admission / lifecycle contracts are defined in [CONTRACT.md](CONTRACT.md); the TYPE registry sits in [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1.
+
+Requirements are **zone primitives**: each requirement is a single YAML file under `canon/elements/01_motivation/requirements/`, named by its canonical ID, carrying the admission record ([CONTRACT.md](CONTRACT.md) §6, `zone: canon`) plus the primitive lifecycle ([CONTRACT.md](CONTRACT.md) §7) and the requirement-specific frontmatter below.
+
+---
+
+## 1. REQUIREMENT vs CONSTRAINT — by form of the obligation
+
+The motivation layer carries two element types with overlapping vocabularies but distinct semantics. The boundary is the **form of the obligation**:
+
+| | REQUIREMENT | CONSTRAINT |
+|---|---|---|
+| **What it is** | A positive obligation — an action or state the org must achieve | A restriction or prohibition — a boundary the org must not cross |
+| **Typical wording** | "MUST", "SHALL", "must submit", "must register", "must maintain", "must obtain" | "MUST NOT", "SHALL NOT", "is limited to", "cannot exceed", "must not exceed" |
+| **Test** | "What do we have to do?" | "What are we forbidden from?" |
+| **Element TYPE** | `REQUIREMENT` | `CONSTRAINT` |
+| **Folder** | `canon/elements/01_motivation/requirements/` | `canon/elements/01_motivation/constraints/` |
+
+Both types are first-class motivation elements (per ArchiMate 3.2). Both may carry the same regulatory attributes (`deadline`, `obligation_level`, `requirement_type`, `derived_from`) — the form distinction is orthogonal to the regulatory dimension. A REQUIREMENT and a CONSTRAINT derived from the same source law sit side by side in the model, distinguished only by their form.
+
+**Boundary examples:**
+
+| Wording | Type | Why |
+|---|---|---|
+| "Manufacturer must obtain premarket approval for Class III devices" | REQUIREMENT | positive action — *obtain* approval |
+| "Class III devices cannot be marketed without prior approval" | CONSTRAINT | restriction — *cannot* be marketed |
+| "Manufacturer must register its establishment annually with the regulator" | REQUIREMENT | positive action — *register* |
+| "An unregistered establishment cannot manufacture or distribute" | CONSTRAINT | restriction — *cannot* manufacture |
+
+The same regulation often produces a REQUIREMENT and a corresponding CONSTRAINT (the two sides of the same rule). Both are valid; both may be modelled.
+
+---
+
+## 2. Frontmatter — canonical schema
+
+```yaml
+notation: requirement
+id: REQUIREMENT-DATA-ERASURE-1
+title: "Personal-data erasure on user request within 30 days"
+description: "On request from a data subject, the controller must erase personal data within 30 days. The window starts at the time the request is received and verified."
+
+# Optional regulatory attributes
+severity: high                  # high | medium | low — organisation-defined priority
+derived_from:                   # typed IDs of source documents this requirement is drawn from
+  - LAW-PERSONAL-DATA-2017-1
+  - REGULATION-GDPR-2016-1
+
+# Admission record (CONTRACT.md §6) — required
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — required
+valid_from: "2017-05-01"
+valid_to: null
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | Fixed value `requirement`. Machine-readable type tag (redundant with the ID prefix but useful for tooling that reads files without parsing IDs). |
+| `id` | yes | string | Canonical ID per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §1: `REQUIREMENT-[<middle>-]<INTEGER>`. |
+| `title` | yes | string | One-line statement of the requirement. |
+| `description` | yes | string | Longer-form explanation of the obligation, its scope, and the conditions under which it applies. |
+| `severity` | no | string | One of `high`, `medium`, `low`. Organisation-defined priority for planning and reporting. Distinct from `obligation_level` (regulatory force, RFC 2119 — out of scope for v1; see [§5](#5-evolution)). |
+| `derived_from` | no | list | Typed IDs of the codex artefacts this requirement is drawn from. Permitted TYPEs: `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD`. Empty or absent for internal-only requirements with no codex source. |
+| `zone` | yes | string | Always `canon` for REQUIREMENT — see [CONTRACT.md](CONTRACT.md) §6. |
+| `admitted_at` | yes | string | Date admitted to canon — quoted ISO 8601 per [CONTRACT.md](CONTRACT.md) §4. |
+| `admitted_by` | yes | string | Person handle or tool ID that ran the admission gate. |
+| `gate_checks` | yes | map | Standard canon checks (`uniqueness`, `consistency`, `completeness`); see [CONTRACT.md](CONTRACT.md) §6. |
+| `valid_from` | yes | string | Date the requirement took effect — quoted ISO 8601 per [CONTRACT.md](CONTRACT.md) §7. |
+| `valid_to` | yes | string \| null | Date the requirement ceased to be in effect, or `null` if still in effect — see [CONTRACT.md](CONTRACT.md) §7. |
+
+Field naming follows the conventions in [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) and [CONTRACT.md](CONTRACT.md); no requirement-specific naming conventions are introduced.
+
+---
+
+## 3. File location and naming
+
+```
+canon/elements/01_motivation/requirements/<ID>.yaml
+```
+
+One artefact per file, named by its canonical ID. Examples:
+
+- `canon/elements/01_motivation/requirements/REQUIREMENT-DATA-ERASURE-1.yaml`
+- `canon/elements/01_motivation/requirements/REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml`
+
+The folder sits alongside `canon/elements/01_motivation/constraints/` — the two motivation-layer obligation catalogues are peers, not nested.
+
+---
+
+## 4. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `REQ-001` | error | `id` is missing or does not match the canonical grammar `REQUIREMENT-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §1); or any required field from §2 (`notation`, `title`, `description`, `zone`, `admitted_at`, `admitted_by`, `gate_checks`, `valid_from`, `valid_to`) is missing. |
+| `REQ-002` | error | A value in `derived_from` is a well-formed typed ID but does not resolve to any admitted codex artefact in the organisation's `codex/` zone. |
+| `REQ-003` | error | A value in `derived_from` resolves to an artefact whose TYPE is not one of `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD`. Requirements derive only from codex source documents. |
+
+The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3) and header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2) rules apply to REQUIREMENT files in addition to the REQ-* rules above.
+
+---
+
+## 5. Evolution
+
+Pending design work (separate strategy-hub tasks) extends the REQUIREMENT schema with regulatory attributes that apply symmetrically to REQUIREMENT and CONSTRAINT:
+
+- `deadline` (ISO 8601 date) and an extended `status` vocabulary (`active` / `upcoming` / `past_due` / `compliant` / `deprecated` / `retired`).
+- `obligation_level` (`SHALL` / `SHOULD` / `MAY` — RFC 2119 language for positive obligations; the corresponding `SHALL_NOT` / `SHOULD_NOT` apply on CONSTRAINT).
+- `requirement_type` (`DEFINITIONAL` / `PRODUCT` / `PROCESS` / `DOCUMENTATION` / `ORGANIZATIONAL` / `REPORTING`).
+- A structured `derived_from` block (`document_id` + `section` + `section_url` + extraction provenance).
+
+A separate notation (`ASSERTION`, planned) will link a REQUIREMENT to the elements that realise it (products / processes / capabilities) with status and evidence. Until that lands, a REQUIREMENT records the obligation; the model carries no machine-readable claim about whether it is satisfied.
+
+A worked example yaml under `organizations/acme_corp/canon/elements/01_motivation/requirements/` plus a per-folder README is planned alongside the broader compliance worked-examples wave; not part of this initial registration.
+
+---
+
+## 6. References
+
+- TYPE registry and ID grammar: [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1 (entry), §1 (grammar), §4 (uniqueness scope).
+- Zone model, admission record, primitive lifecycle: [CONTRACT.md](CONTRACT.md) §5, §6, §7.
+- Codex source documents that requirements derive from: [14-codex.md](14-codex.md).

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -84,7 +84,8 @@ Elements that get referenced across documents.
 | `EQUIPMENT` | physical instrument, device, or facility a process stage depends on | Process Blueprint |
 | `INFORMATION_ENTITY` | data, document, or record produced or consumed by a process stage | Process Blueprint |
 | `RULE` | business rule (business layer per ArchiMate 3.2) | Rules catalogue (`elements/02_business/rules/`); referenceable from any notation via `applies_to:` |
-| `CONSTRAINT` | design / operating constraint (motivation layer per ArchiMate 3.2) | Constraints catalogue (`elements/01_motivation/constraints/`); referenced from FGCA factors via `references_constraint:` |
+| `CONSTRAINT` | design / operating constraint (motivation layer per ArchiMate 3.2) — a restriction or prohibition the organisation must not cross | Constraints catalogue (`elements/01_motivation/constraints/`); referenced from FGCA factors via `references_constraint:` |
+| `REQUIREMENT` | regulatory or organisational requirement (motivation layer per ArchiMate 3.2) — a positive obligation the organisation must fulfil. Distinct from `CONSTRAINT` by **form of the obligation**: REQUIREMENT = positive action ("must submit", "must register", "must obtain approval"); CONSTRAINT = restriction ("must not", "cannot exceed"). | Requirements catalogue (`elements/01_motivation/requirements/`); cites its source via `derived_from:` (codex `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`). Schema: [15-requirement.md](15-requirement.md). |
 
 ### 3.2 Document-level types
 
@@ -151,6 +152,7 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | `EQUIPMENT`, `INFORMATION_ENTITY` | within the notation document that defines them (today: a Process Blueprint). No organisation-wide catalogue is mandated yet; the TYPEs are registered so the IDs already conform to the canonical grammar and can be promoted to a future catalogue without renaming. |
 | `RULE` | within the organisation's element catalogue (`elements/02_business/rules/`), one file per RULE. |
 | `CONSTRAINT` | within the organisation's element catalogue (`elements/01_motivation/constraints/`), one file per CONSTRAINT. |
+| `REQUIREMENT` | within the organisation's element catalogue (`elements/01_motivation/requirements/`), one file per REQUIREMENT. |
 | `INTERVIEW`, `SURVEY`, `OBSERVATION`, `DRAFT` | within the organisation's `field/` zone. Contradictions between Field artefacts are allowed; only the IDs must be unique. |
 | `LAW`, `REGULATION` | within the organisation's `codex/external/` zone. |
 | `POLICY`, `INTERNAL_STANDARD` | within the organisation's `codex/internal/` zone. |


### PR DESCRIPTION
## Summary

Phase 1 of the compliance epic. Establishes REQUIREMENT as a first-class motivation-layer element, distinct from CONSTRAINT by the **form of the obligation** — positive action ("must submit", "must obtain") vs restriction ("must not", "cannot exceed").

- `notations/IDS_AND_REFERENCES.md` §3.1 — register `REQUIREMENT` TYPE alongside `CONSTRAINT`, with the form-based boundary statement.
- `notations/IDS_AND_REFERENCES.md` §4 — uniqueness scope (one file per REQUIREMENT in `canon/elements/01_motivation/requirements/`).
- `notations/15-requirement.md` (new) — canonical schema spec following the `14-codex.md` precedent for zone primitives:
  - §1 REQUIREMENT vs CONSTRAINT — worked boundary examples ("must obtain premarket approval" → REQUIREMENT; "cannot be marketed without approval" → CONSTRAINT).
  - §2 Frontmatter schema — `notation` / `id` / `title` / `description` + optional `severity`, `derived_from` + the standard admission record (CONTRACT.md §6) and primitive lifecycle (CONTRACT.md §7).
  - §3 File location and naming.
  - §4 Validation rules — `REQ-001` (id grammar + required fields), `REQ-002` (`derived_from` doesn't resolve), `REQ-003` (`derived_from` TYPE not in `{LAW, REGULATION, POLICY, INTERNAL_STANDARD}`).
  - §5 Evolution — flags pending symmetric REQUIREMENT/CONSTRAINT regulatory attributes (`deadline`, `obligation_level`, `requirement_type`, structured `derived_from`) and the planned `ASSERTION` notation; worked example yaml + acme_corp folder README deferred to Phase 4 per epic phasing.

## Scope decisions

- **Scope reconfirmed (not narrowed).** The session brief proposed narrowing Phase 1 to "REQ-001..003 validators only (element type already in place from prior work)". Verification showed REQUIREMENT was *not* in main — no entry in IDS, no folder, no commit. Confirmed with the user: Phase 1 keeps its existing scope as written in the epic body (registration + schema + validators). #94 closed as subsumed with honest framing.
- **Schema home.** Per the epic body's "your call" — chose a dedicated `notations/15-requirement.md` over inlining into `notations/CONTRACT.md`. CONTRACT.md remains the shared-contract document; per-element schemas live in numbered notation specs, mirroring the `14-codex.md` precedent.
- **No worked example yaml; no acme_corp folder README.** Per the epic body's Phase 1 acceptance ("no example yet"), worked examples land in Phase 4.
- **Schema includes lifecycle fields.** `valid_from` / `valid_to` are required per CONTRACT.md §7 (Wave 1 of the temporal model, just merged via #42).

## Out of scope (deferred)

- Worked-example yaml + folder README in `organizations/acme_corp/canon/elements/01_motivation/requirements/` — Phase 4.
- Regulatory attributes `deadline` / `obligation_level` / `requirement_type` / structured `derived_from` — separate strategy-hub tasks (now declared symmetric on REQUIREMENT and CONSTRAINT in their respective issue bodies).
- The `ASSERTION` notation linking REQUIREMENT to realising elements — Phase 2.
- Codex `applies_to.{entities, processes}` retirement — Phase 3.

## Test plan

- [x] Both touched files end with newline + a complete final line (per working rule #2)
- [x] No private-strategy hyperlinks in tracked files (`grep "vkgeorgia/strategy"` empty in tracked files)
- [x] No client codenames or "real client" framing in any new content
- [x] IDS additions sit alongside CONSTRAINT (§3.1) and follow the existing column shape; uniqueness-scope entry matches the per-folder one-file pattern
- [x] 15-requirement.md cross-references resolve (CONTRACT §§5/6/7, IDS_AND_REFERENCES §1/§3.1/§4, 14-codex.md)
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)