### PR TITLE
Add lifecycle-backfill transform to 0.4 → 0.5 migration recipe (strategy#78 Phase 2)

### DIFF
--- a/migrations/0.4-to-0.5/README.md
+++ b/migrations/0.4-to-0.5/README.md
@@ -2,11 +2,12 @@
 
 This folder is the **on-disk migration recipe** an adopter follows when upgrading their repository from methodology version 0.4 to 0.5. The format is defined for all future migration recipes per [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §10.4 and [`RELEASING.md`](../../RELEASING.md).
 
-This first published recipe is **demonstrative**: it covers one transform from the 0.4 → 0.5 cycle so the format is established and exercised end-to-end. Additional transforms from the 0.4 → 0.5 deprecated list (see [`CHANGELOG.md`](../../CHANGELOG.md) Deprecated under 0.5.0) land in subsequent commits to this folder; the codemod and validator extend additively.
+This recipe ships incrementally — each transform in the 0.4 → 0.5 cycle (see [`CHANGELOG.md`](../../CHANGELOG.md) Deprecated under 0.5.0) lands as an additive extension to the same `codemod.mjs` + `validate.mjs` + a per-pattern fixture pair under `fixtures/before/` and `fixtures/after/`.
 
 ## What this recipe covers
 
 - **Codex `applies_to.{entities, processes}` retirement.** In 0.5.0, external and internal codex artefacts no longer carry an `applies_to` block (see [`notations/14-codex.md`](../../notations/14-codex.md) §8 — Migration). Bindings move to `REQUIREMENT.derived_from` plus `ASSERTION`. Codex artefacts that still carry `applies_to` produce a `CODEX-004` deprecation warning; the recipe removes the field.
+- **Primitive lifecycle backfill.** In 0.5.0, every canonical element MUST carry `valid_from` and `valid_to` ([`notations/CONTRACT.md`](../../notations/CONTRACT.md) §7). Adopters with element primitives under `canon/elements/` missing those fields get them backfilled: `valid_from` adopts the file's `last_updated:` value when present, otherwise falls back to the sensible epoch `"2024-01-01"` per the §7.4 migration recipe. `valid_to` defaults to `null` (currently in effect).
 
 ## Folder shape (canonical for all migration recipes)
 
@@ -69,16 +70,22 @@ diff -r /tmp/recipe-test migrations/0.4-to-0.5/fixtures/after
 
 ## Manual steps after the codemod
 
-The recipe handles the mechanical removal. The architectural redirect — *where the binding semantics moved to* — is the adopter's call and not codemod-able:
+The recipe handles the mechanical edits. Architectural redirects — *where the semantics moved to* — are the adopter's call and not codemod-able:
 
-1. For every `applies_to.entities[]` or `applies_to.processes[]` entry the codemod removed, the adopter decides whether that entry encoded:
-   - An obligation the org must fulfil → create a `REQUIREMENT-…` element under `canon/elements/01_motivation/requirements/` with `derived_from: [<codex artefact ID>]` (see [`15-requirement.md`](../../notations/15-requirement.md)).
-   - A compliance claim about a subject → create an `ASSERTION-…` under `canon/assertions/` linking the requirement to the subject (see [`16-assertion.md`](../../notations/16-assertion.md)).
-2. After the new REQUIREMENT / ASSERTION primitives are admitted, the original codex artefact's `applies_to` data is fully captured in canon.
+### Codex `applies_to` → REQUIREMENT + ASSERTION
 
-This is a model-shape choice the adopter makes once per binding; the codemod can't infer the right REQUIREMENT / ASSERTION shape automatically.
+For every `applies_to.entities[]` or `applies_to.processes[]` entry the codemod removed, the adopter decides whether that entry encoded:
 
-## What this recipe deliberately does NOT cover
+- An obligation the org must fulfil → create a `REQUIREMENT-…` element under `canon/elements/01_motivation/requirements/` with `derived_from: [<codex artefact ID>]` (see [`15-requirement.md`](../../notations/15-requirement.md)).
+- A compliance claim about a subject → create an `ASSERTION-…` under `canon/assertions/` linking the requirement to the subject (see [`16-assertion.md`](../../notations/16-assertion.md)).
+
+After the new REQUIREMENT / ASSERTION primitives are admitted, the original codex artefact's `applies_to` data is fully captured in canon. This is a model-shape choice the adopter makes once per binding; the codemod can't infer the right REQUIREMENT / ASSERTION shape automatically.
+
+### Lifecycle backfill date review
+
+The lifecycle backfill picks `valid_from` mechanically — `last_updated:` when present, otherwise `"2024-01-01"`. After running the codemod, the adopter SHOULD spot-check the backfilled `valid_from` values and adjust any that don't reflect the actual date the element took effect. The codemod's value is a safe default, not a historically-accurate claim.
+
+## What this recipe deliberately does NOT yet cover
 
 Other 0.4 → 0.5 deprecated patterns are listed in [`CHANGELOG.md`](../../CHANGELOG.md) under the 0.5.0 entry. Adding them to this recipe is straightforward — each is its own transform inside the same `codemod.mjs` + `validate.mjs` + per-pattern fixture:
 
@@ -87,7 +94,6 @@ Other 0.4 → 0.5 deprecated patterns are listed in [`CHANGELOG.md`](../../CHANG
 - Inline `goals: [GOAL-…]` on activity entries → REL `activity_goal` files.
 - Inline `current_maturity` / `owner_role` / `target_date` on capability-map → sidecar.
 - Inline `owner_role` / `vendor` / `maturity` on applications → sidecar.
-- Lifecycle backfill on element primitives without `valid_from` / `valid_to`.
 - Capability ID canonical form residual (`scenarios` + supporting docs).
 
 Each transform follows the same conventions (idempotent, dry-run-supporting, diff-summary-printing, unsafe-ambiguity-bailing) and ships its own fixture pair. The order and packaging of those subsequent transforms is a separate task.
@@ -97,4 +103,6 @@ Each transform follows the same conventions (idempotent, dry-run-supporting, dif
 - Versioning and compatibility policy: [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §10.
 - Per-release operational checklist: [`RELEASING.md`](../../RELEASING.md).
 - The 0.5.0 release notes that drove this recipe: [`CHANGELOG.md`](../../CHANGELOG.md) under `0.5.0`.
-- The codex spec change that this transform implements: [`notations/14-codex.md`](../../notations/14-codex.md) §8.
+- Spec sources for the transforms shipped:
+  - Codex `applies_to` retirement — [`notations/14-codex.md`](../../notations/14-codex.md) §8.
+  - Lifecycle backfill — [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §7 (rule) and §7.4 (migration recipe).

--- a/migrations/0.4-to-0.5/codemod.mjs
+++ b/migrations/0.4-to-0.5/codemod.mjs
@@ -1,26 +1,34 @@
 #!/usr/bin/env node
 // Migration codemod — methodology 0.4 → 0.5.
 //
-// CURRENT TRANSFORM: remove applies_to.{entities, processes} from external
-// and internal codex artefacts (per notations/14-codex.md §8 Migration).
+// TRANSFORMS (extensible; each entry in `transforms` below is independent):
+//
+//   1. codex applies_to retirement (notations/14-codex.md §8 Migration)
+//      Walks <target>/codex/**/*.yaml and strips applies_to: blocks
+//      (both indented-children and inline-array forms).
+//
+//   2. lifecycle backfill (notations/CONTRACT.md §7.4 Migration)
+//      Walks <target>/canon/elements/**/*.yaml and appends valid_from
+//      + valid_to to any element primitive missing lifecycle. Uses
+//      the file's last_updated: when present, otherwise the sensible
+//      epoch "2024-01-01" per the §7.4 recipe.
 //
 // Conventions (canonical for every migration recipe):
 //   - Pure-Node. Runs on a stock Node ≥ 20 with no native deps.
-//   - Idempotent. Running twice on the same input produces identical output.
+//   - Idempotent. Running twice on the same input produces identical
+//     output — files already in 0.5 form are no-ops.
 //   - CLI: [--dry-run] [target-dir]. Default target = current working dir.
-//   - Diff-style summary printed on every run, live or dry.
+//   - Per-transform diff-style summary printed on every run, live or
+//     dry, plus an overall summary at the end.
 //   - Exits non-zero on unsafe ambiguity; safe transforms apply normally.
 //
-// Strategy: line-based YAML transformation. The applies_to: block always
-// appears at a fixed indentation depth on a codex artefact (top level for
-// the canonical shape); we strip the line and any continuation lines that
-// are indented strictly deeper than applies_to's own indent. This handles
-// nested entities / processes maps and inline-array forms without parsing
-// the YAML — preserves comments and formatting on the lines we keep, which
-// js-yaml dump would otherwise normalise away.
+// Strategy: line-based YAML transformation, NOT js-yaml roundtrip. The
+// transforms preserve comments, key order, and original formatting on
+// every line we don't touch. js-yaml dump would normalise comments and
+// keys away.
 
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
-import { join, relative, resolve, sep } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 // --- CLI --------------------------------------------------------------------
 
@@ -33,7 +41,7 @@ if (!existsSync(target)) {
   process.exit(2);
 }
 
-// --- Discover codex YAML files ----------------------------------------------
+// --- Shared file-walker -----------------------------------------------------
 
 function walkYaml(dir, out = []) {
   let entries;
@@ -48,19 +56,7 @@ function walkYaml(dir, out = []) {
   return out;
 }
 
-const codexRoot = join(target, 'codex');
-if (!existsSync(codexRoot)) {
-  console.log(`No codex/ directory under ${target} — nothing to do.`);
-  process.exit(0);
-}
-
-const candidateFiles = walkYaml(codexRoot);
-if (candidateFiles.length === 0) {
-  console.log(`No .yaml files under ${codexRoot} — nothing to do.`);
-  process.exit(0);
-}
-
-// --- Transform: strip applies_to block from a single file -------------------
+// --- Transform 1: strip codex applies_to ------------------------------------
 
 function stripAppliesTo(content) {
   const lines = content.split('\n');
@@ -78,10 +74,7 @@ function stripAppliesTo(content) {
       continue;
     }
 
-    // Sanity: applies_to under a key-value (no value on its own line +
-    // children indented) is the only canonical shape. An inline value
-    // (`applies_to: [X, Y]`) on a single line is also valid — we strip
-    // the line and continue.
+    // Inline-array form: `applies_to: [X, Y]` — strip the single line.
     const hasInlineValue = line.match(/^\s*applies_to\s*:\s*\S/);
     if (hasInlineValue) {
       removedBlockCount++;
@@ -89,10 +82,10 @@ function stripAppliesTo(content) {
       continue;
     }
 
-    // Block form: skip the applies_to: line plus all subsequent lines
-    // that are indented strictly deeper than the applies_to: line's own
-    // indent. Blank lines INSIDE the block (preceded and followed by
-    // strictly-deeper-indented lines) are skipped as part of the block.
+    // Block form: strip the line plus subsequent lines indented strictly
+    // deeper than applies_to's own indent. Blanks INSIDE the block are
+    // consumed; the first blank or sibling-indented line after the block
+    // is preserved (and not consumed by this transform).
     const ownIndent = m[1].length;
     removedBlockCount++;
     i++;
@@ -104,82 +97,144 @@ function stripAppliesTo(content) {
 
       if (trimmedEmpty) {
         // Peek ahead: if the next non-blank line is still strictly deeper
-        // than applies_to's indent, this blank is inside the block — skip.
-        // Otherwise the blank is the separator after the block — emit and stop.
+        // than applies_to's indent, this blank belongs to the block — skip.
         let j = i + 1;
         while (j < lines.length && lines[j].trim() === '') j++;
         if (j < lines.length) {
           const peekIndent = lines[j].match(/^(\s*)/)[1].length;
           if (peekIndent > ownIndent) {
-            // blank still inside the block; skip
             i++;
             continue;
           }
         }
-        // blank is outside the block — emit it (preserves spacing) and stop
         out.push(next);
         i++;
         break;
       }
 
       if (nextIndent > ownIndent) {
-        i++; // inside the block; skip
+        i++;
       } else {
-        break; // back to sibling indent; stop, do NOT consume this line
+        break;
       }
     }
   }
 
-  return { content: out.join('\n'), removedBlockCount, bailed };
+  return { content: out.join('\n'), modified: removedBlockCount, bailed };
 }
 
-// --- Run over every candidate -----------------------------------------------
+// --- Transform 2: lifecycle backfill ----------------------------------------
 
-let modifiedFiles = 0;
-let totalRemovedBlocks = 0;
-let failed = 0;
-
-for (const file of candidateFiles) {
-  let original;
-  try {
-    original = readFileSync(file, 'utf8');
-  } catch (e) {
-    console.error(`! ${relative(target, file)}: read failed (${e.message}) — skipping`);
-    failed++;
-    continue;
+function backfillLifecycle(content) {
+  // Idempotency: if `valid_from:` appears anywhere at any indent, treat
+  // the file as already migrated and leave it alone. A partial-state
+  // file (has valid_from but not valid_to) is flagged for manual review;
+  // we do not auto-correct it.
+  if (/^\s*valid_from\s*:/m.test(content)) {
+    return { content, modified: 0, bailed: false };
   }
 
-  const { content: result, removedBlockCount, bailed } = stripAppliesTo(original);
+  // Pick a valid_from value. Prefer the file's last_updated: when
+  // present; else the §7.4 epoch fallback.
+  const lu = content.match(/^\s*last_updated\s*:\s*["']?([^"'\n#]+?)["']?\s*(?:#.*)?$/m);
+  const validFrom = (lu ? lu[1].trim() : '2024-01-01');
 
-  if (bailed) {
-    console.error(`! ${relative(target, file)}: codemod bailed on ambiguity — file unchanged`);
-    failed++;
-    continue;
-  }
+  const block =
+    '\n# Primitive lifecycle (CONTRACT.md §7) — backfilled by 0.4 → 0.5 migration\n' +
+    `valid_from: "${validFrom}"\n` +
+    'valid_to: null\n';
 
-  if (removedBlockCount === 0) {
-    // unchanged — typical for an artefact that has no applies_to or has
-    // already been migrated. Idempotent.
-    continue;
-  }
-
-  if (!dryRun) {
-    writeFileSync(file, result);
-  }
-  modifiedFiles++;
-  totalRemovedBlocks += removedBlockCount;
-  console.log(`${dryRun ? '[dry-run] ' : ''}~ ${relative(target, file)}: removed ${removedBlockCount} applies_to block${removedBlockCount === 1 ? '' : 's'}`);
+  const result = (content.endsWith('\n') ? content : content + '\n') + block;
+  return { content: result, modified: 1, bailed: false };
 }
 
-// --- Summary ----------------------------------------------------------------
+// --- Transform registry -----------------------------------------------------
 
-console.log(``);
-console.log(`Summary:`);
-console.log(`  files scanned        ${candidateFiles.length}`);
-console.log(`  files modified       ${modifiedFiles}${dryRun ? ' (dry-run; no files written)' : ''}`);
-console.log(`  applies_to removed   ${totalRemovedBlocks}`);
-if (failed > 0) {
-  console.error(`  files skipped        ${failed}`);
+const transforms = [
+  {
+    name: 'codex applies_to retirement',
+    rootName: 'codex',
+    fn: stripAppliesTo,
+    unit: 'applies_to block',
+    units: 'applies_to blocks',
+  },
+  {
+    name: 'lifecycle backfill',
+    rootName: 'canon/elements',
+    fn: backfillLifecycle,
+    unit: 'lifecycle block appended',
+    units: 'lifecycle blocks appended',
+  },
+];
+
+// --- Run --------------------------------------------------------------------
+
+let totalScanned = 0;
+let totalModified = 0;
+let totalUnits = 0;
+let totalFailed = 0;
+
+for (const t of transforms) {
+  const root = join(target, t.rootName);
+  console.log(`Transform: ${t.name}`);
+
+  if (!existsSync(root)) {
+    console.log(`  ${t.rootName}/ not present under target — skipping.`);
+    console.log('');
+    continue;
+  }
+
+  const files = walkYaml(root);
+  console.log(`  scanning ${files.length} .yaml file(s) under ${t.rootName}/`);
+
+  let modified = 0;
+  let units = 0;
+  let failed = 0;
+
+  for (const file of files) {
+    let original;
+    try {
+      original = readFileSync(file, 'utf8');
+    } catch (e) {
+      console.error(`  ! ${relative(target, file)}: read failed (${e.message}) — skipping`);
+      failed++;
+      continue;
+    }
+
+    const result = t.fn(original);
+
+    if (result.bailed) {
+      console.error(`  ! ${relative(target, file)}: bailed on ambiguity — file unchanged`);
+      failed++;
+      continue;
+    }
+
+    if (result.modified === 0) continue;
+
+    if (!dryRun) writeFileSync(file, result.content);
+    modified++;
+    units += result.modified;
+    const u = result.modified === 1 ? t.unit : t.units;
+    console.log(`  ${dryRun ? '[dry-run] ' : ''}~ ${relative(target, file)}: ${result.modified} ${u}`);
+  }
+
+  console.log(`  → ${modified} file(s) modified, ${units} ${units === 1 ? t.unit : t.units}${dryRun ? ' (dry-run; no files written)' : ''}`);
+  console.log('');
+
+  totalScanned += files.length;
+  totalModified += modified;
+  totalUnits += units;
+  totalFailed += failed;
+}
+
+// --- Overall summary --------------------------------------------------------
+
+console.log(`Summary across ${transforms.length} transform(s):`);
+console.log(`  files scanned     ${totalScanned}`);
+console.log(`  files modified    ${totalModified}${dryRun ? ' (dry-run)' : ''}`);
+console.log(`  units applied     ${totalUnits}`);
+if (totalFailed > 0) {
+  console.error(`  files skipped     ${totalFailed}`);
   process.exit(1);
 }
 process.exit(0);

--- a/migrations/0.4-to-0.5/fixtures/after/canon/elements/01_motivation/constraints/CONSTRAINT-EPOCH-DEMO-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/elements/01_motivation/constraints/CONSTRAINT-EPOCH-DEMO-1.yaml
@@ -1,0 +1,18 @@
+# Fixture — adopter element primitive BEFORE the 0.4 → 0.5 migration.
+# Has NO last_updated and NO lifecycle. The codemod uses the §7.4 epoch
+# fallback "2024-01-01" as valid_from.
+
+id: CONSTRAINT-EPOCH-DEMO-1
+name: "Demonstration constraint (fixture, no last_updated)"
+type: constraint
+statement: >
+  Illustrative constraint used as a migration fixture. No last_updated;
+  the codemod uses the sensible epoch from CONTRACT §7.4.
+status: active
+
+source: "Fixture external regulation"
+severity: mandatory
+
+# Primitive lifecycle (CONTRACT.md §7) — backfilled by 0.4 → 0.5 migration
+valid_from: "2024-01-01"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/after/canon/elements/02_business/rules/RULE-CLEAN-LIFECYCLE-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/elements/02_business/rules/RULE-CLEAN-LIFECYCLE-1.yaml
@@ -1,0 +1,18 @@
+# Fixture — adopter element primitive already in 0.5 form.
+# Has both valid_from and valid_to; the codemod's idempotency check
+# treats this as already migrated and leaves it untouched.
+
+id: RULE-CLEAN-LIFECYCLE-1
+name: "Already-migrated rule (fixture)"
+type: rule
+statement: >
+  Fixture for idempotency: already carries lifecycle. The codemod must
+  leave this file unchanged on the first AND any subsequent run.
+status: active
+
+source: "Fixture"
+owner_role: ROLE-FIXTURE-1
+severity: mandatory
+
+valid_from: "2025-01-01"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/after/canon/elements/02_business/rules/RULE-LASTUPDATED-DEMO-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/elements/02_business/rules/RULE-LASTUPDATED-DEMO-1.yaml
@@ -1,0 +1,20 @@
+# Fixture — adopter element primitive BEFORE the 0.4 → 0.5 migration.
+# Has a last_updated: field but no lifecycle. The codemod uses the
+# last_updated value as valid_from per CONTRACT.md §7.4 migration recipe.
+
+id: RULE-LASTUPDATED-DEMO-1
+name: "Demonstration business rule (fixture, with last_updated)"
+type: rule
+statement: >
+  Illustrative business rule used as a migration fixture. Has a
+  last_updated value that the codemod adopts as valid_from.
+status: active
+
+source: "Fixture internal policy"
+owner_role: ROLE-FIXTURE-1
+severity: mandatory
+last_updated: "2026-03-15"
+
+# Primitive lifecycle (CONTRACT.md §7) — backfilled by 0.4 → 0.5 migration
+valid_from: "2026-03-15"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/before/canon/elements/01_motivation/constraints/CONSTRAINT-EPOCH-DEMO-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/elements/01_motivation/constraints/CONSTRAINT-EPOCH-DEMO-1.yaml
@@ -1,0 +1,14 @@
+# Fixture — adopter element primitive BEFORE the 0.4 → 0.5 migration.
+# Has NO last_updated and NO lifecycle. The codemod uses the §7.4 epoch
+# fallback "2024-01-01" as valid_from.
+
+id: CONSTRAINT-EPOCH-DEMO-1
+name: "Demonstration constraint (fixture, no last_updated)"
+type: constraint
+statement: >
+  Illustrative constraint used as a migration fixture. No last_updated;
+  the codemod uses the sensible epoch from CONTRACT §7.4.
+status: active
+
+source: "Fixture external regulation"
+severity: mandatory

--- a/migrations/0.4-to-0.5/fixtures/before/canon/elements/02_business/rules/RULE-CLEAN-LIFECYCLE-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/elements/02_business/rules/RULE-CLEAN-LIFECYCLE-1.yaml
@@ -1,0 +1,18 @@
+# Fixture — adopter element primitive already in 0.5 form.
+# Has both valid_from and valid_to; the codemod's idempotency check
+# treats this as already migrated and leaves it untouched.
+
+id: RULE-CLEAN-LIFECYCLE-1
+name: "Already-migrated rule (fixture)"
+type: rule
+statement: >
+  Fixture for idempotency: already carries lifecycle. The codemod must
+  leave this file unchanged on the first AND any subsequent run.
+status: active
+
+source: "Fixture"
+owner_role: ROLE-FIXTURE-1
+severity: mandatory
+
+valid_from: "2025-01-01"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/before/canon/elements/02_business/rules/RULE-LASTUPDATED-DEMO-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/elements/02_business/rules/RULE-LASTUPDATED-DEMO-1.yaml
@@ -1,0 +1,16 @@
+# Fixture — adopter element primitive BEFORE the 0.4 → 0.5 migration.
+# Has a last_updated: field but no lifecycle. The codemod uses the
+# last_updated value as valid_from per CONTRACT.md §7.4 migration recipe.
+
+id: RULE-LASTUPDATED-DEMO-1
+name: "Demonstration business rule (fixture, with last_updated)"
+type: rule
+statement: >
+  Illustrative business rule used as a migration fixture. Has a
+  last_updated value that the codemod adopts as valid_from.
+status: active
+
+source: "Fixture internal policy"
+owner_role: ROLE-FIXTURE-1
+severity: mandatory
+last_updated: "2026-03-15"

--- a/migrations/0.4-to-0.5/validate.mjs
+++ b/migrations/0.4-to-0.5/validate.mjs
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 // Migration validator — methodology 0.4 → 0.5.
 //
-// CURRENT CHECK: assert no codex artefact under <target>/codex/**/*.yaml
-// still carries an applies_to: field. The codemod (codemod.mjs) is
-// responsible for the removal; this script confirms the result.
+// CHECKS (each entry runs independently; failures are aggregated):
 //
-// Run AFTER the codemod. Exits 0 if clean, 1 if any residue, 2 on
-// script-internal error.
+//   1. codex applies_to retirement
+//      No .yaml under <target>/codex/** may still carry an applies_to: field.
+//
+//   2. lifecycle backfill
+//      Every .yaml under <target>/canon/elements/** must carry both
+//      valid_from: and valid_to: keys.
+//
+// Run AFTER the codemod. Exits 0 if clean, 1 if any check fails,
+// 2 on script-internal error.
 //
 // Usage: node validate.mjs [target-dir]
 //   Default target-dir = current working directory
@@ -34,39 +39,80 @@ function walkYaml(dir, out = []) {
   return out;
 }
 
-const codexRoot = join(target, 'codex');
-if (!existsSync(codexRoot)) {
-  console.log(`No codex/ directory under ${target} — nothing to validate.`);
-  process.exit(0);
-}
+const checks = [
+  {
+    name: 'codex applies_to retirement',
+    rootName: 'codex',
+    fn: (text) => /^\s*applies_to\s*:/m.test(text) ? 'still carries applies_to' : null,
+  },
+  {
+    name: 'lifecycle backfill',
+    rootName: 'canon/elements',
+    fn: (text) => {
+      const hasFrom = /^\s*valid_from\s*:/m.test(text);
+      const hasTo = /^\s*valid_to\s*:/m.test(text);
+      if (!hasFrom && !hasTo) return 'missing valid_from and valid_to';
+      if (!hasFrom) return 'missing valid_from';
+      if (!hasTo) return 'missing valid_to';
+      return null;
+    },
+  },
+];
 
-const files = walkYaml(codexRoot);
-if (files.length === 0) {
-  console.log(`No .yaml files under ${codexRoot} — nothing to validate.`);
-  process.exit(0);
-}
+let totalChecked = 0;
+let totalOffenders = 0;
 
-let offenders = 0;
-for (const file of files) {
-  let content;
-  try {
-    content = readFileSync(file, 'utf8');
-  } catch (e) {
-    console.error(`! ${relative(target, file)}: read failed (${e.message})`);
-    offenders++;
+for (const c of checks) {
+  const root = join(target, c.rootName);
+  console.log(`Check: ${c.name}`);
+
+  if (!existsSync(root)) {
+    console.log(`  ${c.rootName}/ not present under target — skipping.`);
+    console.log('');
     continue;
   }
 
-  if (/^\s*applies_to\s*:/m.test(content)) {
-    console.error(`✗ ${relative(target, file)}: still carries applies_to`);
-    offenders++;
+  const files = walkYaml(root);
+  console.log(`  scanning ${files.length} .yaml file(s) under ${c.rootName}/`);
+
+  let offenders = 0;
+
+  for (const file of files) {
+    let content;
+    try {
+      content = readFileSync(file, 'utf8');
+    } catch (e) {
+      console.error(`  ! ${relative(target, file)}: read failed (${e.message})`);
+      offenders++;
+      continue;
+    }
+
+    const issue = c.fn(content);
+    if (issue) {
+      console.error(`  ✗ ${relative(target, file)}: ${issue}`);
+      offenders++;
+    }
   }
+
+  if (offenders === 0) {
+    console.log(`  ✓ all ${files.length} file(s) OK`);
+  } else {
+    console.error(`  ✗ ${offenders} file(s) failed this check`);
+  }
+  console.log('');
+
+  totalChecked += files.length;
+  totalOffenders += offenders;
 }
 
-console.log(``);
-if (offenders > 0) {
-  console.error(`FAIL: ${offenders} codex file${offenders === 1 ? '' : 's'} still carry applies_to. Re-run the codemod, then re-validate.`);
+console.log(`Summary across ${checks.length} check(s):`);
+console.log(`  files checked     ${totalChecked}`);
+console.log(`  offenders         ${totalOffenders}`);
+
+if (totalOffenders > 0) {
+  console.error(``);
+  console.error(`FAIL: ${totalOffenders} file(s) failed validation. Re-run the codemod, review any '! ... bailed' messages, then re-validate.`);
   process.exit(1);
 }
-console.log(`OK: ${files.length} codex file${files.length === 1 ? '' : 's'} validated; no applies_to present.`);
+console.log(`OK: all checks passed.`);
 process.exit(0);


### PR DESCRIPTION
## Summary

Second transform in the 0.4 → 0.5 migration recipe. Backfills the primitive lifecycle (CONTRACT.md §7) onto element primitives that predate Wave 1 of the temporal-model epic.

The transform is intentionally a **different shape** from the codex \`applies_to\` retirement (PR #72) — that one DELETED a block; this one INSERTS one. Together they exercise both styles in the multi-transform recipe format.

## Algorithm

- Walk \`<target>/canon/elements/**/*.yaml\`.
- Idempotency check: if \`valid_from:\` appears anywhere at any indent, the file is treated as already migrated and left untouched. Partial-state files (one of {\`valid_from\`, \`valid_to\`} but not both) are flagged by \`validate.mjs\` for manual review; the codemod does NOT auto-correct.
- For files missing lifecycle, pick \`valid_from\`:
  - **Preferred:** the file's \`last_updated:\` value when present.
  - **Fallback:** the §7.4 sensible epoch \`"2024-01-01"\`.
- \`valid_to\` defaults to \`null\` (currently in effect).
- Append at end of file:
  \`\`\`yaml
  # Primitive lifecycle (CONTRACT.md §7) — backfilled by 0.4 → 0.5 migration
  valid_from: "<date>"
  valid_to: null
  \`\`\`

## Codemod refactor

\`codemod.mjs\` now uses a \`transforms\` registry — each transform is \`{name, rootName, fn, unit, units}\`. Adding a new transform is a one-entry append; the existing codex applies_to transform behaviour is preserved 1:1. Per-transform summary in live output plus an overall summary at the end. Same conventions hold: idempotent, \`--dry-run\`-supporting, diff-style summary, non-zero on unsafe ambiguity.

\`validate.mjs\` analogously: a \`checks\` registry. The codex check is preserved 1:1; the lifecycle check asserts that every \`canon/elements/**/*.yaml\` has BOTH \`valid_from\` AND \`valid_to\`.

## Fixtures (3 new each side)

| File | Purpose |
|---|---|
| \`before/.../RULE-LASTUPDATED-DEMO-1.yaml\` | has \`last_updated: 2026-03-15\` → codemod uses it as \`valid_from\` |
| \`before/.../CONSTRAINT-EPOCH-DEMO-1.yaml\` | no \`last_updated\` → codemod uses the \`2024-01-01\` epoch fallback |
| \`before/.../RULE-CLEAN-LIFECYCLE-1.yaml\` | already has lifecycle → idempotency test, must remain untouched |
| \`after/...\` mirrors | each with the backfilled lifecycle blocks |

## Smoke-test result (verified)

\`\`\`
=== dry-run ===
Transform: codex applies_to retirement
  → 2 file(s) modified, 2 applies_to blocks (dry-run)
Transform: lifecycle backfill
  → 2 file(s) modified, 2 lifecycle blocks appended (dry-run)
Summary: files scanned 6 / files modified 4 (dry-run) / units applied 4

=== apply ===  (same diff, written)
=== diff vs after/ ===
(no output = bit-identical)

=== idempotency: second run ===
Summary: files scanned 6 / files modified 0 / units applied 0
(no output = idempotent)

=== validate ===
Check: codex applies_to retirement → ✓ all 3 file(s) OK
Check: lifecycle backfill → ✓ all 3 file(s) OK
OK: all checks passed.
\`\`\`

## README updated

- New transform listed under "What this recipe covers" with the date-sourcing rule called out.
- Manual-steps section split — codex side covers the REQUIREMENT / ASSERTION redirect (unchanged); lifecycle side notes the adopter SHOULD spot-check the backfilled \`valid_from\` values since the codemod picks a safe default, not a historical claim.
- "Deliberately does NOT cover" list pruned — lifecycle backfill is now covered; remaining 6 transforms stay as follow-ups.

## Test plan

- [x] All YAML fixtures parse cleanly under \`yaml.safe_load\`
- [x] All Markdown files end with newline + complete final line
- [x] No \`vkgeorgia/strategy\` hyperlinks, client codenames, or "real client"/"the client" framing
- [x] Smoke test (dry-run → apply → diff → idempotency → validate) passes end-to-end for BOTH transforms
- [x] Codex transform behaviour preserved 1:1 from PR #72 (verified by running over codex fixtures only)
- [ ] (self-merge per today's autonomous authority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)