### PR TITLE
Wave 1 example sweep PR 3 — capability-map + process-map skeleton READMEs teach valid_from/valid_to

### DIFF
--- a/organizations/acme_corp/canon/views/capabilities/README.md
+++ b/organizations/acme_corp/canon/views/capabilities/README.md
@@ -30,18 +30,24 @@ capability_map:
       applications:
         - "APP-OMS-1"
         - "APP-CRM-1"
+      valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline capability, recursively
+      valid_to: null
       children:
         - id: "CAPABILITY-V1.1"
           name: "Order Intake"
           type: "domain"
           current_maturity: 3
           target_maturity: 3
+          valid_from: "2026-05-26"
+          valid_to: null
         - id: "CAPABILITY-V1.2"
           name: "Order Fulfilment"
           type: "domain"
           current_maturity: 2
           target_maturity: 3
           target_date: "2026-09-30"
+          valid_from: "2026-05-26"
+          valid_to: null
     - id: "CAPABILITY-V2"
       name: "Customer Relationship"
       type: "domain"
@@ -50,9 +56,13 @@ capability_map:
       owner_role: "ROLE-SALES-1"
       applications:
         - "APP-CRM-1"
+      valid_from: "2026-05-26"
+      valid_to: null
 ```
 
 `CAPABILITY-V1` / `CAPABILITY-V1.1` are canonical capability IDs (V/H sub-grammar per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §2); **every** capability, including children, carries `type` (required). The maturity history of an individual capability lives on its element file, not here.
+
+`valid_from` / `valid_to` are required on every inline capability (recursively, including nested `children[]`) per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. The capability-map document itself does not carry a lifecycle field. The notation-spec's "Planned" / "Active" / "Retired" state vocabulary ([`notations/05-capability-map.md`](../../../../notations/05-capability-map.md) §7) is a *derived view* over `valid_from` / `valid_to` + today's date — not a separate stored mechanism.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/processmap/README.md
+++ b/organizations/acme_corp/canon/views/processmap/README.md
@@ -19,7 +19,7 @@ process_map:
   version: "1.0"
   updated_at: "2026-05-26"
 
-  groups:
+  groups:                               # groups are organisational containers, not elements — no lifecycle on the group itself
     - id: "GRP-OPERATING"
       name: "Operating Processes"
       type: "operating"                 # operating | supporting | management
@@ -29,14 +29,18 @@ process_map:
           owner_role: "ROLE-OPS-1"
           capability: "CAPABILITY-V1"
           maturity: 2
-          status: "Active"                    # Draft | Active | Deprecated
+          status: "Active"                    # operational state: Draft | Active | Deprecated
           bpmn_file: "canon/views/bpmn/order-fulfilment.bpmn.transitrix.yaml"
+          valid_from: "2026-05-26"            # CONTRACT.md §7 — required on every inline process; distinct from operational `status`
+          valid_to: null
         - process_id: "PROC-CUST-ONBOARD-1"
           name: "Customer Onboarding"
           owner_role: "ROLE-SALES-1"
           capability: "CAPABILITY-V2"
           maturity: 1
           status: "Draft"
+          valid_from: "2026-05-26"
+          valid_to: null
 
     - id: "GRP-SUPPORTING"
       name: "Supporting Processes"
@@ -46,6 +50,8 @@ process_map:
           name: "Customer Support Resolution"
           owner_role: "ROLE-CS-1"
           status: "Active"
+          valid_from: "2026-05-26"
+          valid_to: null
 
     - id: "GRP-MANAGEMENT"
       name: "Management Processes"
@@ -55,9 +61,13 @@ process_map:
           name: "Annual Strategy Planning"
           owner_role: "ROLE-EXEC-1"
           status: "Active"
+          valid_from: "2026-05-26"
+          valid_to: null
 ```
 
 `process_id`, `owner_role`, and `capability` hold **element / capability IDs**, not display names.
+
+`valid_from` / `valid_to` are required on every inline process entry per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7 and are distinct from the per-process `status` (`Draft` / `Active` / `Deprecated`) which is an operational state. Process groups (`groups[]`) are organisational containers, not elements, and carry no lifecycle of their own; the process-map document itself carries none either.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Third example-sweep PR of Wave 1. Capability+process family — pure documentation: update the two view-skeleton README YAML blocks (`capabilities/` + `processmap/`) to teach the lifecycle pattern on inline elements. Same minimal additive pattern as PR #53.

## Changes

- **`capabilities/README.md`** — added `valid_from` + `valid_to` to every inline capability, **recursively including nested `children[]`** (CAPABILITY-V1, V1.1, V1.2, V2). Trailing prose:
  - Lifecycle is recursive on `children[]`.
  - The notation-spec's "Planned" / "Active" / "Retired" state vocabulary (05-capability-map §7) is a **derived view** over `valid_from` / `valid_to` + today, **not a separate stored mechanism**.

- **`processmap/README.md`** — added `valid_from` + `valid_to` to every inline process under `groups[].processes[]` (4 processes across 3 groups). Plus:
  - Inline comment on the `groups[]` line: groups are organisational containers, not elements.
  - Inline comment on the first process's `status` field contrasts operational status with element-lifecycle.
  - Trailing prose makes both distinctions explicit.

All `valid_from` values use `"2026-05-26"` (consistent with PR #53); all `valid_to: null`.

## Remaining Wave 1 example-sweep work

- **PR 4 (next)** — catalogue family (`products/` + `applications/`) — 2 READMEs
- **PR 5** — standalone (`bpmn/` + `blocks/` + `scenarios/` + `issues/` + `process-blueprint/`) — 5 READMEs

## Test plan

- [x] Every YAML code block in both READMEs parses cleanly under `yaml.safe_load`
- [x] Both markdowns end with newline + complete final line
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Diff stat: 2 files changed, 22 insertions, 2 deletions
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)