### PR TITLE
Compliance Phase 2 — ASSERTION notation + 16-assertion.md + ASSERT-001..008

### DIFF
--- a/notations/16-assertion.md
+++ b/notations/16-assertion.md
@@ -1,0 +1,184 @@
+---
+title: "Assertion — REQUIREMENT realisation claim"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-05-28"
+status: "draft"
+---
+
+# Assertion — Reference
+
+**Scope:** The `ASSERTION` type — the canonical compliance claim that a **subject** (`PRODUCT` / `PROCESS` / `CAPABILITY`) satisfies a **`REQUIREMENT`**, with an explicit status and supporting evidence. The shared header / zone / admission / lifecycle contracts are defined in [CONTRACT.md](CONTRACT.md); the TYPE registry sits in [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.6.
+
+Assertions are canon-zone artefacts that live **outside** the `elements/` tree, under `canon/assertions/`. Each assertion is a single YAML file named by its canonical ID, carrying the admission record ([CONTRACT.md](CONTRACT.md) §6, `zone: canon`) plus the primitive lifecycle ([CONTRACT.md](CONTRACT.md) §7) and the assertion-specific frontmatter below.
+
+---
+
+## 1. What an Assertion is
+
+A REQUIREMENT records *what the organisation is obliged to do*. An Assertion records *whether a specific subject satisfies that obligation, and how the organisation knows*. The pair `(subject, requirement)` is the unit of compliance: one assertion per pair. Multiple subjects against the same requirement → multiple assertions; the same subject against multiple requirements → multiple assertions.
+
+```
+   REQUIREMENT-DATA-ERASURE-1                  ─── about ──┐
+   PRODUCT-MOBILE-1            ─── subject ────────────────┤
+                                                            ▼
+                          ASSERTION-PRODUCT-MOBILE-DATA-ERASURE-1
+                            status: compliant
+                            realised_via:
+                              - CAPABILITY-V1.2
+                              - PROCESS-USER-DATA-PURGE-1
+                            evidence: […]
+                            assessed_at, next_review_at
+                            valid_from / valid_to
+```
+
+`realised_via[]` names the **elements that technically deliver the requirement** — capabilities, processes, internal standards, applications. These are factual references, not claims; the claim itself is the `status` field. Status and evidence are mutable over the assertion's lifecycle; the realisation set may also change (a process is replaced, a capability matures).
+
+Assertions are about **REQUIREMENTs only.** CONSTRAINT compliance — the parallel question "is the organisation respecting the restriction?" — is **out of scope for v1.** A CONSTRAINT is either honoured or violated, and that is currently modelled inline on the CONSTRAINT artefact or via downstream tooling, not via an ASSERTION. (See §5.)
+
+---
+
+## 2. Frontmatter — canonical schema
+
+```yaml
+notation: assertion
+id: ASSERTION-PRODUCT-MOBILE-DATA-ERASURE-1
+about: REQUIREMENT-DATA-ERASURE-1        # required; must resolve to a REQUIREMENT
+subject: PRODUCT-MOBILE-1                 # required; exactly one typed ID; TYPE ∈ {PRODUCT, PROCESS, CAPABILITY}
+realised_via:                             # optional; any number of typed IDs of elements that realise the requirement
+  - CAPABILITY-V1.2
+  - PROCESS-USER-DATA-PURGE-1
+  - INTERNAL_STANDARD-DATA-RETENTION-1
+status: compliant                         # required; compliant | partial | non_compliant | under_review | n_a
+evidence:                                 # optional; hybrid array of evidence entries
+  - kind: canonical_ref
+    ref: PROCESS-USER-DATA-PURGE-1
+  - kind: external_doc
+    title: "Q1 2026 data-erasure SLA report"
+    url: "https://internal.example/reports/Q1-2026-erasure-sla.pdf"
+  - kind: note
+    text: "Quarterly DPO review on 2026-03-15 confirmed 100% erasure compliance over the period."
+
+assessed_at: "2026-05-15"                 # optional but recommended; date the current status was determined
+assessed_by: ROLE-DPO-1                   # optional; ROLE typed ID, or free-text handle in quotes
+next_review_at: "2026-11-15"              # optional; drives the ASSERT-008 staleness warning
+
+# Admission record (CONTRACT.md §6) — required
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — required
+valid_from: "2026-05-28"
+valid_to: null
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | Fixed value `assertion`. Machine-readable type tag (redundant with the ID prefix, useful for tooling that reads files without parsing IDs). |
+| `id` | yes | string | Canonical ID per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §1: `ASSERTION-[<middle>-]<INTEGER>`. |
+| `about` | yes | string | Typed ID of the REQUIREMENT this assertion is about. The validator resolves it (`ASSERT-002`). |
+| `subject` | yes | string | Exactly one typed ID of the element that owns the claim. TYPE MUST be one of `PRODUCT`, `PROCESS`, `CAPABILITY` (`ASSERT-003`). |
+| `realised_via` | no | list | Typed IDs of elements that technically realise the requirement for the subject. Any number; the validator resolves each (`ASSERT-004`). No TYPE restriction. |
+| `status` | yes | string | One of: `compliant`, `partial`, `non_compliant`, `under_review`, `n_a`. See §3 below. |
+| `evidence` | no | list | Hybrid array of evidence entries; each carries a `kind` and kind-specific fields. See §4. |
+| `assessed_at` | no | string | Date the current status was determined — quoted ISO 8601 per [CONTRACT.md](CONTRACT.md) §4. |
+| `assessed_by` | no | string | A `ROLE-…` typed ID, or a free-text handle in quotes. |
+| `next_review_at` | no | string | Date by which the assertion should be re-reviewed — quoted ISO 8601. Drives the `ASSERT-008` staleness warning. |
+| `zone` | yes | string | Always `canon` for ASSERTION — see [CONTRACT.md](CONTRACT.md) §6. |
+| `admitted_at` | yes | string | Date admitted to canon. |
+| `admitted_by` | yes | string | Person handle or tool ID that ran the admission gate. |
+| `gate_checks` | yes | map | Standard canon checks (`uniqueness`, `consistency`, `completeness`). |
+| `valid_from` | yes | string | Date the assertion took effect — see [CONTRACT.md](CONTRACT.md) §7. |
+| `valid_to` | yes | string \| null | Date the assertion ceased to be in effect, or `null` if still in effect. |
+
+---
+
+## 3. Status vocabulary
+
+| Value | Meaning |
+|---|---|
+| `compliant` | The subject satisfies the requirement at the assessment date. |
+| `partial` | The subject partially satisfies the requirement (named gaps documented in `evidence` or in a follow-up). |
+| `non_compliant` | The subject does not satisfy the requirement. |
+| `under_review` | A review is in flight; the prior status no longer holds and the new status has not been determined. |
+| `n_a` | The requirement does not apply to this subject (jurisdictional / categorical exclusion). |
+
+Status is the **current** judgement. Status history over an assertion's lifecycle is the concern of the planned versioned-attribute sidecar (Wave 2 of the temporal model); v1 records only the current value.
+
+---
+
+## 4. Evidence — three kinds
+
+Each entry in `evidence[]` carries a `kind` plus kind-specific fields. Mix freely within one assertion.
+
+```yaml
+- kind: canonical_ref     # an internal artefact in this organisation's canon
+  ref: <TYPED-ID>          # required; the validator resolves it (ASSERT-005)
+
+- kind: external_doc      # a document outside the model (audit report, certification, vendor attestation)
+  title: "..."             # required
+  url: "..."               # required
+
+- kind: note              # free-text observation
+  text: "..."              # required
+```
+
+`canonical_ref` is preferred when the evidence already lives in the model (a process file, a rule file, a process-blueprint stage). `external_doc` is the fallback when the evidence is a PDF / web report / vendor attestation. `note` is the lightweight form for human-readable observations that do not justify a separate artefact.
+
+---
+
+## 5. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `ASSERT-001` | error | A required field from §2 is missing, or `id` does not match the canonical grammar `ASSERTION-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §1). |
+| `ASSERT-002` | error | `about` is missing, malformed, or resolves to an artefact whose TYPE is not `REQUIREMENT`. |
+| `ASSERT-003` | error | `subject` is missing, does not resolve, or resolves to an artefact whose TYPE is not in `{PRODUCT, PROCESS, CAPABILITY}`. |
+| `ASSERT-004` | error | A value in `realised_via` does not resolve to any admitted canonical element. |
+| `ASSERT-005` | error | An `evidence[]` entry with `kind: canonical_ref` has a `ref` that does not resolve. |
+| `ASSERT-006` | error | `status` is not one of `compliant`, `partial`, `non_compliant`, `under_review`, `n_a`. |
+| `ASSERT-007` | warning | `evidence` is empty AND `status` is `compliant` or `partial`. A positive status without evidence is undefended. |
+| `ASSERT-008` | warning | `next_review_at` is set and is in the past relative to today. The assertion is stale and due for re-review. |
+
+The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3) and header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2) rules apply to ASSERTION files in addition to the ASSERT-* rules above.
+
+---
+
+## 6. File location and naming
+
+```
+canon/assertions/<ID>.yaml
+```
+
+One artefact per file, named by its canonical ID. The folder sits at the canon-zone root (not under `canon/elements/`). Examples:
+
+- `canon/assertions/ASSERTION-PRODUCT-MOBILE-DATA-ERASURE-1.yaml`
+- `canon/assertions/ASSERTION-PROCESS-CUST-ONBOARD-KYC-1.yaml`
+
+A typical naming convention encodes the subject + requirement in the middle segments (`ASSERTION-<SUBJECT-HINT>-<REQUIREMENT-HINT>-<N>`), but the canonical grammar imposes only `ASSERTION-[<middle>-]<INTEGER>`; teams may pick a different middle-segment convention.
+
+---
+
+## 7. Evolution
+
+Out of scope for this initial schema:
+
+- **CONSTRAINT-side assertions.** A CONSTRAINT is honoured or violated; that is currently modelled inline on the CONSTRAINT artefact or via downstream tooling. A parallel ASSERTION-against-CONSTRAINT mechanism MAY be added later if the use case proves out.
+- **Status history.** v1 records the current status. The planned versioned-attribute sidecar (Wave 2 of the temporal model) will host the time series.
+- **Coverage analysis.** "Which requirements have no assertion targeting them?" is the concern of `REQ-COVERAGE-001` (planned as a cross-cutting validator rule).
+- **Dead-link detection.** "Is this assertion bound to a retired element?" is the concern of `ASSERT-DEAD-LINK-001` (planned as a cross-cutting validator rule).
+- **Worked examples** under `organizations/acme_corp/canon/assertions/` plus a per-folder README — planned alongside the broader compliance worked-examples wave; not part of this initial registration.
+
+---
+
+## 8. References
+
+- TYPE registry and ID grammar: [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.6 (entry), §1 (grammar), §4 (uniqueness scope).
+- Zone model, admission record, primitive lifecycle: [CONTRACT.md](CONTRACT.md) §5, §6, §7.
+- The REQUIREMENT element type assertions are about: [15-requirement.md](15-requirement.md).
+- Codex source documents requirements derive from: [14-codex.md](14-codex.md).

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -134,6 +134,14 @@ External constraints and internal authority documents in the **Codex** zone — 
 | `POLICY` | codex / internal | an internal policy the organisation issues |
 | `INTERNAL_STANDARD` | codex / internal | an internal standard or convention |
 
+### 3.6 Assertion type
+
+Compliance claims linking a `REQUIREMENT` to the elements that realise it. Assertions are canonical (canon zone) but live **outside** the `elements/` tree, under `canon/assertions/`. Schema: [16-assertion.md](16-assertion.md).
+
+| TYPE | What it is |
+|---|---|
+| `ASSERTION` | a claim that a subject (`PRODUCT` / `PROCESS` / `CAPABILITY`) satisfies a `REQUIREMENT`, with status and evidence |
+
 ---
 
 ## 4. Uniqueness scope
@@ -153,6 +161,7 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | `RULE` | within the organisation's element catalogue (`elements/02_business/rules/`), one file per RULE. |
 | `CONSTRAINT` | within the organisation's element catalogue (`elements/01_motivation/constraints/`), one file per CONSTRAINT. |
 | `REQUIREMENT` | within the organisation's element catalogue (`elements/01_motivation/requirements/`), one file per REQUIREMENT. |
+| `ASSERTION` | within the organisation's `canon/assertions/` folder, one file per ASSERTION. |
 | `INTERVIEW`, `SURVEY`, `OBSERVATION`, `DRAFT` | within the organisation's `field/` zone. Contradictions between Field artefacts are allowed; only the IDs must be unique. |
 | `LAW`, `REGULATION` | within the organisation's `codex/external/` zone. |
 | `POLICY`, `INTERNAL_STANDARD` | within the organisation's `codex/internal/` zone. |


### PR DESCRIPTION
## Summary

Phase 2 of the compliance epic. Adds the canonical compliance-claim mechanism — an ASSERTION ties a subject (`PRODUCT` / `PROCESS` / `CAPABILITY`) to a REQUIREMENT with status + evidence + assessment cadence.

- `notations/IDS_AND_REFERENCES.md` — new §3.6 "Assertion type" parallel to §3.5 codex, registering ASSERTION. §4 — uniqueness scope (one file per ASSERTION under `canon/assertions/`).
- `notations/16-assertion.md` (new) — canonical schema spec following the `14-codex.md` / `15-requirement.md` precedent:
  - §1 What an Assertion is — (subject, requirement) pair model with a worked diagram. Explicit "REQUIREMENT only, not CONSTRAINT" boundary; CONSTRAINT-side compliance flagged as v1-out-of-scope.
  - §2 Frontmatter schema — `notation` / `id` / `about` / `subject` / `realised_via` + `status` + `evidence` (hybrid array) + `assessed_at` / `assessed_by` / `next_review_at` + the standard admission record (CONTRACT.md §6) + primitive lifecycle (CONTRACT.md §7).
  - §3 Status vocabulary — `compliant` / `partial` / `non_compliant` / `under_review` / `n_a`. v1 records the current value only; status history planned via the temporal model's Wave 2 sidecar.
  - §4 Evidence — three kinds: `canonical_ref` / `external_doc` / `note`, mixable within one assertion.
  - §5 Validation rules — `ASSERT-001` (id grammar + required fields), `002` (about → REQUIREMENT), `003` (subject TYPE in `{PRODUCT, PROCESS, CAPABILITY}`), `004` (realised_via resolves), `005` (canonical_ref evidence resolves), `006` (status enum), `007` (positive status with empty evidence — warning), `008` (stale `next_review_at` — warning).
  - §6 File location — `canon/assertions/<ID>.yaml` at the canon-zone root, outside the `elements/` tree.
  - §7 Evolution flags — CONSTRAINT-side assertions, status history, `REQ-COVERAGE-001` + `ASSERT-DEAD-LINK-001` cross-cutting rules (Phase 5), worked examples (Phase 4).

## Scope decisions

- **ID prefix `ASSERTION-`, not `ASSERT-`.** The epic body sketched IDs as `ASSERT-<short>-<integer>`, but IDS §1 requires the full TYPE name as prefix (no abbreviation). The `ASSERT-NNN` validation codes keep the short form since codes are not ID prefixes.
- **Registry placement = new §3.6.** ASSERTION is canon-zone but lives outside the `elements/` tree, so adding to §3.1 "Element types" misrepresented its location. New §3.6 parallels §3.5 codex (same shape: short table with one TYPE).
- **Schema home = dedicated 16-assertion.md.** Same convention as 15-requirement.md.
- **Subject TYPE restricted to PRODUCT / PROCESS / CAPABILITY** per epic body. ASSERT-003 enforces.

## Out of scope (deferred)

- **Worked examples** under `organizations/acme_corp/canon/assertions/` + folder README — Phase 4.
- **`REQ-COVERAGE-001`** (warning: REQUIREMENT with no ASSERTION targeting it) and **`ASSERT-DEAD-LINK-001`** (warning: subject / `realised_via` references a primitive with `valid_to` in the past) — Phase 5.
- **Codex `applies_to.{entities, processes}` retirement** — Phase 3.
- **CONSTRAINT-side assertions** — out of v1 scope; flagged in §7.
- **Status history sidecar** — Wave 2 of the temporal model.

## Test plan

- [x] Both touched files end with newline + a complete final line
- [x] `grep "vkgeorgia/strategy"`, client codenames, "real client" / "the client" framing — all empty in tracked files
- [x] IDS §3.6 entry parallels §3.5 codex structure; §4 uniqueness scope row matches the per-folder one-file pattern
- [x] 16-assertion.md cross-references resolve (CONTRACT §§5/6/7, IDS §1/§3.6/§4, 15-requirement.md, 14-codex.md)
- [x] Validation rules ASSERT-001..008 each name the specific failure condition and reference the relevant frontmatter field
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)