### PR TITLE
docs(migrations): goal-parent REL extraction transform on 0.4 → 0.5 recipe (strategy#78 Phase 2)

### DIFF
--- a/migrations/0.4-to-0.5/README.md
+++ b/migrations/0.4-to-0.5/README.md
@@ -9,6 +9,7 @@ This recipe ships incrementally — each transform in the 0.4 → 0.5 cycle (see
 - **Codex `applies_to.{entities, processes}` retirement.** In 0.5.0, external and internal codex artefacts no longer carry an `applies_to` block (see [`notations/14-codex.md`](../../notations/14-codex.md) §8 — Migration). Bindings move to `REQUIREMENT.derived_from` plus `ASSERTION`. Codex artefacts that still carry `applies_to` produce a `CODEX-004` deprecation warning; the recipe removes the field.
 - **Primitive lifecycle backfill.** In 0.5.0, every canonical element MUST carry `valid_from` and `valid_to` ([`notations/CONTRACT.md`](../../notations/CONTRACT.md) §7). Adopters with element primitives under `canon/elements/` missing those fields get them backfilled: `valid_from` adopts the file's `last_updated:` value when present, otherwise falls back to the sensible epoch `"2024-01-01"` per the §7.4 migration recipe. `valid_to` defaults to `null` (currently in effect).
 - **Capability ID canonical form.** In 0.5.0, capability identifiers in view documents take the canonical `CAPABILITY-V…` / `CAPABILITY-H…` form, and capability-map document IDs take `CAPABILITY_MAP-…` (no zero-padding) per [`notations/IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §2 (rule) and §6 (migration checklist). The recipe gates on the file's `notation:` header — only `capability-map`, `process-map`, `products`, `applications`, `scenarios` — and rewrites bare `V…` / `H…` IDs in `id:`, `capability:`, inline-array `capabilities: [V1, V2]`, and block-form `capabilities:\n  - V1` positions. CM- document IDs are normalised to `CAPABILITY_MAP-…` and stripped of leading zeros.
+- **Goal `parent` → REL `goal_parent` extraction.** In 0.5.0, the goal-to-goal parent link is declared **time-aware** per [`notations/04-goals.md`](../../notations/04-goals.md) "Time-aware relations" — its canonical home is a `REL-…` file under `canon/relations/` with `type: goal_parent` per [`notations/17-relations.md`](../../notations/17-relations.md) §3. The inline `parent: GOAL-…` form on goal entries stays available transitionally; the recipe migrates each inline link to a first-class REL file. The codemod gates on `notation: goals`, drops each inline `parent:` line, and emits `canon/relations/REL-GOAL-<from-id>-PARENT-1.yaml` per dropped link. The REL's `valid_from` and `admitted_at` inherit the host goals doc's `date:` (fallback `"2024-01-01"`); `admitted_by` is the placeholder `"migration-codemod-0.4-to-0.5"`.
 
 ## Folder shape (canonical for all migration recipes)
 
@@ -86,12 +87,21 @@ After the new REQUIREMENT / ASSERTION primitives are admitted, the original code
 
 The lifecycle backfill picks `valid_from` mechanically — `last_updated:` when present, otherwise `"2024-01-01"`. After running the codemod, the adopter SHOULD spot-check the backfilled `valid_from` values and adjust any that don't reflect the actual date the element took effect. The codemod's value is a safe default, not a historically-accurate claim.
 
+### REL `goal_parent` admission review
+
+Each emitted `REL-…goal_parent…` file inherits the host goals doc's `date:` for both `valid_from` and `admitted_at`, and uses the placeholder marker `admitted_by: "migration-codemod-0.4-to-0.5"`. After running the codemod the adopter SHOULD:
+
+- replace `admitted_by` with the real operator handle once each REL has been reviewed in their canon (`grep -r migration-codemod-0.4-to-0.5 canon/relations/` lists the migration-generated files);
+- adjust `valid_from` if the parent link in fact took effect on a date other than the host doc's `date:`;
+- re-run the codemod and `validate.mjs` after the manual review — they remain idempotent.
+
+The codemod refuses to overwrite a REL file at the same `canon/relations/REL-….yaml` path if its content differs from what the codemod would emit, so manual edits to a REL file made between two codemod runs are preserved — the second run bails on that file with an explicit message instead of clobbering.
+
 ## What this recipe deliberately does NOT yet cover
 
 Other 0.4 → 0.5 deprecated patterns are listed in [`CHANGELOG.md`](../../CHANGELOG.md) under the 0.5.0 entry. Adding them to this recipe is straightforward — each is its own transform inside the same `codemod.mjs` + `validate.mjs` + per-pattern fixture:
 
 - Inline `children[]` on capability-map view documents → REL `parent` files.
-- Inline `parent: GOAL-…` on goal entries → REL `goal_parent` files.
 - Inline `goals: [GOAL-…]` on activity entries → REL `activity_goal` files.
 - Inline `current_maturity` / `owner_role` / `target_date` on capability-map → sidecar.
 - Inline `owner_role` / `vendor` / `maturity` on applications → sidecar.
@@ -107,3 +117,4 @@ Each transform follows the same conventions (idempotent, dry-run-supporting, dif
   - Codex `applies_to` retirement — [`notations/14-codex.md`](../../notations/14-codex.md) §8.
   - Lifecycle backfill — [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §7 (rule) and §7.4 (migration recipe).
   - Capability ID canonical form — [`notations/IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §2 and §6.
+  - Goal `parent` → REL `goal_parent` — [`notations/04-goals.md`](../../notations/04-goals.md) "Time-aware relations" + [`notations/17-relations.md`](../../notations/17-relations.md) §3 (enum) and §6 (migration).

--- a/migrations/0.4-to-0.5/codemod.mjs
+++ b/migrations/0.4-to-0.5/codemod.mjs
@@ -21,6 +21,14 @@
 //      capability-map / process-map / products / applications /
 //      scenarios documents are touched.
 //
+//   4. goal `parent` → REL goal_parent extraction (notations/17-relations.md §6,
+//      notations/04-goals.md "Time-aware relations")
+//      Walks <target>/canon/views/**/*.yaml with notation: goals, finds
+//      inline `parent: GOAL-…` on goal entries, drops the inline line,
+//      and emits a `canon/relations/REL-GOAL-<from-hint>-PARENT-1.yaml`
+//      REL primitive per dropped parent. valid_from / admitted_at on the
+//      emitted REL inherit the host doc's date: (fallback "2024-01-01").
+//
 // Conventions (canonical for every migration recipe):
 //   - Pure-Node. Runs on a stock Node ≥ 20 with no native deps.
 //   - Idempotent. Running twice on the same input produces identical
@@ -35,8 +43,8 @@
 // every line we don't touch. js-yaml dump would normalise comments and
 // keys away.
 
-import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 
 // --- CLI --------------------------------------------------------------------
 
@@ -244,6 +252,103 @@ function capabilityIdCanonical(content) {
   return { content: out.join('\n'), modified, bailed: false };
 }
 
+// --- Transform 4: goal `parent` → REL goal_parent extraction ----------------
+
+const GOALS_NOTATIONS = new Set(['goals']);
+
+function relGoalParentBody(relId, fromId, toId, validFrom) {
+  return [
+    'notation: relation',
+    `id: ${relId}`,
+    'type: goal_parent',
+    `from: ${fromId}`,
+    `to: ${toId}`,
+    '',
+    '# Admission record (CONTRACT.md §6) — emitted by 0.4 → 0.5 migration codemod.',
+    '# admitted_by is a placeholder marker — adopters should replace with the',
+    '# operator handle once the REL has been reviewed in their canon.',
+    'zone: canon',
+    `admitted_at: "${validFrom}"`,
+    'admitted_by: "migration-codemod-0.4-to-0.5"',
+    'gate_checks:',
+    '  uniqueness: pass',
+    '  consistency: pass',
+    '  completeness: pass',
+    '',
+    '# Primitive lifecycle (CONTRACT.md §7) — inherits the host doc date as a',
+    '# sensible epoch. Adopters should adjust if the parent link in fact took',
+    '# effect on a different date than the host doc.',
+    `valid_from: "${validFrom}"`,
+    'valid_to: null',
+    '',
+  ].join('\n');
+}
+
+function goalParentToRel(content) {
+  const notationMatch = content.match(/^notation\s*:\s*(\S+)/m);
+  if (!notationMatch) return { content, modified: 0, bailed: false };
+  if (!GOALS_NOTATIONS.has(notationMatch[1])) return { content, modified: 0, bailed: false };
+
+  // Host doc's date: drives the emitted REL's valid_from / admitted_at.
+  // Falls back to the same epoch as Transform 2 when the doc has no date.
+  const dateMatch = content.match(/^date\s*:\s*["']?([^"'\n#]+?)["']?\s*(?:#.*)?$/m);
+  const validFrom = dateMatch ? dateMatch[1].trim() : '2024-01-01';
+
+  const lines = content.split('\n');
+  const out = [];
+  const emits = [];
+  let modified = 0;
+  let inGoalsBlock = null;     // indent of the document-root `goals:` line, or null
+  let currentGoalId = null;    // most recently seen goal entry id inside the block
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    const indent = line.match(/^(\s*)/)[1].length;
+
+    // Exit the goals: block when indent returns to <= block-line indent.
+    if (inGoalsBlock !== null && trimmed !== '' && indent <= inGoalsBlock) {
+      inGoalsBlock = null;
+      currentGoalId = null;
+    }
+
+    // Outside any goals: block — only watch for the head and pass everything through.
+    if (inGoalsBlock === null) {
+      const head = line.match(/^(\s*)goals\s*:\s*(?:#.*)?$/);
+      if (head) inGoalsBlock = head[1].length;
+      out.push(line);
+      continue;
+    }
+
+    // Inside the goals: block. A new entry starts with `- id: GOAL-…`.
+    const dashId = line.match(/^\s*-\s+id\s*:\s*["']?(GOAL-\S+?)["']?\s*(?:#.*)?$/);
+    if (dashId) {
+      currentGoalId = dashId[1];
+      out.push(line);
+      continue;
+    }
+
+    // Inline parent on the current goal entry — drop the line, queue a REL emit.
+    if (currentGoalId !== null) {
+      const parentMatch = line.match(/^\s*parent\s*:\s*["']?(GOAL-\S+?)["']?\s*(?:#.*)?$/);
+      if (parentMatch) {
+        const fromId = currentGoalId;
+        const toId = parentMatch[1];
+        const fromHint = fromId.replace(/^GOAL-/, '');
+        const relId = `REL-GOAL-${fromHint}-PARENT-1`;
+        const relPath = `canon/relations/${relId}.yaml`;
+        emits.push({ path: relPath, content: relGoalParentBody(relId, fromId, toId, validFrom) });
+        modified++;
+        continue; // drop the inline parent: line
+      }
+    }
+
+    out.push(line);
+  }
+
+  return { content: out.join('\n'), modified, bailed: false, emits };
+}
+
 // --- Transform registry -----------------------------------------------------
 
 const transforms = [
@@ -268,12 +373,20 @@ const transforms = [
     unit: 'capability id rewritten',
     units: 'capability ids rewritten',
   },
+  {
+    name: 'goal parent → REL goal_parent extraction',
+    rootName: 'canon/views',
+    fn: goalParentToRel,
+    unit: 'inline parent extracted',
+    units: 'inline parents extracted',
+  },
 ];
 
 // --- Run --------------------------------------------------------------------
 
 let totalScanned = 0;
 let totalModified = 0;
+let totalEmitted = 0;
 let totalUnits = 0;
 let totalFailed = 0;
 
@@ -291,6 +404,7 @@ for (const t of transforms) {
   console.log(`  scanning ${files.length} .yaml file(s) under ${t.rootName}/`);
 
   let modified = 0;
+  let emitted = 0;
   let units = 0;
   let failed = 0;
 
@@ -314,18 +428,48 @@ for (const t of transforms) {
 
     if (result.modified === 0) continue;
 
-    if (!dryRun) writeFileSync(file, result.content);
+    // Emit any auxiliary files the transform produced (e.g. REL primitives).
+    // Skip silently on byte-equal existing files (idempotency); bail loudly
+    // on byte-different existing files (adopter manually edited — codemod
+    // refuses to overwrite).
+    const emits = result.emits ?? [];
+    let conflict = false;
+    for (const e of emits) {
+      const abs = join(target, e.path);
+      if (existsSync(abs)) {
+        const existing = readFileSync(abs, 'utf8');
+        if (existing !== e.content) {
+          console.error(`  ! ${relative(target, file)}: would emit ${e.path} but a different version already exists — bailing`);
+          conflict = true;
+          break;
+        }
+      }
+    }
+    if (conflict) { failed++; continue; }
+
+    if (!dryRun) {
+      writeFileSync(file, result.content);
+      for (const e of emits) {
+        const abs = join(target, e.path);
+        if (!existsSync(dirname(abs))) mkdirSync(dirname(abs), { recursive: true });
+        writeFileSync(abs, e.content);
+      }
+    }
     modified++;
+    emitted += emits.length;
     units += result.modified;
     const u = result.modified === 1 ? t.unit : t.units;
-    console.log(`  ${dryRun ? '[dry-run] ' : ''}~ ${relative(target, file)}: ${result.modified} ${u}`);
+    const emitNote = emits.length > 0 ? `, emitted ${emits.length} file(s)` : '';
+    console.log(`  ${dryRun ? '[dry-run] ' : ''}~ ${relative(target, file)}: ${result.modified} ${u}${emitNote}`);
   }
 
-  console.log(`  → ${modified} file(s) modified, ${units} ${units === 1 ? t.unit : t.units}${dryRun ? ' (dry-run; no files written)' : ''}`);
+  const emitSummary = emitted > 0 ? `, ${emitted} file(s) emitted` : '';
+  console.log(`  → ${modified} file(s) modified${emitSummary}, ${units} ${units === 1 ? t.unit : t.units}${dryRun ? ' (dry-run; no files written)' : ''}`);
   console.log('');
 
   totalScanned += files.length;
   totalModified += modified;
+  totalEmitted += emitted;
   totalUnits += units;
   totalFailed += failed;
 }
@@ -335,6 +479,7 @@ for (const t of transforms) {
 console.log(`Summary across ${transforms.length} transform(s):`);
 console.log(`  files scanned     ${totalScanned}`);
 console.log(`  files modified    ${totalModified}${dryRun ? ' (dry-run)' : ''}`);
+if (totalEmitted > 0) console.log(`  files emitted     ${totalEmitted}${dryRun ? ' (dry-run)' : ''}`);
 console.log(`  units applied     ${totalUnits}`);
 if (totalFailed > 0) {
   console.error(`  files skipped     ${totalFailed}`);

--- a/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-GOAL-BERLIN-1-PARENT-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-GOAL-BERLIN-1-PARENT-1.yaml
@@ -1,0 +1,22 @@
+notation: relation
+id: REL-GOAL-BERLIN-1-PARENT-1
+type: goal_parent
+from: GOAL-BERLIN-1
+to: GOAL-EU-1
+
+# Admission record (CONTRACT.md §6) — emitted by 0.4 → 0.5 migration codemod.
+# admitted_by is a placeholder marker — adopters should replace with the
+# operator handle once the REL has been reviewed in their canon.
+zone: canon
+admitted_at: "2026-05-26"
+admitted_by: "migration-codemod-0.4-to-0.5"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — inherits the host doc date as a
+# sensible epoch. Adopters should adjust if the parent link in fact took
+# effect on a different date than the host doc.
+valid_from: "2026-05-26"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-GOAL-EU-1-PARENT-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-GOAL-EU-1-PARENT-1.yaml
@@ -1,0 +1,22 @@
+notation: relation
+id: REL-GOAL-EU-1-PARENT-1
+type: goal_parent
+from: GOAL-EU-1
+to: GOAL-REVENUE-1
+
+# Admission record (CONTRACT.md §6) — emitted by 0.4 → 0.5 migration codemod.
+# admitted_by is a placeholder marker — adopters should replace with the
+# operator handle once the REL has been reviewed in their canon.
+zone: canon
+admitted_at: "2026-05-26"
+admitted_by: "migration-codemod-0.4-to-0.5"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — inherits the host doc date as a
+# sensible epoch. Adopters should adjust if the parent link in fact took
+# effect on a different date than the host doc.
+valid_from: "2026-05-26"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/goals/already-extracted.goals.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/goals/already-extracted.goals.transitrix.yaml
@@ -1,0 +1,25 @@
+# Fixture — goals view already in 0.5 form (no inline parents; relations live
+# as REL files under canon/relations/). The codemod must leave it untouched.
+
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-CLEAN-1
+name: "Goals tree with all parents already extracted to REL"
+date: "2026-05-29"
+author: Transitrix
+
+goal_types:
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
+
+goals:
+  - id: GOAL-CLEAN-1
+    name: "Root goal"
+    type: "Strategy"
+    level: 0
+
+  - id: GOAL-CLEAN-2
+    name: "Child goal — parent already in REL form"
+    type: "Strategic Goal"
+    level: 1

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/goals/strategy-2026.goals.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/goals/strategy-2026.goals.transitrix.yaml
@@ -1,0 +1,37 @@
+# Fixture — goals view BEFORE the 0.4 → 0.5 migration.
+# Uses inline `parent: GOAL-…` on goal entries (the v0.x transitional form).
+# The codemod drops each inline parent and emits a `REL-…goal_parent…` file
+# under canon/relations/ per notations/17-relations.md §6.
+
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-STRAT-1
+name: "Strategy 2026 — Goals Tree"
+description: "Goal hierarchy across Strategy → Strategic Goal → Project Goal levels for the 2026 plan."
+period: "2026"
+version: "0.1"
+date: "2026-05-26"
+author: Transitrix
+
+goal_types:
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
+  - { name: "Project Goal",   level: 2 }
+
+goals:
+  - id: GOAL-REVENUE-1
+    name: "Triple revenue in 3 years"
+    type: "Strategy"
+    level: 0
+    # No parent — root.
+
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 1
+
+  - id: GOAL-BERLIN-1
+    name: "Open Berlin office"
+    type: "Project Goal"
+    level: 2

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/goals/already-extracted.goals.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/goals/already-extracted.goals.transitrix.yaml
@@ -1,0 +1,25 @@
+# Fixture — goals view already in 0.5 form (no inline parents; relations live
+# as REL files under canon/relations/). The codemod must leave it untouched.
+
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-CLEAN-1
+name: "Goals tree with all parents already extracted to REL"
+date: "2026-05-29"
+author: Transitrix
+
+goal_types:
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
+
+goals:
+  - id: GOAL-CLEAN-1
+    name: "Root goal"
+    type: "Strategy"
+    level: 0
+
+  - id: GOAL-CLEAN-2
+    name: "Child goal — parent already in REL form"
+    type: "Strategic Goal"
+    level: 1

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/goals/strategy-2026.goals.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/goals/strategy-2026.goals.transitrix.yaml
@@ -1,0 +1,39 @@
+# Fixture — goals view BEFORE the 0.4 → 0.5 migration.
+# Uses inline `parent: GOAL-…` on goal entries (the v0.x transitional form).
+# The codemod drops each inline parent and emits a `REL-…goal_parent…` file
+# under canon/relations/ per notations/17-relations.md §6.
+
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-STRAT-1
+name: "Strategy 2026 — Goals Tree"
+description: "Goal hierarchy across Strategy → Strategic Goal → Project Goal levels for the 2026 plan."
+period: "2026"
+version: "0.1"
+date: "2026-05-26"
+author: Transitrix
+
+goal_types:
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
+  - { name: "Project Goal",   level: 2 }
+
+goals:
+  - id: GOAL-REVENUE-1
+    name: "Triple revenue in 3 years"
+    type: "Strategy"
+    level: 0
+    # No parent — root.
+
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+
+  - id: GOAL-BERLIN-1
+    name: "Open Berlin office"
+    type: "Project Goal"
+    level: 2
+    parent: GOAL-EU-1

--- a/migrations/0.4-to-0.5/validate.mjs
+++ b/migrations/0.4-to-0.5/validate.mjs
@@ -16,6 +16,12 @@
 //      may carry bare V/H capability IDs, CM- document IDs, or bare
 //      V/H entries inside a capabilities[] cross-reference.
 //
+//   4. goal parent first-class form
+//      No .yaml under <target>/canon/views/** (whose notation: is goals)
+//      may carry an inline `parent: GOAL-…` line inside its goals[] block.
+//      The canonical home is a `REL-…` file with `type: goal_parent`
+//      under canon/relations/.
+//
 // Run AFTER the codemod. Exits 0 if clean, 1 if any check fails,
 // 2 on script-internal error.
 //
@@ -112,6 +118,27 @@ const checks = [
         }
         const h = line.match(/^(\s*)capabilities\s*:\s*(?:#.*)?$/);
         if (h) inCap = h[1].length;
+      }
+      return null;
+    },
+  },
+  {
+    name: 'goal parent first-class form',
+    rootName: 'canon/views',
+    fn: (text) => {
+      const nm = text.match(/^notation\s*:\s*(\S+)/m);
+      if (!nm || nm[1] !== 'goals') return null;
+      const lines = text.split('\n');
+      let inGoals = null;
+      for (const line of lines) {
+        const trimmed = line.trim();
+        const indent = line.match(/^(\s*)/)[1].length;
+        if (inGoals !== null && trimmed !== '' && indent <= inGoals) inGoals = null;
+        if (inGoals !== null && /^\s*parent\s*:\s*["']?GOAL-\S+/.test(line)) {
+          return 'has inline parent: GOAL-… on goal entry (use REL goal_parent instead)';
+        }
+        const h = line.match(/^(\s*)goals\s*:\s*(?:#.*)?$/);
+        if (h) inGoals = h[1].length;
       }
       return null;
     },


### PR DESCRIPTION
## Summary

Fourth transform on the 0.4 → 0.5 migration recipe — the first that **emits new files** in addition to editing the source. Drops inline `parent: GOAL-…` on goal entries in `notation: goals` view documents and emits a first-class `REL-…goal_parent…` file under `canon/relations/` per host link, per `notations/04-goals.md` "Time-aware relations" + `notations/17-relations.md` §3 (enum) + §6 (migration).

### Dispatcher extension

Each transform's `fn` can now return an `emits` array of `{path, content}` pairs. The driver creates parent dirs, writes the auxiliary files, and surfaces them in the per-transform and overall summary. Idempotency is preserved:

- Existing file at an emit path with **byte-equal** content → silent noop.
- Existing file with **byte-different** content → **bail loudly** with the offending path. The codemod refuses to overwrite an adopter-edited REL.

### REL emission shape (codemod-local decisions)

These were the two non-obvious shape questions called out in the [Phase 2 status comment on #78](https://github.com/vkgeorgia/strategy/issues/78#issuecomment-4570849185). Resolved here:

- **REL id naming.** `REL-GOAL-<full from-id tail>-PARENT-1`. The middle segment encodes the full source goal id, including the integer suffix — collision-free per inline migration (each goal has at most one inline parent). Compatible with the spec's example aesthetic (`REL-GOAL-EU-PARENT-1`) while remaining safe when two goals share the same domain hint.
- **`admitted_by`.** Placeholder marker `"migration-codemod-0.4-to-0.5"`. README adds a manual-step section telling adopters to grep+replace once each REL has been reviewed in canon.
- **`valid_from` / `admitted_at`.** Inherit the host goals doc's `date:` (fallback `"2024-01-01"`, matching the lifecycle-backfill epoch convention).

### Validator check 4

Walks `canon/views/**` with `notation: goals`, scans the `goals:` block, and flags any inline `parent: GOAL-…` line.

### Fixtures

- 2 before files: one dirty goals doc with two inline parents, one already-clean goals doc for idempotency.
- 4 after files: the two unchanged goals docs + two emitted REL files under `canon/relations/`.

Refs strategy#78 (Phase 2 — migration recipe format).

## Test plan

- [x] Dry-run reports 2 inline parents extracted + 2 file(s) emitted across the recipe.
- [x] `diff -r recipe-test fixtures/after` empty after apply.
- [x] Second-run on the migrated tree produces zero changes (idempotent).
- [x] `validate.mjs recipe-test` reports clean.
- [x] `validate.mjs fixtures/before` reports all 9 expected offenders (2 codex + 2 lifecycle + 4 capability-id + 1 goal-parent).
- [x] File integrity verified — proper EOF on README.md, codemod.mjs, validate.mjs, all fixture files.
- [ ] CI conformance + smoke-test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)