### PR TITLE
Wave 3 PR 3 — 04-goals + 07-activities declare goal_parent / activity_goal time-aware

### DIFF
--- a/notations/04-goals.md
+++ b/notations/04-goals.md
@@ -32,6 +32,18 @@ Every inline element this notation defines — entries in `goals[]` — carries 
 
 ---
 
+## Time-aware relations
+
+A goal's **`parent`** relationship — its position under another goal in the hierarchy — is declared **time-aware** per the temporal model. The canonical home for a goal-to-goal parent link is a `REL-…` file under `canon/relations/` with `type: goal_parent` (see [17-relations.md](17-relations.md) §3 for the closed enum). A goal re-parented mid-stream — a tactical goal moved under a different strategic goal during a planning cycle — produces a new REL file; the old REL ends with `valid_to` set.
+
+**Inline `parent: GOAL-…` — v0.x transitional.** The inline `parent` field on goal entries (§5.2) stays available for authoring convenience while the relation files coexist for history; the renderer prefers REL files when both are present. `REL-004` will begin firing on inline `parent` once an adopter's validator is configured to enforce post-migration.
+
+The `goal_types[]` array is a **static vocabulary** and carries no time-awareness — it is not a relation between primitives but a per-document type declaration.
+
+The Activity → Goal cross-reference (`activity.goals: [GOAL-…]`) is documented as **time-aware** in [07-activities.md](07-activities.md); its canonical REL home uses `type: activity_goal`.
+
+---
+
 ## 1. Overview
 
 A goals tree is a hierarchical view that arranges Goal elements from `elements/01_motivation/` into a top-down tree — from broad strategic ambitions down to specific tactical objectives.

--- a/notations/07-activities.md
+++ b/notations/07-activities.md
@@ -32,6 +32,18 @@ Every inline element this notation defines — entries in `activities[]` — car
 
 ---
 
+## Time-aware relations
+
+An activity's **`goals: [GOAL-…]`** cross-reference — the goals an activity serves — is declared **time-aware** per the temporal model. An activity re-aimed mid-stream (a build activity originally serving GOAL-A pivoted to serve GOAL-B as priorities shift) is a temporal event that loses information when inlined. The canonical home for an Activity → Goal link is a `REL-…` file under `canon/relations/` with `type: activity_goal` (see [17-relations.md](17-relations.md) §3).
+
+**Inline `goals: [GOAL-…]` — v0.x transitional.** The inline `goals` array on activity entries (§5.2 Per-activity fields) stays available for authoring convenience while the relation files coexist for history; the renderer prefers REL files when both are present. `REL-004` will begin firing on inline `goals` once an adopter's validator is configured to enforce post-migration. Adopters extracting links to REL files use `valid_from = activity.valid_from` as a sensible epoch for the initial relation.
+
+**`predecessors: [ACTIVITY-…]` stays timeless.** The predecessor DAG within a project plan is a structural property of the plan as a whole, not a temporal event — re-jiggering predecessors mid-stream is a new plan version, not a re-aiming of a single relation. `predecessors` is **not** declared time-aware; it stays inline.
+
+**`delivers_changes: [CHANGE-…]`** (BDN linkage) stays inline in v1 (timeless within the activity's lifecycle).
+
+---
+
 ## 1. Overview
 
 An **Activities** document describes a directed acyclic graph (DAG) of activities and the dependencies between them, optionally placed in calendar time. It is the text-native form of a project schedule with two coexisting renderings:


### PR DESCRIPTION
## Summary

Third PR of Wave 3 of the temporal-model epic. Adds Time-aware relations declarations to the remaining v1 time-aware kinds (per the epic body §5) in their canonical home specs.

## Changes

- **`04-goals.md`** — declares Goal **`parent`** as time-aware (REL `type: goal_parent`). Re-parenting semantics: a tactical goal moved under a different strategic goal mid-cycle produces a new REL; old one ended. \`goal_types[]\` explicitly **not** time-aware (static vocabulary, not a relation). The Activity → Goal cross-reference is noted with a pointer at 07-activities for the canonical declaration.

- **`07-activities.md`** — declares Activity **`goals: [GOAL-…]`** cross-reference as time-aware (REL `type: activity_goal`). Use case: an activity re-aimed mid-stream (a build originally serving GOAL-A pivoted to serve GOAL-B). \`predecessors[]\` explicitly **stays timeless** — the predecessor DAG is a structural property of the plan as a whole; re-jiggering predecessors mid-stream is a new plan version, not a re-aiming of a single relation. \`delivers_changes\` stays inline in v1.

Both specs document the **v0.x transitional position**: inline fields stay available for authoring convenience; REL-004 fires post-migration when adopters' validators enforce.

## Wave 3 enum coverage now complete

Together with PR #62 (capability-map `parent`), all v1 time-aware candidates from the epic body §5 are now declared:

| `type` | Endpoints | Declared in |
|---|---|---|
| `parent` | CAPABILITY → CAPABILITY | 05-capability-map.md §13a (#62) |
| `goal_parent` | GOAL → GOAL | 04-goals.md (this PR) |
| `activity_goal` | ACTIVITY → GOAL | 07-activities.md (this PR) |
| `unit_parent` | UNIT → UNIT | reserved; no OrgUnit primitives in v1 |

## What lands next

**Wave 3 PR 4 (final)** — acme_corp worked example: at least one REL file demonstrating a re-parenting or re-aiming event (one ended relation + one new relation).

## Test plan

- [x] Both files end with newline + complete final line
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing
- [x] Each spec's new "Time-aware relations" section cross-references 17-relations.md §3 (the closed enum)
- [x] +24 lines across 2 files
- [ ] (self-merge under today's autonomous authority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)