### PR TITLE
Compliance Phase 5 (final) — cross-cutting REQ-COVERAGE-001 + ASSERT-DEAD-LINK-001 + CONTRACT §8 aggregated table

### DIFF
--- a/notations/15-requirement.md
+++ b/notations/15-requirement.md
@@ -110,8 +110,9 @@ The folder sits alongside `canon/elements/01_motivation/constraints/` — the tw
 | `REQ-001` | error | `id` is missing or does not match the canonical grammar `REQUIREMENT-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §1); or any required field from §2 (`notation`, `title`, `description`, `zone`, `admitted_at`, `admitted_by`, `gate_checks`, `valid_from`, `valid_to`) is missing. |
 | `REQ-002` | error | A value in `derived_from` is a well-formed typed ID but does not resolve to any admitted codex artefact in the organisation's `codex/` zone. |
 | `REQ-003` | error | A value in `derived_from` resolves to an artefact whose TYPE is not one of `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD`. Requirements derive only from codex source documents. |
+| `REQ-COVERAGE-001` | warning | A REQUIREMENT has no ASSERTION targeting it — no file under `canon/assertions/` carries `about: <this REQ id>`. Surfaces a compliance gap: the obligation exists in the model but the organisation makes no recorded claim about whether any subject satisfies it. The rule is `warning` rather than `error` because a newly admitted REQUIREMENT legitimately has no assertion yet. Cross-cutting — fires on the REQUIREMENT but is computed by scanning the assertions catalogue. |
 
-The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3) and header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2) rules apply to REQUIREMENT files in addition to the REQ-* rules above.
+The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3) and header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2) rules apply to REQUIREMENT files in addition to the REQ-* rules above. The aggregated compliance-domain rules table (covering both REQUIREMENT and ASSERTION) lives in [CONTRACT.md](CONTRACT.md) §8.
 
 ---
 

--- a/notations/16-assertion.md
+++ b/notations/16-assertion.md
@@ -144,8 +144,9 @@ Each entry in `evidence[]` carries a `kind` plus kind-specific fields. Mix freel
 | `ASSERT-006` | error | `status` is not one of `compliant`, `partial`, `non_compliant`, `under_review`, `n_a`. |
 | `ASSERT-007` | warning | `evidence` is empty AND `status` is `compliant` or `partial`. A positive status without evidence is undefended. |
 | `ASSERT-008` | warning | `next_review_at` is set and is in the past relative to today. The assertion is stale and due for re-review. |
+| `ASSERT-DEAD-LINK-001` | warning | The assertion's `subject` or any entry in `realised_via` resolves to a primitive whose `valid_to` is set and is earlier than today — the assertion is bound to a currently-retired element. The rule is `warning` rather than `error` because an assertion MAY be intentionally preserved as a historical record after one of its bound elements retires (the claim itself remains true for the period it covered). Distinct from `LIFECYCLE-004` ([CONTRACT.md](CONTRACT.md) §7.3), which checks the referenced primitive's `valid_to` against the *referrer's* `valid_from` rather than against today. |
 
-The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3) and header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2) rules apply to ASSERTION files in addition to the ASSERT-* rules above.
+The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3) and header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2) rules apply to ASSERTION files in addition to the ASSERT-* rules above. The aggregated compliance-domain rules table (covering both REQUIREMENT and ASSERTION) lives in [CONTRACT.md](CONTRACT.md) §8.
 
 ---
 

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -2,7 +2,7 @@
 
 All eleven Transitrix notations share the same file-header contract: the same required field, the same reserved field, the same validator rules, and the same extension/content match guarantee. This document defines those shared rules once. Each notation spec links here and lists only its per-notation values (the `notation:` short name and the file extension).
 
-This document also defines three organisation-level contracts shared across all notations: the **zone model** (§5), the **admission record** (§6), and the **primitive lifecycle** (§7) that every organisation artefact carries.
+This document also defines three organisation-level contracts shared across all notations: the **zone model** (§5), the **admission record** (§6), and the **primitive lifecycle** (§7) that every organisation artefact carries. §8 aggregates the validation rules of the compliance domain (REQUIREMENT + ASSERTION) for discoverability — the per-notation specs remain authoritative for the rule definitions themselves.
 
 A change to the rules below applies to all eleven notations simultaneously — they should be edited here, not duplicated into each spec.
 
@@ -157,3 +157,29 @@ The lifecycle fields are required on every canonical primitive once a notation s
 - **Branching timelines.** Alternative futures are the concern of the Scenarios notation (`notations/11-scenarios.md`), not of the primitive lifecycle.
 - **Sub-day precision.** ISO 8601 date precision only; no timestamps, no timezones in canon. "Today" is the date of the query or render.
 - **First-class time-aware relations.** Promoting relations like `parent` / `applies_to` / activity→goal to first-class lifecycle-bearing files is planned for Wave 3 of the temporal model. In v1 such relations remain inline and timeless on their host primitive.
+
+---
+
+## 8. Compliance-domain rules
+
+The compliance domain spans two notations — **`REQUIREMENT`** (motivation-layer element, [15-requirement.md](15-requirement.md)) and **`ASSERTION`** (canon-zone primitive linking a requirement to a subject, [16-assertion.md](16-assertion.md)). For discoverability, the validation rules for both are aggregated below in a single table. The per-notation specs remain the authoritative source for the rule definitions; this table is an index.
+
+| Rule | Severity | Notation | Short description | Authoritative spec |
+|---|---|---|---|---|
+| `REQ-001` | error | REQUIREMENT | `id` grammar invalid, or any required field missing | [15-requirement.md](15-requirement.md) §4 |
+| `REQ-002` | error | REQUIREMENT | `derived_from` references an ID that does not resolve | [15-requirement.md](15-requirement.md) §4 |
+| `REQ-003` | error | REQUIREMENT | `derived_from` ID is not of TYPE `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD` | [15-requirement.md](15-requirement.md) §4 |
+| `REQ-COVERAGE-001` | warning | REQUIREMENT (cross-cutting) | REQUIREMENT has no ASSERTION targeting it — compliance gap | [15-requirement.md](15-requirement.md) §4 |
+| `ASSERT-001` | error | ASSERTION | a required field is missing, or `id` grammar invalid | [16-assertion.md](16-assertion.md) §5 |
+| `ASSERT-002` | error | ASSERTION | `about` is missing, malformed, or resolves to a non-REQUIREMENT | [16-assertion.md](16-assertion.md) §5 |
+| `ASSERT-003` | error | ASSERTION | `subject` does not resolve, or TYPE not in `{PRODUCT, PROCESS, CAPABILITY}` | [16-assertion.md](16-assertion.md) §5 |
+| `ASSERT-004` | error | ASSERTION | a `realised_via` entry does not resolve | [16-assertion.md](16-assertion.md) §5 |
+| `ASSERT-005` | error | ASSERTION | an `evidence[]` entry with `kind: canonical_ref` has a `ref` that does not resolve | [16-assertion.md](16-assertion.md) §5 |
+| `ASSERT-006` | error | ASSERTION | `status` not in the enum (`compliant` / `partial` / `non_compliant` / `under_review` / `n_a`) | [16-assertion.md](16-assertion.md) §5 |
+| `ASSERT-007` | warning | ASSERTION | `evidence` is empty AND `status` is `compliant` or `partial` — undefended positive claim | [16-assertion.md](16-assertion.md) §5 |
+| `ASSERT-008` | warning | ASSERTION | `next_review_at` is set and is in the past — assertion is stale | [16-assertion.md](16-assertion.md) §5 |
+| `ASSERT-DEAD-LINK-001` | warning | ASSERTION (cross-cutting) | `subject` or `realised_via` references a primitive whose `valid_to` is in the past — bound to a currently-retired element | [16-assertion.md](16-assertion.md) §5 |
+
+In addition, the shared header rules (`HDR-001..004`, §2) and primitive-lifecycle rules (`LIFECYCLE-001..004`, §7.3) apply to REQUIREMENT and ASSERTION files as they do to every other canonical artefact.
+
+The two `*-COVERAGE-001` / `*-DEAD-LINK-001` rules are **cross-cutting**: their checks span more than one file (a REQUIREMENT's coverage depends on the assertions catalogue; an ASSERTION's dead-link state depends on the lifecycle dates of the primitives it references). Notation-local rules check a single file in isolation; cross-cutting rules require the validator to be loaded with the full canon catalogue.


### PR DESCRIPTION
## Summary

Final phase of the compliance epic. Adds the two cross-cutting validator rules sketched in the epic body and aggregates the full compliance-domain rule set into `notations/CONTRACT.md` §8 as a single-source-of-truth index.

## Changes

- **`notations/15-requirement.md` §4** — adds `REQ-COVERAGE-001` (warning): a REQUIREMENT has no ASSERTION targeting it (no file under `canon/assertions/` carries `about: <this REQ id>`). Surfaces compliance gaps. Warning rather than error because a newly admitted REQUIREMENT legitimately has no assertion yet. Cross-cutting — fires on REQUIREMENT but is computed by scanning the assertions catalogue.

- **`notations/16-assertion.md` §5** — adds `ASSERT-DEAD-LINK-001` (warning): the assertion's `subject` or any `realised_via` entry resolves to a primitive whose `valid_to` is in the past. Warning because an assertion may be intentionally preserved as a historical record after one of its bound elements retires. Distinct from `LIFECYCLE-004`: that rule checks the referent's `valid_to` vs the *referrer's* `valid_from` (a static consistency check); `ASSERT-DEAD-LINK-001` checks the referent's `valid_to` vs *today* (a staleness check at query time).

- **`notations/CONTRACT.md` — new §8 "Compliance-domain rules"** — aggregated table listing all `REQ-*` + `ASSERT-*` rules (the existing 3 + 8 plus the two new cross-cutting ones), each row pointing at the authoritative per-notation spec. The intro paragraph adds a one-liner mentioning §8. A closing note distinguishes notation-local rules (single-file checks) from cross-cutting rules (need full canon catalogue loaded).

## Scope decisions

- **§8 is an index, not a relocation.** Per-notation specs (15-requirement.md §4, 16-assertion.md §5) remain authoritative for the rule definitions; §8 is the discoverable single-source-of-truth table with pointers. This preserves the existing convention (per-notation rules live in per-notation specs; CONTRACT.md hosts only truly shared rules like HDR-* and LIFECYCLE-*).
- **Coverage rule lives on REQUIREMENT side.** Conceptually it's about "is this REQUIREMENT covered by some ASSERTION?", so REQUIREMENT is the natural owner. The validator computation scans the assertions catalogue from the REQUIREMENT side.
- **Dead-link rule lives on ASSERTION side** for the same reason — the assertion is the artefact with the cross-references that may go dead.
- **Cross-cutting checks are explicit about catalogue loading.** §8 closing note: notation-local rules check a single file in isolation; cross-cutting rules require the validator to be loaded with the full canon catalogue.

## Acceptance for the epic as a whole

This PR closes out the compliance epic:

- **Phase 1** (#43, merged) — REQUIREMENT element type registered, schema spec at `notations/15-requirement.md`, REQ-001..003 validators.
- **Phase 2** (#44, merged) — ASSERTION notation at `notations/16-assertion.md`, ASSERT-001..008 validators, `canon/assertions/` folder convention.
- **Phase 3** (#45, merged) — codex `applies_to.{entities, processes}` retired; CODEX-004 deprecation warning; migration note in 14-codex.md §8.
- **Phase 4** (#46, merged) — worked examples in `acme_corp`: 2 REQUIREMENTs, 3 ASSERTIONs (compliant / partial / under_review across PRODUCT / PROCESS / CAPABILITY subjects), folder READMEs.
- **Phase 5** (this PR) — cross-cutting REQ-COVERAGE-001 + ASSERT-DEAD-LINK-001, CONTRACT.md §8 aggregated table.

## Test plan

- [x] All 3 touched markdowns end with newline + complete final line
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client" / "the client" framing in tracked files
- [x] CONTRACT.md §8 table includes every REQ-* (4 total) + every ASSERT-* (9 total) rule, each pointing at the correct per-notation spec
- [x] The acme_corp Phase 4 examples align with the new rules: `REQUIREMENT-AUDIT-LOG-RETENTION-1` has no assertion (would trigger REQ-COVERAGE-001 — intentional demo); `ASSERTION-CRM-…` has empty evidence but `status: under_review` (does NOT trigger ASSERT-007); none of the demo assertions bind to retired primitives (so ASSERT-DEAD-LINK-001 does not fire on the worked examples).
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)