### PR TITLE
Temporal model Wave 1 PR 5/n — BPMN / blocks / scenarios / issues / process-blueprint reference CONTRACT §7

### DIFF
--- a/notations/01-bpmn.md
+++ b/notations/01-bpmn.md
@@ -26,6 +26,14 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+BPMN files use **file-local labels** for the nodes they describe (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`). Per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.3 these labels are not canonical elements — they identify nodes within one BPMN document only, not artefacts that the organisation registers in its element catalogue. Accordingly, neither the BPMN nodes nor the BPMN document itself carry the canonical primitive lifecycle (`valid_from` / `valid_to`) defined in [CONTRACT.md](CONTRACT.md) §7.
+
+The lifecycle of the **process** this BPMN file describes lives on the corresponding `PROCESS-…` element registered in the process landscape map ([06-process-map.md](06-process-map.md)); the BPMN file is the detailed flow representation of that process, not the lifecycle bearer.
+
+---
+
 ## 1. Overview
 
 A process file describes a BPMN 2.0 process as a structured YAML document. The notation captures one pool, one or more lanes, typed elements inside lanes, and named sequence flows between elements. Coordinates and visual styling are **not** part of the notation — layout is computed deterministically at compile time and embedded as `bpmndi:` blocks in the output XML.

--- a/notations/08-blocks.md
+++ b/notations/08-blocks.md
@@ -26,6 +26,14 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+A `block.id` MAY follow the canonical `<TYPE>-…-<INTEGER>` grammar to cross-link into an organisational catalogue element (e.g. `CAPABILITY-V1.2`, `APPLICATION-OMS-1`), OR it MAY be a document-local label that the block diagram authors solely for layout purposes. The canonical primitive lifecycle ([CONTRACT.md](CONTRACT.md) §7) is borne by the **target element's own file** when a block cross-links — the block here is a layout placement, not a separate element. When `block.id` is a document-local label there is no canonical element to bear lifecycle, and none is required.
+
+The nested_blocks document itself does not carry a `valid_from` / `valid_to` field — it is a view, not an element ([CONTRACT.md](CONTRACT.md) §7.1).
+
+---
+
 ## 1. Overview
 
 A nested block diagram answers the question **what contains what?** It is a tree of named blocks; each block may contain child blocks; the rendered diagram shows containment as spatial nesting (a child block is drawn *inside* its parent's box).

--- a/notations/11-scenarios.md
+++ b/notations/11-scenarios.md
@@ -30,6 +30,14 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline scenario entry (`SCENARIO` canonical TYPE per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1) carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline scenarios in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each scenario entry; the scenarios document itself does not carry a lifecycle field.
+
+The entities scoped *within* a scenario (its goals, capabilities, activities, products, processes, applications) are references to other canonical elements — those references inherit lifecycle from their own canonical element files, not from the scenario. A scenario's `valid_from` / `valid_to` marks the period the scenario itself is admitted as a planning consideration; it is distinct from any time horizon the scenario's narrative may describe (e.g. "scenario for 2027").
+
+---
+
 ## 1. Overview
 
 A **Scenario** in Transitrix represents an alternative strategic development path for an enterprise. Scenarios allow organisations to model, compare, and select between different futures before committing to a direction.

--- a/notations/12-issues.md
+++ b/notations/12-issues.md
@@ -25,6 +25,14 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+Every inline issue entry under `issues[]` (`ISSUE` canonical TYPE per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1) carries the canonical primitive lifecycle in its frontmatter: `valid_from` and `valid_to`. The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7 and apply uniformly to inline issues in this notation. Per [CONTRACT.md](CONTRACT.md) §7.1, the lifecycle sits on each issue entry; the issues-catalogue document itself does not carry a lifecycle field.
+
+The issue's `status` (`open` / `in_progress` / `blocked` / `resolved` / `closed`), `created_at`, and `resolved_at` fields describe the **issue-handling timeline** — when the issue was opened, where it currently stands, when it was closed. These are operational state, distinct from `valid_from` / `valid_to` which mark the period the issue artefact itself is admitted to canon and considered in effect. In typical practice the two coincide for `open` issues (`valid_from ≈ created_at`, `valid_to: null`); closing an issue may or may not retire the artefact depending on the organisation's archive policy.
+
+---
+
 ## 1. Overview
 
 An **Issues** document is a register of issues an organisation is tracking. Each issue carries a lifecycle `status` and an optional `parent`, so the register is also a hierarchy: a broad issue decomposes into sub-issues, which decompose further.

--- a/notations/13-process-blueprint.md
+++ b/notations/13-process-blueprint.md
@@ -26,6 +26,17 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
+## Element lifecycle
+
+This notation's inline arrays split into two groups for lifecycle purposes:
+
+- **Canonical-TYPE arrays** — `equipment[]` (`EQUIPMENT`) and `information_entities[]` (`INFORMATION_ENTITY`), both registered in [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1. Each entry carries the canonical primitive lifecycle (`valid_from` / `valid_to`) per [CONTRACT.md](CONTRACT.md) §7.
+- **Document-local arrays** — `stages[]`, `systems[]`, `actors[]`. These use document-local identifiers (e.g. `STAGE-1`, `STAGE-2`) that are not registered as canonical TYPEs in [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1; they are scoped to the blueprint document and do not carry their own lifecycle. When a `systems[]` or `actors[]` entry is intended to reference a registered element (an `APPLICATION-…` or `ROLE-…`), the lifecycle lives on that target's canonical file.
+
+The contract, field semantics, and validation rules (`LIFECYCLE-001..004`) are defined once in [CONTRACT.md](CONTRACT.md) §7. Per [CONTRACT.md](CONTRACT.md) §7.1, the process-blueprint document itself does not carry a lifecycle field.
+
+---
+
 ## 1. Overview
 
 A **process blueprint** answers the question: **for each stage of a value chain, what does it take to operate that stage?**


### PR DESCRIPTION
## Summary

Fifth and final per-notation-spec PR of Wave 1. Adds "Element lifecycle" reference sections to the five standalone notations, completing the spec-reference sweep across all 13 catalogued view notations. (`14-codex.md`, `15-requirement.md`, and `16-assertion.md` already reference CONTRACT §6/§7 directly — they were authored that way during the compliance epic.)

Each section is tuned to its notation's element shape:

| Spec | Section flavour |
|---|---|
| **01-bpmn.md** | explicit "no lifecycle" case — BPMN local labels (POOL-…, GW-…, TASK-…, SF-…, SE-…, EE-…) are file-local per IDS §3.3, not canonical elements; the BPMN document itself is the detailed flow representation. Lifecycle of the process this BPMN describes lives on its `PROCESS-…` element in process-map. |
| **08-blocks.md** | split case — `block.id` MAY cross-link to a canonical element (lifecycle on target file) OR be a document-local layout label (no lifecycle). Document carries no lifecycle. |
| **11-scenarios.md** | inline SCENARIO elements bear lifecycle. Scenario-scoped entities inherit lifecycle from their own canonical files. `valid_from`/`valid_to` ≠ the scenario's narrative time horizon. |
| **12-issues.md** | inline ISSUE elements bear lifecycle. Per-issue `status`/`created_at`/`resolved_at` are issue-handling timeline (operational state), distinct from element lifecycle; in practice `valid_from ≈ created_at` while open. |
| **13-process-blueprint.md** | split-by-array case — `equipment[]` and `information_entities[]` are canonical TYPEs and bear lifecycle. `stages[]`/`systems[]`/`actors[]` use document-local identifiers (not registered TYPEs) and don't carry their own. |

## Wave 1 spec-reference sweep — done

| Spec | Reference added in |
|---|---|
| 02-fgca, 03-fga, 04-goals, 07-activities | PR #48 |
| 05-capability-map, 06-process-map | PR #49 |
| 09-products, 10-applications | PR #50 |
| 01-bpmn, 08-blocks, 11-scenarios, 12-issues, 13-process-blueprint | **this PR (#51)** |
| 14-codex, 15-requirement, 16-assertion | already done in the compliance epic |

After this merges, every published notation spec references CONTRACT §7 for primitive lifecycle. Remaining Wave 1 work: example sweep — mechanical backfill of `valid_from`/`valid_to` onto every canonical primitive in `acme_corp/`'s example files (one PR per notation family per "don't bundle").

## Scope decisions

- **01-bpmn explicitly carries no lifecycle.** The section flips the usual narrative — explains why there is no lifecycle here rather than asserting one. Aligns with the IDS §3.3 file-local distinction.
- **08-blocks split.** Block IDs are dual-natured (pointer vs local); the section names both branches.
- **13-process-blueprint split-by-array.** Of its five inline arrays, two bear lifecycle (canonical TYPEs in IDS §3.1) and three are document-local. Calling that out explicitly avoids ambiguity for adopters.
- **12-issues `created_at`/`resolved_at` disambiguation.** Without the note, an adopter could assume the existing `created_at`/`resolved_at` fields ARE the lifecycle. The section clarifies they are operational state and that `valid_from`/`valid_to` are a parallel admission-side concern (typically `valid_from ≈ created_at`).
- **11-scenarios narrative-vs-element-lifecycle disambiguation.** A scenario "for 2027" describes a future state; its `valid_from`/`valid_to` describes when the *scenario document* is in effect as a planning artefact.

## Test plan

- [x] All 5 markdowns end with newline + complete final line
- [x] Each spec has exactly one new "Element lifecycle" section
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Section placement consistent across all 5 (after "File header", before "## 1. Overview")
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)