### PR TITLE
docs(migrations): activity-goals REL extraction transform on 0.4 → 0.5 recipe (strategy#78 Phase 2)

### DIFF
--- a/migrations/0.4-to-0.5/README.md
+++ b/migrations/0.4-to-0.5/README.md
@@ -10,6 +10,7 @@ This recipe ships incrementally — each transform in the 0.4 → 0.5 cycle (see
 - **Primitive lifecycle backfill.** In 0.5.0, every canonical element MUST carry `valid_from` and `valid_to` ([`notations/CONTRACT.md`](../../notations/CONTRACT.md) §7). Adopters with element primitives under `canon/elements/` missing those fields get them backfilled: `valid_from` adopts the file's `last_updated:` value when present, otherwise falls back to the sensible epoch `"2024-01-01"` per the §7.4 migration recipe. `valid_to` defaults to `null` (currently in effect).
 - **Capability ID canonical form.** In 0.5.0, capability identifiers in view documents take the canonical `CAPABILITY-V…` / `CAPABILITY-H…` form, and capability-map document IDs take `CAPABILITY_MAP-…` (no zero-padding) per [`notations/IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §2 (rule) and §6 (migration checklist). The recipe gates on the file's `notation:` header — only `capability-map`, `process-map`, `products`, `applications`, `scenarios` — and rewrites bare `V…` / `H…` IDs in `id:`, `capability:`, inline-array `capabilities: [V1, V2]`, and block-form `capabilities:\n  - V1` positions. CM- document IDs are normalised to `CAPABILITY_MAP-…` and stripped of leading zeros.
 - **Goal `parent` → REL `goal_parent` extraction.** In 0.5.0, the goal-to-goal parent link is declared **time-aware** per [`notations/04-goals.md`](../../notations/04-goals.md) "Time-aware relations" — its canonical home is a `REL-…` file under `canon/relations/` with `type: goal_parent` per [`notations/17-relations.md`](../../notations/17-relations.md) §3. The inline `parent: GOAL-…` form on goal entries stays available transitionally; the recipe migrates each inline link to a first-class REL file. The codemod gates on `notation: goals`, drops each inline `parent:` line, and emits `canon/relations/REL-GOAL-<from-id>-PARENT-1.yaml` per dropped link. The REL's `valid_from` and `admitted_at` inherit the host goals doc's `date:` (fallback `"2024-01-01"`); `admitted_by` is the placeholder `"migration-codemod-0.4-to-0.5"`.
+- **Activity `goals: [GOAL-…]` → REL `activity_goal` extraction.** In 0.5.0, the activity-to-goal link is declared **time-aware** per [`notations/07-activities.md`](../../notations/07-activities.md) "Time-aware relations" — canonical home is a `REL-…` file with `type: activity_goal` per [`notations/17-relations.md`](../../notations/17-relations.md) §3. The codemod gates on `notation: activities`, drops each inline `goals: [GOAL-A, GOAL-B]` array on activity entries, and emits one `canon/relations/REL-<activity-id>-GOAL-<goal-id-tail>-1.yaml` per goal id in the dropped array. Same `valid_from` / `admitted_at` / `admitted_by` conventions as the goal-parent extraction.
 
 ## Folder shape (canonical for all migration recipes)
 
@@ -87,12 +88,12 @@ After the new REQUIREMENT / ASSERTION primitives are admitted, the original code
 
 The lifecycle backfill picks `valid_from` mechanically — `last_updated:` when present, otherwise `"2024-01-01"`. After running the codemod, the adopter SHOULD spot-check the backfilled `valid_from` values and adjust any that don't reflect the actual date the element took effect. The codemod's value is a safe default, not a historically-accurate claim.
 
-### REL `goal_parent` admission review
+### REL admission review (`goal_parent`, `activity_goal`)
 
-Each emitted `REL-…goal_parent…` file inherits the host goals doc's `date:` for both `valid_from` and `admitted_at`, and uses the placeholder marker `admitted_by: "migration-codemod-0.4-to-0.5"`. After running the codemod the adopter SHOULD:
+Every REL emitted by the codemod — both `goal_parent` and `activity_goal` — inherits the host view doc's `date:` for both `valid_from` and `admitted_at`, and uses the placeholder marker `admitted_by: "migration-codemod-0.4-to-0.5"`. After running the codemod the adopter SHOULD:
 
 - replace `admitted_by` with the real operator handle once each REL has been reviewed in their canon (`grep -r migration-codemod-0.4-to-0.5 canon/relations/` lists the migration-generated files);
-- adjust `valid_from` if the parent link in fact took effect on a date other than the host doc's `date:`;
+- adjust `valid_from` if the link in fact took effect on a date other than the host doc's `date:`;
 - re-run the codemod and `validate.mjs` after the manual review — they remain idempotent.
 
 The codemod refuses to overwrite a REL file at the same `canon/relations/REL-….yaml` path if its content differs from what the codemod would emit, so manual edits to a REL file made between two codemod runs are preserved — the second run bails on that file with an explicit message instead of clobbering.
@@ -102,7 +103,6 @@ The codemod refuses to overwrite a REL file at the same `canon/relations/REL-…
 Other 0.4 → 0.5 deprecated patterns are listed in [`CHANGELOG.md`](../../CHANGELOG.md) under the 0.5.0 entry. Adding them to this recipe is straightforward — each is its own transform inside the same `codemod.mjs` + `validate.mjs` + per-pattern fixture:
 
 - Inline `children[]` on capability-map view documents → REL `parent` files.
-- Inline `goals: [GOAL-…]` on activity entries → REL `activity_goal` files.
 - Inline `current_maturity` / `owner_role` / `target_date` on capability-map → sidecar.
 - Inline `owner_role` / `vendor` / `maturity` on applications → sidecar.
 
@@ -118,3 +118,4 @@ Each transform follows the same conventions (idempotent, dry-run-supporting, dif
   - Lifecycle backfill — [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §7 (rule) and §7.4 (migration recipe).
   - Capability ID canonical form — [`notations/IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §2 and §6.
   - Goal `parent` → REL `goal_parent` — [`notations/04-goals.md`](../../notations/04-goals.md) "Time-aware relations" + [`notations/17-relations.md`](../../notations/17-relations.md) §3 (enum) and §6 (migration).
+  - Activity `goals: [GOAL-…]` → REL `activity_goal` — [`notations/07-activities.md`](../../notations/07-activities.md) "Time-aware relations" + [`notations/17-relations.md`](../../notations/17-relations.md) §3 (enum) and §6 (migration).

--- a/migrations/0.4-to-0.5/codemod.mjs
+++ b/migrations/0.4-to-0.5/codemod.mjs
@@ -29,6 +29,14 @@
 //      REL primitive per dropped parent. valid_from / admitted_at on the
 //      emitted REL inherit the host doc's date: (fallback "2024-01-01").
 //
+//   5. activity `goals: [GOAL-…]` → REL activity_goal extraction
+//      (notations/17-relations.md §6, notations/07-activities.md "Time-aware
+//      relations") Walks <target>/canon/views/**/*.yaml with notation:
+//      activities, finds inline `goals: [GOAL-A, GOAL-B]` arrays on activity
+//      entries, drops the inline line, and emits N REL files (one per goal)
+//      under canon/relations/ with `type: activity_goal`. valid_from /
+//      admitted_at on each emitted REL inherit the host doc's date:.
+//
 // Conventions (canonical for every migration recipe):
 //   - Pure-Node. Runs on a stock Node ≥ 20 with no native deps.
 //   - Idempotent. Running twice on the same input produces identical
@@ -349,6 +357,110 @@ function goalParentToRel(content) {
   return { content: out.join('\n'), modified, bailed: false, emits };
 }
 
+// --- Transform 5: activity `goals[]` → REL activity_goal extraction ---------
+
+const ACTIVITIES_NOTATIONS = new Set(['activities']);
+
+function relActivityGoalBody(relId, fromId, toId, validFrom) {
+  return [
+    'notation: relation',
+    `id: ${relId}`,
+    'type: activity_goal',
+    `from: ${fromId}`,
+    `to: ${toId}`,
+    '',
+    '# Admission record (CONTRACT.md §6) — emitted by 0.4 → 0.5 migration codemod.',
+    '# admitted_by is a placeholder marker — adopters should replace with the',
+    '# operator handle once the REL has been reviewed in their canon.',
+    'zone: canon',
+    `admitted_at: "${validFrom}"`,
+    'admitted_by: "migration-codemod-0.4-to-0.5"',
+    'gate_checks:',
+    '  uniqueness: pass',
+    '  consistency: pass',
+    '  completeness: pass',
+    '',
+    '# Primitive lifecycle (CONTRACT.md §7) — inherits the host doc date as a',
+    '# sensible epoch. Adopters should adjust if the link in fact took effect',
+    '# on a different date than the host doc.',
+    `valid_from: "${validFrom}"`,
+    'valid_to: null',
+    '',
+  ].join('\n');
+}
+
+function activityGoalsToRel(content) {
+  const notationMatch = content.match(/^notation\s*:\s*(\S+)/m);
+  if (!notationMatch) return { content, modified: 0, bailed: false };
+  if (!ACTIVITIES_NOTATIONS.has(notationMatch[1])) return { content, modified: 0, bailed: false };
+
+  const dateMatch = content.match(/^date\s*:\s*["']?([^"'\n#]+?)["']?\s*(?:#.*)?$/m);
+  const validFrom = dateMatch ? dateMatch[1].trim() : '2024-01-01';
+
+  const lines = content.split('\n');
+  const out = [];
+  const emits = [];
+  let modified = 0;
+  let inActivitiesBlock = null;
+  let currentActivityId = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    const indent = line.match(/^(\s*)/)[1].length;
+
+    if (inActivitiesBlock !== null && trimmed !== '' && indent <= inActivitiesBlock) {
+      inActivitiesBlock = null;
+      currentActivityId = null;
+    }
+
+    if (inActivitiesBlock === null) {
+      const head = line.match(/^(\s*)activities\s*:\s*(?:#.*)?$/);
+      if (head) inActivitiesBlock = head[1].length;
+      out.push(line);
+      continue;
+    }
+
+    // New activity entry — `- id: <X>` (activity IDs may carry any prefix:
+    // A-001, PHASE-DESIGN, M-LAUNCH; opaque token, preserved as-is).
+    const dashId = line.match(/^\s*-\s+id\s*:\s*["']?(\S+?)["']?\s*(?:#.*)?$/);
+    if (dashId) {
+      currentActivityId = dashId[1];
+      out.push(line);
+      continue;
+    }
+
+    // Inline `goals: [GOAL-A, GOAL-B]` on the current activity entry — extract.
+    if (currentActivityId !== null) {
+      const goalsInline = line.match(/^\s*goals\s*:\s*\[([^\]]*)\]\s*(?:#.*)?$/);
+      if (goalsInline) {
+        const items = goalsInline[1]
+          .split(',')
+          .map(s => s.trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean);
+        const goalIds = items.filter(it => /^GOAL-\S+$/.test(it));
+        if (goalIds.length === 0) {
+          // No GOAL- IDs in the array — leave line alone.
+          out.push(line);
+          continue;
+        }
+        for (const toId of goalIds) {
+          const goalTail = toId.replace(/^GOAL-/, '');
+          const relId = `REL-${currentActivityId}-GOAL-${goalTail}-1`;
+          const relPath = `canon/relations/${relId}.yaml`;
+          emits.push({ path: relPath, content: relActivityGoalBody(relId, currentActivityId, toId, validFrom) });
+        }
+        modified += goalIds.length;
+        continue; // drop the inline goals: line
+      }
+    }
+
+    out.push(line);
+  }
+
+  return { content: out.join('\n'), modified, bailed: false, emits };
+}
+
 // --- Transform registry -----------------------------------------------------
 
 const transforms = [
@@ -379,6 +491,13 @@ const transforms = [
     fn: goalParentToRel,
     unit: 'inline parent extracted',
     units: 'inline parents extracted',
+  },
+  {
+    name: 'activity goals → REL activity_goal extraction',
+    rootName: 'canon/views',
+    fn: activityGoalsToRel,
+    unit: 'inline goal link extracted',
+    units: 'inline goal links extracted',
   },
 ];
 

--- a/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-A-001-GOAL-CUST-001-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-A-001-GOAL-CUST-001-1.yaml
@@ -1,0 +1,22 @@
+notation: relation
+id: REL-A-001-GOAL-CUST-001-1
+type: activity_goal
+from: A-001
+to: GOAL-CUST-001
+
+# Admission record (CONTRACT.md §6) — emitted by 0.4 → 0.5 migration codemod.
+# admitted_by is a placeholder marker — adopters should replace with the
+# operator handle once the REL has been reviewed in their canon.
+zone: canon
+admitted_at: "2026-05-11"
+admitted_by: "migration-codemod-0.4-to-0.5"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — inherits the host doc date as a
+# sensible epoch. Adopters should adjust if the link in fact took effect
+# on a different date than the host doc.
+valid_from: "2026-05-11"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-A-002-GOAL-CUST-001-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-A-002-GOAL-CUST-001-1.yaml
@@ -1,0 +1,22 @@
+notation: relation
+id: REL-A-002-GOAL-CUST-001-1
+type: activity_goal
+from: A-002
+to: GOAL-CUST-001
+
+# Admission record (CONTRACT.md §6) — emitted by 0.4 → 0.5 migration codemod.
+# admitted_by is a placeholder marker — adopters should replace with the
+# operator handle once the REL has been reviewed in their canon.
+zone: canon
+admitted_at: "2026-05-11"
+admitted_by: "migration-codemod-0.4-to-0.5"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — inherits the host doc date as a
+# sensible epoch. Adopters should adjust if the link in fact took effect
+# on a different date than the host doc.
+valid_from: "2026-05-11"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-A-002-GOAL-PLATFORM-002-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-A-002-GOAL-PLATFORM-002-1.yaml
@@ -1,0 +1,22 @@
+notation: relation
+id: REL-A-002-GOAL-PLATFORM-002-1
+type: activity_goal
+from: A-002
+to: GOAL-PLATFORM-002
+
+# Admission record (CONTRACT.md §6) — emitted by 0.4 → 0.5 migration codemod.
+# admitted_by is a placeholder marker — adopters should replace with the
+# operator handle once the REL has been reviewed in their canon.
+zone: canon
+admitted_at: "2026-05-11"
+admitted_by: "migration-codemod-0.4-to-0.5"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — inherits the host doc date as a
+# sensible epoch. Adopters should adjust if the link in fact took effect
+# on a different date than the host doc.
+valid_from: "2026-05-11"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-A-003-GOAL-PLATFORM-002-1.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/relations/REL-A-003-GOAL-PLATFORM-002-1.yaml
@@ -1,0 +1,22 @@
+notation: relation
+id: REL-A-003-GOAL-PLATFORM-002-1
+type: activity_goal
+from: A-003
+to: GOAL-PLATFORM-002
+
+# Admission record (CONTRACT.md §6) — emitted by 0.4 → 0.5 migration codemod.
+# admitted_by is a placeholder marker — adopters should replace with the
+# operator handle once the REL has been reviewed in their canon.
+zone: canon
+admitted_at: "2026-05-11"
+admitted_by: "migration-codemod-0.4-to-0.5"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — inherits the host doc date as a
+# sensible epoch. Adopters should adjust if the link in fact took effect
+# on a different date than the host doc.
+valid_from: "2026-05-11"
+valid_to: null

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/activities/already-extracted.activities.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/activities/already-extracted.activities.transitrix.yaml
@@ -1,0 +1,20 @@
+# Fixture — activities view already in 0.5 form (no inline goals[] arrays;
+# activity → goal links live as REL files under canon/relations/).
+# The codemod must leave it untouched.
+
+notation: activities
+spec_version: "0.1"
+
+title: Clean Activities Document
+date: "2026-05-29"
+author: "Valerii Korobeinikov"
+
+activities:
+  - id: A-CLEAN-1
+    name: Activity with no inline goals
+    duration: 3
+
+  - id: A-CLEAN-2
+    name: Activity whose goal link is already in REL form
+    duration: 5
+    predecessors: [A-CLEAN-1]

--- a/migrations/0.4-to-0.5/fixtures/after/canon/views/activities/launch-2026.activities.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/after/canon/views/activities/launch-2026.activities.transitrix.yaml
@@ -1,0 +1,29 @@
+# Fixture — activities view BEFORE the 0.4 → 0.5 migration.
+# Uses inline `goals: [GOAL-…]` on activity entries (the v0.x transitional form).
+# The codemod drops each inline goals: array and emits one
+# `REL-…activity_goal…` file per goal link under canon/relations/
+# per notations/17-relations.md §6.
+
+notation: activities
+spec_version: "0.1"
+
+title: Platform Launch 2026
+description: "Critical path through customer-facing platform launch."
+version: "0.1"
+date: "2026-05-11"
+author: "Valerii Korobeinikov"
+
+activities:
+  - id: A-001
+    name: Requirements analysis
+    duration: 5
+
+  - id: A-002
+    name: Architecture design
+    duration: 8
+    predecessors: [A-001]
+
+  - id: A-003
+    name: Backend implementation
+    duration: 15
+    predecessors: [A-002]

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/activities/already-extracted.activities.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/activities/already-extracted.activities.transitrix.yaml
@@ -1,0 +1,20 @@
+# Fixture — activities view already in 0.5 form (no inline goals[] arrays;
+# activity → goal links live as REL files under canon/relations/).
+# The codemod must leave it untouched.
+
+notation: activities
+spec_version: "0.1"
+
+title: Clean Activities Document
+date: "2026-05-29"
+author: "Valerii Korobeinikov"
+
+activities:
+  - id: A-CLEAN-1
+    name: Activity with no inline goals
+    duration: 3
+
+  - id: A-CLEAN-2
+    name: Activity whose goal link is already in REL form
+    duration: 5
+    predecessors: [A-CLEAN-1]

--- a/migrations/0.4-to-0.5/fixtures/before/canon/views/activities/launch-2026.activities.transitrix.yaml
+++ b/migrations/0.4-to-0.5/fixtures/before/canon/views/activities/launch-2026.activities.transitrix.yaml
@@ -1,0 +1,32 @@
+# Fixture — activities view BEFORE the 0.4 → 0.5 migration.
+# Uses inline `goals: [GOAL-…]` on activity entries (the v0.x transitional form).
+# The codemod drops each inline goals: array and emits one
+# `REL-…activity_goal…` file per goal link under canon/relations/
+# per notations/17-relations.md §6.
+
+notation: activities
+spec_version: "0.1"
+
+title: Platform Launch 2026
+description: "Critical path through customer-facing platform launch."
+version: "0.1"
+date: "2026-05-11"
+author: "Valerii Korobeinikov"
+
+activities:
+  - id: A-001
+    name: Requirements analysis
+    duration: 5
+    goals: [GOAL-CUST-001]
+
+  - id: A-002
+    name: Architecture design
+    duration: 8
+    predecessors: [A-001]
+    goals: [GOAL-CUST-001, GOAL-PLATFORM-002]
+
+  - id: A-003
+    name: Backend implementation
+    duration: 15
+    predecessors: [A-002]
+    goals: [GOAL-PLATFORM-002]

--- a/migrations/0.4-to-0.5/validate.mjs
+++ b/migrations/0.4-to-0.5/validate.mjs
@@ -22,6 +22,12 @@
 //      The canonical home is a `REL-…` file with `type: goal_parent`
 //      under canon/relations/.
 //
+//   5. activity goals first-class form
+//      No .yaml under <target>/canon/views/** (whose notation: is activities)
+//      may carry an inline `goals: [GOAL-…]` line inside its activities[]
+//      block. The canonical home is one or more `REL-…` files with
+//      `type: activity_goal` under canon/relations/.
+//
 // Run AFTER the codemod. Exits 0 if clean, 1 if any check fails,
 // 2 on script-internal error.
 //
@@ -139,6 +145,30 @@ const checks = [
         }
         const h = line.match(/^(\s*)goals\s*:\s*(?:#.*)?$/);
         if (h) inGoals = h[1].length;
+      }
+      return null;
+    },
+  },
+  {
+    name: 'activity goals first-class form',
+    rootName: 'canon/views',
+    fn: (text) => {
+      const nm = text.match(/^notation\s*:\s*(\S+)/m);
+      if (!nm || nm[1] !== 'activities') return null;
+      const lines = text.split('\n');
+      let inAct = null;
+      for (const line of lines) {
+        const trimmed = line.trim();
+        const indent = line.match(/^(\s*)/)[1].length;
+        if (inAct !== null && trimmed !== '' && indent <= inAct) inAct = null;
+        if (inAct !== null) {
+          const m = line.match(/^\s*goals\s*:\s*\[([^\]]*)\]/);
+          if (m && /\bGOAL-\S/.test(m[1])) {
+            return 'has inline goals: [GOAL-…] on activity entry (use REL activity_goal instead)';
+          }
+        }
+        const h = line.match(/^(\s*)activities\s*:\s*(?:#.*)?$/);
+        if (h) inAct = h[1].length;
       }
       return null;
     },


### PR DESCRIPTION
## Summary

Fifth transform on the 0.4 → 0.5 migration recipe. Mirror of #75 (goal-parent extraction) but for the activity → goal link — handles the array variant. Each inline `goals: [GOAL-A, GOAL-B]` on an activity entry drops the line and emits N REL files (one per goal id) with `type: activity_goal`. Reuses the dispatcher's `emits` machinery from #75 unchanged.

Spec sources:
- `notations/07-activities.md` "Time-aware relations" — declares activity → goal as time-aware.
- `notations/17-relations.md` §3 (enum) + §6 (migration).

### REL emission shape

- **REL id** = `REL-<activity-id>-GOAL-<goal-id-tail>-1`. Both endpoints encoded in the middle segment — collision-safe when an activity serves multiple goals or when several activities share a domain hint. Activity IDs are preserved as-is (`A-001`, `PHASE-DESIGN`, `M-LAUNCH` all valid opaque tokens).
- **`valid_from` / `admitted_at` / `admitted_by`** — same conventions as #75 (host doc `date:` + placeholder marker for `admitted_by`).

### Validator check 5

Flags inline `goals: [GOAL-…]` arrays on activity entries under `canon/views/**` with `notation: activities`.

### Fixtures

- 2 before files: one dirty activities doc with three inline `goals[]` arrays (4 total links), one already-clean activities doc for idempotency.
- 6 after files: two unchanged activities docs + four emitted REL files under `canon/relations/`.

Refs strategy#78 (Phase 2 — migration recipe format).

## Test plan

- [x] Dry-run reports 4 inline goal links extracted + 4 emitted files.
- [x] `diff -r recipe-test fixtures/after` empty after apply.
- [x] Second-run on the migrated tree produces zero changes (idempotent).
- [x] `validate.mjs recipe-test` reports clean.
- [x] `validate.mjs fixtures/before` flags all 10 expected offenders (2 codex + 2 lifecycle + 4 capability-id + 1 goal-parent + 1 activity-goals).
- [x] File integrity verified — proper EOF on all touched files.
- [ ] CI conformance + smoke-test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)