### PR TITLE
05-capability-map declares current_maturity / owner_role / target_date time-varying (temporal model Wave 2, PR 2/n)

### DIFF
--- a/notations/05-capability-map.md
+++ b/notations/05-capability-map.md
@@ -221,24 +221,20 @@ capability_map:
     - id: "CAPABILITY-V1"
       name: "Order Management"
       type: "domain"                       # domain | supporting
-      current_maturity: 2
-      target_maturity: 3
-      target_date: "2026-12-31"
-      owner_role: "ROLE-OPS-001"
+      target_maturity: 3                   # stable planning aspiration (forward-looking)
       business_process: "PROC-ORD-FULFILL-001"
       applications:
         - "APP-OMS-001"
         - "APP-CRM-001"
+      # current_maturity, owner_role, target_date are time-varying — they
+      # live in CAPABILITY-V1.history.yaml (CONTRACT.md §9), not inline.
       children:
         - id: "CAPABILITY-V1.1"
           name: "Order Intake"
-          current_maturity: 3
           target_maturity: 3
         - id: "CAPABILITY-V1.2"
           name: "Order Fulfilment"
-          current_maturity: 2
           target_maturity: 3
-          target_date: "2026-09-30"
 ```
 
 ---
@@ -253,40 +249,47 @@ capability_map:
 | `id` | Yes | Capability ID — canonical form `CAPABILITY-V1`, `CAPABILITY-V1.1`, `CAPABILITY-H1` (see [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §2) |
 | `name` | Yes | Capability name |
 | `type` | Yes | `domain` or `supporting` |
-| `current_maturity` | Yes | Current CMM level (1–5) |
-| `target_maturity` | No | Target CMM level |
-| `target_date` | No | When the target should be reached (YYYY-MM-DD) |
-| `owner_role` | No | Reference to BusinessRole element ID |
-| `business_process` | No | Reference to BusinessProcess element ID |
-| `applications` | No | List of ApplicationComponent element IDs |
-| `children` | No | List of child capabilities |
+| `current_maturity` | Yes | Current CMM level (1–5). **Time-varying** — lives in the sidecar `<capability_id>.history.yaml` ([CONTRACT.md](CONTRACT.md) §9), not inline. Inline placement triggers `VERSIONED-004`. |
+| `target_maturity` | No | Target CMM level. Stable forward-looking aspiration; stays inline. |
+| `target_date` | No | When the target should be reached (YYYY-MM-DD). **Time-varying** — sidecar, not inline. |
+| `owner_role` | No | Reference to BusinessRole element ID. **Time-varying** — sidecar, not inline. |
+| `business_process` | No | Reference to BusinessProcess element ID. Stays inline in v1 (relations are Wave 3 territory). |
+| `applications` | No | List of ApplicationComponent element IDs. Stays inline in v1 (relations are Wave 3 territory). |
+| `children` | No | List of child capabilities. |
 
 ---
 
-## 14. Maturity history on the element
+## 14. Time-varying attributes — sidecar history
 
-Individual capability elements in `elements/02_business/` carry the full maturity history:
+A capability's `current_maturity`, `owner_role`, and `target_date` evolve within the capability's overall lifetime. Per [CONTRACT.md](CONTRACT.md) §9, these fields are stored in a sidecar file co-located with the capability's element file, **not inline** on the capability-map view or on the element file:
+
+```
+canon/elements/02_business/capabilities/CAPABILITY-V1.yaml          # stable fields
+canon/elements/02_business/capabilities/CAPABILITY-V1.history.yaml  # time-varying fields
+```
+
+Sidecar shape:
 
 ```yaml
-id: "CAPABILITY-V1"
-name: "Order Management"
-type: "Capability"
-layer: "Business"
-metadata:
-  status: "Active"
-  owner: "firstname.lastname"
-  updated_at: "2026-05-08"
-properties:
-  capability_id: "CAPABILITY-V1"
-  maturity_levels:
-    - level: 1
-      effective_from: "2024-01-01"
-    - level: 2
-      effective_from: "2025-06-01"
-      status: "Current"
-  target_maturity: 3
-  target_date: "2026-12-31"
+target: CAPABILITY-V1
+attribute_versions:
+  current_maturity:
+    - { valid_from: "2024-01-01", value: 1 }
+    - { valid_from: "2025-06-01", value: 2 }
+    - { valid_from: "2026-09-15", value: 3 }
+  owner_role:
+    - { valid_from: "2024-01-01", value: ROLE-OPS-1 }
+    - { valid_from: "2026-07-01", value: ROLE-OPS-2 }
+  target_date:
+    - { valid_from: "2024-01-01", value: "2027-06-30" }
+    - { valid_from: "2026-04-01", value: "2026-12-31" }
 ```
+
+Current-value resolution: pick the entry with the largest `valid_from <= today`. See [CONTRACT.md](CONTRACT.md) §9.2.
+
+Migration: adopters with existing inline values move each value into a single-entry sidecar with `valid_from = capability.valid_from`. The `VERSIONED-001..005` rules apply ([CONTRACT.md](CONTRACT.md) §9.3).
+
+`target_maturity` is **not** time-varying — it is a stable forward-looking planning aspiration and stays inline on the capability.
 
 ---
 


### PR DESCRIPTION
## Summary

Second PR of Wave 2 of the temporal-model epic. Updates `notations/05-capability-map.md` to use the sidecar pattern (CONTRACT.md §9) for the three time-varying fields: `current_maturity`, `owner_role`, `target_date`.

## Changes

- **§12 Top-level structure example** — removes the three time-varying fields from inline placement. `target_maturity` stays inline (stable forward-looking aspiration). An inline comment marks where the time-varying fields now live (sidecar).
- **§13 Fields table** — each of the three time-varying fields annotated `Time-varying — sidecar, not inline. Inline placement triggers VERSIONED-004.`. `target_maturity` annotated as staying inline. `business_process` and `applications` annotated as relations (Wave 3 territory).
- **§14** — was "Maturity history on the element"; fully rewritten as "Time-varying attributes — sidecar history". The old inline `maturity_levels` block on element files is replaced by the `<capability_id>.history.yaml` sidecar pattern. Section now includes a complete sidecar example with three attributes, a current-value-resolution pointer to CONTRACT.md §9.2, and a migration note.

## Scope decisions

- **`target_maturity` is NOT time-varying.** It's a stable forward-looking planning aspiration (the level the org wants to reach), not a value that drifts as the capability operates. Adopters who treat it as evolving can promote later.
- **Strict, per the epic.** `VERSIONED-004` is an error (per epic body §9.3); adopters with inline `current_maturity` migrate by moving the value into a single-entry sidecar with `valid_from = capability.valid_from`. The migration is mechanical and documented in §14 of this spec.
- **Relations stay inline.** `business_process` and `applications` are cross-references; promoting them to first-class lifecycle-bearing relations is Wave 3 territory per CONTRACT.md §9.5 out-of-scope.

## What lands next

- **PR 3** — `10-applications.md` declares `lifecycle_stage`, `responsible_unit`, `vendor` time-varying.
- **PR 4** — at least one acme_corp sidecar worked example (the obvious candidate: a capability's `maturity_level` history).

## Test plan

- [x] `05-capability-map.md` parses as markdown; §1..§15 structure intact; ends with newline + complete final line
- [x] Only one file touched
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing in tracked files
- [x] §12 example no longer carries `current_maturity`/`owner_role`/`target_date` inline; an inline YAML comment points adopters at the sidecar location
- [x] §13 fields-table annotations distinguish: time-varying (sidecar), stable inline, and relations (Wave 3 territory)
- [ ] (self-merge under today's autonomous authority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)