### PR TITLE
Temporal model Wave 1 PR 3/n — capability-map + process-map reference CONTRACT §7

### DIFF
--- a/notations/05-capability-map.md
+++ b/notations/05-capability-map.md
@@ -30,6 +30,14 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline element this notation defines — entries in `capabilities[]`, recursively including nested `children[]` — carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline elements in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each capability entry; the capability-map document itself does not carry a lifecycle field.
+
+The capability-specific state vocabulary (`Planned` / `Active` / `Retired`) in §7 below is a **derived view** computed by comparing `valid_from` / `valid_to` against today's date — not a separate stored mechanism. The legacy "Start Date" / "End Date" framing in §7 refers to the same canonical `valid_from` / `valid_to` fields; subsequent revisions will unify the field naming.
+
+---
+
 ## 1. Overview
 
 A capabilities map is a hierarchical view that shows what the organisation **can do** and how well it does it. It answers two questions in one artefact:

--- a/notations/06-process-map.md
+++ b/notations/06-process-map.md
@@ -25,6 +25,12 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline process entry under `groups[].processes[]` carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline elements in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each process entry; neither the process-map document nor the process groups carry a lifecycle field — groups are organisational containers, not elements.
+
+---
+
 ## 1. Overview
 
 The process landscape map answers the question: **what processes does the organisation have?**


### PR DESCRIPTION
## Summary

Third PR of Wave 1 of the temporal-model epic. Adds the "Element lifecycle" reference section to the capability+process family. Same minimal pattern as PR #48 (strategy-chain family).

## Changes

- **`05-capability-map.md`** — declares `capabilities[]` (recursively including nested `children[]`) lifecycle-bearing per CONTRACT §7. The capability-specific state vocabulary already documented in this spec's §7 (`Planned` / `Active` / `Retired`) is explicitly called out as a **derived view** computed from `valid_from` / `valid_to` + today's date, not a separate mechanism. The legacy "Start Date" / "End Date" framing in this spec's §7 refers to the canonical `valid_from` / `valid_to` fields; subsequent revisions will unify the naming.
- **`06-process-map.md`** — declares the inline process entries under `groups[].processes[]` lifecycle-bearing. Groups themselves are explicitly noted as organisational containers, not elements — they carry no lifecycle.

## Scope decisions

- **05's pre-existing `## 7. Lifecycle states` is preserved.** Renaming "Start Date" / "End Date" to `valid_from` / `valid_to` in the body of §7 is a content rewrite beyond "reference the contract rule"; I called out the equivalence in the new section but left the §7 wording for a subsequent unification PR.
- **Groups are not elements** in 06 — they're document structure. Only the `processes[]` entries inside groups carry lifecycle. Stated explicitly to avoid an over-broad interpretation.

## Test plan

- [x] Both markdowns end with newline + complete final line
- [x] Each spec has exactly one "Element lifecycle" section + reference to LIFECYCLE-001..004
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Section placement consistent with PR #48 (after "File header", before "## 1. Overview")
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)