### PR TITLE
Wave 1 example sweep PR 4 — products + applications skeleton READMEs teach valid_from/valid_to

### DIFF
--- a/organizations/acme_corp/canon/views/applications/README.md
+++ b/organizations/acme_corp/canon/views/applications/README.md
@@ -26,16 +26,18 @@ applications_catalogue:
       domain: "Operations"
       owner_role: "ROLE-TECH-1"
       vendor: "Internal"
-      status: "Active"                  # Draft | Active | Deprecated | Decommissioning
+      status: "Active"                  # operational state: Draft | Active | Deprecated | Decommissioning
       maturity: 3
       description: "Core system for order lifecycle management"
       capabilities: ["CAPABILITY-V1"]
       products: ["PROD-ECOMM-1"]
-      integrations:
+      integrations:                     # nested integration descriptors share the parent app's lifecycle — no own valid_from/valid_to
         - target: "APP-CRM-1"
           direction: "outbound"
           protocol: "REST"
           description: "Sends order events to CRM"
+      valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline applications-catalogue entry, regardless of `type`; distinct from operational `status`
+      valid_to: null
 
     - app_id: "APP-CRM-1"
       name: "CRM System"
@@ -45,9 +47,13 @@ applications_catalogue:
       vendor: "Salesforce"
       status: "Active"
       description: "Customer relationship and sales pipeline management"
+      valid_from: "2026-05-26"
+      valid_to: null
 ```
 
 `capabilities` and `products` hold **element IDs**, not display names. Integrations may be inlined (as above) or modelled as their own `type: integration` entries.
+
+`valid_from` / `valid_to` are required on every inline applications-catalogue entry per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7, regardless of `type` (`application` / `integration` / `platform` / `data_store`). They are distinct from the per-entry `status` field (operational state). Per-application nested `integrations[]` descriptors share the parent's lifecycle and carry no `valid_from` / `valid_to` of their own; when an integration is promoted to a top-level `type: integration` entry, it becomes a first-class lifecycle-bearing element with its own dates.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/products/README.md
+++ b/organizations/acme_corp/canon/views/products/README.md
@@ -25,12 +25,14 @@ products_catalogue:
       type: "digital_product"           # digital_product | service | platform | bundle
       domain: "Digital"
       owner_role: "ROLE-PROD-1"
-      status: "Active"                  # Draft | Active | Deprecated
+      status: "Active"                  # operational state: Draft | Active | Deprecated
       maturity: 3
       description: "Online storefront and order management for end customers"
       capabilities: ["CAPABILITY-V1", "CAPABILITY-V2"]
       processes: ["PROC-ORD-FULFILL-1"]
       supporting_apps: ["APP-OMS-1", "APP-CRM-1"]
+      valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline product; distinct from operational `status`
+      valid_to: null
 
     - product_id: "SVC-SUPPORT-1"
       name: "Customer Support Service"
@@ -39,9 +41,13 @@ products_catalogue:
       owner_role: "ROLE-CS-1"
       status: "Active"
       description: "Tier-1 and Tier-2 support for customers via chat, email, and phone"
+      valid_from: "2026-05-26"
+      valid_to: null
 ```
 
 `capabilities`, `processes`, and `supporting_apps` hold **element IDs** (`CAPABILITY-V1`, `PROC-…`, `APP-…`), not display names — the catalogue references the elements, it does not duplicate them.
+
+`valid_from` / `valid_to` are required on every inline product entry per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7 and are distinct from the per-product `status` field (`Active` / `Deprecated`), which is an operational state. The products-catalogue document itself does not carry a lifecycle field.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Fourth example-sweep PR of Wave 1. Catalogue family — pure documentation: update the two view-skeleton README YAML blocks (`products/` + `applications/`) to teach the lifecycle pattern on inline elements.

## Changes

- **`products/README.md`** — added `valid_from` + `valid_to` to every inline product (PROD-ECOMM-1, SVC-SUPPORT-1). Inline comment on the first product's `status` field flags it as operational state, distinct from lifecycle. Trailing prose makes the distinction explicit.

- **`applications/README.md`** — added `valid_from` + `valid_to` to every inline applications-catalogue entry (APP-OMS-1, APP-CRM-1). Two key disambiguations:
  1. `type` field (`application` / `integration` / `platform` / `data_store`) does **not** gate lifecycle — every catalogue entry is an element.
  2. Per-application nested `integrations[]` descriptors **share the parent's lifecycle** — no own `valid_from` / `valid_to`. Inline comment on the `integrations[]` line plus trailing prose. The escalation path is also noted: promoting an integration to a top-level `type: integration` entry makes it a first-class lifecycle bearer with its own dates.

All `valid_from` values use `"2026-05-26"` (consistent with PRs #53 and #54); all `valid_to: null`.

## Remaining Wave 1 example-sweep work

- **PR 5 (final)** — standalone (`bpmn/` + `blocks/` + `scenarios/` + `issues/` + `process-blueprint/`) — 5 READMEs. After this, the example sweep is done and Wave 1 of the temporal-model epic closes.

## Test plan

- [x] Every YAML code block in both READMEs parses cleanly under `yaml.safe_load`
- [x] Both markdowns end with newline + complete final line
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Diff stat: 2 files changed, 15 insertions, 3 deletions
- [ ] (gated by Valerii) merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)