### PR TITLE
docs(migrations): capability-id canonical-form transform on 0.4 → 0.5 recipe (strategy#78 Phase 2)

### DIFF
--- a/migrations/0.4-to-0.5/README.md
+++ b/migrations/0.4-to-0.5/README.md
@@ -8,6 +8,7 @@ This recipe ships incrementally — each transform in the 0.4 → 0.5 cycle (see
 
 - **Codex `applies_to.{entities, processes}` retirement.** In 0.5.0, external and internal codex artefacts no longer carry an `applies_to` block (see [`notations/14-codex.md`](../../notations/14-codex.md) §8 — Migration). Bindings move to `REQUIREMENT.derived_from` plus `ASSERTION`. Codex artefacts that still carry `applies_to` produce a `CODEX-004` deprecation warning; the recipe removes the field.
 - **Primitive lifecycle backfill.** In 0.5.0, every canonical element MUST carry `valid_from` and `valid_to` ([`notations/CONTRACT.md`](../../notations/CONTRACT.md) §7). Adopters with element primitives under `canon/elements/` missing those fields get them backfilled: `valid_from` adopts the file's `last_updated:` value when present, otherwise falls back to the sensible epoch `"2024-01-01"` per the §7.4 migration recipe. `valid_to` defaults to `null` (currently in effect).
+- **Capability ID canonical form.** In 0.5.0, capability identifiers in view documents take the canonical `CAPABILITY-V…` / `CAPABILITY-H…` form, and capability-map document IDs take `CAPABILITY_MAP-…` (no zero-padding) per [`notations/IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §2 (rule) and §6 (migration checklist). The recipe gates on the file's `notation:` header — only `capability-map`, `process-map`, `products`, `applications`, `scenarios` — and rewrites bare `V…` / `H…` IDs in `id:`, `capability:`, inline-array `capabilities: [V1, V2]`, and block-form `capabilities:\n  - V1` positions. CM- document IDs are normalised to `CAPABILITY_MAP-…` and stripped of leading zeros.
 
 ## Folder shape (canonical for all migration recipes)
 
@@ -94,7 +95,6 @@ Other 0.4 → 0.5 deprecated patterns are listed in [`CHANGELOG.md`](../../CHANG
 - Inline `goals: [GOAL-…]` on activity entries → REL `activity_goal` files.
 - Inline `current_maturity` / `owner_role` / `target_date` on capability-map → sidecar.
 - Inline `owner_role` / `vendor` / `maturity` on applications → sidecar.
-- Capability ID canonical form residual (`scenarios` + supporting docs).
 
 Each transform follows the same conventions (idempotent, dry-run-supporting, diff-summary-printing, unsafe-ambiguity-bailing) and ships its own fixture pair. The order and packaging of those subsequent transforms is a separate task.
 
@@ -106,3 +106,4 @@ Each transform follows the same conventions (idempotent, dry-run-supporting, dif
 - Spec sources for the transforms shipped:
   - Codex `applies_to` retirement — [`notations/14-codex.md`](../../notations/14-codex.md) §8.
   - Lifecycle backfill — [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §7 (rule) and §7.4 (migration recipe).
+  - Capability ID canonical form — [`notations/IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §2 and §6.

--- a/migrations/0.4-to-0.5/codemod.mjs
+++ b/migrations/0.4-to-0.5/codemod.mjs
@@ -13,6 +13,14 @@
 //      the file's last_updated: when present, otherwise the sensible
 //      epoch "2024-01-01" per the §7.4 recipe.
 //
+//   3. capability ID canonical form (notations/IDS_AND_REFERENCES.md §6)
+//      Walks <target>/canon/views/**/*.yaml and rewrites bare capability
+//      IDs (V1 / V1.2 / H1) to canonical form (CAPABILITY-V1 etc.) plus
+//      capability-map document IDs (CM-…) to CAPABILITY_MAP-…. Per-file
+//      notation: header gate keeps the transform context-safe: only
+//      capability-map / process-map / products / applications /
+//      scenarios documents are touched.
+//
 // Conventions (canonical for every migration recipe):
 //   - Pure-Node. Runs on a stock Node ≥ 20 with no native deps.
 //   - Idempotent. Running twice on the same input produces identical
@@ -74,7 +82,6 @@ function stripAppliesTo(content) {
       continue;
     }
 
-    // Inline-array form: `applies_to: [X, Y]` — strip the single line.
     const hasInlineValue = line.match(/^\s*applies_to\s*:\s*\S/);
     if (hasInlineValue) {
       removedBlockCount++;
@@ -82,10 +89,6 @@ function stripAppliesTo(content) {
       continue;
     }
 
-    // Block form: strip the line plus subsequent lines indented strictly
-    // deeper than applies_to's own indent. Blanks INSIDE the block are
-    // consumed; the first blank or sibling-indented line after the block
-    // is preserved (and not consumed by this transform).
     const ownIndent = m[1].length;
     removedBlockCount++;
     i++;
@@ -96,8 +99,6 @@ function stripAppliesTo(content) {
       const nextIndent = next.match(/^(\s*)/)[1].length;
 
       if (trimmedEmpty) {
-        // Peek ahead: if the next non-blank line is still strictly deeper
-        // than applies_to's indent, this blank belongs to the block — skip.
         let j = i + 1;
         while (j < lines.length && lines[j].trim() === '') j++;
         if (j < lines.length) {
@@ -126,16 +127,10 @@ function stripAppliesTo(content) {
 // --- Transform 2: lifecycle backfill ----------------------------------------
 
 function backfillLifecycle(content) {
-  // Idempotency: if `valid_from:` appears anywhere at any indent, treat
-  // the file as already migrated and leave it alone. A partial-state
-  // file (has valid_from but not valid_to) is flagged for manual review;
-  // we do not auto-correct it.
   if (/^\s*valid_from\s*:/m.test(content)) {
     return { content, modified: 0, bailed: false };
   }
 
-  // Pick a valid_from value. Prefer the file's last_updated: when
-  // present; else the §7.4 epoch fallback.
   const lu = content.match(/^\s*last_updated\s*:\s*["']?([^"'\n#]+?)["']?\s*(?:#.*)?$/m);
   const validFrom = (lu ? lu[1].trim() : '2024-01-01');
 
@@ -146,6 +141,107 @@ function backfillLifecycle(content) {
 
   const result = (content.endsWith('\n') ? content : content + '\n') + block;
   return { content: result, modified: 1, bailed: false };
+}
+
+// --- Transform 3: capability ID canonical form ------------------------------
+
+const CAPABILITY_NOTATIONS = new Set([
+  'capability-map',
+  'process-map',
+  'products',
+  'applications',
+  'scenarios',
+]);
+
+function capabilityIdCanonical(content) {
+  // Per-file gate: only act on view documents that reference capabilities.
+  // Outside these notations the bare V/H pattern would be a false positive.
+  const notationMatch = content.match(/^notation\s*:\s*(\S+)/m);
+  if (!notationMatch) return { content, modified: 0, bailed: false };
+  if (!CAPABILITY_NOTATIONS.has(notationMatch[1])) return { content, modified: 0, bailed: false };
+
+  const lines = content.split('\n');
+  const out = [];
+  let modified = 0;
+  let inCapabilitiesBlock = null; // indent of the `capabilities:` line, or null
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+    const lineIndent = line.match(/^(\s*)/)[1].length;
+
+    // Exit capabilities: block when indent returns to <= block-line indent.
+    if (inCapabilitiesBlock !== null && line.trim() !== '' && lineIndent <= inCapabilitiesBlock) {
+      inCapabilitiesBlock = null;
+    }
+
+    // Inside capabilities: block — rewrite bare V/H array entries.
+    if (inCapabilitiesBlock !== null) {
+      const arrEntry = line.match(/^(\s*-\s*)(["']?)([VH]\d+(?:\.\d+)*)\2(\s*(?:#.*)?)$/);
+      if (arrEntry) {
+        out.push(`${arrEntry[1]}${arrEntry[2]}CAPABILITY-${arrEntry[3]}${arrEntry[2]}${arrEntry[4]}`);
+        modified++;
+        continue;
+      }
+    }
+
+    // Enter block-form `capabilities:` block.
+    const capArrayHead = line.match(/^(\s*)capabilities\s*:\s*(?:#.*)?$/);
+    if (capArrayHead) {
+      inCapabilitiesBlock = capArrayHead[1].length;
+      out.push(line);
+      continue;
+    }
+
+    // Inline-array form: `capabilities: ["V1", "V2"]` → rewrite scalars inside.
+    const capInlineArray = line.match(/^(\s*capabilities\s*:\s*\[)([^\]]*)(\]\s*(?:#.*)?)$/);
+    if (capInlineArray) {
+      const items = capInlineArray[2].split(',').map(s => s.trim()).filter(Boolean);
+      let lineModified = 0;
+      const rewritten = items.map(item => {
+        const qm = item.match(/^(["']?)([VH]\d+(?:\.\d+)*)\1$/);
+        if (qm) {
+          lineModified++;
+          return `${qm[1]}CAPABILITY-${qm[2]}${qm[1]}`;
+        }
+        return item;
+      });
+      if (lineModified > 0) {
+        out.push(`${capInlineArray[1]}${rewritten.join(', ')}${capInlineArray[3]}`);
+        modified += lineModified;
+        continue;
+      }
+    }
+
+    // Single-value: `id: V1` / `id: H1.2` / `id: "V1"` → CAPABILITY-…
+    const idCH = line.match(/^(\s*-?\s*id\s*:\s*)(["']?)([VH]\d+(?:\.\d+)*)\2(\s*(?:#.*)?)$/);
+    if (idCH) {
+      out.push(`${idCH[1]}${idCH[2]}CAPABILITY-${idCH[3]}${idCH[2]}${idCH[4]}`);
+      modified++;
+      continue;
+    }
+
+    // Single-value: `id: CM-DOMAIN-NNN` → `CAPABILITY_MAP-DOMAIN-N`
+    // The non-greedy middle capture pulls in multi-segment domains
+    // (NB-RETAIL); the `-0*(\d+)` tail drops any zero-padding per IDS §1.
+    const idCM = line.match(/^(\s*-?\s*id\s*:\s*)(["']?)CM-([A-Z][A-Z0-9_-]*?)-0*(\d+)\2(\s*(?:#.*)?)$/);
+    if (idCM) {
+      out.push(`${idCM[1]}${idCM[2]}CAPABILITY_MAP-${idCM[3]}-${idCM[4]}${idCM[2]}${idCM[5]}`);
+      modified++;
+      continue;
+    }
+
+    // Single-value: `capability: V1` (process-map cross-reference)
+    const capCH = line.match(/^(\s*capability\s*:\s*)(["']?)([VH]\d+(?:\.\d+)*)\2(\s*(?:#.*)?)$/);
+    if (capCH) {
+      out.push(`${capCH[1]}${capCH[2]}CAPABILITY-${capCH[3]}${capCH[2]}${capCH[4]}`);
+      modified++;
+      continue;
+    }
+
+    out.push(line);
+  }
+
+  return { content: out.join('\n'), modified, bailed: false };
 }
 
 // --- Transform registry -----------------------------------------------------
@@ -164,6 +260,13 @@ const transforms = [
     fn: backfillLifecycle,
     unit: 'lifecycle block appended',
     units: 'lifecycle blocks appended',
+  },
+  {
+    name: 'capability ID canonical form',
+    rootName: 'canon/views',
+    fn: capabilityIdCanonical,
+    unit: 'capability id rewritten',
+    units: 'capability ids rewritten',
   },
 ];
 

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/applications/portfolio.applications.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/applications/portfolio.applications.transitrix.yaml
@@ -1,0 +1,22 @@
+# Fixture — applications view BEFORE the 0.4 → 0.5 migration.
+# Uses block-form `capabilities:` arrays. The codemod tracks the parent
+# block by indent and rewrites each `- V…` array entry.
+
+notation: applications
+spec_version: "0.1"
+
+applications_catalogue:
+  id: "APP-CAT-1"
+  name: "Demo Applications"
+
+  applications:
+    - app_id: "APP-DEMO-1"
+      name: "Demo App A"
+      capabilities:
+        - CAPABILITY-V1.2
+        - CAPABILITY-V2.1
+        - CAPABILITY-H1
+    - app_id: "APP-DEMO-2"
+      name: "Demo App B"
+      capabilities:
+        - "CAPABILITY-V1"

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/capabilities/already-clean.capability-map.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/capabilities/already-clean.capability-map.transitrix.yaml
@@ -1,0 +1,21 @@
+# Fixture — capability-map view already in 0.5 form (canonical IDs).
+# The codemod's transform must leave this file untouched (idempotency).
+
+notation: capability-map
+spec_version: "0.1"
+
+capability_map:
+  id: "CAPABILITY_MAP-CLEAN-1"
+  name: "Clean Capabilities Map"
+  assessment_date: "2026-05-26"
+
+  capabilities:
+    - id: "CAPABILITY-V1"
+      name: "Order Management"
+      type: domain
+    - id: "CAPABILITY-V1.1"
+      name: "Order Intake"
+      type: domain
+    - id: "CAPABILITY-H1"
+      name: "Master Data Management"
+      type: supporting

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/capabilities/business.capability-map.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/capabilities/business.capability-map.transitrix.yaml
@@ -1,0 +1,22 @@
+# Fixture — capability-map view BEFORE the 0.4 → 0.5 migration.
+# Uses bare V/H capability IDs and CM- document ID; the codemod rewrites
+# both to canonical form per IDS_AND_REFERENCES.md §6.
+
+notation: capability-map
+spec_version: "0.1"
+
+capability_map:
+  id: "CAPABILITY_MAP-BUSINESS-1"
+  name: "Business Capabilities Map"
+  assessment_date: "2026-05-08"
+
+  capabilities:
+    - id: "CAPABILITY-V1"
+      name: "Order Management"
+      type: domain
+    - id: CAPABILITY-V1.1
+      name: "Order Intake"
+      type: domain
+    - id: "CAPABILITY-H1"
+      name: "Master Data Management"
+      type: supporting

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/processmap/landscape.process-map.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/processmap/landscape.process-map.transitrix.yaml
@@ -1,0 +1,25 @@
+# Fixture — process-map view BEFORE the 0.4 → 0.5 migration.
+# Uses bare V/H capability cross-references; the codemod rewrites the
+# `capability:` single-value fields.
+
+notation: process-map
+spec_version: "0.1"
+
+process_map:
+  id: PM-DEMO-1
+  name: "Demo Process Landscape"
+
+  groups:
+    - id: GRP-OPERATING
+      name: "Operating"
+      type: operating
+      processes:
+        - process_id: PROC-DEMO-1
+          name: "Demo process A"
+          capability: "CAPABILITY-V1"
+        - process_id: PROC-DEMO-2
+          name: "Demo process B"
+          capability: CAPABILITY-V1.2
+        - process_id: PROC-DEMO-3
+          name: "Demo process C"
+          capability: CAPABILITY-H1

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/products/portfolio.products.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/products/portfolio.products.transitrix.yaml
@@ -1,0 +1,18 @@
+# Fixture — products view BEFORE the 0.4 → 0.5 migration.
+# Uses inline-array form: `capabilities: ["V1", "V2"]`. The codemod
+# rewrites each scalar inside the inline array, preserving quotes.
+
+notation: products
+spec_version: "0.1"
+
+products_catalogue:
+  id: "PROD-CAT-1"
+  name: "Demo Products"
+
+  products:
+    - product_id: "PROD-DEMO-1"
+      name: "Demo Product A"
+      capabilities: ["CAPABILITY-V1", "CAPABILITY-V2"]
+    - product_id: "PROD-DEMO-2"
+      name: "Demo Product B"
+      capabilities: [CAPABILITY-V1.1, CAPABILITY-H1]

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/applications/portfolio.applications.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/applications/portfolio.applications.transitrix.yaml
@@ -1,0 +1,22 @@
+# Fixture — applications view BEFORE the 0.4 → 0.5 migration.
+# Uses block-form `capabilities:` arrays. The codemod tracks the parent
+# block by indent and rewrites each `- V…` array entry.
+
+notation: applications
+spec_version: "0.1"
+
+applications_catalogue:
+  id: "APP-CAT-1"
+  name: "Demo Applications"
+
+  applications:
+    - app_id: "APP-DEMO-1"
+      name: "Demo App A"
+      capabilities:
+        - V1.2
+        - V2.1
+        - H1
+    - app_id: "APP-DEMO-2"
+      name: "Demo App B"
+      capabilities:
+        - "V1"

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/capabilities/already-clean.capability-map.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/capabilities/already-clean.capability-map.transitrix.yaml
@@ -1,0 +1,21 @@
+# Fixture — capability-map view already in 0.5 form (canonical IDs).
+# The codemod's transform must leave this file untouched (idempotency).
+
+notation: capability-map
+spec_version: "0.1"
+
+capability_map:
+  id: "CAPABILITY_MAP-CLEAN-1"
+  name: "Clean Capabilities Map"
+  assessment_date: "2026-05-26"
+
+  capabilities:
+    - id: "CAPABILITY-V1"
+      name: "Order Management"
+      type: domain
+    - id: "CAPABILITY-V1.1"
+      name: "Order Intake"
+      type: domain
+    - id: "CAPABILITY-H1"
+      name: "Master Data Management"
+      type: supporting

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/capabilities/business.capability-map.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/capabilities/business.capability-map.transitrix.yaml
@@ -1,0 +1,22 @@
+# Fixture — capability-map view BEFORE the 0.4 → 0.5 migration.
+# Uses bare V/H capability IDs and CM- document ID; the codemod rewrites
+# both to canonical form per IDS_AND_REFERENCES.md §6.
+
+notation: capability-map
+spec_version: "0.1"
+
+capability_map:
+  id: "CM-BUSINESS-001"
+  name: "Business Capabilities Map"
+  assessment_date: "2026-05-08"
+
+  capabilities:
+    - id: "V1"
+      name: "Order Management"
+      type: domain
+    - id: V1.1
+      name: "Order Intake"
+      type: domain
+    - id: "H1"
+      name: "Master Data Management"
+      type: supporting

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/processmap/landscape.process-map.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/processmap/landscape.process-map.transitrix.yaml
@@ -1,0 +1,25 @@
+# Fixture — process-map view BEFORE the 0.4 → 0.5 migration.
+# Uses bare V/H capability cross-references; the codemod rewrites the
+# `capability:` single-value fields.
+
+notation: process-map
+spec_version: "0.1"
+
+process_map:
+  id: PM-DEMO-1
+  name: "Demo Process Landscape"
+
+  groups:
+    - id: GRP-OPERATING
+      name: "Operating"
+      type: operating
+      processes:
+        - process_id: PROC-DEMO-1
+          name: "Demo process A"
+          capability: "V1"
+        - process_id: PROC-DEMO-2
+          name: "Demo process B"
+          capability: V1.2
+        - process_id: PROC-DEMO-3
+          name: "Demo process C"
+          capability: H1

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/products/portfolio.products.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/products/portfolio.products.transitrix.yaml
@@ -1,0 +1,18 @@
+# Fixture — products view BEFORE the 0.4 → 0.5 migration.
+# Uses inline-array form: `capabilities: ["V1", "V2"]`. The codemod
+# rewrites each scalar inside the inline array, preserving quotes.
+
+notation: products
+spec_version: "0.1"
+
+products_catalogue:
+  id: "PROD-CAT-1"
+  name: "Demo Products"
+
+  products:
+    - product_id: "PROD-DEMO-1"
+      name: "Demo Product A"
+      capabilities: ["V1", "V2"]
+    - product_id: "PROD-DEMO-2"
+      name: "Demo Product B"
+      capabilities: [V1.1, H1]

--- a/migrations/0.4-to-0.5/validate.mjs
+++ b/migrations/0.4-to-0.5/validate.mjs
@@ -10,6 +10,12 @@
 //      Every .yaml under <target>/canon/elements/** must carry both
 //      valid_from: and valid_to: keys.
 //
+//   3. capability ID canonical form
+//      No .yaml under <target>/canon/views/** (whose notation: is one of
+//      capability-map / process-map / products / applications / scenarios)
+//      may carry bare V/H capability IDs, CM- document IDs, or bare
+//      V/H entries inside a capabilities[] cross-reference.
+//
 // Run AFTER the codemod. Exits 0 if clean, 1 if any check fails,
 // 2 on script-internal error.
 //
@@ -39,6 +45,14 @@ function walkYaml(dir, out = []) {
   return out;
 }
 
+const CAPABILITY_NOTATIONS = new Set([
+  'capability-map',
+  'process-map',
+  'products',
+  'applications',
+  'scenarios',
+]);
+
 const checks = [
   {
     name: 'codex applies_to retirement',
@@ -54,6 +68,51 @@ const checks = [
       if (!hasFrom && !hasTo) return 'missing valid_from and valid_to';
       if (!hasFrom) return 'missing valid_from';
       if (!hasTo) return 'missing valid_to';
+      return null;
+    },
+  },
+  {
+    name: 'capability ID canonical form',
+    rootName: 'canon/views',
+    fn: (text) => {
+      // Per-file gate — only inspect view documents that reference capabilities.
+      const nm = text.match(/^notation\s*:\s*(\S+)/m);
+      if (!nm || !CAPABILITY_NOTATIONS.has(nm[1])) return null;
+
+      // Single-value bare V/H in id: position.
+      if (/^\s*-?\s*id\s*:\s*["']?[VH]\d+(?:\.\d+)*["']?\s*(?:#.*)?$/m.test(text)) {
+        return 'has bare V/H capability id (should be CAPABILITY-V/H)';
+      }
+      // Single-value bare V/H in capability: position.
+      if (/^\s*capability\s*:\s*["']?[VH]\d+(?:\.\d+)*["']?\s*(?:#.*)?$/m.test(text)) {
+        return 'has bare V/H capability cross-reference';
+      }
+      // CM- document id.
+      if (/^\s*-?\s*id\s*:\s*["']?CM-/m.test(text)) {
+        return 'has CM- document id (should be CAPABILITY_MAP-)';
+      }
+      // Inline-array form: capabilities: [V1, V2]. Parse the line to test each
+      // item — a naive `\b[VH]\d` regex false-positives on `CAPABILITY-V1`
+      // because `-` is a word boundary.
+      const inlineArr = text.match(/^\s*capabilities\s*:\s*\[([^\]]*)\]/m);
+      if (inlineArr) {
+        const items = inlineArr[1].split(',').map((s) => s.trim()).filter(Boolean);
+        if (items.some((it) => /^["']?[VH]\d+(?:\.\d+)*["']?$/.test(it))) {
+          return 'has bare V/H in capabilities inline array';
+        }
+      }
+      // Block-form: scan for `- V1` style entries under a capabilities: parent.
+      const lines = text.split('\n');
+      let inCap = null;
+      for (const line of lines) {
+        const indent = line.match(/^(\s*)/)[1].length;
+        if (inCap !== null && line.trim() !== '' && indent <= inCap) inCap = null;
+        if (inCap !== null && /^\s*-\s*["']?[VH]\d+(?:\.\d+)*["']?\s*(?:#.*)?$/.test(line)) {
+          return 'has bare V/H in capabilities block array';
+        }
+        const h = line.match(/^(\s*)capabilities\s*:\s*(?:#.*)?$/);
+        if (h) inCap = h[1].length;
+      }
       return null;
     },
   },


### PR DESCRIPTION
## Summary

Third transform on the 0.4 → 0.5 migration recipe — rewrites bare V/H capability identifiers to canonical `CAPABILITY-V/H` form and CM- document IDs to `CAPABILITY_MAP-` form per `notations/IDS_AND_REFERENCES.md` §2 (rule) and §6 (migration checklist). Per-file `notation:` header gate (`capability-map` / `process-map` / `products` / `applications` / `scenarios`) so non-view documents are untouched.

Covers four surfaces:

- `id: V1` → `id: CAPABILITY-V1`
- `id: CM-FOO-001` → `id: CAPABILITY_MAP-FOO-1`
- `capability: V1` → `capability: CAPABILITY-V1`
- `capabilities: [V1, V2]` → `capabilities: [CAPABILITY-V1, CAPABILITY-V2]`
- `capabilities:\n  - V1` → `capabilities:\n  - CAPABILITY-V1`

Quote style preserved; CM- IDs lose zero-padding.

The codemod's `transforms` registry and the validator's `checks` registry each get one new entry — the per-transform additive shape established in PR #72 and PR #73 is preserved.

Five before/after fixture pairs under `fixtures/{before,after}/canon/views/` cover all four surfaces plus an already-clean idempotency check.

Validator fix: the inline-array check previously false-positived on canonical `CAPABILITY-V1` because `\b` is a word boundary across the `-`. Replaced with an item-by-item parse anchored on the line head.

Refs strategy#78 (Phase 2 — migration recipe format).

## Test plan

- [x] Dry-run on `fixtures/before/` shows expected modifications (15 capability ids across 4 files; `already-clean.capability-map.yaml` untouched).
- [x] `diff -r recipe-test fixtures/after` is empty after apply.
- [x] Second-run on the migrated tree produces no changes (idempotent).
- [x] `validate.mjs recipe-test` reports clean (0 offenders).
- [x] `validate.mjs fixtures/before` reports all 8 expected offenders (2 codex + 2 lifecycle + 4 capability-id).
- [x] File integrity verified — no truncation, proper EOF on README.md, codemod.mjs, validate.mjs.
- [ ] CI conformance + smoke-test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)