### PR TITLE
Temporal model Wave 1 PR 2/n — strategy-chain specs reference CONTRACT §7

### DIFF
--- a/notations/02-fgca.md
+++ b/notations/02-fgca.md
@@ -21,6 +21,12 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline element this notation defines — entries in `factors[]`, `goals[]`, `changes[]`, `activities[]` — carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline elements in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each inline element entry; the FGCA document itself does not carry a lifecycle field.
+
+---
+
 ## Method Author
 
 This method is authored by **Valerii Korobeinikov**.

--- a/notations/03-fga.md
+++ b/notations/03-fga.md
@@ -25,6 +25,12 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline element this notation defines — entries in `factors[]`, `goals[]`, `activities[]` — carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline elements in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each inline element entry; the FGA document itself does not carry a lifecycle field.
+
+---
+
 ## 1. Overview
 
 FGA is the simplified variant of FGCA. It is used when the transformation step between goals and activities is implicit or trivial — when activities directly and obviously serve goals without needing an intermediate change layer.

--- a/notations/04-goals.md
+++ b/notations/04-goals.md
@@ -26,6 +26,12 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline element this notation defines — entries in `goals[]` — carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline elements in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each inline element entry; the goals-tree document itself does not carry a lifecycle field. The `goal_types[]` entries are a static vocabulary, not elements, and carry no lifecycle.
+
+---
+
 ## 1. Overview
 
 A goals tree is a hierarchical view that arranges Goal elements from `elements/01_motivation/` into a top-down tree — from broad strategic ambitions down to specific tactical objectives.

--- a/notations/07-activities.md
+++ b/notations/07-activities.md
@@ -26,6 +26,12 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline element this notation defines — entries in `activities[]` — carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline elements in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each inline element entry; the activities document itself does not carry a lifecycle field. Per-activity scheduling fields (`start_date`, `end_date`) describe *when work is planned to happen*, distinct from `valid_from`/`valid_to` which describe *when the activity element itself is considered in effect*; both coexist.
+
+---
+
 ## 1. Overview
 
 An **Activities** document describes a directed acyclic graph (DAG) of activities and the dependencies between them, optionally placed in calendar time. It is the text-native form of a project schedule with two coexisting renderings:


### PR DESCRIPTION
## Summary

Second PR of Wave 1 of the temporal-model epic. Adds an "Element lifecycle" reference section to each of the four strategy-chain notation specs (FGCA / FGA / Goals / Activities), pointing at CONTRACT.md §7 for the shared rule + field semantics + LIFECYCLE-001..004 validation codes.

Per the epic body: *"Update each notation spec to reference the CONTRACT rule. No per-spec restatement."* Each section is 3–5 lines.

## Changes

| Spec | Element arrays declared lifecycle-bearing |
|---|---|
| [`02-fgca.md`](https://github.com/transitrix/methodology/blob/main/notations/02-fgca.md) | `factors[]`, `goals[]`, `changes[]`, `activities[]` |
| [`03-fga.md`](https://github.com/transitrix/methodology/blob/main/notations/03-fga.md) | `factors[]`, `goals[]`, `activities[]` |
| [`04-goals.md`](https://github.com/transitrix/methodology/blob/main/notations/04-goals.md) | `goals[]` (with explicit note that `goal_types[]` is a static vocabulary, not lifecycle-bearing) |
| [`07-activities.md`](https://github.com/transitrix/methodology/blob/main/notations/07-activities.md) | `activities[]` (with explicit note distinguishing per-activity scheduling `start_date`/`end_date` — work timeline — from `valid_from`/`valid_to` — element lifecycle) |

Each section names which inline element arrays carry `valid_from` / `valid_to`, points at CONTRACT §7 for the contract and §7.1 for the inline-vs-document distinction, and notes that the view document itself does not carry a lifecycle field.

## Scope decisions

- **No schema-example rewrites.** Per the epic's "no per-spec restatement" rule. Adopters who need field-level detail look up CONTRACT §7. Example sweeps land in subsequent Wave 1 PRs per "don't bundle".
- **Family-batched.** Strategy-chain family (FGCA/FGA/Goals/Activities) in one PR. Next batches: capability+process family (05/06), catalogue family (09/10), standalone (01/08/11/12/13), and 14/15/16 zone primitives are partially-covered already.
- **Goal_types[] explicitly excluded.** A static vocabulary, not an element, so doesn't bear lifecycle.
- **Per-activity scheduling fields disambiguated.** `start_date`/`end_date` describe *when work is planned to happen*; `valid_from`/`valid_to` describe *when the activity element itself is in effect*. Both coexist on the same entry. Activities is the one notation where this distinction is non-obvious, so 07's section calls it out explicitly.

## Test plan

- [x] All 4 markdowns end with newline + complete final line
- [x] Each spec has exactly one "Element lifecycle" section + reference to LIFECYCLE-001..004
- [x] No private-strategy hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Section placement consistent across all 4 (after "File header", before "## 1. Overview" or equivalent first body section)
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)