### PR TITLE
Compliance Phase 4 — worked REQUIREMENT + ASSERTION examples in acme_corp

### DIFF
--- a/organizations/acme_corp/canon/assertions/ASSERTION-CRM-DATA-ERASURE-1.yaml
+++ b/organizations/acme_corp/canon/assertions/ASSERTION-CRM-DATA-ERASURE-1.yaml
@@ -1,0 +1,37 @@
+# Worked example — under-review assertion with empty evidence.
+# Schema: notations/16-assertion.md §2.
+# Demonstrates: subject = CAPABILITY, status = under_review, evidence empty.
+# Status `under_review` deliberately has no evidence yet — the prior judgement
+# no longer holds and the new one has not been determined. The planned
+# ASSERT-007 warning ("positive status with empty evidence") does NOT fire
+# here because under_review is not a positive status.
+
+notation: assertion
+id: ASSERTION-CRM-DATA-ERASURE-1
+about: REQUIREMENT-DATA-ERASURE-1                      # same requirement as the other two
+subject: CAPABILITY-V2                                  # CAPABILITY TYPE; Customer Relationship Management
+
+# realised_via is empty during the review — the team is auditing whether the
+# existing realisation set still holds after a CRM platform change.
+realised_via: []
+
+status: under_review
+
+evidence: []
+
+assessed_at: "2026-05-20"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-06-30"                            # review scheduled within ~6 weeks
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-20"
+valid_to: null

--- a/organizations/acme_corp/canon/assertions/ASSERTION-MOBILE-DATA-ERASURE-1.yaml
+++ b/organizations/acme_corp/canon/assertions/ASSERTION-MOBILE-DATA-ERASURE-1.yaml
@@ -1,0 +1,45 @@
+# Worked example — full-evidence compliant assertion.
+# Schema: notations/16-assertion.md §2.
+# Demonstrates: subject = PRODUCT, status = compliant, evidence with all three
+# kinds (canonical_ref + external_doc + note).
+
+notation: assertion
+id: ASSERTION-MOBILE-DATA-ERASURE-1
+about: REQUIREMENT-DATA-ERASURE-1                      # → canon/elements/01_motivation/requirements/
+subject: PRODUCT-MOBILE-1                              # PRODUCT TYPE; resolves to a product element
+
+realised_via:
+  - CAPABILITY-V2                                       # Customer Relationship Management capability
+  - PROCESS-USER-DATA-PURGE-1                           # operational purge workflow
+  - INTERNAL_STANDARD-coding-conventions-1              # development discipline that bakes erasure into the codebase
+
+status: compliant
+
+evidence:
+  - kind: canonical_ref
+    ref: PROCESS-USER-DATA-PURGE-1                      # the documented purge process is itself the artefact-of-record
+  - kind: external_doc
+    title: "Q1 2026 data-erasure SLA report — Acme Mobile"
+    url: "https://internal.acme.example/reports/2026-Q1-mobile-erasure-sla.pdf"
+  - kind: note
+    text: >
+      DPO review on 2026-03-15 confirmed 100% of in-period erasure requests
+      were completed within the 30-day window. Sample audit of 50 requests
+      across Q1 showed median completion of 4.2 days. No exceptions raised.
+
+assessed_at: "2026-03-15"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-09-15"                            # twice-yearly cadence
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-03-15"
+valid_to: null

--- a/organizations/acme_corp/canon/assertions/ASSERTION-ONBOARD-DATA-ERASURE-1.yaml
+++ b/organizations/acme_corp/canon/assertions/ASSERTION-ONBOARD-DATA-ERASURE-1.yaml
@@ -1,0 +1,46 @@
+# Worked example — partial-status assertion with mixed evidence.
+# Schema: notations/16-assertion.md §2.
+# Demonstrates: subject = PROCESS, status = partial, evidence with two kinds
+# (external_doc + note) and a documented gap.
+
+notation: assertion
+id: ASSERTION-ONBOARD-DATA-ERASURE-1
+about: REQUIREMENT-DATA-ERASURE-1                      # same requirement as the mobile assertion
+subject: PROCESS-CUST-ONBOARD-1                        # PROCESS TYPE; the customer-onboarding process
+
+realised_via:
+  - CAPABILITY-V2                                       # Customer Relationship Management
+  - PROCESS-USER-DATA-PURGE-1                           # same downstream purge — but not yet wired into onboarding rollback
+
+status: partial
+
+evidence:
+  - kind: external_doc
+    title: "Onboarding-system DPIA addendum — erasure paths"
+    url: "https://internal.acme.example/dpia/onboarding-erasure-2026-04.pdf"
+  - kind: note
+    text: >
+      Onboarding correctly forwards verified erasure requests to the central
+      purge workflow within the 30-day window for the happy path. KNOWN GAP:
+      requests received during onboarding ROLLBACK (account creation aborted
+      mid-flow before activation) are not yet routed to purge — the data is
+      retained in the transient onboarding store until the 7-day TTL clears
+      it. Remediation tracked as ISSUE-ONBOARD-ROLLBACK-ERASURE-1; target
+      close 2026-Q3. Status will be re-evaluated at next review.
+
+assessed_at: "2026-04-20"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-07-20"                            # quarterly cadence until partial is closed
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-04-20"
+valid_to: null

--- a/organizations/acme_corp/canon/assertions/README.md
+++ b/organizations/acme_corp/canon/assertions/README.md
@@ -1,0 +1,37 @@
+# `canon/assertions/`
+
+Assertion artefacts — the canonical compliance claim that a subject (`PRODUCT` / `PROCESS` / `CAPABILITY`) satisfies a `REQUIREMENT`, with status and evidence. Each assertion is one file under this folder.
+
+Assertions are canon-zone artefacts but live **outside** the `elements/` tree: `canon/assertions/` is a flat directory at the canon-zone root, peer to `canon/elements/` and `canon/views/`. This reflects that an assertion is a *claim about* canonical elements rather than an element itself.
+
+Schema and validation rules are defined in [`notations/16-assertion.md`](../../../notations/16-assertion.md). TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../notations/IDS_AND_REFERENCES.md) §3.6 (`ASSERTION`), §4 (uniqueness scope).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows the canonical grammar `ASSERTION-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../notations/IDS_AND_REFERENCES.md) §1. A typical middle-segment convention encodes the (subject, requirement) pair — e.g. `ASSERTION-MOBILE-DATA-ERASURE-1` for a claim by `PRODUCT-MOBILE-1` against `REQUIREMENT-DATA-ERASURE-1`. The grammar imposes only the prefix and the terminal integer; teams may pick a different middle-segment convention.
+
+## The (subject, requirement) pair
+
+One assertion per `(subject, requirement)` pair. Multiple subjects against the same requirement → multiple assertions; the same subject against multiple requirements → multiple assertions. Status and evidence are mutable over an assertion's lifecycle; the realisation set (`realised_via`) may also change as the underlying processes / capabilities evolve.
+
+## Status vocabulary
+
+`compliant` / `partial` / `non_compliant` / `under_review` / `n_a`. See [`notations/16-assertion.md`](../../../notations/16-assertion.md) §3 for semantics.
+
+## Examples in this folder
+
+| File | Subject | About | Status | Evidence | Notes |
+|---|---|---|---|---|---|
+| `ASSERTION-MOBILE-DATA-ERASURE-1.yaml` | `PRODUCT-MOBILE-1` | `REQUIREMENT-DATA-ERASURE-1` | `compliant` | all three kinds (`canonical_ref` + `external_doc` + `note`) | full-evidence happy path |
+| `ASSERTION-ONBOARD-DATA-ERASURE-1.yaml` | `PROCESS-CUST-ONBOARD-1` | `REQUIREMENT-DATA-ERASURE-1` | `partial` | `external_doc` + `note` only | mid-remediation; gaps documented |
+| `ASSERTION-CRM-DATA-ERASURE-1.yaml` | `CAPABILITY-V2` | `REQUIREMENT-DATA-ERASURE-1` | `under_review` | empty | demonstrates the `ASSERT-007` warning (positive status absent → no defended claim) |
+
+Three subjects (one each of `PRODUCT`, `PROCESS`, `CAPABILITY`) all targeting the same requirement — the same regulatory obligation has different realisation footprints across the organisation, and each is asserted separately.
+
+`REQUIREMENT-AUDIT-LOG-RETENTION-1` deliberately has **no** assertion targeting it, to surface the planned `REQ-COVERAGE-001` warning (a requirement with no assertion is a compliance gap). See [`notations/16-assertion.md`](../../../notations/16-assertion.md) §7 Evolution.
+
+## See also
+
+- Assertion spec: [`notations/16-assertion.md`](../../../notations/16-assertion.md).
+- The requirements assertions are about: [`../elements/01_motivation/requirements/`](../elements/01_motivation/requirements/) and [`notations/15-requirement.md`](../../../notations/15-requirement.md).
+- Zone model, admission record, primitive lifecycle: [`notations/CONTRACT.md`](../../../notations/CONTRACT.md) §5–7.

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/README.md
@@ -1,0 +1,39 @@
+# `canon/elements/01_motivation/requirements/`
+
+Requirement elements — positive obligations the organisation must fulfil. Each requirement is one file under this folder. Requirements sit on the ArchiMate 3.2 **motivation** layer.
+
+Requirements are distinct from `CONSTRAINT` by the **form of the obligation**: REQUIREMENT = positive action ("must submit", "must register", "must obtain approval"); CONSTRAINT = restriction ("must not", "cannot exceed"). See the full decision guide in [`notations/15-requirement.md`](../../../../../notations/15-requirement.md) §1.
+
+Each requirement may cite zero or more codex sources via `derived_from:` (`LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`). A requirement with no `derived_from` is an internal obligation that has no written codex source.
+
+Requirements are not bound to subjects directly. The compliance claim that a specific subject (`PRODUCT` / `PROCESS` / `CAPABILITY`) satisfies a requirement lives in [`../../../assertions/`](../../../assertions/) as an `ASSERTION` artefact ([`notations/16-assertion.md`](../../../../../notations/16-assertion.md)).
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`REQUIREMENT`), §4 (uniqueness scope).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows the canonical grammar `REQUIREMENT-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §1.
+
+Examples: `REQUIREMENT-DATA-ERASURE-1.yaml`, `REQUIREMENT-1.yaml`.
+
+## Schema
+
+Defined in [`notations/15-requirement.md`](../../../../../notations/15-requirement.md) §2. Every requirement carries:
+
+- The requirement-specific fields: `notation: requirement`, `id`, `title`, `description`, optional `severity` / `derived_from`.
+- The admission record per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
+- The primitive lifecycle per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
+
+## Examples in this folder
+
+| File | Source | Notes |
+|---|---|---|
+| `REQUIREMENT-DATA-ERASURE-1.yaml` | external — `LAW-PERSONAL-DATA-2017-1` | demonstrates a requirement derived from a codex external `LAW` |
+| `REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml` | none (`derived_from` absent) | demonstrates an internal-only requirement with no codex source; intentionally has no assertion targeting it, surfacing the planned `REQ-COVERAGE-001` warning |
+
+## See also
+
+- Requirement spec: [`notations/15-requirement.md`](../../../../../notations/15-requirement.md).
+- Sibling constraints catalogue: [`../constraints/`](../constraints/).
+- Compliance claims linking requirements to subjects: [`../../../assertions/`](../../../assertions/) and [`notations/16-assertion.md`](../../../../../notations/16-assertion.md).
+- Codex sources requirements derive from: [`../../../../codex/`](../../../../codex/) and [`notations/14-codex.md`](../../../../../notations/14-codex.md).

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml
@@ -1,0 +1,32 @@
+# Worked example — internal-only REQUIREMENT with no codex source.
+# Schema: notations/15-requirement.md §2.
+#
+# This requirement intentionally has no assertion targeting it, to demonstrate
+# the planned REQ-COVERAGE-001 cross-cutting warning (a REQUIREMENT with no
+# ASSERTION about it). See notations/16-assertion.md §7 Evolution.
+
+notation: requirement
+id: REQUIREMENT-AUDIT-LOG-RETENTION-1
+title: "Retain operational audit logs for at least 12 months"
+description: >
+  All systems producing operational audit logs must retain those logs for
+  at least 12 months from creation. The obligation is an internal Acme
+  practice; no external codex source binds it. If a future internal
+  standard formalises it, this requirement should be updated to cite that
+  standard via derived_from.
+
+severity: medium
+# derived_from: absent — purely internal obligation
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-01-01"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-DATA-ERASURE-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-DATA-ERASURE-1.yaml
@@ -1,0 +1,29 @@
+# Worked example — REQUIREMENT derived from an external codex source.
+# Schema: notations/15-requirement.md §2.
+# Assertion(s) about this requirement live in canon/assertions/.
+
+notation: requirement
+id: REQUIREMENT-DATA-ERASURE-1
+title: "Personal-data erasure on request within 30 days"
+description: >
+  On a verified request from a data subject, the controller must erase the
+  subject's personal data within 30 days. The window starts at the time the
+  request is received and verified. Applies across every system that stores
+  personal data of natural persons resident in Georgia.
+
+severity: high
+derived_from:
+  - LAW-PERSONAL-DATA-2017-1     # codex/external/ge/
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2017-05-01"           # date the source law took effect
+valid_to: null


### PR DESCRIPTION
## Summary

Phase 4 of the compliance epic. Populates `acme_corp` with the worked examples that demonstrate the end-to-end compliance chain: codex source → REQUIREMENT (`derived_from`) → ASSERTION (`about`, `subject`, `realised_via`) → status + evidence.

## New folders

- `organizations/acme_corp/canon/elements/01_motivation/requirements/`
- `organizations/acme_corp/canon/assertions/` (at the canon-zone root, outside the `elements/` tree per the 16-assertion.md spec)

## Worked examples

**REQUIREMENTs (2):**
- `REQUIREMENT-DATA-ERASURE-1` — external, `derived_from: [LAW-PERSONAL-DATA-2017-1]` (existing codex artefact). Demonstrates the single-external-source case.
- `REQUIREMENT-AUDIT-LOG-RETENTION-1` — internal, **no `derived_from`**. Demonstrates the purely-internal-obligation case. **Intentionally has no assertion targeting it** — surfaces the planned `REQ-COVERAGE-001` cross-cutting warning (compliance gap).

**ASSERTIONs (3, all about `REQUIREMENT-DATA-ERASURE-1` — same regulatory obligation, three subject angles):**

| File | Subject | Status | Evidence | Demonstrates |
|---|---|---|---|---|
| `ASSERTION-MOBILE-DATA-ERASURE-1.yaml` | `PRODUCT-MOBILE-1` | `compliant` | all three kinds (`canonical_ref` + `external_doc` + `note`) | full-evidence happy path |
| `ASSERTION-ONBOARD-DATA-ERASURE-1.yaml` | `PROCESS-CUST-ONBOARD-1` | `partial` | `external_doc` + `note` | mid-remediation; documented gap under tracked issue |
| `ASSERTION-CRM-DATA-ERASURE-1.yaml` | `CAPABILITY-V2` | `under_review` | empty | `ASSERT-007` does **not** fire on `under_review` (only on `compliant`/`partial`) |

Each example carries the admission record (CONTRACT.md §6) and primitive lifecycle (CONTRACT.md §7).

## Folder READMEs

- `requirements/README.md` — file convention, schema pointer to `15-requirement.md`, REQUIREMENT vs CONSTRAINT decision-guide pointer, examples table.
- `assertions/README.md` — file convention with `(subject, requirement)` middle-segment naming, status vocabulary pointer, examples table showing the three demonstrated patterns.

## Scope decisions

- **Subject IDs use canonical full TYPE prefixes** (`PRODUCT-`, `PROCESS-`, `CAPABILITY-`) per IDS §1. In acme_corp's current population some catalogue entries still use deprecated `PROD-`/`PROC-` abbreviations — those are tracked separately for the elements-population task and don't block this PR (the examples teach the canonical form).
- **All three assertions target the same REQUIREMENT** — gives narrative coherence ("data erasure across the org's mobile product, onboarding process, and CRM capability") rather than three unrelated topics. REQUIREMENT-AUDIT-LOG-RETENTION-1 is intentionally uncovered for the REQ-COVERAGE-001 demo.
- **`realised_via: []` on the under_review assertion** — natural for the case (the realisation set is being audited; old set no longer trusted, new not yet determined). The schema allows empty realised_via.
- **Optional third REQUIREMENT** (the multi-source case from the epic body) — **deferred**. Would need a second LAW/REGULATION in acme_corp codex; out of Phase 4 scope.

## Out of scope (next)

- **Phase 5** — cross-cutting validators (`REQ-COVERAGE-001`, `ASSERT-DEAD-LINK-001`) + a single CONTRACT.md table listing all compliance-domain rules.
- **Catalogue ID migration** — `PROD-`/`PROC-` → `PRODUCT-`/`PROCESS-` across the existing acme_corp views (tracked separately under the IDS migration backlog).

## Test plan

- [x] All 5 YAMLs parse cleanly under `yaml.safe_load`
- [x] Both READMEs end with newline + complete final line
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Each assertion's `about` resolves to a sibling REQUIREMENT in the same PR; each `subject` uses a canonical TYPE prefix in `{PRODUCT, PROCESS, CAPABILITY}`; `realised_via` entries use canonical TYPE prefixes
- [x] Three status values (`compliant`, `partial`, `under_review`) and all three evidence kinds (`canonical_ref`, `external_doc`, `note`) all represented
- [x] Empty-realised_via + empty-evidence on the under_review assertion does NOT trigger `ASSERT-007` (rule fires only on `compliant`/`partial`)
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)