### PR TITLE
Project Card notation spec + MILESTONE / PROJECT_CARD TYPEs + reconcile 07-activities §5.9 (strategy#97 Phase 1)

### DIFF
--- a/notations/07-activities.md
+++ b/notations/07-activities.md
@@ -274,9 +274,9 @@ project:
 
 The project block does **not** define the duration unit — that lives in `CONVENTIONS.md` per §5.4. The calendar describes when work happens, not how `duration` is measured.
 
-### 5.9 Milestones — zero-duration activities
+### 5.9 Schedule milestones — zero-duration activities
 
-A **milestone** is an activity with `duration: 0`. It marks a deliverable, gate, or significant date with no work attached. No new entity is introduced; milestones are first-class activities that happen to be instantaneous.
+A **schedule milestone** is an activity with `duration: 0`. It marks a deliverable, gate, or significant date on the project's timeline with no work attached. No new entity is introduced *for scheduling*; schedule milestones are first-class activities that happen to be instantaneous.
 
 ```yaml
 - id: M-LAUNCH
@@ -286,11 +286,13 @@ A **milestone** is an activity with `duration: 0`. It marks a deliverable, gate,
 ```
 
 Renderer behaviour:
-- Network view: milestones render as diamonds (or a distinct shape) rather than rectangles.
-- Gantt view: milestones render as a point marker (typically a diamond on the timeline) rather than a bar.
-- CPM: milestones participate normally — `EF == ES`, slack and critical-path membership follow the standard rules.
+- Network view: schedule milestones render as diamonds (or a distinct shape) rather than rectangles.
+- Gantt view: schedule milestones render as a point marker (typically a diamond on the timeline) rather than a bar.
+- CPM: schedule milestones participate normally — `EF == ES`, slack and critical-path membership follow the standard rules.
 
-Milestones MAY have `start_date` / `end_date` pinned; if both are present they MUST be equal (validator MAY enforce — see §6).
+Schedule milestones MAY have `start_date` / `end_date` pinned; if both are present they MUST be equal (validator MAY enforce — see §6).
+
+**Distinct from project-card milestones.** The Project Card notation ([18-project-card.md](18-project-card.md)) introduces a separate `MILESTONE` element type for **project-narrative** milestones — decision gates, certification dates, programme-level markers that belong in the card's narrative but are not part of the schedule's critical-path computation. The two coexist: a `MILESTONE-…` element in a project card may *also* reference a zero-duration activity here when the same date appears on both the card and the schedule. Use a schedule milestone (zero-duration activity, this section) for timeline computation; use a project-card milestone ([18-project-card.md](18-project-card.md) §3) for narrative gates.
 
 ### 5.10 Phases / summary activities — `parent`
 

--- a/notations/18-project-card.md
+++ b/notations/18-project-card.md
@@ -1,0 +1,196 @@
+---
+title: "Project Card — single-project narrative view"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-05-28"
+status: "draft"
+file_extension: "*.project-card.transitrix.yaml"
+---
+
+# Project Card Notation — Reference
+
+**Version:** 0.1
+**Status:** Draft
+**File extension:** `*.project-card.transitrix.yaml`
+**Scope:** A single-project narrative view that answers *"what is this project, why does it exist, and what does it deliver"* on one page. The card binds a project-typed Activity to the FGCA chain it sits in plus its own narrative milestones.
+**Renderer:** Transitrix Studio (planned)
+
+---
+
+## File header
+
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](CONTRACT.md). This notation's per-notation values:
+
+| Field | Value |
+|---|---|
+| `notation:` value | `project-card` |
+| File extension | `*.project-card.transitrix.yaml` |
+
+---
+
+## 1. What a Project Card is
+
+A Project Card is a **view** over an existing project Activity. It does not duplicate the activity's data; it references the activity by ID and adds card-specific narrative content — project-level milestones — that does not naturally belong on the activity itself.
+
+A "project" is an Activity with `activity_type: Project` (per the Activities notation, [07-activities.md](07-activities.md) §5.2). No new top-level entity is introduced for projects — the activity hierarchy already expresses what a project is. The Project Card is the **narrative surface** on top of the project activity: dates, motivation chain pulled from FGCA, child activities pulled from the activities document, and narrative milestones that live on the card itself.
+
+The renderer assembles the card from three sources:
+
+1. The card document itself — `notation: project-card` — references the project Activity by ID and declares its narrative milestones.
+2. The sibling Activities document(s) in the same view directory — provide the project's `valid_from`, `start_date`, `end_date`, `goals`, `delivers_changes`, and child activities (any activity with `parent` = the project activity's ID).
+3. The sibling FGCA document(s) — provide the motivation chain (Factors → Goals → Changes) scoped to the project's declared `goals: []` and `delivers_changes: []`.
+
+The card does not vendor copies of any of this data; the renderer pulls by reference at view time.
+
+---
+
+## 2. When to use this notation
+
+| Use case | Notation |
+|---|---|
+| Single-page summary of a project for an executive review | Project Card |
+| Project network with dates + dependencies + critical path | Activities ([07-activities.md](07-activities.md)) |
+| Project's strategic context — factors driving its goals — | FGCA ([02-fgca.md](02-fgca.md)) |
+| Programme / portfolio overview across many projects | Out of scope for v0.1 (future) |
+
+The card is **specifically** a single-project view. A multi-project programme deck or a portfolio dashboard would be a separate notation.
+
+---
+
+## 3. Top-level structure
+
+```yaml
+notation: project-card
+spec_version: "0.1"
+
+project_card:
+  id: PROJECT_CARD-EU-PROGRAMME-1                # canonical PROJECT_CARD document ID
+  project: ACTIVITY-EU-PROGRAMME-1               # existing project Activity ID; must resolve
+
+  description: >
+    A narrative summary of the project's purpose, intended for an
+    executive audience. Concise; the activity's full description is
+    on the Activity itself.
+
+  milestones:
+    - id: MILESTONE-EU-CONFORMITY-CERT-1
+      name: "EU MDR conformity-assessment certification obtained"
+      date: "2027-01-31"
+      description: >
+        First product line certified by a notified body; market-access
+        gate cleared.
+      delivers_changes:
+        - CHANGE-EU-COMPLIANCE-1
+    - id: MILESTONE-EU-MARKET-LAUNCH-1
+      name: "First product line live in EU post-certification"
+      date: "2027-03-15"
+      description: >
+        Sales channel opens to EU customers under the new compliance
+        regime.
+      delivers_changes:
+        - CHANGE-EU-COMPLIANCE-1
+```
+
+---
+
+## 4. Fields
+
+### 4.1 Card document
+
+| Field | Required | Description |
+|---|---|---|
+| `project_card.id` | Yes | Canonical PROJECT_CARD document ID per IDS §1 (`PROJECT_CARD-<DOMAIN>-<INTEGER>`). |
+| `project_card.project` | Yes | Canonical ID of the project Activity this card is about. The referenced Activity MUST exist (`PC-001`) and MUST have `activity_type: Project` (`PC-002`). |
+| `project_card.description` | No | One-paragraph narrative summary for an executive audience. The full description lives on the referenced Activity. |
+| `project_card.milestones` | No | Array of milestone entries (see §4.2). May be empty for cards that have no narrative milestones yet. |
+
+### 4.2 Milestones
+
+Each entry in `milestones[]` is a MILESTONE element. Per IDS §3.1 + §4, MILESTONE IDs are scoped to the parent card document (not the organisation as a whole).
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | Yes | Document-scoped MILESTONE ID per IDS §1 (`MILESTONE-<MIDDLE>-<INTEGER>`). |
+| `name` | Yes | One-line milestone label. |
+| `date` | Yes | Date the milestone is reached — quoted ISO 8601 per [CONTRACT.md](CONTRACT.md) §4. |
+| `description` | No | Longer-form context for the milestone. |
+| `delivers_changes` | No | Array of `CHANGE-…` IDs the milestone delivers. Each entry MUST resolve to a CHANGE that appears in the project Activity's `delivers_changes:` (`PC-003`). |
+
+---
+
+## 5. What the card renders, by source
+
+The renderer assembles the card from references — it does not pull the data from the card YAML itself except for the card-specific milestones.
+
+| Card section | Source |
+|---|---|
+| **Project name** | `Activity.name` (from the referenced project Activity) |
+| **Dates: initiation** | `Activity.valid_from` ([CONTRACT.md](CONTRACT.md) §7 — the decision-to-initiate date) |
+| **Dates: planned work** | `Activity.start_date` / `Activity.end_date` (the scheduled work window, distinct from `valid_from` per [07-activities.md](07-activities.md) Element lifecycle) |
+| **Milestones (timeline)** | `project_card.milestones[]` in this document |
+| **Motivation chain — Factors** | FGCA documents in the same view directory; included when the Factor's downstream goals include any goal the project activity references via `Activity.goals` |
+| **Motivation chain — Goals** | The goals the project activity declares (`Activity.goals: [GOAL-…]`), expanded to their definitions in the FGCA document(s) |
+| **Motivation chain — Changes** | The changes the project activity declares it delivers (`Activity.delivers_changes: [CHANGE-…]`), expanded to their definitions in the FGCA document(s) |
+| **Child activities** | Activities documents in the same view directory; any activity where `parent` = the project activity's ID |
+
+The card document itself stays small. Adopters editing a card only touch the card-specific narrative (description + milestones); changes to the project Activity, its goals, its changes, or its children happen in their own canonical documents.
+
+---
+
+## 6. File location and naming
+
+```
+views/project-cards/<DOMAIN>.project-card.transitrix.yaml
+```
+
+One card per file. The card lives alongside the FGCA / Activities documents it draws from; a card and the activities document holding its referenced project Activity are typically in the same view directory so renderers can resolve references without searching the full tree.
+
+---
+
+## 7. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `PC-001` | error | `project_card.project` is missing, malformed, or does not resolve to an admitted Activity in canon. |
+| `PC-002` | error | The Activity referenced by `project_card.project` has `activity_type` other than `Project` (per [07-activities.md](07-activities.md) §5.2). |
+| `PC-003` | error | A `milestone.delivers_changes[]` entry references a `CHANGE-…` that is not in the project Activity's own `delivers_changes:`. The milestone cannot deliver a change the project isn't committed to. |
+| `PC-004` | warning | A `milestone.date` falls outside `[Activity.valid_from, Activity.valid_to]`. A milestone before the project initiated or after it ended is suspicious. |
+
+The shared header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2) and primitive-lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3) rules apply to project-card files in addition to PC-001..004. The card document itself carries `valid_from` / `valid_to` per the lifecycle contract — the card's window is when the narrative artefact is in effect; the project Activity has its own independent lifecycle.
+
+---
+
+## 8. Reconciliation with 07-activities §5.9 schedule milestones
+
+The Activities notation already defines a "milestone" — a zero-duration activity used for critical-path computation ([07-activities.md](07-activities.md) §5.9). The Project Card introduces a **separate** MILESTONE element for narrative gates.
+
+The two are deliberately distinct:
+
+| Aspect | Schedule milestone ([07-activities.md](07-activities.md) §5.9) | Project-card milestone (this notation) |
+|---|---|---|
+| What it is | An Activity with `duration: 0` | A MILESTONE element inside a Project Card |
+| Where it lives | Activities document | Project Card document |
+| Why it exists | To anchor a date on the critical-path computation | To anchor a date in the project narrative (decision gate, certification, programme-level marker) |
+| Renderer | Activities Network view (diamond on the timeline) | Project Card view (milestone in the card's timeline section) |
+
+Both may coexist for the same calendar date: a Project Card milestone "EU MDR certification obtained 2027-01-31" can live alongside a zero-duration Activity `M-EU-CERT-2027` with the same date in the scheduling document. The two are linked at the renderer level through their common date and the activity's parent project, not via a stored cross-reference.
+
+---
+
+## 9. Evolution (v0.1 → future)
+
+Pending design work (separate epics):
+
+- **Stakeholders / Actors block on the card.** v0.1 ships without a stakeholders section. A future epic introduces an Actors or Stakeholders notation and extends the Project Card with a stakeholders block referencing those elements.
+- **Programme card.** A multi-project view (a programme of related projects) is a separate notation, not a generalisation of this single-project card.
+- **Card status field.** The card itself currently has no explicit status (e.g. "draft" / "active" / "archived"). The project Activity's lifecycle (`valid_to: null` vs a set date) already encodes whether the project is active; if the card needs its own status separate from the project's, a future revision can add it.
+
+---
+
+## 10. References
+
+- TYPE registry: [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.1 (`MILESTONE`), §3.2 (`PROJECT_CARD` document type), §4 (uniqueness scope — both document-scoped).
+- The project Activity TYPE this card binds: [07-activities.md](07-activities.md) §5.2 (`activity_type: Project`).
+- Schedule milestones — distinct from project-card milestones: [07-activities.md](07-activities.md) §5.9.
+- Motivation chain the card pulls: [02-fgca.md](02-fgca.md) (FGCA).
+- Zone model, admission record, primitive lifecycle: [CONTRACT.md](CONTRACT.md) §5–7.

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -87,6 +87,7 @@ Elements that get referenced across documents.
 | `CONSTRAINT` | design / operating constraint (motivation layer per ArchiMate 3.2) — a restriction or prohibition the organisation must not cross | Constraints catalogue (`elements/01_motivation/constraints/`); referenced from FGCA factors via `references_constraint:` |
 | `REQUIREMENT` | regulatory or organisational requirement (motivation layer per ArchiMate 3.2) — a positive obligation the organisation must fulfil. Distinct from `CONSTRAINT` by **form of the obligation**: REQUIREMENT = positive action ("must submit", "must register", "must obtain approval"); CONSTRAINT = restriction ("must not", "cannot exceed"). | Requirements catalogue (`elements/01_motivation/requirements/`); cites its source via `derived_from:` (codex `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`). Schema: [15-requirement.md](15-requirement.md). |
 | `REL` | first-class time-aware relation between two canonical primitives — `parent`, `activity_goal`, `goal_parent`, etc. Carries its own `valid_from` / `valid_to` so changes to a relation (a capability re-parenting, a goal re-aimed) are first-class temporal events. | Relations catalogue (`canon/relations/`); one file per relation. Schema: [17-relations.md](17-relations.md). |
+| `MILESTONE` | project-narrative milestone — a decision gate, certification date, or programme-level marker that belongs in a Project Card's narrative. Distinct from a "schedule milestone" (a zero-duration activity inside an Activities document, see [07-activities.md](07-activities.md) §5.9), which exists for critical-path computation. | Defined inside a Project Card document (`*.project-card.transitrix.yaml`); scope is the parent card document. Schema: [18-project-card.md](18-project-card.md). |
 
 ### 3.2 Document-level types
 
@@ -106,6 +107,7 @@ Each notation file carries its own ID using the same grammar; the TYPE names the
 | `BLOCKS` | `*.blocks.transitrix.yaml` |
 | `ISSUES_CAT` | `*.issues.transitrix.yaml` |
 | `PROCESS_BLUEPRINT` | `*.process-blueprint.transitrix.yaml` |
+| `PROJECT_CARD` | `*.project-card.transitrix.yaml` |
 
 BPMN diagrams use their `process.id` as the document identifier; that field is a free-form string defined by the spec, not by this appendix.
 
@@ -163,6 +165,7 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | `CONSTRAINT` | within the organisation's element catalogue (`elements/01_motivation/constraints/`), one file per CONSTRAINT. |
 | `REQUIREMENT` | within the organisation's element catalogue (`elements/01_motivation/requirements/`), one file per REQUIREMENT. |
 | `REL` | within the organisation's `canon/relations/` folder, one file per REL. |
+| `MILESTONE` | within the project-card document that defines it. MILESTONE IDs are not required to be unique across the organisation; they are document-scoped element identifiers (the parent card binds them). |
 | `ASSERTION` | within the organisation's `canon/assertions/` folder, one file per ASSERTION. |
 | `INTERVIEW`, `SURVEY`, `OBSERVATION`, `DRAFT` | within the organisation's `field/` zone. Contradictions between Field artefacts are allowed; only the IDs must be unique. |
 | `LAW`, `REGULATION` | within the organisation's `codex/external/` zone. |


### PR DESCRIPTION
## Summary

First (and currently only) phase of the Project Card epic. Methodology-side spec for the new \`.project-card.transitrix.yaml\` notation that renders a **single-project narrative summary** over an existing project Activity. Studio-side renderer is a separate epic on \`proj:transitrix-studio\`.

## Changes

- **\`notations/IDS_AND_REFERENCES.md\` §3.1** — register \`MILESTONE\` TYPE (project-narrative milestone, distinct from a zero-duration scheduling activity; scoped to its parent Project Card). **§3.2** — register \`PROJECT_CARD\` as a document-level TYPE. **§4** — both scopes added.

- **\`notations/18-project-card.md\` (new)** — full spec following the established template:
  - **§1** What a Project Card is — view over a project Activity (\`activity_type: Project\` per 07-activities §5.2); no new top-level entity.
  - **§3** Top-level structure — \`project_card\` root with \`project\` (ID reference) + \`description\` (narrative) + \`milestones[]\` (id / name / date / description / delivers_changes).
  - **§5** What the card renders by source — table mapping card sections (project name / dates / milestones / motivation chain / child activities) to their source documents.
  - **§7** Validation rules — \`PC-001\` (project doesn't resolve), \`PC-002\` (project Activity isn't \`activity_type: Project\`), \`PC-003\` (milestone delivers a change the project isn't committed to), \`PC-004\` (warning: milestone date outside project's lifecycle window).
  - **§8** Reconciliation with 07-activities §5.9 — explicit table distinguishing **schedule** milestones (zero-duration activity, CPM-bound) from **project-card** milestones (narrative gates). They may coexist for the same date.

- **\`notations/07-activities.md\` §5.9** — renamed "Milestones" to "Schedule milestones" + added a "Distinct from project-card milestones" paragraph clarifying the two concepts coexist. Resolves the reconciliation flagged in the epic body's "Open design threads".

## Scope decisions

- **Stakeholders block deferred** per the epic body's explicit decision — picked up when the Actors notation (epic #98 / #99 territory) lands.
- **No acme_corp worked example in this PR.** Would require an existing project Activity in acme_corp, which isn't there yet. Worked example is a natural follow-up PR once acme_corp gains a project Activity.
- **MILESTONE TYPE document-scoped, not organisation-scoped.** A milestone exists only within a specific card; promoting it to first-class is a future decision if cards start to need cross-card milestone references.
- **Studio-side work** (schema + validator + renderer + activation events) lives in the \`proj:transitrix-studio\` epic per the cross-project routing in the epic body — not in this methodology-spec PR.

## Test plan

- [x] All three touched / new files end with newline + complete final line
- [x] No \`vkgeorgia/strategy\` hyperlinks, client codenames, or "real client"/"the client" framing
- [x] IDS additions sit alongside REL (§3.1) and PROCESS_BLUEPRINT (§3.2) and follow the existing column shapes
- [x] 18-project-card §10 cross-references resolve (CONTRACT §5–7, IDS §1/§3.1/§3.2/§4, 02-fgca, 07-activities §5.2 + §5.9)
- [x] 07-activities §5.9 renaming preserves the existing schedule-milestone rule and renderer behaviour; only adds the reconciliation paragraph
- [ ] (self-merge under today's autonomous authority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)