### PR TITLE
Wave 1 example sweep PR 2 — strategy-chain skeleton READMEs teach valid_from/valid_to

### DIFF
--- a/organizations/acme_corp/canon/views/activities/README.md
+++ b/organizations/acme_corp/canon/views/activities/README.md
@@ -18,30 +18,40 @@ activities:
   - id: ACTIVITY-DISCOVERY-1
     name: "Discovery & research"
     duration_days: 10
-    start_date: "2026-06-01"
+    start_date: "2026-06-01"       # work-timeline field — when the activity is planned to start
     predecessors: []
     goals: [GOAL-CUST-1]
+    valid_from: "2026-05-26"       # element-lifecycle field (CONTRACT.md §7) — when this activity entry is admitted as a planning artefact; distinct from start_date
+    valid_to: null
 
   - id: ACTIVITY-DESIGN-1
     name: "Solution design"
     duration_days: 14
     predecessors: [ACTIVITY-DISCOVERY-1]
     goals: [GOAL-CUST-1]
+    valid_from: "2026-05-26"
+    valid_to: null
 
   - id: ACTIVITY-BUILD-1
     name: "Build & test"
     duration_days: 30
     predecessors: [ACTIVITY-DESIGN-1]
     delivers_changes: [CHANGE-ONBOARD-1]
+    valid_from: "2026-05-26"
+    valid_to: null
 
   - id: ACTIVITY-LAUNCH-1
     name: "Launch"
     duration_days: 5
     predecessors: [ACTIVITY-BUILD-1]
     delivers_changes: [CHANGE-ONBOARD-1]
+    valid_from: "2026-05-26"
+    valid_to: null
 ```
 
 Activities form a DAG via `predecessors:`. The renderer computes Early Start / Late Finish / slack and highlights the critical path in both the PSND view and the Gantt projection. Transitrix Studio renders both views; the toolbar switches between them.
+
+`valid_from` / `valid_to` are required on every inline activity per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7 and are **distinct** from `start_date` / `end_date`: the lifecycle fields say *when this activity entry is admitted to the plan*, while the schedule fields say *when the work is planned to happen*. Both coexist; the activities document itself carries no lifecycle.
 
 ## Cross-references
 

--- a/organizations/acme_corp/canon/views/fga/README.md
+++ b/organizations/acme_corp/canon/views/fga/README.md
@@ -23,17 +23,25 @@ factors:
   - id: FACTOR-COMP-1              # → canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
     name: "Support response time degraded over Q1"
     type: internal
+    valid_from: "2026-05-26"       # CONTRACT.md §7 — required on every inline element
+    valid_to: null
 
 goals:
   - id: GOAL-OPS-1
     name: "Restore P50 response time to under 2 hours by end of Q2"
     factors: [FACTOR-COMP-1]
+    valid_from: "2026-05-26"
+    valid_to: null
 
 activities:
   - id: ACTIVITY-SUPPORT-1
     name: "Add second-shift coverage in EU timezone"
     goals: [GOAL-OPS-1]
+    valid_from: "2026-05-26"
+    valid_to: null
 ```
+
+`valid_from` / `valid_to` are required on every inline element per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. The FGA document itself does not carry a lifecycle field — it is a view, not an element.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/fgca/README.md
+++ b/organizations/acme_corp/canon/views/fgca/README.md
@@ -24,22 +24,32 @@ factors:
     name: "EU regulatory window closing in Q3"
     type: external
     references_constraint: [CONSTRAINT-GDPR-RESIDENCY-1]   # → canon/elements/01_motivation/constraints/
+    valid_from: "2026-05-26"      # CONTRACT.md §7 — required on every inline element
+    valid_to: null
 
 goals:
   - id: GOAL-EU-1
     name: "Operational presence in 3 EU markets by Q4"
     factors: [FACTOR-EU-REG-1]
+    valid_from: "2026-05-26"
+    valid_to: null
 
 changes:
   - id: CHANGE-EU-CRM-1
     name: "Stand up EU-localised CRM and payment processing"
     goals: [GOAL-EU-1]
+    valid_from: "2026-05-26"
+    valid_to: null
 
 activities:
   - id: ACTIVITY-CRM-EU-1
     name: "Implement EU-localised CRM rollout"
     changes: [CHANGE-EU-CRM-1]
+    valid_from: "2026-05-26"
+    valid_to: null
 ```
+
+`valid_from` / `valid_to` are required on every inline element per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. The FGCA document itself does not carry a lifecycle field — it is a view, not an element.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/goals/README.md
+++ b/organizations/acme_corp/canon/views/goals/README.md
@@ -19,7 +19,7 @@ period: "2026"
 date: "2026-05-26"
 author: "Acme Strategy Office"
 
-goal_types:                       # contiguous levels from 0 (GOALS-013)
+goal_types:                       # contiguous levels from 0 (GOALS-013); static vocabulary, no lifecycle
   - { name: "Strategy",       level: 0 }
   - { name: "Strategic Goal", level: 1 }
 
@@ -29,17 +29,25 @@ goals:
     type: "Strategy"
     level: 0
     # root — no parent
+    valid_from: "2026-05-26"      # CONTRACT.md §7 — required on every inline goal
+    valid_to: null
   - id: GOAL-EU-1
     name: "Launch in 3 EU markets"
     type: "Strategic Goal"
     level: 1                       # parent is level 0 → strict N+1 (GOALS-012)
     parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
   - id: GOAL-OPS-1
     name: "Cut support response time by half"
     type: "Strategic Goal"
     level: 1
     parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
 ```
+
+`valid_from` / `valid_to` are required on every inline goal entry per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. The `goal_types[]` entries are a static vocabulary, not elements, and do not carry lifecycle. The goals-tree document itself carries no lifecycle either — it is a view, not an element.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Second example-sweep PR of Wave 1. Updates the four strategy-chain view-skeleton README YAML blocks (`fgca` / `fga` / `goals` / `activities`) to teach the canonical lifecycle pattern on inline elements. No actual view-document YAMLs exist in `acme_corp/canon/views/` today — only README skeletons — so this is **pure documentation work**: showing adopters the canonical shape.

## Changes

| README | Inline element types | Special note added |
|---|---|---|
| `fgca/README.md` | FACTOR, GOAL, CHANGE, ACTIVITY (all 4 layers) | trailing prose: document itself carries no lifecycle |
| `fga/README.md` | FACTOR, GOAL, ACTIVITY | same trailing prose |
| `goals/README.md` | GOAL only | inline comment on `goal_types[]`: static vocabulary, no lifecycle; trailing prose makes the distinction explicit |
| `activities/README.md` | ACTIVITY | inline comment on `start_date` + `valid_from` on first activity contrasts element-lifecycle field (`valid_from`/`valid_to`) with work-timeline field (`start_date`/`end_date`); trailing prose makes the contrast explicit |

All `valid_from` values are `"2026-05-26"` (the documents' admission date, consistent across the family); all `valid_to: null` (elements still in effect).

## Scope decisions

- **`valid_from` value choice.** Used one consistent date across the family rather than fabricating per-element timelines. The skeleton's purpose is teaching the *shape*, not the *content* — adopters fill in real dates from their own admission events.
- **Disambiguation comments.** Where a notation has a near-collision (`goal_types[]` vs lifecycle; `start_date`/`end_date` vs lifecycle), both an inline comment in the YAML block *and* a trailing prose paragraph spell it out — adopters reading skeleton code only vs adopters reading the prose both get the distinction.
- **Activities is the most careful case.** The `valid_from` comment on the first activity is the longest inline comment in any skeleton because the field collision is the most likely to confuse — the prior spec-reference sweep (PR #48) already called it out at the notation level.

## Remaining Wave 1 example-sweep work

Same pattern, by family:
- PR 3 (next) — capability + process (`capabilities/` + `processmap/`) — 2 READMEs
- PR 4 — catalogue (`products/` + `applications/`) — 2 READMEs
- PR 5 — standalone (`bpmn/` + `blocks/` + `scenarios/` + `issues/` + `process-blueprint/`) — 5 READMEs

## Test plan

- [x] Every YAML code block in all 4 READMEs parses cleanly under `yaml.safe_load`
- [x] All 4 markdowns end with newline + complete final line
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Diff stat: 4 files changed, 38 insertions, 2 deletions
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)