### PR TITLE
docs(acme): populate canon/elements/ with example primitives + traceability (strategy#80)

### DIFF
--- a/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
@@ -1,0 +1,25 @@
+# Worked example — FACTOR element primitive (internal driver).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.1 + envelope §3.
+# Referenced inline from the FGA view (canon/views/fga/).
+
+notation: factor
+id: FACTOR-COMP-1
+name: "Support response time degraded over Q1"
+type: internal
+description: >
+  Internal support response time (P50) drifted upward through Q1 2026.
+  The performance gap is the internal driver behind the operational-
+  improvement goal chain.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-EU-REG-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-EU-REG-1.yaml
@@ -1,0 +1,30 @@
+# Worked example — FACTOR element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.1 + envelope §3.
+# Definition home for this factor; referenced inline from the FGCA view
+# (canon/views/fgca/) which is the authoring surface.
+
+notation: factor
+id: FACTOR-EU-REG-1
+name: "EU regulatory window closing in Q3"
+type: external
+description: >
+  A favourable EU market-entry regulatory window is expected to close in
+  Q3 2026. The pressure to act before it closes is the external driver
+  behind the EU-expansion goal chain.
+
+# The factor reflects a standing constraint the organisation must respect.
+references_constraint:
+  - CONSTRAINT-GDPR-RESIDENCY-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/factors/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/README.md
@@ -1,0 +1,30 @@
+# `canon/elements/01_motivation/factors/`
+
+Factor element primitives — each file is one strategic driver (external or internal) on the ArchiMate 3.2 **motivation** layer. Factors open the strategy chain: they justify the goals that follow. The FGCA / FGA views (`../../../views/fgca/`, `../../../views/fga/`) are the authoring surface; a factor shared across documents is materialised here as its canonical record.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`FACTOR`).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows the canonical grammar `FACTOR-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `FACTOR-EU-REG-1.yaml`, `FACTOR-1.yaml`.
+
+## Schema
+
+Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.1 (per-TYPE fields) over the common envelope §3:
+
+- Identity + factor fields: `notation: factor`, `id`, `name`, optional `type` (`external` | `internal`), `description`, `references_constraint: [CONSTRAINT-…]`.
+- Admission record per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
+- Primitive lifecycle per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `FACTOR-EU-REG-1.yaml` | External driver — closing EU regulatory window; references `CONSTRAINT-GDPR-RESIDENCY-1` |
+| `FACTOR-COMP-1.yaml` | Internal driver — degraded support response time |
+
+## See also
+
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.1.
+- FGCA / FGA notations: [`notations/views/02-fgca.md`](../../../../../../notations/views/02-fgca.md), [`notations/views/03-fga.md`](../../../../../../notations/views/03-fga.md).
+- Views over these elements: [`../../../views/fgca/`](../../../views/fgca/), [`../../../views/fga/`](../../../views/fga/).

--- a/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-CUST-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-CUST-1.yaml
@@ -1,0 +1,26 @@
+# Worked example — GOAL element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.2 + envelope §3.
+# Referenced from the activities view (the onboarding-delivery network)
+# via activity `goals: [GOAL-CUST-1]`.
+
+notation: goal
+id: GOAL-CUST-1
+name: "Improve customer onboarding experience"
+type: "Strategic Goal"
+level: 1
+description: >
+  Reduce time-to-value for new customers by reworking the onboarding
+  journey. The driving goal behind the onboarding-delivery activity network.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-EU-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-EU-1.yaml
@@ -1,0 +1,30 @@
+# Worked example — GOAL element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.2 + envelope §3.
+# Shared element: defined here, referenced from the goals-tree and FGCA views.
+# The goal's parent (GOAL-REVENUE-1) is a time-aware relation (goal_parent)
+# carried inline by the goals-tree view in v0.x; not stored on this element
+# file. See ELEMENT_PRIMITIVES.md §7.2 + notations/elements/17-relations.md §3.
+
+notation: goal
+id: GOAL-EU-1
+name: "Launch in 3 EU markets"
+type: "Strategic Goal"
+level: 1
+factors:
+  - FACTOR-EU-REG-1
+description: >
+  Establish operational presence in three EU markets within the 2026 plan
+  horizon. Driven by the closing EU regulatory window.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-OPS-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-OPS-1.yaml
@@ -1,0 +1,29 @@
+# Worked example — GOAL element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.2 + envelope §3.
+# Shared element: defined here, referenced from the goals-tree, FGA, and
+# process-map views. Parent (GOAL-REVENUE-1) carried inline by the goals
+# tree in v0.x — not on this element file.
+
+notation: goal
+id: GOAL-OPS-1
+name: "Cut support response time by half"
+type: "Strategic Goal"
+level: 1
+factors:
+  - FACTOR-COMP-1
+description: >
+  Halve the customer-support response time (P50) by the end of Q2 2026,
+  restoring it to under two hours.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-REVENUE-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-REVENUE-1.yaml
@@ -1,0 +1,25 @@
+# Worked example — GOAL element primitive (root strategy).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.2 + envelope §3.
+# Definition home; arranged by the goals-tree view (canon/views/goals/).
+
+notation: goal
+id: GOAL-REVENUE-1
+name: "Triple revenue in 3 years"
+type: "Strategy"
+level: 0
+description: >
+  Root strategic ambition for the 2026 plan. All strategic goals in the
+  tree decompose from this one.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/goals/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/goals/README.md
@@ -1,0 +1,33 @@
+# `canon/elements/01_motivation/goals/`
+
+Goal element primitives — each file is one strategic or tactical goal on the ArchiMate 3.2 **motivation** layer. Goals are the most cross-referenced strategy-chain element (goals tree, FGCA, FGA, activities). The goals-tree view (`../../../views/goals/`) arranges them into a hierarchy; this folder holds their canonical records.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`GOAL`).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows the canonical grammar `GOAL-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `GOAL-REVENUE-1.yaml`, `GOAL-EU-1.yaml`.
+
+## Schema
+
+Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.2 over the common envelope §3:
+
+- Identity + goal fields: `notation: goal`, `id`, `name`, optional `type` (goal-type label), `level`, `factors: [FACTOR-…]`, `description`, `link`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+A goal's **`parent`** (`GOAL → GOAL`) is a first-class time-aware relation (`goal_parent`, [`notations/elements/17-relations.md`](../../../../../../notations/elements/17-relations.md) §3); it is carried inline by the goals-tree view in v0.x and is **not** stored on the element file.
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `GOAL-REVENUE-1.yaml` | Root strategy goal (`level: 0`) |
+| `GOAL-EU-1.yaml` | Strategic goal driven by `FACTOR-EU-REG-1` |
+| `GOAL-OPS-1.yaml` | Strategic goal driven by `FACTOR-COMP-1` |
+| `GOAL-CUST-1.yaml` | Strategic goal behind the onboarding activity network |
+
+## See also
+
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.2.
+- Goals-tree notation: [`notations/views/04-goals.md`](../../../../../../notations/views/04-goals.md).
+- Views over these elements: [`../../../views/goals/`](../../../views/goals/), [`../../../views/fgca/`](../../../views/fgca/), [`../../../views/fga/`](../../../views/fga/).

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.2.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.2.yaml
@@ -1,0 +1,31 @@
+# Worked example — Capability element primitive (stable fields only).
+# Schema: notations/views/05-capability-map.md §13 + admission record
+# (CONTRACT.md §6) + primitive lifecycle (CONTRACT.md §7).
+#
+# Time-varying attributes (current_maturity, owner_role, target_date) live
+# in the sidecar CAPABILITY-V1.2.history.yaml per CONTRACT.md §9 (not
+# provided for this minimal example). Parent (CAPABILITY-V1.2 -> CAPABILITY-V1)
+# is carried inline by the capability-map view's children[] in v0.x.
+
+notation: capability
+id: CAPABILITY-V1.2
+name: "Order Fulfilment"
+type: domain                            # domain | supporting
+description: >
+  Pick, pack, route, and close out customer orders. Sits beneath Order
+  Management alongside Order Intake (CAPABILITY-V1.1).
+
+target_maturity: 3
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.yaml
@@ -20,10 +20,10 @@ target_maturity: 3
 
 # Relations — stay inline in v1 (Wave 3 may promote to first-class
 # time-aware relation files)
-business_process: PROC-ORD-FULFILL-1
+business_process: PROCESS-ORD-FULFILL-1
 applications:
-  - APP-OMS-1
-  - APP-CRM-1
+  - APPLICATION-OMS-1
+  - APPLICATION-CRM-1
 
 # Admission record (CONTRACT.md §6)
 zone: canon

--- a/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-CS-RESOLVE-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-CS-RESOLVE-1.yaml
@@ -1,0 +1,22 @@
+# Worked example — PROCESS element primitive (supporting process).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.5 + envelope §3.
+
+notation: process
+id: PROCESS-CS-RESOLVE-1
+name: "Customer Support Resolution"
+owner_role: ROLE-CS-1
+description: >
+  Receive, triage, and resolve customer support requests across channels.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-CUST-ONBOARD-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-CUST-ONBOARD-1.yaml
@@ -1,0 +1,24 @@
+# Worked example — PROCESS element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.5 + envelope §3.
+
+notation: process
+id: PROCESS-CUST-ONBOARD-1
+name: "Customer Onboarding"
+owner_role: ROLE-SALES-1
+capability: CAPABILITY-V2
+maturity: 1
+description: >
+  Bring a new customer from signed agreement to first productive use.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml
@@ -1,0 +1,28 @@
+# Worked example — PROCESS element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.5 + envelope §3.
+# Arranged by the process-map view (canon/views/processmap/); the detailed
+# flow lives in canon/views/bpmn/.
+
+notation: process
+id: PROCESS-ORD-FULFILL-1
+name: "Order Fulfilment"
+owner_role: ROLE-OPS-1
+capability: CAPABILITY-V1
+maturity: 2
+bpmn_file: "canon/views/bpmn/order-fulfilment.bpmn.transitrix.yaml"
+description: >
+  End-to-end fulfilment of a customer order, from validated intake through
+  pick / pack / ship to close-out.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-STRAT-PLAN-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-STRAT-PLAN-1.yaml
@@ -1,0 +1,23 @@
+# Worked example — PROCESS element primitive (management process).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.5 + envelope §3.
+
+notation: process
+id: PROCESS-STRAT-PLAN-1
+name: "Annual Strategy Planning"
+owner_role: ROLE-EXEC-1
+description: >
+  Annual cycle that sets organisational strategy, goals, and the change
+  portfolio for the coming year.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/processes/README.md
+++ b/organizations/acme_corp/canon/elements/02_business/processes/README.md
@@ -1,0 +1,31 @@
+# `canon/elements/02_business/processes/`
+
+Process element primitives — each file is one business process on the ArchiMate 3.2 **business** layer. The process-map view (`../../../views/processmap/`) catalogues them by Operating / Supporting / Management; detailed flows live in `../../../views/bpmn/`.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`PROCESS`).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows `PROCESS-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `PROCESS-ORD-FULFILL-1.yaml`.
+
+## Schema
+
+Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.5 over the common envelope §3:
+
+- Identity + process fields: `notation: process`, `id`, `name`, `owner_role: ROLE-…`, `capability: CAPABILITY-…`, `maturity` (CMM 1–5), `bpmn_file`, `description`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `PROCESS-ORD-FULFILL-1.yaml` | Operating — realises `CAPABILITY-V1`, owned by `ROLE-OPS-1` |
+| `PROCESS-CUST-ONBOARD-1.yaml` | Operating — realises `CAPABILITY-V2` |
+| `PROCESS-CS-RESOLVE-1.yaml` | Supporting |
+| `PROCESS-STRAT-PLAN-1.yaml` | Management |
+
+## See also
+
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.5.
+- Process-map notation: [`notations/views/06-process-map.md`](../../../../../../notations/views/06-process-map.md).
+- Views over these elements: [`../../../views/processmap/`](../../../views/processmap/), [`../../../views/bpmn/`](../../../views/bpmn/).

--- a/organizations/acme_corp/canon/elements/02_business/products/PRODUCT-ECOMM-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/products/PRODUCT-ECOMM-1.yaml
@@ -1,0 +1,34 @@
+# Worked example — PRODUCT element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.6 + envelope §3.
+# Arranged by the products-catalogue view (canon/views/products/).
+
+notation: product
+id: PRODUCT-ECOMM-1
+name: "E-Commerce Platform"
+type: digital_product                   # digital_product | service | platform | bundle
+domain: "Digital"
+owner_role: ROLE-PROD-1
+maturity: 3
+description: >
+  Online storefront and order management for end customers.
+capabilities:
+  - CAPABILITY-V1
+  - CAPABILITY-V2
+processes:
+  - PROCESS-ORD-FULFILL-1
+supporting_apps:
+  - APPLICATION-OMS-1
+  - APPLICATION-CRM-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/products/PRODUCT-SUPPORT-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/products/PRODUCT-SUPPORT-1.yaml
@@ -1,0 +1,25 @@
+# Worked example — PRODUCT element primitive (a service).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.6 + envelope §3.
+# `type: service` — a PRODUCT in the catalogue, not a separate SVC TYPE.
+
+notation: product
+id: PRODUCT-SUPPORT-1
+name: "Customer Support Service"
+type: service                           # digital_product | service | platform | bundle
+domain: "Operations"
+owner_role: ROLE-CS-1
+description: >
+  Tier-1 and Tier-2 support for customers via chat, email, and phone.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/products/README.md
+++ b/organizations/acme_corp/canon/elements/02_business/products/README.md
@@ -1,0 +1,29 @@
+# `canon/elements/02_business/products/`
+
+Product element primitives — each file is one product or service on the ArchiMate 3.2 **business** layer. Services are products with `type: service` (there is no separate `SVC` TYPE). The products-catalogue view (`../../../views/products/`) renders them; this folder holds their canonical records.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`PRODUCT`).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows `PRODUCT-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `PRODUCT-ECOMM-1.yaml`, `PRODUCT-SUPPORT-1.yaml`.
+
+## Schema
+
+Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.6 over the common envelope §3:
+
+- Identity + product fields: `notation: product`, `id`, `name`, `type` (`digital_product` | `service` | `platform` | `bundle`, required), `domain`, `owner_role: ROLE-…`, `maturity`, `description`, `capabilities: [CAPABILITY-…]`, `processes: [PROCESS-…]`, `supporting_apps: [APPLICATION-…]`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `PRODUCT-ECOMM-1.yaml` | `digital_product` — references capabilities, a process, and supporting apps |
+| `PRODUCT-SUPPORT-1.yaml` | `service` — a support offering |
+
+## See also
+
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.6.
+- Products notation: [`notations/views/09-products.md`](../../../../../../notations/views/09-products.md).
+- View over these elements: [`../../../views/products/`](../../../views/products/).

--- a/organizations/acme_corp/canon/elements/02_business/roles/README.md
+++ b/organizations/acme_corp/canon/elements/02_business/roles/README.md
@@ -1,0 +1,34 @@
+# `canon/elements/02_business/roles/`
+
+Role element primitives — each file is one business role on the ArchiMate 3.2 **business** layer. Roles are the accountable parties referenced as `owner_role: ROLE-…` across the notations (processes, products, capabilities, applications, issues). This folder is their canonical home.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`ROLE`).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows `ROLE-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `ROLE-OPS-1.yaml`.
+
+## Schema
+
+Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.9 over the common envelope §3:
+
+- Identity + role fields: `notation: role`, `id`, `name`, `description`, optional `responsibility_area`, `unit: UNIT-…`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+A `ROLE` names a position, not a person; named individuals are `EMPLOYEE` elements (§7.11).
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `ROLE-OPS-1.yaml` | Operations Lead |
+| `ROLE-SALES-1.yaml` | Sales Lead |
+| `ROLE-PROD-1.yaml` | Product Lead |
+| `ROLE-TECH-1.yaml` | Technology Lead |
+| `ROLE-CS-1.yaml` | Customer Support Lead |
+| `ROLE-EXEC-1.yaml` | Executive Sponsor |
+
+## See also
+
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.9.
+- Cross-reference field `owner_role:` appears across the view notations under [`notations/views/`](../../../../../../notations/views/).

--- a/organizations/acme_corp/canon/elements/02_business/roles/ROLE-CS-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/roles/ROLE-CS-1.yaml
@@ -1,0 +1,23 @@
+# Worked example — ROLE element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+
+notation: role
+id: ROLE-CS-1
+name: "Customer Support Lead"
+responsibility_area: "Customer Support"
+description: >
+  Accountable for the customer-support resolution process and the support
+  service offering.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/roles/ROLE-EXEC-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/roles/ROLE-EXEC-1.yaml
@@ -1,0 +1,23 @@
+# Worked example — ROLE element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+
+notation: role
+id: ROLE-EXEC-1
+name: "Executive Sponsor"
+responsibility_area: "Executive"
+description: >
+  Executive accountable for annual strategy planning and the change
+  portfolio.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/roles/ROLE-OPS-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/roles/ROLE-OPS-1.yaml
@@ -1,0 +1,24 @@
+# Worked example — ROLE element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+# ROLEs are the accountable parties referenced as owner_role across notations.
+
+notation: role
+id: ROLE-OPS-1
+name: "Operations Lead"
+responsibility_area: "Operations"
+description: >
+  Accountable for order-fulfilment operations and operational capability
+  maturity.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/roles/ROLE-PROD-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/roles/ROLE-PROD-1.yaml
@@ -1,0 +1,22 @@
+# Worked example — ROLE element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+
+notation: role
+id: ROLE-PROD-1
+name: "Product Lead"
+responsibility_area: "Product"
+description: >
+  Accountable for the product catalogue and the e-commerce product line.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/roles/ROLE-SALES-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/roles/ROLE-SALES-1.yaml
@@ -1,0 +1,23 @@
+# Worked example — ROLE element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+
+notation: role
+id: ROLE-SALES-1
+name: "Sales Lead"
+responsibility_area: "Sales"
+description: >
+  Accountable for the sales pipeline, the CRM application, and customer
+  onboarding.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/roles/ROLE-TECH-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/roles/ROLE-TECH-1.yaml
@@ -1,0 +1,23 @@
+# Worked example — ROLE element primitive.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+
+notation: role
+id: ROLE-TECH-1
+name: "Technology Lead"
+responsibility_area: "Technology"
+description: >
+  Accountable for the application estate, including the order-management
+  system and its integrations.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-CRM-1.yaml
+++ b/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-CRM-1.yaml
@@ -1,0 +1,28 @@
+# Worked example — APPLICATION element primitive (stable fields only).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.7 + envelope §3.
+# Time-varying fields (owner_role, vendor, lifecycle_stage, maturity) are
+# sidecar-bound per CONTRACT.md §9 — not inline here.
+
+notation: application
+id: APPLICATION-CRM-1
+name: "CRM System"
+type: application                       # application | integration | platform | data_store
+domain: "Sales"
+description: >
+  Customer-relationship and sales-pipeline management. Receives order
+  events from the order-management system.
+capabilities:
+  - CAPABILITY-V2
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-OMS-1.yaml
+++ b/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-OMS-1.yaml
@@ -1,0 +1,35 @@
+# Worked example — APPLICATION element primitive (stable fields only).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.7 + envelope §3.
+# Arranged by the applications-catalogue view (canon/views/applications/).
+#
+# Time-varying fields (owner_role, vendor, lifecycle_stage, maturity) are
+# sidecar-bound per CONTRACT.md §9 — kept out of this file (inline placement
+# would trigger VERSIONED-004). No sidecar is provided for this minimal
+# example; the catalogue view shows their current values.
+
+notation: application
+id: APPLICATION-OMS-1
+name: "Order Management System"
+type: application                       # application | integration | platform | data_store
+domain: "Operations"
+description: >
+  Core system for the order lifecycle — intake, validation, routing, and
+  fulfilment hand-off. Integrates outbound to the CRM (see the catalogue
+  view's nested integration descriptor).
+capabilities:
+  - CAPABILITY-V1
+products:
+  - PRODUCT-ECOMM-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/03_application/applications/README.md
+++ b/organizations/acme_corp/canon/elements/03_application/applications/README.md
@@ -1,0 +1,31 @@
+# `canon/elements/03_application/applications/`
+
+Application element primitives — each file is one application on the ArchiMate 3.2 **application** layer. The applications-catalogue view (`../../../views/applications/`) renders them and their integrations; this folder holds their canonical records.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`APPLICATION`, `INTEGRATION`).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows `APPLICATION-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `APPLICATION-OMS-1.yaml`.
+
+## Schema
+
+Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.7 over the common envelope §3:
+
+- Identity + application fields: `notation: application`, `id`, `name`, `type` (`application` | `integration` | `platform` | `data_store`, required), `domain`, `description`, `capabilities: [CAPABILITY-…]`, `products: [PRODUCT-…]`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+**Time-varying** fields — `owner_role`, `vendor`, `lifecycle_stage`, `maturity` — are sidecar-bound ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §9), **not** inline (inline placement triggers `VERSIONED-004`). `INTEGRATION` is view-defined (nested under its source application in the catalogue) in v1 and promotable to a standalone `../integrations/` file — see [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.8.
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `APPLICATION-OMS-1.yaml` | Order Management System — supports `CAPABILITY-V1`, used by `PRODUCT-ECOMM-1` |
+| `APPLICATION-CRM-1.yaml` | CRM System — supports `CAPABILITY-V2` |
+
+## See also
+
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.7–§7.8.
+- Applications notation: [`notations/views/10-applications.md`](../../../../../../notations/views/10-applications.md).
+- View over these elements: [`../../../views/applications/`](../../../views/applications/).

--- a/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-BUILD-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-BUILD-1.yaml
@@ -1,0 +1,26 @@
+# Worked example — ACTIVITY element primitive (Work Package).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.4 + envelope §3.
+
+notation: activity
+id: ACTIVITY-BUILD-1
+name: "Build & test"
+duration_days: 30
+predecessors:
+  - ACTIVITY-DESIGN-1
+delivers_changes:
+  - CHANGE-ONBOARD-1
+description: >
+  Build-and-test phase; delivers the onboarding-rework change.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-CRM-EU-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-CRM-EU-1.yaml
@@ -1,0 +1,26 @@
+# Worked example — ACTIVITY element primitive (Work Package).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.4 + envelope §3.
+# ArchiMate Implementation & Migration layer (05_implementation).
+# Arranged by the FGCA view (canon/views/fgca/).
+
+notation: activity
+id: ACTIVITY-CRM-EU-1
+name: "Implement EU-localised CRM rollout"
+delivers_changes:
+  - CHANGE-EU-CRM-1
+description: >
+  Workstream that delivers the EU-localised CRM change in the EU-expansion
+  chain.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-DESIGN-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-DESIGN-1.yaml
@@ -1,0 +1,26 @@
+# Worked example — ACTIVITY element primitive (Work Package).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.4 + envelope §3.
+
+notation: activity
+id: ACTIVITY-DESIGN-1
+name: "Solution design"
+duration_days: 14
+predecessors:
+  - ACTIVITY-DISCOVERY-1
+goals:
+  - GOAL-CUST-1
+description: >
+  Solution-design phase; follows discovery.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-DISCOVERY-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-DISCOVERY-1.yaml
@@ -1,0 +1,28 @@
+# Worked example — ACTIVITY element primitive (Work Package).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.4 + envelope §3.
+# First node of the onboarding-delivery network (canon/views/activities/).
+# `predecessors` stays inline/timeless per ELEMENT_PRIMITIVES.md §7.4.
+
+notation: activity
+id: ACTIVITY-DISCOVERY-1
+name: "Discovery & research"
+duration_days: 10
+start_date: "2026-06-01"
+predecessors: []
+goals:
+  - GOAL-CUST-1
+description: >
+  Discovery and research phase for the onboarding rework.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-LAUNCH-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-LAUNCH-1.yaml
@@ -1,0 +1,26 @@
+# Worked example — ACTIVITY element primitive (Work Package).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.4 + envelope §3.
+
+notation: activity
+id: ACTIVITY-LAUNCH-1
+name: "Launch"
+duration_days: 5
+predecessors:
+  - ACTIVITY-BUILD-1
+delivers_changes:
+  - CHANGE-ONBOARD-1
+description: >
+  Launch phase; closes out the onboarding-rework change.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-SUPPORT-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-SUPPORT-1.yaml
@@ -1,0 +1,25 @@
+# Worked example — ACTIVITY element primitive (Work Package).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.4 + envelope §3.
+# Arranged by the FGA view (canon/views/fga/).
+
+notation: activity
+id: ACTIVITY-SUPPORT-1
+name: "Add second-shift coverage in EU timezone"
+goals:
+  - GOAL-OPS-1
+description: >
+  Operational workstream to add second-shift support coverage, serving the
+  response-time goal.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/activities/README.md
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/README.md
@@ -1,0 +1,32 @@
+# `canon/elements/05_implementation/activities/`
+
+Activity element primitives — each file is one initiative / workstream (an ArchiMate 3.2 *Work Package*) on the **Implementation & Migration** layer. Activities are recursive: an initiative aggregates programmes → projects → tasks, all one TYPE via `parent`. They are arranged by the activities view (`../../../views/activities/`) as a precedence network, and by the FGCA / FGA chains.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`ACTIVITY`). Layer rationale: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §6.1.
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows `ACTIVITY-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `ACTIVITY-DISCOVERY-1.yaml`.
+
+## Schema
+
+Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.4 over the common envelope §3:
+
+- Identity + activity fields: `notation: activity`, `id`, `name`, `duration_days`, `goals: [GOAL-…]`, `delivers_changes: [CHANGE-…]`, `predecessors: [ACTIVITY-…]`, `parent: ACTIVITY-…`, schedule/cost fields, `description`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+`goals` is a first-class time-aware relation (`activity_goal`) in the temporal model; inline `goals` is v0.x transitional. `predecessors` stays inline/timeless. The element-lifecycle `valid_from`/`valid_to` are **distinct** from the schedule `start_date`/`end_date` — see [`notations/views/07-activities.md`](../../../../../../notations/views/07-activities.md).
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `ACTIVITY-CRM-EU-1.yaml` | Delivers `CHANGE-EU-CRM-1` (FGCA chain) |
+| `ACTIVITY-SUPPORT-1.yaml` | Serves `GOAL-OPS-1` (FGA chain) |
+| `ACTIVITY-DISCOVERY-1.yaml` … `ACTIVITY-LAUNCH-1.yaml` | Onboarding precedence network, linked by `predecessors` |
+
+## See also
+
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.4, layer §6.1.
+- Activities notation: [`notations/views/07-activities.md`](../../../../../../notations/views/07-activities.md).
+- Sibling changes catalogue: [`../changes/`](../changes/).

--- a/organizations/acme_corp/canon/elements/05_implementation/changes/CHANGE-EU-CRM-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/changes/CHANGE-EU-CRM-1.yaml
@@ -1,0 +1,27 @@
+# Worked example — CHANGE element primitive (BDN Gap).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.3 + envelope §3.
+# ArchiMate Implementation & Migration layer (05_implementation).
+# Arranged by the FGCA view (canon/views/fgca/).
+
+notation: change
+id: CHANGE-EU-CRM-1
+name: "Stand up EU-localised CRM and payment processing"
+goals:
+  - GOAL-EU-1
+description: >
+  The required delta to operate in EU markets: an EU-localised CRM
+  configuration and EU payment processing. Capability-level change; may
+  decompose into process- and step-level changes via parent CHANGEs.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/changes/CHANGE-ONBOARD-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/changes/CHANGE-ONBOARD-1.yaml
@@ -1,0 +1,26 @@
+# Worked example — CHANGE element primitive (BDN Gap).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.3 + envelope §3.
+# Referenced from the activities view via `delivers_changes: [CHANGE-ONBOARD-1]`.
+
+notation: change
+id: CHANGE-ONBOARD-1
+name: "Rework the customer onboarding journey"
+goals:
+  - GOAL-CUST-1
+description: >
+  The delta needed to improve the onboarding experience — a reworked
+  onboarding journey delivered by the discovery → design → build → launch
+  activity network.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/changes/README.md
+++ b/organizations/acme_corp/canon/elements/05_implementation/changes/README.md
@@ -1,0 +1,29 @@
+# `canon/elements/05_implementation/changes/`
+
+Change element primitives — each file is one BDN **business change** (an ArchiMate 3.2 *Gap*) on the **Implementation & Migration** layer. A change is a required delta to reach the target state, at any granularity; higher-level changes decompose into lower-level ones via a `parent` relation. Changes are arranged by the FGCA view (`../../../views/fgca/`) and delivered by activities (`../activities/`).
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CHANGE`). Layer rationale: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §6.1.
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows `CHANGE-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `CHANGE-EU-CRM-1.yaml`.
+
+## Schema
+
+Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.3 over the common envelope §3:
+
+- Identity + change fields: `notation: change`, `id`, `name`, `goals: [GOAL-…]`, optional `parent: CHANGE-…` (multi-scale decomposition), `description`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `CHANGE-EU-CRM-1.yaml` | Stand up EU-localised CRM; delivers `GOAL-EU-1` |
+| `CHANGE-ONBOARD-1.yaml` | Onboarding rework; delivers `GOAL-CUST-1` |
+
+## See also
+
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.3, layer §6.1.
+- FGCA notation: [`notations/views/02-fgca.md`](../../../../../../notations/views/02-fgca.md).
+- Sibling activities catalogue: [`../activities/`](../activities/).

--- a/organizations/acme_corp/canon/views/applications/README.md
+++ b/organizations/acme_corp/canon/views/applications/README.md
@@ -13,14 +13,14 @@ notation: applications
 spec_version: "0.1"
 
 applications_catalogue:
-  id: "APP-CAT-1"
+  id: "APPLICATIONS_CAT-1"
   name: "Acme Corp Applications Catalogue"
   description: "Applications and integrations in operation at Acme Corp"
   version: "1.0"
   updated_at: "2026-05-26"
 
   applications:
-    - app_id: "APP-OMS-1"               # → canon/elements/03_application/applications/APP-OMS-1.yaml
+    - app_id: "APPLICATION-OMS-1"               # → canon/elements/03_application/applications/APPLICATION-OMS-1.yaml
       name: "Order Management System"
       type: "application"               # application | integration | platform | data_store
       domain: "Operations"
@@ -30,16 +30,16 @@ applications_catalogue:
       maturity: 3
       description: "Core system for order lifecycle management"
       capabilities: ["CAPABILITY-V1"]
-      products: ["PROD-ECOMM-1"]
+      products: ["PRODUCT-ECOMM-1"]
       integrations:                     # nested integration descriptors share the parent app's lifecycle — no own valid_from/valid_to
-        - target: "APP-CRM-1"
+        - target: "APPLICATION-CRM-1"
           direction: "outbound"
           protocol: "REST"
           description: "Sends order events to CRM"
       valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline applications-catalogue entry, regardless of `type`; distinct from operational `status`
       valid_to: null
 
-    - app_id: "APP-CRM-1"
+    - app_id: "APPLICATION-CRM-1"
       name: "CRM System"
       type: "application"
       domain: "Sales"

--- a/organizations/acme_corp/canon/views/capabilities/README.md
+++ b/organizations/acme_corp/canon/views/capabilities/README.md
@@ -26,10 +26,10 @@ capability_map:
       target_maturity: 3
       target_date: "2026-12-31"
       owner_role: "ROLE-OPS-1"
-      business_process: "PROC-ORD-FULFILL-1"
+      business_process: "PROCESS-ORD-FULFILL-1"
       applications:
-        - "APP-OMS-1"
-        - "APP-CRM-1"
+        - "APPLICATION-OMS-1"
+        - "APPLICATION-CRM-1"
       valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline capability, recursively
       valid_to: null
       children:
@@ -55,7 +55,7 @@ capability_map:
       target_maturity: 3
       owner_role: "ROLE-SALES-1"
       applications:
-        - "APP-CRM-1"
+        - "APPLICATION-CRM-1"
       valid_from: "2026-05-26"
       valid_to: null
 ```

--- a/organizations/acme_corp/canon/views/processmap/README.md
+++ b/organizations/acme_corp/canon/views/processmap/README.md
@@ -24,7 +24,7 @@ process_map:
       name: "Operating Processes"
       type: "operating"                 # operating | supporting | management
       processes:
-        - process_id: "PROC-ORD-FULFILL-1"   # → canon/elements/02_business/processes/PROC-ORD-FULFILL-1.yaml
+        - process_id: "PROCESS-ORD-FULFILL-1"   # → canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml
           name: "Order Fulfilment"
           owner_role: "ROLE-OPS-1"
           capability: "CAPABILITY-V1"
@@ -33,7 +33,7 @@ process_map:
           bpmn_file: "canon/views/bpmn/order-fulfilment.bpmn.transitrix.yaml"
           valid_from: "2026-05-26"            # CONTRACT.md §7 — required on every inline process; distinct from operational `status`
           valid_to: null
-        - process_id: "PROC-CUST-ONBOARD-1"
+        - process_id: "PROCESS-CUST-ONBOARD-1"
           name: "Customer Onboarding"
           owner_role: "ROLE-SALES-1"
           capability: "CAPABILITY-V2"
@@ -46,7 +46,7 @@ process_map:
       name: "Supporting Processes"
       type: "supporting"
       processes:
-        - process_id: "PROC-CS-RESOLVE-1"
+        - process_id: "PROCESS-CS-RESOLVE-1"
           name: "Customer Support Resolution"
           owner_role: "ROLE-CS-1"
           status: "Active"
@@ -57,7 +57,7 @@ process_map:
       name: "Management Processes"
       type: "management"
       processes:
-        - process_id: "PROC-STRAT-PLAN-1"
+        - process_id: "PROCESS-STRAT-PLAN-1"
           name: "Annual Strategy Planning"
           owner_role: "ROLE-EXEC-1"
           status: "Active"

--- a/organizations/acme_corp/canon/views/products/README.md
+++ b/organizations/acme_corp/canon/views/products/README.md
@@ -13,14 +13,14 @@ notation: products
 spec_version: "0.1"
 
 products_catalogue:
-  id: "PROD-CAT-1"
+  id: "PRODUCTS_CAT-1"
   name: "Acme Corp Products Catalogue"
   description: "Products and services offered by Acme Corp"
   version: "1.0"
   updated_at: "2026-05-26"
 
   products:
-    - product_id: "PROD-ECOMM-1"        # → canon/elements/02_business/products/PROD-ECOMM-1.yaml
+    - product_id: "PRODUCT-ECOMM-1"        # → canon/elements/02_business/products/PRODUCT-ECOMM-1.yaml
       name: "E-Commerce Platform"
       type: "digital_product"           # digital_product | service | platform | bundle
       domain: "Digital"
@@ -29,12 +29,12 @@ products_catalogue:
       maturity: 3
       description: "Online storefront and order management for end customers"
       capabilities: ["CAPABILITY-V1", "CAPABILITY-V2"]
-      processes: ["PROC-ORD-FULFILL-1"]
-      supporting_apps: ["APP-OMS-1", "APP-CRM-1"]
+      processes: ["PROCESS-ORD-FULFILL-1"]
+      supporting_apps: ["APPLICATION-OMS-1", "APPLICATION-CRM-1"]
       valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline product; distinct from operational `status`
       valid_to: null
 
-    - product_id: "SVC-SUPPORT-1"
+    - product_id: "PRODUCT-SUPPORT-1"
       name: "Customer Support Service"
       type: "service"
       domain: "Operations"


### PR DESCRIPTION
## What

Populates `organizations/acme_corp/canon/elements/` with example element-primitive files — one per cross-reference ID in the refreshed view-README skeletons — per the #79 element-primitive schema (PR #84, now on main). Adopters cloning `acme_corp` now see both "how a view looks" and "what a primitive file looks like", with end-to-end traceability.

Closes the #53 wave-3 remainder; was blocked on #79.

## Two commits (one concern each)

1. **Populate** — 24 new element files + 8 per-folder READMEs:
   - `01_motivation/factors/` — FACTOR-EU-REG-1, FACTOR-COMP-1
   - `01_motivation/goals/` — GOAL-REVENUE-1, GOAL-EU-1, GOAL-OPS-1, GOAL-CUST-1
   - `02_business/capabilities/` — CAPABILITY-V1.2 (was referenced, no file)
   - `02_business/processes/` — PROCESS-ORD-FULFILL-1, -CUST-ONBOARD-1, -CS-RESOLVE-1, -STRAT-PLAN-1
   - `02_business/products/` — PRODUCT-ECOMM-1, PRODUCT-SUPPORT-1 (`type: service`)
   - `02_business/roles/` — ROLE-OPS/SALES/PROD/TECH/CS/EXEC-1
   - `03_application/applications/` — APPLICATION-OMS-1, APPLICATION-CRM-1
   - `05_implementation/changes/` — CHANGE-EU-CRM-1, CHANGE-ONBOARD-1
   - `05_implementation/activities/` — ACTIVITY-CRM-EU-1, -SUPPORT-1, -DISCOVERY/DESIGN/BUILD/LAUNCH-1
   - Reuses the existing constraints/ + rules/ + capabilities/ (V1/V1.1/V2) primitives.

2. **Canonicalise** — the view skeletons referenced apps/processes/products with non-canonical prefixes (`APP-`/`PROC-`/`PROD-`/`SVC-`, doc-ids `APP-CAT-`/`PROD-CAT-`) the #79 schema forbids. Conformed them (`APPLICATION-`/`PROCESS-`/`PRODUCT-`/`APPLICATIONS_CAT`/`PRODUCTS_CAT`) across 4 view READMEs + the existing `CAPABILITY-V1.yaml` cross-refs, so the new element files resolve. (Drift-direction confirmed with the maintainer before editing.)

## Verification

- Every new YAML parses; all carry the full envelope (`notation` + admission record + lifecycle) per #79 §3.
- **Traceability: 33/33** cross-reference IDs in `canon/views/` resolve to a real file under `canon/elements/` — zero dangling references.
- All embedded YAML blocks in the edited skeletons still parse.

## Scope notes / follow-ups

- New per-folder READMEs use the **correct** `notations/` link depth. The **existing** example READMEs (element-folder + view) have a pre-existing off-by-one in their `notations/` links (element folders use 5 ups, need 6; views use 4, need 5) — flagged as a separate cleanup, not fixed here.
- Remaining `APP-`/`PROC-` forms live only in `.templates/` and onboarding prose — the separate **F-1** template-reconciliation follow-up from #79, out of scope.
- `EMPLOYEE`/`UNIT` not populated (no such IDs referenced by the skeletons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
