### PR TITLE
Temporal model Wave 1 PR 4/n — products + applications catalogues reference CONTRACT §7

### DIFF
--- a/notations/09-products.md
+++ b/notations/09-products.md
@@ -25,6 +25,12 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline product or service entry under `products[]` carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline elements in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each `products[]` entry; the products-catalogue document itself does not carry a lifecycle field. The catalogue's own `status` field (e.g. `active` / `deprecated`) is a notation-specific operational state, distinct from `valid_from` / `valid_to` which mark the period the product element is asserted to exist.
+
+---
+
 ## 1. Overview
 
 The products catalogue answers the question: **what products and services does the organisation offer?**

--- a/notations/10-applications.md
+++ b/notations/10-applications.md
@@ -25,6 +25,12 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline entry under `applications[]` — whether `type: application`, `integration`, `platform`, or `data_store` — carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline elements in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each catalogue entry; the applications-catalogue document itself does not carry a lifecycle field. Per-application `integrations[]` sub-entries (outbound integration descriptors nested inside an application) share their parent application's lifecycle and do not carry their own `valid_from` / `valid_to`. The catalogue's own `status` field (`Active` / `Draft` / `Deprecated` / `Decommissioning`) is a notation-specific operational state, distinct from `valid_from` / `valid_to` which mark the period the application element is asserted to exist.
+
+---
+
 ## 1. Overview
 
 The applications catalogue answers the question: **what applications and integrations does the organisation operate?**


### PR DESCRIPTION
## Summary

Fourth PR of Wave 1 of the temporal-model epic. Catalogue family — `09-products.md` and `10-applications.md` each pick up the short "Element lifecycle" reference section pointing at CONTRACT §7. Same minimal pattern as PRs #48 (strategy chain) and #49 (capability+process).

## Changes

- **`09-products.md`** — declares `products[]` entries lifecycle-bearing. The catalogue's own `status` field (`active` / `deprecated`) is called out as a notation-specific *operational* state, distinct from `valid_from`/`valid_to` which mark *the period the product element is asserted to exist*.
- **`10-applications.md`** — declares `applications[]` entries lifecycle-bearing regardless of `type` (`application` / `integration` / `platform` / `data_store`). Per-application `integrations[]` sub-entries (nested outbound integration descriptors) are explicitly noted as sharing the parent's lifecycle and not carrying their own `valid_from`/`valid_to`. Status disambiguation mirrors 09.

## Scope decisions

- **`type` doesn't gate lifecycle** in 10-applications — every catalogue entry is an element regardless of which `application`/`integration`/`platform`/`data_store` flavour.
- **Nested `integrations[]` sub-entries share parent lifecycle.** Reflects that those descriptors are scoped to their parent application; promoting them to first-class lifecycle-bearing files would be a Wave 3 relations concern, not Wave 1.
- **Operational `status` vs lifecycle is the recurring disambiguation** for these two specs. Both call out the distinction in identical phrasing.

## Test plan

- [x] Both markdowns end with newline + complete final line
- [x] Each spec has exactly one "Element lifecycle" section + reference to LIFECYCLE-001..004
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Section placement consistent with PRs #48 + #49 (after "File header", before "## 1. Overview")
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)