### PR TITLE
Wave 1 example sweep PR 5 (final) — standalone skeleton READMEs get Lifecycle prose notes

### DIFF
--- a/organizations/acme_corp/canon/views/blocks/README.md
+++ b/organizations/acme_corp/canon/views/blocks/README.md
@@ -46,6 +46,10 @@ Recommended maximum: **5 levels** (root = level 1). The validator warns at depth
 
 A block's `id` MAY use the canonical `<TYPE>-…-<INTEGER>` form to cross-link into an organisational catalogue (`APPLICATION-OMS-1`, `CAPABILITY-V1.2`). Otherwise it is a document-local label and is accepted as-is. See [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md).
 
+## Lifecycle
+
+When `block.id` cross-links into the catalogue (canonical `<TYPE>-…-<INTEGER>` form), the primitive lifecycle ([`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7) is borne by the target element's own file — the block here is a layout placement, not a separate element. When `block.id` is a document-local label, there is no canonical element to bear lifecycle and the block carries none. The nested_blocks document itself carries no lifecycle either — it is a view.
+
 ## Tooling
 
 Rendered natively by Transitrix Studio — no external binaries required. The previous Python + `svgbob_cli` pipeline was retired in Studio 1.1.0.

--- a/organizations/acme_corp/canon/views/bpmn/README.md
+++ b/organizations/acme_corp/canon/views/bpmn/README.md
@@ -15,6 +15,10 @@ Two starting templates ship with the methodology:
 - `.templates/bpmn/process_template.bpmn.transitrix.yaml` — basic single-pool, single-lane process.
 - `.templates/bpmn/advanced-process-with-lanes.bpmn.transitrix.yaml` — multi-lane, multi-stage process with KPIs.
 
+## Lifecycle
+
+BPMN files use **file-local labels** for their nodes (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) — per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §3.3 these are not canonical elements. Neither the BPMN nodes nor the BPMN file itself carries the primitive lifecycle ([`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7). The lifecycle of the process this BPMN represents lives on its corresponding `PROCESS-…` element in [`../processmap/`](../processmap/) — the BPMN is the detailed flow, not the lifecycle bearer.
+
 ## See also
 
 - `method/methodology.md` §6.4 — BPMN process diagrams

--- a/organizations/acme_corp/canon/views/issues/README.md
+++ b/organizations/acme_corp/canon/views/issues/README.md
@@ -8,6 +8,10 @@ Register of issues — problems, defects, open questions — in a parent/child t
 
 See [`notations/12-issues.md`](../../../../notations/12-issues.md) for the full spec.
 
+## Lifecycle
+
+Every inline issue entry under `issues[]` (`ISSUE` canonical TYPE per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §3.1) carries `valid_from` and `valid_to` per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. These are distinct from the issue's own `status` / `created_at` / `resolved_at` fields, which describe the issue-handling timeline (operational state). In typical practice `valid_from ≈ created_at` while the issue is open; closing the issue may or may not retire the artefact, depending on the organisation's archive policy. The issues-catalogue document itself carries no lifecycle.
+
 ## See also
 
 - [`notations/examples/issues/`](../../../../notations/examples/issues/) — worked example

--- a/organizations/acme_corp/canon/views/process-blueprint/README.md
+++ b/organizations/acme_corp/canon/views/process-blueprint/README.md
@@ -8,6 +8,15 @@ Wide value-chain blueprint — stages laid out left-to-right, each carrying its 
 
 See [`notations/13-process-blueprint.md`](../../../../notations/13-process-blueprint.md) for the full spec.
 
+## Lifecycle
+
+The blueprint's per-aspect arrays split for lifecycle purposes:
+
+- **Canonical-TYPE arrays** — `equipment[]` (`EQUIPMENT`) and `information_entities[]` (`INFORMATION_ENTITY`), both registered in [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §3.1. Each entry carries `valid_from` and `valid_to` per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7.
+- **Document-local arrays** — `stages[]`, `systems[]`, `actors[]`. These use document-local identifiers (e.g. `STAGE-1`) that are not registered as canonical TYPEs and so carry no lifecycle of their own. When a `systems[]` or `actors[]` entry is intended to reference a registered element (an `APPLICATION-…` or `ROLE-…`), the lifecycle lives on that target's canonical file.
+
+The process-blueprint document itself carries no lifecycle.
+
 ## See also
 
 - [`notations/examples/process-blueprint/`](../../../../notations/examples/process-blueprint/) — worked example

--- a/organizations/acme_corp/canon/views/scenarios/README.md
+++ b/organizations/acme_corp/canon/views/scenarios/README.md
@@ -8,6 +8,10 @@ Alternative strategic development paths — each scenario scopes its own goals, 
 
 See [`notations/11-scenarios.md`](../../../../notations/11-scenarios.md) for the full spec.
 
+## Lifecycle
+
+Every inline scenario entry (`SCENARIO` canonical TYPE per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §3.1) carries `valid_from` and `valid_to` in its frontmatter per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. These mark the period the scenario itself is admitted as a planning consideration — distinct from any time horizon the scenario's narrative may describe (e.g. "scenario for 2027"). The scenario-scoped goals / capabilities / activities / products / processes / applications are references to other canonical elements; their lifecycle lives on each target's own canonical file. The scenarios document itself carries no lifecycle.
+
 ## See also
 
 - [`notations/examples/scenarios/`](../../../../notations/examples/scenarios/) — worked examples


### PR DESCRIPTION
## Summary

**Final** example-sweep PR of Wave 1. Standalone family — pure documentation: adds a short Lifecycle prose section to each of the five standalone-notation view-skeleton READMEs.

Four of the five READMEs carry no YAML skeleton today (just file-convention + see-also pointers). For those, a 2–4-line prose paragraph is the teaching surface; it points adopters at CONTRACT.md §7 and explains per-notation specifics.

## Per-README changes

| README | Lifecycle teaching |
|---|---|
| **bpmn/** | Explicit "no lifecycle" case. Local labels (POOL-, GW-, TASK-, SF-, SE-, EE-) are not canonical elements per IDS §3.3. Neither nodes nor file carry lifecycle; the process's lifecycle lives on its `PROCESS-…` element in `canon/views/processmap/`. Section added after "Templates". |
| **blocks/** | Skeleton exists but all IDs are document-local labels (no `valid_from`/`valid_to` in YAML). Added a Lifecycle section after Cross-references: when `block.id` cross-links to a canonical element, lifecycle lives on the target; when local label, no lifecycle. |
| **scenarios/** | Added Lifecycle section. Inline scenarios carry `valid_from`/`valid_to` per CONTRACT §7. Disambiguates from the scenario's narrative time horizon ("scenario for 2027" is content, not lifecycle). Scoped entities inherit lifecycle from their own canonical files. |
| **issues/** | Added Lifecycle section. Inline issues carry `valid_from`/`valid_to`. Disambiguates from the issue's own `status`/`created_at`/`resolved_at` (operational state); `valid_from ≈ created_at` while open. |
| **process-blueprint/** | Added Lifecycle section. Split case: `equipment[]` and `information_entities[]` (canonical TYPEs in IDS §3.1) bear lifecycle; `stages[]`/`systems[]`/`actors[]` use document-local IDs and carry none. |

+25 lines across 5 files. The only YAML block (in `blocks/`) parses cleanly.

## Wave 1 closure (after this merges)

With this PR landing, Wave 1 of the temporal-model epic is **complete end-to-end**:

| Scope | Delivered in |
|---|---|
| `notations/CONTRACT.md` §7 — primitive lifecycle contract + LIFECYCLE-001..004 | #42 |
| All 13 view-notation specs reference §7 | #48 (strategy chain) + #49 (capability+process) + #50 (catalogue) + #51 (standalone) |
| All 3 zone-primitive specs reference §7 | already done in the compliance epic |
| `acme_corp`'s existing canon-zone element-primitive YAMLs backfilled | #52 |
| All 13 `acme_corp` view-skeleton READMEs teach the lifecycle pattern | #53 (strategy chain) + #54 (capability+process) + #55 (catalogue) + **this PR** (standalone) |

10 of the view READMEs carry inline lifecycle fields in their YAML skeletons; the 3 skeleton-less standalone READMEs (scenarios, issues, process-blueprint) carry the teaching as prose. Plus the BPMN and blocks pair, which have notation-specific lifecycle stories told as prose.

## Test plan

- [x] Every YAML code block (only `blocks/` has one) parses cleanly under `yaml.safe_load`
- [x] All 5 markdowns end with newline + complete final line
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] Diff stat: 5 files changed, 25 insertions
- [ ] (gated by Valerii) merge — closes out Wave 1 of the temporal-model epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)