### PR TITLE
docs(notations): worked example for the Project Card notation (strategy#97)

### DIFF
--- a/notations/examples/project-card/README.md
+++ b/notations/examples/project-card/README.md
@@ -1,0 +1,43 @@
+# Project Card
+
+Single-project narrative view. One document per project, naming the project Activity it summarises plus a list of narrative milestones (decision gates, certifications, programme-level markers). The card pulls the rest of its content — name, dates, motivation chain, child activities — by reference from sibling FGCA and Activities documents.
+
+**File extension:** `*.project-card.transitrix.yaml`
+**Spec:** [`notations/views/18-project-card.md`](../../views/18-project-card.md)
+
+## Minimal structure
+
+```yaml
+notation: project-card
+spec_version: "0.1"
+
+project_card:
+  id: PROJECT_CARD-<DOMAIN>-<N>
+  project: ACTIVITY-<DOMAIN>-<N>            # existing project Activity; must resolve
+
+  description: >
+    One-paragraph executive summary. Concise — the full description lives
+    on the referenced Activity.
+
+  milestones:
+    - id: MILESTONE-<MIDDLE>-<N>            # document-scoped
+      name: "<milestone label>"
+      date: "<YYYY-MM-DD>"
+      description: >
+        Optional longer-form context.
+      delivers_changes:
+        - CHANGE-<...>                      # must appear in the project Activity's delivers_changes[]
+```
+
+## Rules
+
+- One project per card document. The `project_card.project:` field MUST resolve to an Activity whose `activity_type:` is `Project` (`PC-001` / `PC-002`).
+- `MILESTONE-…` IDs are **document-scoped** — uniqueness is enforced within the card, not across the organisation ([IDS_AND_REFERENCES.md §4](../../IDS_AND_REFERENCES.md)).
+- Each `milestones[].delivers_changes[]` entry MUST resolve to a `CHANGE-…` that is also listed in the project Activity's `delivers_changes:` (`PC-003`) — the milestone delivers a strict subset of the project's overall changes.
+- Project-card milestones are **distinct** from the zero-duration "schedule milestones" defined in [`07-activities.md`](../../views/07-activities.md) §5.9. The two coexist by design: schedule milestones drive critical-path computation; project-card milestones anchor narrative gates. The reconciliation is documented in [18-project-card.md §8](../../views/18-project-card.md).
+
+## Examples in this folder
+
+| File | Description |
+|---|---|
+| `eu-programme.project-card.transitrix.yaml` | EU regulatory-conformity programme — one project Activity, two narrative milestones (certification gate + market launch). Mirrors the running example in the spec. |

--- a/notations/examples/project-card/eu-programme.project-card.transitrix.yaml
+++ b/notations/examples/project-card/eu-programme.project-card.transitrix.yaml
@@ -1,0 +1,41 @@
+notation: project-card
+spec_version: "0.1"
+
+# Worked example — EU regulatory-conformity programme.
+# Single-project narrative view per notations/views/18-project-card.md.
+# The card binds to an existing project Activity (ACTIVITY-EU-PROGRAMME-1)
+# and adds two narrative milestones for the certification gate and the
+# market-launch follow-on. The motivation chain, child activities, and
+# remaining metadata are pulled by reference from sibling FGCA and
+# Activities documents — they are not duplicated here.
+
+project_card:
+  id: PROJECT_CARD-EU-PROGRAMME-1
+  project: ACTIVITY-EU-PROGRAMME-1
+
+  description: >
+    Programme of work bringing the company's first product line into
+    compliance with the EU Medical Device Regulation, certified by a
+    notified body, and live in EU markets under the new regime.
+    Spans 2026-Q2 through 2027-Q1.
+
+  milestones:
+    - id: MILESTONE-EU-CONFORMITY-CERT-1
+      name: "EU MDR conformity-assessment certification obtained"
+      date: "2027-01-31"
+      description: >
+        First product line certified by a notified body under the EU
+        Medical Device Regulation. The certification is a hard gate
+        for EU market access — no sales until this date clears.
+      delivers_changes:
+        - CHANGE-EU-COMPLIANCE-1
+
+    - id: MILESTONE-EU-MARKET-LAUNCH-1
+      name: "First product line live in EU post-certification"
+      date: "2027-03-15"
+      description: >
+        Sales channel opens to EU customers under the new compliance
+        regime. Marketing, support, and supply-chain handovers are
+        complete by this date.
+      delivers_changes:
+        - CHANGE-EU-COMPLIANCE-1


### PR DESCRIPTION
## Summary

Completes the methodology-side acceptance for the Project Card epic. The spec already lives at `notations/views/18-project-card.md` and the `07-activities.md` §5.9 reconciliation already distinguishes schedule milestones from project-card milestones; the only remaining bit on the methodology side was the worked example under `notations/examples/`.

### Adds `notations/examples/project-card/`

- **`README.md`** — one-pager: what the card is, minimal-structure code block, four-rule recap (one project per doc, document-scoped MILESTONE IDs, `delivers_changes[]` subset rule, schedule-vs-narrative milestone distinction), and an Examples table.
- **`eu-programme.project-card.transitrix.yaml`** — EU regulatory-conformity programme card: one project Activity reference, two narrative milestones (certification gate at 2027-01-31, market launch at 2027-03-15), both delivering `CHANGE-EU-COMPLIANCE-1`. Mirrors the running example in the spec so adopters reading the example see the same shape they see in the spec's §3.

Closes the methodology side of strategy#97. Studio-side renderer is tracked in `proj:transitrix-studio` per the epic's cross-project routing — this PR does not touch that.

## Test plan

- [x] New folder under `notations/examples/` parallel to existing examples (process-blueprint, etc.).
- [x] README follows the established example-folder pattern: spec link, minimal-structure block, rules, examples table.
- [x] YAML example matches the spec's §3 running example in shape; passes spot-check with `tail -c` / line-count.
- [ ] CI conformance check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)