### PR TITLE
docs: worked-example consistency cleanup (strategy#103 items 1-3)

### DIFF
--- a/notations/elements/15-requirement.md
+++ b/notations/elements/15-requirement.md
@@ -46,7 +46,7 @@ The same regulation often produces a REQUIREMENT and a corresponding CONSTRAINT 
 ```yaml
 notation: requirement
 id: REQUIREMENT-DATA-ERASURE-1
-title: "Personal-data erasure on user request within 30 days"
+name: "Personal-data erasure on user request within 30 days"
 description: "On request from a data subject, the controller must erase personal data within 30 days. The window starts at the time the request is received and verified."
 
 # Optional regulatory attributes
@@ -73,7 +73,7 @@ valid_to: null
 |---|---|---|---|
 | `notation` | yes | string | Fixed value `requirement`. Machine-readable type tag (redundant with the ID prefix but useful for tooling that reads files without parsing IDs). |
 | `id` | yes | string | Canonical ID per [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §1: `REQUIREMENT-[<middle>-]<INTEGER>`. |
-| `title` | yes | string | One-line statement of the requirement. |
+| `name` | yes | string | One-line statement of the requirement. (Was `title` before the 2026-05-29 single-label-field decision; see [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §3.) |
 | `description` | yes | string | Longer-form explanation of the obligation, its scope, and the conditions under which it applies. |
 | `severity` | no | string | One of `high`, `medium`, `low`. Organisation-defined priority for planning and reporting. Distinct from `obligation_level` (regulatory force, RFC 2119 — out of scope for v1; see [§5](#5-evolution)). |
 | `derived_from` | no | list | Typed IDs of the codex artefacts this requirement is drawn from. Permitted TYPEs: `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD`. Empty or absent for internal-only requirements with no codex source. |
@@ -107,7 +107,7 @@ The folder sits alongside `canon/elements/01_motivation/constraints/` — the tw
 
 | Rule | Severity | Description |
 |---|---|---|
-| `REQ-001` | error | `id` is missing or does not match the canonical grammar `REQUIREMENT-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §1); or any required field from §2 (`notation`, `title`, `description`, `zone`, `admitted_at`, `admitted_by`, `gate_checks`, `valid_from`, `valid_to`) is missing. |
+| `REQ-001` | error | `id` is missing or does not match the canonical grammar `REQUIREMENT-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §1); or any required field from §2 (`notation`, `name`, `description`, `zone`, `admitted_at`, `admitted_by`, `gate_checks`, `valid_from`, `valid_to`) is missing. |
 | `REQ-002` | error | A value in `derived_from` is a well-formed typed ID but does not resolve to any admitted codex artefact in the organisation's `codex/` zone. |
 | `REQ-003` | error | A value in `derived_from` resolves to an artefact whose TYPE is not one of `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD`. Requirements derive only from codex source documents. |
 | `REQ-COVERAGE-001` | warning | A REQUIREMENT has no ASSERTION targeting it — no file under `canon/assertions/` carries `about: <this REQ id>`. Surfaces a compliance gap: the obligation exists in the model but the organisation makes no recorded claim about whether any subject satisfies it. The rule is `warning` rather than `error` because a newly admitted REQUIREMENT legitimately has no assertion yet. Cross-cutting — fires on the REQUIREMENT but is computed by scanning the assertions catalogue. |

--- a/organizations/acme_corp/canon/elements/01_motivation/constraints/CONSTRAINT-GDPR-RESIDENCY-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/constraints/CONSTRAINT-GDPR-RESIDENCY-1.yaml
@@ -1,6 +1,6 @@
+notation: constraint
 id: CONSTRAINT-GDPR-RESIDENCY-1
 name: "EU customer personal data must be stored within EU/EEA jurisdictions"
-type: constraint
 statement: >
   Personal data of EU customers MUST NOT be persisted, processed, or backed up
   outside EU / EEA jurisdictions unless an adequacy decision or an approved
@@ -21,6 +21,15 @@ rationale: >
   countries. Non-compliance carries administrative fines under Art. 83 (up
   to 4% of global annual turnover) and reputational risk; storage decisions
   for any system holding EU customer PII MUST reflect this constraint.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
 
 # Primitive lifecycle (CONTRACT.md §7) — GDPR Art. 44–49 effective since
 # 2018-05-25 (GDPR enforcement date); the org's adoption of this constraint

--- a/organizations/acme_corp/canon/elements/01_motivation/constraints/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/constraints/README.md
@@ -14,17 +14,19 @@ Examples: `CONSTRAINT-GDPR-1.yaml`, `CONSTRAINT-1.yaml`.
 
 ## Element schema
 
-The schema is shared between `RULE` and `CONSTRAINT` elements — `type` distinguishes them and folder placement mirrors the ArchiMate layer.
+The schema is shared between `RULE` and `CONSTRAINT` elements — `notation` (plus the ID prefix and folder placement) distinguishes them; folder placement mirrors the ArchiMate layer. See the common envelope in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §3 and the CONSTRAINT field set in §7.13.
 
 ### Required
 
 | Field | Description |
 |---|---|
+| `notation` | literal `constraint` |
 | `id` | `CONSTRAINT-[<middle>-]<INTEGER>` |
 | `name` | one-line statement |
-| `type` | literal `constraint` |
 | `statement` | normative wording — `MUST` / `SHOULD` / `MUST NOT` recommended |
 | `status` | one of `active` / `proposed` / `deprecated` / `retired` |
+| admission record | `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks` — [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6 |
+| lifecycle | `valid_from`, `valid_to` — [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7 |
 
 ### Optional
 
@@ -39,18 +41,31 @@ The schema is shared between `RULE` and `CONSTRAINT` elements — `type` disting
 ## Skeleton
 
 ```yaml
+notation: constraint
 id: CONSTRAINT-SAMPLE-1
 name: "Short one-line statement"
-type: constraint
 statement: "MUST / SHOULD / MUST NOT wording, single sentence."
 status: active
 
-# Optional fields below
+# Optional fields
 applies_to: []            # e.g. [PROCESS-ORDER-1, APPLICATION-OMS-1]
 source: "Regulation §X.Y / Contract §Z"
 owner_role: ROLE-OWNER-1
 severity: mandatory       # mandatory | recommended | advisory
 rationale: "Why this constraint exists in the organisation."
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "firstname.lastname"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2018-05-25"
+valid_to: null
 ```
 
 ## Examples in this folder

--- a/organizations/acme_corp/canon/elements/01_motivation/constraints/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/constraints/README.md
@@ -4,7 +4,7 @@ Constraint elements — design / operating constraints that bind the organisatio
 
 Constraints are referenced by FGCA factors via `references_constraint:` — the existence of a constraint is itself a factor for the organisation that acts on it. They may also be referenced from any other notation via `applies_to:` once a register-view notation lands; v1 ships the elements only.
 
-TYPE registry: see [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CONSTRAINT`).
+TYPE registry: see [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CONSTRAINT`).
 
 ## File convention
 
@@ -61,6 +61,6 @@ rationale: "Why this constraint exists in the organisation."
 
 ## See also
 
-- TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CONSTRAINT`), §4 (uniqueness scope).
+- TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CONSTRAINT`), §4 (uniqueness scope).
 - Sibling rules catalogue: [`../../02_business/rules/`](../../02_business/rules/).
-- FGCA cross-reference field `references_constraint:` on FACTOR: [`notations/views/02-fgca.md`](../../../../../notations/views/02-fgca.md) § Fields → `factors[]`.
+- FGCA cross-reference field `references_constraint:` on FACTOR: [`notations/views/02-fgca.md`](../../../../../../notations/views/02-fgca.md) § Fields → `factors[]`.

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/README.md
@@ -20,7 +20,7 @@ Examples: `REQUIREMENT-DATA-ERASURE-1.yaml`, `REQUIREMENT-1.yaml`.
 
 Defined in [`notations/elements/15-requirement.md`](../../../../../../notations/elements/15-requirement.md) §2. Every requirement carries:
 
-- The requirement-specific fields: `notation: requirement`, `id`, `title`, `description`, optional `severity` / `derived_from`.
+- The requirement-specific fields: `notation: requirement`, `id`, `name`, `description`, optional `severity` / `derived_from`.
 - The admission record per [`notations/CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
 - The primitive lifecycle per [`notations/CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
 

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/README.md
@@ -2,27 +2,27 @@
 
 Requirement elements — positive obligations the organisation must fulfil. Each requirement is one file under this folder. Requirements sit on the ArchiMate 3.2 **motivation** layer.
 
-Requirements are distinct from `CONSTRAINT` by the **form of the obligation**: REQUIREMENT = positive action ("must submit", "must register", "must obtain approval"); CONSTRAINT = restriction ("must not", "cannot exceed"). See the full decision guide in [`notations/elements/15-requirement.md`](../../../../../notations/elements/15-requirement.md) §1.
+Requirements are distinct from `CONSTRAINT` by the **form of the obligation**: REQUIREMENT = positive action ("must submit", "must register", "must obtain approval"); CONSTRAINT = restriction ("must not", "cannot exceed"). See the full decision guide in [`notations/elements/15-requirement.md`](../../../../../../notations/elements/15-requirement.md) §1.
 
 Each requirement may cite zero or more codex sources via `derived_from:` (`LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`). A requirement with no `derived_from` is an internal obligation that has no written codex source.
 
-Requirements are not bound to subjects directly. The compliance claim that a specific subject (`PRODUCT` / `PROCESS` / `CAPABILITY`) satisfies a requirement lives in [`../../../assertions/`](../../../assertions/) as an `ASSERTION` artefact ([`notations/elements/16-assertion.md`](../../../../../notations/elements/16-assertion.md)).
+Requirements are not bound to subjects directly. The compliance claim that a specific subject (`PRODUCT` / `PROCESS` / `CAPABILITY`) satisfies a requirement lives in [`../../../assertions/`](../../../assertions/) as an `ASSERTION` artefact ([`notations/elements/16-assertion.md`](../../../../../../notations/elements/16-assertion.md)).
 
-TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`REQUIREMENT`), §4 (uniqueness scope).
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`REQUIREMENT`), §4 (uniqueness scope).
 
 ## File convention
 
-`<id>.yaml`, where `<id>` follows the canonical grammar `REQUIREMENT-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §1.
+`<id>.yaml`, where `<id>` follows the canonical grammar `REQUIREMENT-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1.
 
 Examples: `REQUIREMENT-DATA-ERASURE-1.yaml`, `REQUIREMENT-1.yaml`.
 
 ## Schema
 
-Defined in [`notations/elements/15-requirement.md`](../../../../../notations/elements/15-requirement.md) §2. Every requirement carries:
+Defined in [`notations/elements/15-requirement.md`](../../../../../../notations/elements/15-requirement.md) §2. Every requirement carries:
 
 - The requirement-specific fields: `notation: requirement`, `id`, `title`, `description`, optional `severity` / `derived_from`.
-- The admission record per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
-- The primitive lifecycle per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
+- The admission record per [`notations/CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
+- The primitive lifecycle per [`notations/CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
 
 ## Examples in this folder
 
@@ -33,7 +33,7 @@ Defined in [`notations/elements/15-requirement.md`](../../../../../notations/ele
 
 ## See also
 
-- Requirement spec: [`notations/elements/15-requirement.md`](../../../../../notations/elements/15-requirement.md).
+- Requirement spec: [`notations/elements/15-requirement.md`](../../../../../../notations/elements/15-requirement.md).
 - Sibling constraints catalogue: [`../constraints/`](../constraints/).
-- Compliance claims linking requirements to subjects: [`../../../assertions/`](../../../assertions/) and [`notations/elements/16-assertion.md`](../../../../../notations/elements/16-assertion.md).
-- Codex sources requirements derive from: [`../../../../codex/`](../../../../codex/) and [`notations/elements/14-codex.md`](../../../../../notations/elements/14-codex.md).
+- Compliance claims linking requirements to subjects: [`../../../assertions/`](../../../assertions/) and [`notations/elements/16-assertion.md`](../../../../../../notations/elements/16-assertion.md).
+- Codex sources requirements derive from: [`../../../../codex/`](../../../../codex/) and [`notations/elements/14-codex.md`](../../../../../../notations/elements/14-codex.md).

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml
@@ -7,7 +7,7 @@
 
 notation: requirement
 id: REQUIREMENT-AUDIT-LOG-RETENTION-1
-title: "Retain operational audit logs for at least 12 months"
+name: "Retain operational audit logs for at least 12 months"
 description: >
   All systems producing operational audit logs must retain those logs for
   at least 12 months from creation. The obligation is an internal Acme

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-DATA-ERASURE-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-DATA-ERASURE-1.yaml
@@ -4,7 +4,7 @@
 
 notation: requirement
 id: REQUIREMENT-DATA-ERASURE-1
-title: "Personal-data erasure on request within 30 days"
+name: "Personal-data erasure on request within 30 days"
 description: >
   On a verified request from a data subject, the controller must erase the
   subject's personal data within 30 days. The window starts at the time the

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/README.md
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/README.md
@@ -2,23 +2,23 @@
 
 Capability element primitives — each file is one capability the organisation can perform, sitting on the ArchiMate 3.2 **business** layer. The hierarchical view over these elements (with CMM maturity overlay) lives at [`../../../views/capabilities/`](../../../views/capabilities/).
 
-Time-varying attributes (`current_maturity`, `owner_role`, `target_date`) live in a co-located sidecar (`<id>.history.yaml`) per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §9. They are **not** stored inline on the element file; inline placement triggers `VERSIONED-004`.
+Time-varying attributes (`current_maturity`, `owner_role`, `target_date`) live in a co-located sidecar (`<id>.history.yaml`) per [`notations/CONTRACT.md`](../../../../../../notations/CONTRACT.md) §9. They are **not** stored inline on the element file; inline placement triggers `VERSIONED-004`.
 
-TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CAPABILITY`), §2 (V/H sub-grammar), §4 (uniqueness scope).
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CAPABILITY`), §2 (V/H sub-grammar), §4 (uniqueness scope).
 
 ## File convention
 
-`<id>.yaml`, where `<id>` follows the canonical `CAPABILITY-V[N][.N[.N]]` or `CAPABILITY-H[N][.N]` grammar from [`IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §2 (the V/H exception to the general `<TYPE>-…-<INTEGER>` form).
+`<id>.yaml`, where `<id>` follows the canonical `CAPABILITY-V[N][.N[.N]]` or `CAPABILITY-H[N][.N]` grammar from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §2 (the V/H exception to the general `<TYPE>-…-<INTEGER>` form).
 
-For each capability, an optional sidecar `<id>.history.yaml` carries the time-varying attribute history per [`CONTRACT.md`](../../../../../notations/CONTRACT.md) §9. The sidecar has no `notation:` header and no admission record of its own — it follows its target primitive.
+For each capability, an optional sidecar `<id>.history.yaml` carries the time-varying attribute history per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §9. The sidecar has no `notation:` header and no admission record of its own — it follows its target primitive.
 
 ## Schema
 
-Stable fields live on the element file. Defined in [`notations/views/05-capability-map.md`](../../../../../notations/views/05-capability-map.md) §13 (fields table) with the inline/sidecar split annotated. Each capability element carries:
+Stable fields live on the element file. Defined in [`notations/views/05-capability-map.md`](../../../../../../notations/views/05-capability-map.md) §13 (fields table) with the inline/sidecar split annotated. Each capability element carries:
 
 - The capability-specific stable fields: `notation: capability`, `id`, `name`, `type`, `description`, optional `target_maturity`, `business_process`, `applications`, `children`.
-- The admission record per [`CONTRACT.md`](../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
-- The primitive lifecycle per [`CONTRACT.md`](../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
+- The admission record per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
+- The primitive lifecycle per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
 
 Time-varying fields (`current_maturity`, `owner_role`, `target_date`) live in the sidecar — not inline.
 
@@ -31,6 +31,6 @@ Time-varying fields (`current_maturity`, `owner_role`, `target_date`) live in th
 
 ## See also
 
-- Capability-map view notation: [`notations/views/05-capability-map.md`](../../../../../notations/views/05-capability-map.md) — full field-table schema (incl. inline/sidecar split) and §14 sidecar reference.
-- Sidecar contract: [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §9.
+- Capability-map view notation: [`notations/views/05-capability-map.md`](../../../../../../notations/views/05-capability-map.md) — full field-table schema (incl. inline/sidecar split) and §14 sidecar reference.
+- Sidecar contract: [`notations/CONTRACT.md`](../../../../../../notations/CONTRACT.md) §9.
 - Capability-map views over these elements: [`../../../views/capabilities/`](../../../views/capabilities/).

--- a/organizations/acme_corp/canon/elements/02_business/rules/README.md
+++ b/organizations/acme_corp/canon/elements/02_business/rules/README.md
@@ -14,17 +14,19 @@ Examples: `RULE-DUAL-APPROVAL-1.yaml`, `RULE-1.yaml`.
 
 ## Element schema
 
-The schema is shared between `RULE` and `CONSTRAINT` elements — `type` distinguishes them and folder placement mirrors the ArchiMate layer.
+The schema is shared between `RULE` and `CONSTRAINT` elements — `notation` (plus the ID prefix and folder placement) distinguishes them; folder placement mirrors the ArchiMate layer. See the common envelope in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §3 and the RULE field set in §7.12.
 
 ### Required
 
 | Field | Description |
 |---|---|
+| `notation` | literal `rule` |
 | `id` | `RULE-[<middle>-]<INTEGER>` |
 | `name` | one-line statement |
-| `type` | literal `rule` |
 | `statement` | normative wording — `MUST` / `SHOULD` / `MUST NOT` recommended |
 | `status` | one of `active` / `proposed` / `deprecated` / `retired` |
+| admission record | `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks` — [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6 |
+| lifecycle | `valid_from`, `valid_to` — [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7 |
 
 ### Optional
 
@@ -39,18 +41,31 @@ The schema is shared between `RULE` and `CONSTRAINT` elements — `type` disting
 ## Skeleton
 
 ```yaml
+notation: rule
 id: RULE-SAMPLE-1
 name: "Short one-line statement"
-type: rule
 statement: "MUST / SHOULD / MUST NOT wording, single sentence."
 status: active
 
-# Optional fields below
+# Optional fields
 applies_to: []            # e.g. [PROCESS-EXPENSE-APPROVAL-1]
 source: "Internal Policy §X.Y / Board decision YYYY-MM-DD"
 owner_role: ROLE-OWNER-1
 severity: mandatory       # mandatory | recommended | advisory
 rationale: "Why this rule exists."
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "firstname.lastname"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-01-15"
+valid_to: null
 ```
 
 ## Examples in this folder

--- a/organizations/acme_corp/canon/elements/02_business/rules/README.md
+++ b/organizations/acme_corp/canon/elements/02_business/rules/README.md
@@ -4,7 +4,7 @@ Rule elements — business rules an organisation enforces. Each rule is one file
 
 Rules describe operational policy (approval thresholds, segregation of duties, eligibility criteria, …). They may be referenced from any other notation via `applies_to:` once a register-view notation lands; v1 ships the elements only. Rules contrast with **constraints** (`canon/elements/01_motivation/constraints/`) — constraints are binding rules imposed from outside or above (regulation, contract); rules are the organisation's own operating policy.
 
-TYPE registry: see [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`RULE`).
+TYPE registry: see [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`RULE`).
 
 ## File convention
 
@@ -61,5 +61,5 @@ rationale: "Why this rule exists."
 
 ## See also
 
-- TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`RULE`), §4 (uniqueness scope).
+- TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`RULE`), §4 (uniqueness scope).
 - Sibling constraints catalogue: [`../../01_motivation/constraints/`](../../01_motivation/constraints/).

--- a/organizations/acme_corp/canon/elements/02_business/rules/RULE-DUAL-APPROVAL-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/rules/RULE-DUAL-APPROVAL-1.yaml
@@ -1,6 +1,6 @@
+notation: rule
 id: RULE-DUAL-APPROVAL-1
 name: "Expense claims above 5 000 EUR require dual approval"
-type: rule
 statement: >
   Expense claims with a total value greater than EUR 5 000 MUST be approved
   by both the requester's direct manager AND the finance lead before any
@@ -18,6 +18,15 @@ rationale: >
   workflows. Dual approval above the materiality threshold reduces the risk
   of fraud, simple error, and single-point-of-failure on high-value
   payments.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
 
 # Primitive lifecycle (CONTRACT.md §7) — Board decision 2026-01-15
 # (per source above) is the date this rule took effect.

--- a/organizations/acme_corp/canon/views/activities/README.md
+++ b/organizations/acme_corp/canon/views/activities/README.md
@@ -6,7 +6,7 @@ Project schedule as an **Activity-on-Node** precedence network (PSND), with an o
 
 `*.activities.transitrix.yaml`
 
-See [`notations/views/07-activities.md`](../../../../notations/views/07-activities.md) for the full spec — including PSND semantics, the critical-path computation, and the Gantt projection contract.
+See [`notations/views/07-activities.md`](../../../../../notations/views/07-activities.md) for the full spec — including PSND semantics, the critical-path computation, and the Gantt projection contract.
 
 ## Skeleton
 
@@ -51,7 +51,7 @@ activities:
 
 Activities form a DAG via `predecessors:`. The renderer computes Early Start / Late Finish / slack and highlights the critical path in both the PSND view and the Gantt projection. Transitrix Studio renders both views; the toolbar switches between them.
 
-`valid_from` / `valid_to` are required on every inline activity per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7 and are **distinct** from `start_date` / `end_date`: the lifecycle fields say *when this activity entry is admitted to the plan*, while the schedule fields say *when the work is planned to happen*. Both coexist; the activities document itself carries no lifecycle.
+`valid_from` / `valid_to` are required on every inline activity per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7 and are **distinct** from `start_date` / `end_date`: the lifecycle fields say *when this activity entry is admitted to the plan*, while the schedule fields say *when the work is planned to happen*. Both coexist; the activities document itself carries no lifecycle.
 
 ## Cross-references
 
@@ -59,10 +59,10 @@ Activities form a DAG via `predecessors:`. The renderer computes Early Start / L
 - `delivers_changes: [CHANGE-…]` — Change IDs from the FGCA chain.
 - `predecessors: [ACTIVITY-…]` — other activity IDs in the same file.
 
-All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar from [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md).
+All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar from [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md).
 
 ## See also
 
-- [`notations/views/07-activities.md`](../../../../notations/views/07-activities.md) — the notation spec
-- [`notations/examples/activities/platform-launch.activities.transitrix.yaml`](../../../../notations/examples/activities/platform-launch.activities.transitrix.yaml) — worked example
+- [`notations/views/07-activities.md`](../../../../../notations/views/07-activities.md) — the notation spec
+- [`notations/examples/activities/platform-launch.activities.transitrix.yaml`](../../../../../notations/examples/activities/platform-launch.activities.transitrix.yaml) — worked example
 - `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/canon/views/applications/README.md
+++ b/organizations/acme_corp/canon/views/applications/README.md
@@ -53,7 +53,7 @@ applications_catalogue:
 
 `capabilities` and `products` hold **element IDs**, not display names. Integrations may be inlined (as above) or modelled as their own `type: integration` entries.
 
-`valid_from` / `valid_to` are required on every inline applications-catalogue entry per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7, regardless of `type` (`application` / `integration` / `platform` / `data_store`). They are distinct from the per-entry `status` field (operational state). Per-application nested `integrations[]` descriptors share the parent's lifecycle and carry no `valid_from` / `valid_to` of their own; when an integration is promoted to a top-level `type: integration` entry, it becomes a first-class lifecycle-bearing element with its own dates.
+`valid_from` / `valid_to` are required on every inline applications-catalogue entry per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7, regardless of `type` (`application` / `integration` / `platform` / `data_store`). They are distinct from the per-entry `status` field (operational state). Per-application nested `integrations[]` descriptors share the parent's lifecycle and carry no `valid_from` / `valid_to` of their own; when an integration is promoted to a top-level `type: integration` entry, it becomes a first-class lifecycle-bearing element with its own dates.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/blocks/README.md
+++ b/organizations/acme_corp/canon/views/blocks/README.md
@@ -6,7 +6,7 @@ Nested block diagrams — multi-level container layouts where you want to show *
 
 `*.blocks.transitrix.yaml`
 
-The notation is structured YAML: a `nested_blocks:` root with a recursive `block` tree (`id`, `name`, optional `description`, optional `children[]`). See [`notations/views/08-blocks.md`](../../../../notations/views/08-blocks.md) for the full spec.
+The notation is structured YAML: a `nested_blocks:` root with a recursive `block` tree (`id`, `name`, optional `description`, optional `children[]`). See [`notations/views/08-blocks.md`](../../../../../notations/views/08-blocks.md) for the full spec.
 
 ## Skeleton
 
@@ -44,11 +44,11 @@ Recommended maximum: **5 levels** (root = level 1). The validator warns at depth
 
 ## Cross-references
 
-A block's `id` MAY use the canonical `<TYPE>-…-<INTEGER>` form to cross-link into an organisational catalogue (`APPLICATION-OMS-1`, `CAPABILITY-V1.2`). Otherwise it is a document-local label and is accepted as-is. See [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md).
+A block's `id` MAY use the canonical `<TYPE>-…-<INTEGER>` form to cross-link into an organisational catalogue (`APPLICATION-OMS-1`, `CAPABILITY-V1.2`). Otherwise it is a document-local label and is accepted as-is. See [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md).
 
 ## Lifecycle
 
-When `block.id` cross-links into the catalogue (canonical `<TYPE>-…-<INTEGER>` form), the primitive lifecycle ([`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7) is borne by the target element's own file — the block here is a layout placement, not a separate element. When `block.id` is a document-local label, there is no canonical element to bear lifecycle and the block carries none. The nested_blocks document itself carries no lifecycle either — it is a view.
+When `block.id` cross-links into the catalogue (canonical `<TYPE>-…-<INTEGER>` form), the primitive lifecycle ([`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7) is borne by the target element's own file — the block here is a layout placement, not a separate element. When `block.id` is a document-local label, there is no canonical element to bear lifecycle and the block carries none. The nested_blocks document itself carries no lifecycle either — it is a view.
 
 ## Tooling
 
@@ -56,6 +56,6 @@ Rendered natively by Transitrix Studio — no external binaries required. The pr
 
 ## See also
 
-- [`notations/views/08-blocks.md`](../../../../notations/views/08-blocks.md) — the notation spec
-- [`notations/examples/blocks/architecture.blocks.transitrix.yaml`](../../../../notations/examples/blocks/architecture.blocks.transitrix.yaml) — worked example
+- [`notations/views/08-blocks.md`](../../../../../notations/views/08-blocks.md) — the notation spec
+- [`notations/examples/blocks/architecture.blocks.transitrix.yaml`](../../../../../notations/examples/blocks/architecture.blocks.transitrix.yaml) — worked example
 - `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/canon/views/bpmn/README.md
+++ b/organizations/acme_corp/canon/views/bpmn/README.md
@@ -17,7 +17,7 @@ Two starting templates ship with the methodology:
 
 ## Lifecycle
 
-BPMN files use **file-local labels** for their nodes (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) — per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §3.3 these are not canonical elements. Neither the BPMN nodes nor the BPMN file itself carries the primitive lifecycle ([`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7). The lifecycle of the process this BPMN represents lives on its corresponding `PROCESS-…` element in [`../processmap/`](../processmap/) — the BPMN is the detailed flow, not the lifecycle bearer.
+BPMN files use **file-local labels** for their nodes (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) — per [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.3 these are not canonical elements. Neither the BPMN nodes nor the BPMN file itself carries the primitive lifecycle ([`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7). The lifecycle of the process this BPMN represents lives on its corresponding `PROCESS-…` element in [`../processmap/`](../processmap/) — the BPMN is the detailed flow, not the lifecycle bearer.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/capabilities/README.md
+++ b/organizations/acme_corp/canon/views/capabilities/README.md
@@ -60,9 +60,9 @@ capability_map:
       valid_to: null
 ```
 
-`CAPABILITY-V1` / `CAPABILITY-V1.1` are canonical capability IDs (V/H sub-grammar per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §2); **every** capability, including children, carries `type` (required). The maturity history of an individual capability lives on its element file, not here.
+`CAPABILITY-V1` / `CAPABILITY-V1.1` are canonical capability IDs (V/H sub-grammar per [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §2); **every** capability, including children, carries `type` (required). The maturity history of an individual capability lives on its element file, not here.
 
-`valid_from` / `valid_to` are required on every inline capability (recursively, including nested `children[]`) per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. The capability-map document itself does not carry a lifecycle field. The notation-spec's "Planned" / "Active" / "Retired" state vocabulary ([`notations/views/05-capability-map.md`](../../../../notations/views/05-capability-map.md) §7) is a *derived view* over `valid_from` / `valid_to` + today's date — not a separate stored mechanism.
+`valid_from` / `valid_to` are required on every inline capability (recursively, including nested `children[]`) per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. The capability-map document itself does not carry a lifecycle field. The notation-spec's "Planned" / "Active" / "Retired" state vocabulary ([`notations/views/05-capability-map.md`](../../../../../notations/views/05-capability-map.md) §7) is a *derived view* over `valid_from` / `valid_to` + today's date — not a separate stored mechanism.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/fga/README.md
+++ b/organizations/acme_corp/canon/views/fga/README.md
@@ -41,7 +41,7 @@ activities:
     valid_to: null
 ```
 
-`valid_from` / `valid_to` are required on every inline element per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. The FGA document itself does not carry a lifecycle field — it is a view, not an element.
+`valid_from` / `valid_to` are required on every inline element per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. The FGA document itself does not carry a lifecycle field — it is a view, not an element.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/fgca/README.md
+++ b/organizations/acme_corp/canon/views/fgca/README.md
@@ -49,7 +49,7 @@ activities:
     valid_to: null
 ```
 
-`valid_from` / `valid_to` are required on every inline element per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. The FGCA document itself does not carry a lifecycle field — it is a view, not an element.
+`valid_from` / `valid_to` are required on every inline element per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. The FGCA document itself does not carry a lifecycle field — it is a view, not an element.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/goals/README.md
+++ b/organizations/acme_corp/canon/views/goals/README.md
@@ -47,7 +47,7 @@ goals:
     valid_to: null
 ```
 
-`valid_from` / `valid_to` are required on every inline goal entry per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. The `goal_types[]` entries are a static vocabulary, not elements, and do not carry lifecycle. The goals-tree document itself carries no lifecycle either — it is a view, not an element.
+`valid_from` / `valid_to` are required on every inline goal entry per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. The `goal_types[]` entries are a static vocabulary, not elements, and do not carry lifecycle. The goals-tree document itself carries no lifecycle either — it is a view, not an element.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/issues/README.md
+++ b/organizations/acme_corp/canon/views/issues/README.md
@@ -6,13 +6,13 @@ Register of issues — problems, defects, open questions — in a parent/child t
 
 `*.issues.transitrix.yaml`
 
-See [`notations/views/12-issues.md`](../../../../notations/views/12-issues.md) for the full spec.
+See [`notations/views/12-issues.md`](../../../../../notations/views/12-issues.md) for the full spec.
 
 ## Lifecycle
 
-Every inline issue entry under `issues[]` (`ISSUE` canonical TYPE per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §3.1) carries `valid_from` and `valid_to` per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. These are distinct from the issue's own `status` / `created_at` / `resolved_at` fields, which describe the issue-handling timeline (operational state). In typical practice `valid_from ≈ created_at` while the issue is open; closing the issue may or may not retire the artefact, depending on the organisation's archive policy. The issues-catalogue document itself carries no lifecycle.
+Every inline issue entry under `issues[]` (`ISSUE` canonical TYPE per [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1) carries `valid_from` and `valid_to` per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. These are distinct from the issue's own `status` / `created_at` / `resolved_at` fields, which describe the issue-handling timeline (operational state). In typical practice `valid_from ≈ created_at` while the issue is open; closing the issue may or may not retire the artefact, depending on the organisation's archive policy. The issues-catalogue document itself carries no lifecycle.
 
 ## See also
 
-- [`notations/examples/issues/`](../../../../notations/examples/issues/) — worked example
+- [`notations/examples/issues/`](../../../../../notations/examples/issues/) — worked example
 - `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/canon/views/process-blueprint/README.md
+++ b/organizations/acme_corp/canon/views/process-blueprint/README.md
@@ -6,18 +6,18 @@ Wide value-chain blueprint — stages laid out left-to-right, each carrying its 
 
 `*.process-blueprint.transitrix.yaml`
 
-See [`notations/views/13-process-blueprint.md`](../../../../notations/views/13-process-blueprint.md) for the full spec.
+See [`notations/views/13-process-blueprint.md`](../../../../../notations/views/13-process-blueprint.md) for the full spec.
 
 ## Lifecycle
 
 The blueprint's per-aspect arrays split for lifecycle purposes:
 
-- **Canonical-TYPE arrays** — `equipment[]` (`EQUIPMENT`) and `information_entities[]` (`INFORMATION_ENTITY`), both registered in [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §3.1. Each entry carries `valid_from` and `valid_to` per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7.
+- **Canonical-TYPE arrays** — `equipment[]` (`EQUIPMENT`) and `information_entities[]` (`INFORMATION_ENTITY`), both registered in [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1. Each entry carries `valid_from` and `valid_to` per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7.
 - **Document-local arrays** — `stages[]`, `systems[]`, `actors[]`. These use document-local identifiers (e.g. `STAGE-1`) that are not registered as canonical TYPEs and so carry no lifecycle of their own. When a `systems[]` or `actors[]` entry is intended to reference a registered element (an `APPLICATION-…` or `ROLE-…`), the lifecycle lives on that target's canonical file.
 
 The process-blueprint document itself carries no lifecycle.
 
 ## See also
 
-- [`notations/examples/process-blueprint/`](../../../../notations/examples/process-blueprint/) — worked example
+- [`notations/examples/process-blueprint/`](../../../../../notations/examples/process-blueprint/) — worked example
 - `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/canon/views/processmap/README.md
+++ b/organizations/acme_corp/canon/views/processmap/README.md
@@ -67,7 +67,7 @@ process_map:
 
 `process_id`, `owner_role`, and `capability` hold **element / capability IDs**, not display names.
 
-`valid_from` / `valid_to` are required on every inline process entry per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7 and are distinct from the per-process `status` (`Draft` / `Active` / `Deprecated`) which is an operational state. Process groups (`groups[]`) are organisational containers, not elements, and carry no lifecycle of their own; the process-map document itself carries none either.
+`valid_from` / `valid_to` are required on every inline process entry per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7 and are distinct from the per-process `status` (`Draft` / `Active` / `Deprecated`) which is an operational state. Process groups (`groups[]`) are organisational containers, not elements, and carry no lifecycle of their own; the process-map document itself carries none either.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/products/README.md
+++ b/organizations/acme_corp/canon/views/products/README.md
@@ -47,7 +47,7 @@ products_catalogue:
 
 `capabilities`, `processes`, and `supporting_apps` hold **element IDs** (`CAPABILITY-V1`, `PROC-…`, `APP-…`), not display names — the catalogue references the elements, it does not duplicate them.
 
-`valid_from` / `valid_to` are required on every inline product entry per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7 and are distinct from the per-product `status` field (`Active` / `Deprecated`), which is an operational state. The products-catalogue document itself does not carry a lifecycle field.
+`valid_from` / `valid_to` are required on every inline product entry per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7 and are distinct from the per-product `status` field (`Active` / `Deprecated`), which is an operational state. The products-catalogue document itself does not carry a lifecycle field.
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/scenarios/README.md
+++ b/organizations/acme_corp/canon/views/scenarios/README.md
@@ -6,13 +6,13 @@ Alternative strategic development paths — each scenario scopes its own goals, 
 
 `*.scenarios.transitrix.yaml`
 
-See [`notations/views/11-scenarios.md`](../../../../notations/views/11-scenarios.md) for the full spec.
+See [`notations/views/11-scenarios.md`](../../../../../notations/views/11-scenarios.md) for the full spec.
 
 ## Lifecycle
 
-Every inline scenario entry (`SCENARIO` canonical TYPE per [`notations/IDS_AND_REFERENCES.md`](../../../../notations/IDS_AND_REFERENCES.md) §3.1) carries `valid_from` and `valid_to` in its frontmatter per [`notations/CONTRACT.md`](../../../../notations/CONTRACT.md) §7. These mark the period the scenario itself is admitted as a planning consideration — distinct from any time horizon the scenario's narrative may describe (e.g. "scenario for 2027"). The scenario-scoped goals / capabilities / activities / products / processes / applications are references to other canonical elements; their lifecycle lives on each target's own canonical file. The scenarios document itself carries no lifecycle.
+Every inline scenario entry (`SCENARIO` canonical TYPE per [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1) carries `valid_from` and `valid_to` in its frontmatter per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. These mark the period the scenario itself is admitted as a planning consideration — distinct from any time horizon the scenario's narrative may describe (e.g. "scenario for 2027"). The scenario-scoped goals / capabilities / activities / products / processes / applications are references to other canonical elements; their lifecycle lives on each target's own canonical file. The scenarios document itself carries no lifecycle.
 
 ## See also
 
-- [`notations/examples/scenarios/`](../../../../notations/examples/scenarios/) — worked examples
+- [`notations/examples/scenarios/`](../../../../../notations/examples/scenarios/) — worked examples
 - `method/methodology.md` §6 — notation kit


### PR DESCRIPTION
## What

Worked-example consistency cleanup exposed by the element-primitive epic (#79/#80). Three independent commits, one concern each (strategy#103 items 1-3):

1. **Fix off-by-one in example-README `notations/` links** — element-folder READMEs used 5 `../` (need 6), view READMEs used 4 (need 5); all resolved to a non-existent `organizations/notations/`. Anchored on the markdown `](` so the correct 6-up links added in #80 are untouched. **Verified: all 120 `notations/` links across 26 READMEs resolve.**
2. **Backfill `notation:` + admission record on the CONSTRAINT / RULE examples** — `CONSTRAINT-GDPR-RESIDENCY-1` and `RULE-DUAL-APPROVAL-1` predated the header/admission contract (the only element files missing the full envelope). Added `notation:` + admission record; dropped the redundant `type:` (the TYPE is carried by `notation` + ID prefix + folder, per ELEMENT_PRIMITIVES.md §3/§7.12-7.13). Updated the two folder READMEs to match.
3. **Migrate REQUIREMENT `title` → `name`** — per the single-label-field decision (strategy#102): `name` is canonical, no aliases. Renamed in `15-requirement.md` (field row, example, REQ-001 list), the two example files, and the README.

## Verification

- **Whole `canon/elements/` tree now validates against the ELEMENT_PRIMITIVES.md §3 envelope: 36/36 files clean** (was 4 with gaps).
- All 120 `notations/` README links resolve.

## Scope

Item 4 of #103 (reconcile `.templates/` + residual `APP-`/`PROC-` in onboarding prose — the F-1 follow-up) is **not** in this PR; it's larger and tracked separately. Adopter-facing migration recipe for `title→name` stays under the upgrade-path epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
