### PR TITLE
Wave 1 example sweep PR 1 — backfill valid_from/valid_to on existing element primitives (CONSTRAINT, RULE)

### DIFF
--- a/organizations/acme_corp/canon/elements/01_motivation/constraints/CONSTRAINT-GDPR-RESIDENCY-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/constraints/CONSTRAINT-GDPR-RESIDENCY-1.yaml
@@ -21,3 +21,9 @@ rationale: >
   countries. Non-compliance carries administrative fines under Art. 83 (up
   to 4% of global annual turnover) and reputational risk; storage decisions
   for any system holding EU customer PII MUST reflect this constraint.
+
+# Primitive lifecycle (CONTRACT.md §7) — GDPR Art. 44–49 effective since
+# 2018-05-25 (GDPR enforcement date); the org's adoption of this constraint
+# takes effect from the same date in the model.
+valid_from: "2018-05-25"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/rules/RULE-DUAL-APPROVAL-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/rules/RULE-DUAL-APPROVAL-1.yaml
@@ -18,3 +18,8 @@ rationale: >
   workflows. Dual approval above the materiality threshold reduces the risk
   of fraud, simple error, and single-point-of-failure on high-value
   payments.
+
+# Primitive lifecycle (CONTRACT.md §7) — Board decision 2026-01-15
+# (per source above) is the date this rule took effect.
+valid_from: "2026-01-15"
+valid_to: null


### PR DESCRIPTION
## Summary

First example-sweep PR of Wave 1. Backfills the canonical primitive lifecycle (CONTRACT.md §7) onto the two existing element-primitive files in `acme_corp` that predate Wave 1 and were missing `valid_from` / `valid_to`. After this PR, every canonical primitive in `acme_corp`'s canon zone carries lifecycle.

| File | `valid_from` | Sourcing |
|---|---|---|
| `CONSTRAINT-GDPR-RESIDENCY-1.yaml` | `"2018-05-25"` | GDPR Art. 44–49 enforcement date, per the existing `source` field |
| `RULE-DUAL-APPROVAL-1.yaml` | `"2026-01-15"` | Board decision date, per the existing `source` field |

Both files: `valid_to: null` (still in effect).

## Scope decisions

- **Date sourcing.** The epic body says "from the file's `last_updated` or a sensible epoch (`2024-01-01`)". Neither file carries `last_updated`; both `source` fields already cite a meaningful effective date, so the lifecycle adopts those rather than the generic epoch. Adopters running the mechanical backfill in their own repos may default to `2024-01-01` when no better date is available — both options remain valid.
- **Out of scope:** both files lack the admission record (`zone` / `admitted_at` / `admitted_by` / `gate_checks` per CONTRACT.md §6). They predate epic #72 and were not caught by its `acme_corp` sweep. **Fixing this is #72-completion work, not Wave 1.** Adding only lifecycle here keeps PR scope clean (one concern); the files remain incomplete vs CONTRACT.md §6 but no more so than before this PR.

## Remaining Wave 1 example-sweep work

No actual view-document YAMLs exist in `acme_corp/canon/views/` today — only `README.md` skeletons. So the rest of the example sweep is **pure documentation work**: updating each `canon/views/<notation>/README.md` skeleton YAML block to teach the lifecycle pattern on inline elements. One PR per notation family per the epic's "don't bundle" rule. Order:
- Strategy chain (fgca / fga / goals / activities) — 4 READMEs
- Capability + process (capabilities / processmap) — 2 READMEs
- Catalogue (products / applications) — 2 READMEs
- Standalone (bpmn / blocks / scenarios / issues / process-blueprint) — 5 READMEs

## Test plan

- [x] Both YAMLs parse cleanly under `yaml.safe_load`; `valid_from` and `valid_to` both present and well-typed
- [x] No other fields touched (`git diff --stat`: 2 files changed, 11 insertions only)
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)