### PR TITLE
Methodology upgrade-path Phase 1 — CONTRACT.md §10 versioning & compatibility + RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,42 @@
+# Releasing the methodology
+
+This document defines the per-release process for the Transitrix methodology. The compatibility policy itself — what `MAJOR` / `MINOR` / `PATCH` mean for adopters — is in [`notations/CONTRACT.md`](notations/CONTRACT.md) §10. This file describes the **process** the methodology maintainer follows to cut and ship a release.
+
+The methodology is **pre-1.0**. Standard pre-1.0 SemVer applies (see CONTRACT §10.3) — `MINOR` bumps may carry breaking changes until the 1.0 cut. The full versioning-and-compatibility policy lives in CONTRACT §10; this file is the operational checklist.
+
+---
+
+## When to bump
+
+| Bump | Examples |
+|---|---|
+| **PATCH** (`0.x.0` → `0.x.1`) | Clarification of an existing spec sentence; fixing a broken link; correcting a typo in an example; renumbering subsections without changing rule codes or field names. No schema change of any kind. |
+| **MINOR** (`0.x` → `0.(x+1)`) | New optional field on an existing notation; new validation code at `info` or `warning` severity; new TYPE in `IDS_AND_REFERENCES.md` §3; new section in CONTRACT.md (e.g. §9 sidecar pattern); new notation spec file (e.g. `15-requirement.md`); pre-1.0 may also include changes that are technically breaking but that the maintainer judges low-impact. |
+| **MAJOR** (`0.x` → `1.0`, `1.x` → `2.0`) | Renamed or removed field on an existing notation; changed validation severity (`warning` → `error`); changed enum membership in a closed enum (relations type, status enum, etc.); changed canonical ID grammar; required new field on an existing notation. Post-1.0, anything that breaks a previously-valid adopter file. |
+
+If a single release combines multiple kinds of change, the bump is the **highest** of any individual change in the set.
+
+---
+
+## Per-release checklist
+
+For every release, in order:
+
+1. **Confirm the bump category.** Read every PR landed since the previous tag; categorise each change per the table above; pick the bump.
+2. **Update `methodology_version` in `organizations/acme_corp/transitrix.yaml`** to the new version. acme_corp is the fixture adopter and tracks the latest released version.
+3. **Update each notation spec's `version:` frontmatter** if any spec changed in this release. (`spec_version` on individual files is informational — see CONTRACT §10.1 — so this step is bookkeeping for discoverability, not enforcement.)
+4. **Write release notes** describing what changed by category (`Added`, `Changed`, `Fixed`, `Removed`). Reference PR numbers.
+5. **For a `MAJOR` release** — ship a migration recipe under `migrations/<prev>-to-<this>/` (format defined in epic #78 Phase 2). The recipe is a precondition for the tag.
+6. **Tag** the release commit with `vX.Y.Z`.
+7. **Publish** the release notes as a GitHub Release on the tag.
+8. **Announce** the release (channel TBD with the maintainer).
+
+---
+
+## What this file does NOT cover
+
+- **Compatibility semantics** — what each bump promises adopters. See [`notations/CONTRACT.md`](notations/CONTRACT.md) §10.
+- **Migration recipe format** — epic #78 Phase 2 (separate task).
+- **Migration CLI (`transitrix migrate`)** — epic #78 Phase 3 (lives in Studio, not in this repo).
+- **The 1.0 cut decision** — epic #78 Phase 4 (gated on in-flight schema epics landing).
+- **Releases of Transitrix Studio, DSM, the Skill bundle, or any other downstream artefact** — each has its own SemVer policy and its own RELEASING.md.

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -2,7 +2,7 @@
 
 All eleven Transitrix notations share the same file-header contract: the same required field, the same reserved field, the same validator rules, and the same extension/content match guarantee. This document defines those shared rules once. Each notation spec links here and lists only its per-notation values (the `notation:` short name and the file extension).
 
-This document also defines four organisation-level contracts shared across all notations: the **zone model** (§5), the **admission record** (§6), the **primitive lifecycle** (§7), and the **versioned-attribute sidecar** (§9) — the four shared shapes every organisation artefact may carry. §8 aggregates the validation rules of the compliance domain (REQUIREMENT + ASSERTION) for discoverability — the per-notation specs remain authoritative for the rule definitions themselves.
+This document also defines four organisation-level contracts shared across all notations: the **zone model** (§5), the **admission record** (§6), the **primitive lifecycle** (§7), and the **versioned-attribute sidecar** (§9) — the four shared shapes every organisation artefact may carry. §8 aggregates the validation rules of the compliance domain (REQUIREMENT + ASSERTION) for discoverability — the per-notation specs remain authoritative for the rule definitions themselves. §10 sets the **versioning and compatibility policy** for the methodology itself — what kind of change each SemVer bump may carry, and what adopters can rely on across releases.
 
 A change to the rules below applies to all eleven notations simultaneously — they should be edited here, not duplicated into each spec.
 
@@ -264,3 +264,52 @@ Each notation's "Element lifecycle" or "Fields" section will, in a follow-up PR,
 - **Versioning relations, not attributes.** The sidecar is a shape for *attributes* (scalar fields of an element). Versioning relations (`parent`, cross-references) is the concern of Wave 3 — first-class time-aware relation files — not Wave 2.
 - **Versioning the lifecycle itself.** `valid_from` / `valid_to` on the primitive are not versionable. To change a primitive's lifecycle, rewrite the file via git; the git history is the audit trail.
 - **Auto-derived rollups.** Cross-attribute computations (e.g. "average maturity over Q3 2026") are query-time concerns of the renderer / DSM, not of the sidecar schema.
+
+---
+
+## 10. Versioning and compatibility
+
+The methodology evolves. Each release changes the contract this document defines, the per-notation specs, or both. Adopters need to know what kind of change a release brings — does it break their existing files, or can they upgrade transparently? This section defines the compatibility policy.
+
+### 10.1 Where versions live
+
+Two version slots exist:
+
+| Slot | Lives in | Records |
+|---|---|---|
+| `transitrix.yaml` `methodology_version` | adopter repository root (see [`MANIFEST.md`](MANIFEST.md)) | The methodology release the **whole repo** conforms to. Single source of truth for the repo. |
+| `spec_version` on each notation file (§1) | every notation file's header | The notation-spec version the **individual file** declares. Informational; the manifest decides what version the repo is on. |
+
+**Mixed-version repositories are not supported in v1.** Every artefact in an adopter repo conforms to the `methodology_version` declared in `transitrix.yaml`. No per-folder override; no per-notation override.
+
+### 10.2 SemVer with explicit semantics
+
+Methodology releases use [SemVer](https://semver.org) (`MAJOR.MINOR.PATCH`) with the semantics below. Each kind of release commits to a different compatibility promise.
+
+| Bump | Kinds of change | Adopter action |
+|---|---|---|
+| **`MAJOR`** | Breaking schema change: renamed field, removed field, new required field, changed validation severity (warning → error), changed enum membership in a closed enum, etc. | **Migration required.** Adopter follows the migration recipe shipped with the release (defined in a subsequent epic) and updates `methodology_version` in `transitrix.yaml`. |
+| **`MINOR`** | Additive only: new optional field, new notation, new validation code at `info` / `warning`, new TYPE in the registry, new section in a spec. Existing files validate cleanly against the new release. | None required. Adopter MAY adopt new fields when convenient. May update `methodology_version` in `transitrix.yaml` to make the upgrade explicit. |
+| **`PATCH`** | Clarifications, doc fixes, example fixes, no schema change. | None. |
+
+### 10.3 Pre-1.0 disclaimer
+
+> **The methodology is pre-1.0.** Until the methodology reaches `v1.0.0`, `MINOR` bumps **may carry breaking changes** — standard SemVer pre-1.0 rules apply. Adopters pinning a pre-1.0 version with a caret range (`^0.4.x`) may be broken by a subsequent `0.5.0`. **Pin exactly** (`0.4.2`) in production adopter repos until the 1.0 cut.
+
+Once the methodology hits `v1.0.0`, MINOR bumps will be additive only — the policy in §10.2 holds without the pre-1.0 exception.
+
+### 10.4 The release promise
+
+A released version of the methodology, once tagged, is **immutable**. Subsequent fixes to that version branch happen as a new `PATCH` bump; the old tag is not retroactively edited.
+
+A `MINOR` or `PATCH` release (post-1.0) MUST NOT break any adopter repo that was valid against the previous release of the same `MAJOR` line. The validator's `error`-level rules added in a `MINOR` or `PATCH` release apply only to files authored against that release or later, not to files already in adopters' canon.
+
+A `MAJOR` release SHOULD ship with a migration recipe under `migrations/<from>-to-<to>/` defining the codemod and manual steps an adopter follows to upgrade. The recipe format is the concern of Phase 2 of this epic.
+
+### 10.5 What this section does NOT cover
+
+- **Migration recipe on-disk format.** Phase 2 of this epic.
+- **Migration CLI** (`transitrix migrate`). Phase 3 of this epic.
+- **The 1.0 cut decision.** Phase 4 of this epic — gated on the in-flight schema epics landing.
+- **Per-notation versioning.** `spec_version` on individual files is informational; only `methodology_version` in `transitrix.yaml` drives compatibility decisions.
+- **Migration for adopter repositories of non-methodology versions** (DSM, Studio, CLI). Those have their own SemVer policies.


### PR DESCRIPTION
## Summary

First phase of the methodology-upgrade-path epic. Adds the compatibility-policy section to the shared contract, plus a per-release process checklist at the repo root. Pure policy — no schema changes, no tooling.

## Changes

- **`notations/CONTRACT.md`** adds **§10 Versioning and compatibility**:
  - §10.1 — `transitrix.yaml` `methodology_version` is the single source of truth; per-file `spec_version` is informational; mixed-version repos not supported in v1.
  - §10.2 — SemVer with explicit semantics: **MAJOR** (breaking → migration), **MINOR** (additive only → no action), **PATCH** (clarifications). Bump = highest of any change in the set.
  - §10.3 — **Pre-1.0 disclaimer**: until v1.0.0, MINOR bumps may carry breaking changes per standard pre-1.0 SemVer. Adopters pin exactly until 1.0.
  - §10.4 — Tagged versions are immutable. Post-1.0 MINOR/PATCH must not break previously-valid adopter repos.
  - §10.5 — Explicit out-of-scope: recipe format (Phase 2), CLI (Phase 3), 1.0 cut decision (Phase 4), per-notation versioning, downstream-component releases.
  - Intro paragraph updated to mention §10.

- **`RELEASING.md` (new, at repo root)** — operational checklist:
  - When to bump (concrete examples per category)
  - Per-release checklist (8 steps, in order)
  - Explicit out-of-scope pointing at the rest of the epic's phases

## Scope decisions

- **§10 vs RELEASING.md split.** CONTRACT.md hosts the policy (what each bump promises adopters); RELEASING.md hosts the operational process (what the maintainer does to ship a release). Same family, different audiences — adopters read CONTRACT, maintainer reads RELEASING.
- **Pre-1.0 caret-pin caution called out loudly.** §10.3 is a prominent disclaimer block; without it, adopters following standard SemVer instincts would pin with caret and get burned by breaking 0.x.0 releases.
- **No tooling in this PR.** Migration recipe format, CLI, 1.0 cut decision all explicitly deferred to subsequent phases.

## Test plan

- [x] `CONTRACT.md` parses as markdown; §1..§10 structure intact (§10 added at end); ends with newline + complete final line
- [x] `RELEASING.md` ends with newline + complete final line
- [x] No `vkgeorgia/strategy` hyperlinks, client codenames, or "real client"/"the client" framing
- [x] Cross-references: §10 → MANIFEST.md (`transitrix.yaml`); RELEASING.md → CONTRACT.md §10 and acme_corp/transitrix.yaml; both resolve
- [ ] (self-merge under today's autonomous authority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)