### PR TITLE
docs(acme): reconcile copy-and-fill templates to canonical schema (strategy#103 item 4 pt1)

### DIFF
--- a/organizations/acme_corp/.templates/capability-map_template.yaml
+++ b/organizations/acme_corp/.templates/capability-map_template.yaml
@@ -24,10 +24,10 @@ capability_map:
       current_maturity: 2              # CMM level 1–5 (REQUIRED)
       target_maturity: 3               # optional
       target_date: "2026-12-31"        # optional, YYYY-MM-DD
-      owner_role: "ROLE-XXX-1"         # optional — BusinessRole element ID
-      business_process: "PROC-XXX-1"   # optional — BusinessProcess element ID
-      applications:                    # optional — ApplicationComponent element IDs
-        - "APP-XXX-1"
+      owner_role: "ROLE-XXX-1"         # optional — ROLE element ID
+      business_process: "PROCESS-XXX-1" # optional — PROCESS element ID
+      applications:                    # optional — APPLICATION element IDs
+        - "APPLICATION-XXX-1"
       children:                        # optional — nested capabilities (same fields)
         - id: "CAPABILITY-V1.1"
           name: "<Child capability>"

--- a/organizations/acme_corp/.templates/elements/01_motivation_template.yaml
+++ b/organizations/acme_corp/.templates/elements/01_motivation_template.yaml
@@ -1,30 +1,38 @@
-# Transitrix Element Template: Motivation Layer
-# Purpose: Capture business drivers, goals, principles, and constraints
-# Location: elements/01_motivation/
-# Naming Convention: [TYPE]-[SHORT_CODE].yaml (e.g., GOAL-PERF-001.yaml)
+# Transitrix element-primitive template — Motivation layer (01_motivation)
+# Canonical schema: notations/ELEMENT_PRIMITIVES.md §3 (common envelope) + the
+# per-TYPE field sets in §7. One element per file, at
+#   canon/elements/01_motivation/<plural-type>/<ID>.yaml
+#
+# TYPEs in this layer:
+#   FACTOR       notation: factor        folder factors/       fields: ELEMENT_PRIMITIVES.md §7.1
+#   GOAL         notation: goal          folder goals/         fields: §7.2
+#   CONSTRAINT   notation: constraint    folder constraints/   fields: §7.13
+#   REQUIREMENT  notation: requirement   folder requirements/  fields: notations/elements/15-requirement.md
+#
+# Worked examples: organizations/acme_corp/canon/elements/01_motivation/.
+# Copy the envelope below, set notation/id/name, and add the per-TYPE fields.
 
-id: "GOAL-XXX-001"
-name: "Business Goal Name"
-type: "Goal"  # Valid types: Goal, Principle, Constraint, Driver, Outcome, Value
-layer: "Motivation"
+notation: goal                         # element TYPE short name (lowercased TYPE)
+id: GOAL-EXAMPLE-1                      # canonical ID — IDS_AND_REFERENCES.md §1 (no leading zeros)
+name: "Human-readable label"           # single label field — no `title` alias (§3)
+# type: "Strategic Goal"               # per-TYPE subtype where defined (FACTOR: external|internal; GOAL: goal-type label)
+description: >
+  One-paragraph elaboration.
 
-metadata:
-  status: "Draft"  # Values: Draft, Active, Deprecated, Archived
-  owner: "firstname.lastname"
-  created_at: "2026-05-03"
-  updated_at: "2026-05-03"
-  tags: ["strategic", "performance"]
+# ── per-TYPE fields (ELEMENT_PRIMITIVES.md §7) ──
+# GOAL:        factors: [FACTOR-…]            (parent is a time-aware REL, not inline — §7.2)
+# FACTOR:      references_constraint: [CONSTRAINT-…]
+# CONSTRAINT / REQUIREMENT: statement / derived_from / severity / source / owner_role …
 
-properties:
-  description: "Clear and concise description of the business goal"
-  scope: "Enterprise"  # Values: Enterprise, Department, Team, Project
-  priority: "High"  # Values: Critical, High, Medium, Low
-  timeline: "2026-Q3"
-  success_criteria:
-    - "Measurable metric 1"
-    - "Measurable metric 2"
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-01-01"              # quoted ISO 8601 (CONTRACT.md §4)
+admitted_by: "firstname.lastname"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
 
-# Optional references to stakeholders or related elements
-references:
-  stakeholders: []  # List of person/role IDs who are accountable
-  related_goals: []  # IDs of other Goal elements
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-01-01"
+valid_to: null

--- a/organizations/acme_corp/.templates/elements/02_business_template.yaml
+++ b/organizations/acme_corp/.templates/elements/02_business_template.yaml
@@ -1,44 +1,44 @@
-# Transitrix Element Template: Business Layer
-# Purpose: Capture business roles, actors, processes, and functions
-# Location: elements/02_business/
-# Naming Convention: [TYPE]-[SHORT_CODE].yaml (e.g., ROLE-SALES-001.yaml, PROC-ORD-001.yaml)
+# Transitrix element-primitive template — Business layer (02_business)
+# Canonical schema: notations/ELEMENT_PRIMITIVES.md §3 (common envelope) + the
+# per-TYPE field sets in §7. One element per file, at
+#   canon/elements/02_business/<plural-type>/<ID>.yaml
+#
+# TYPEs in this layer:
+#   CAPABILITY   notation: capability   folder capabilities/  fields: notations/views/05-capability-map.md §13
+#   PROCESS      notation: process      folder processes/     fields: ELEMENT_PRIMITIVES.md §7.5
+#   PRODUCT      notation: product      folder products/      fields: §7.6
+#   ROLE         notation: role         folder roles/         fields: §7.9
+#   UNIT         notation: unit         folder units/         fields: §7.10
+#   EMPLOYEE     notation: employee     folder employees/     fields: §7.11
+#   RULE         notation: rule         folder rules/         fields: §7.12
+#
+# Worked examples: organizations/acme_corp/canon/elements/02_business/.
+# CAPABILITY uses the V/H ID sub-grammar (IDS §2); its time-varying attributes
+# (current_maturity, owner_role, target_date) live in a <id>.history.yaml sidecar
+# (CONTRACT.md §9), never inline.
 
-id: "ROLE-XXX-001"
-name: "Business Role / Function / Process Name"
-type: "BusinessRole"  # Valid types: BusinessRole, BusinessActor, BusinessProcess, BusinessFunction, Service
-layer: "Business"
+notation: process                      # element TYPE short name (lowercased TYPE)
+id: PROCESS-EXAMPLE-1                   # canonical ID — IDS_AND_REFERENCES.md §1
+name: "Human-readable label"
+# type: "digital_product"              # per-TYPE subtype where defined (PRODUCT, APPLICATION)
+description: >
+  One-paragraph elaboration.
 
-metadata:
-  status: "Draft"  # Values: Draft, Active, Deprecated, Archived
-  owner: "firstname.lastname"
-  created_at: "2026-05-03"
-  updated_at: "2026-05-03"
-  tags: ["business", "core"]
+# ── per-TYPE fields (ELEMENT_PRIMITIVES.md §7) ──
+# PROCESS:  owner_role: ROLE-… ; capability: CAPABILITY-… ; maturity: 1-5 ; bpmn_file: …
+# PRODUCT:  type ; capabilities: [CAPABILITY-…] ; processes: [PROCESS-…] ; supporting_apps: [APPLICATION-…]
+# ROLE / UNIT / EMPLOYEE:  responsibility_area / unit / roles …
+# RULE:     statement ; applies_to: [PROCESS-…|APPLICATION-…] ; severity ; source ; owner_role
 
-properties:
-  description: "Detailed description of the business element"
-  scope: "Organization unit or process scope"
-  criticality: "Medium"  # Values: Critical, High, Medium, Low
-  responsibility_area: "Explicit domain or function area"
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-01-01"              # quoted ISO 8601 (CONTRACT.md §4)
+admitted_by: "firstname.lastname"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
 
-  # For BusinessProcess: define key steps or activities
-  process_steps: []  # Reference to BPMN process or sequential steps
-
-  # For BusinessRole: define competencies and capabilities
-  competencies: []
-
-  # For BusinessFunction: define inputs and outputs
-  inputs: []
-  outputs: []
-
-# Metadata about governance
-governance:
-  approval_required: false
-  compliance_frameworks: []  # e.g., GDPR, SOC2, ISO27001
-  audit_frequency: "Annual"  # e.g., Annual, Quarterly, Continuous
-
-# Optional references to stakeholders or related elements
-references:
-  responsible_parties: []  # IDs of roles/actors
-  related_processes: []
-  parent_function: null  # ID of parent function if hierarchical
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-01-01"
+valid_to: null

--- a/organizations/acme_corp/.templates/elements/03_application_template.yaml
+++ b/organizations/acme_corp/.templates/elements/03_application_template.yaml
@@ -1,58 +1,38 @@
-# Transitrix Element Template: Application Layer
-# Purpose: Capture application components, services, and interfaces
-# Location: elements/03_application/
-# Naming Convention: [TYPE]-[SHORT_CODE].yaml (e.g., APP-SRVC-001.yaml, INTFC-API-001.yaml)
+# Transitrix element-primitive template — Application layer (03_application)
+# Canonical schema: notations/ELEMENT_PRIMITIVES.md §3 (common envelope) + the
+# per-TYPE field sets in §7. One element per file, at
+#   canon/elements/03_application/<plural-type>/<ID>.yaml
+#
+# TYPEs in this layer:
+#   APPLICATION  notation: application   folder applications/  fields: ELEMENT_PRIMITIVES.md §7.7
+#   INTEGRATION  notation: integration   folder integrations/  fields: §7.8 (view-defined/nested in v1; promotable)
+#
+# Worked examples: organizations/acme_corp/canon/elements/03_application/.
+# Time-varying fields (owner_role, vendor, lifecycle_stage, maturity) live in a
+# <id>.history.yaml sidecar (CONTRACT.md §9), never inline (would trigger VERSIONED-004).
 
-id: "APP-XXX-001"
-name: "Application Service / Component Name"
-type: "ApplicationComponent"  # Valid types: ApplicationComponent, ApplicationService, DataObject, ApplicationInterface
-layer: "Application"
+notation: application                  # element TYPE short name (lowercased TYPE)
+id: APPLICATION-EXAMPLE-1              # canonical ID — IDS_AND_REFERENCES.md §1
+name: "Human-readable label"
+type: application                      # application | integration | platform | data_store (REQUIRED)
+description: >
+  One-paragraph elaboration.
 
-metadata:
-  status: "Draft"  # Values: Draft, Active, Deprecated, Archived
-  owner: "firstname.lastname"
-  created_at: "2026-05-03"
-  updated_at: "2026-05-03"
-  tags: ["microservice", "api"]
+# ── per-TYPE fields (ELEMENT_PRIMITIVES.md §7.7) ──
+# domain: "…"
+# capabilities: [CAPABILITY-…]
+# products: [PRODUCT-…]
+# (owner_role / vendor / lifecycle_stage / maturity are time-varying — sidecar, not inline)
 
-properties:
-  description: "Clear and concise description of the application component"
-  criticality: "High"  # Values: Critical, High, Medium, Low
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-01-01"              # quoted ISO 8601 (CONTRACT.md §4)
+admitted_by: "firstname.lastname"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
 
-  # Technical stack and implementation details
-  tech_stack: "Technology/Framework (e.g., Python 3.12, FastAPI)"
-  programming_language: "Python"  # e.g., Python, Java, Go, Node.js
-  repository_url: "https://github.com/org/repo"  # Git repository URL
-
-  # Service/API specifics
-  api_type: "REST"  # Values: REST, GraphQL, gRPC, SOAP, Async
-  api_endpoints: []  # e.g., GET /api/v1/products, POST /api/v1/orders
-
-  # Data scope
-  data_classification: "Internal"  # Values: Public, Internal, Confidential, Restricted
-
-  # Operational characteristics
-  deployment_model: "Kubernetes"  # e.g., Kubernetes, EC2, Serverless, On-Premises
-  scaling_strategy: "Horizontal"  # Values: Horizontal, Vertical, Mixed, Fixed
-  sla_availability: "99.9%"
-
-# Version and build information
-versioning:
-  current_version: "1.0.0"
-  release_cycle: "Continuous"  # Values: Continuous, Sprint, Fixed Release, On-Demand
-
-# Dependencies and integrations
-dependencies: []  # IDs of other ApplicationComponents this depends on
-integrations: []  # IDs of external systems or services
-
-# Quality and testing
-quality_attributes:
-  test_coverage: "0%"  # Percentage
-  security_scanning: false
-  performance_tested: false
-
-# Optional governance
-governance:
-  change_control_required: true
-  approval_required: false
-  build_pipeline: "CI/CD Pipeline name"
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-01-01"
+valid_to: null

--- a/organizations/acme_corp/.templates/elements/04_technology_template.yaml
+++ b/organizations/acme_corp/.templates/elements/04_technology_template.yaml
@@ -1,75 +1,32 @@
-# Transitrix Element Template: Technology Layer
-# Purpose: Capture infrastructure nodes, systems software, and artifacts
-# Location: elements/04_technology/
-# Naming Convention: [TYPE]-[SHORT_CODE].yaml (e.g., NODE-DB-001.yaml, ARTIFACT-IMG-001.yaml)
+# Transitrix element-primitive template — Technology layer (04_technology)
+#
+# NOTE: the TYPE registry (notations/IDS_AND_REFERENCES.md §3.1) does not yet
+# register any element TYPE for the technology layer. The layer folder exists
+# for forward compatibility; when a technology-layer TYPE is registered it will
+# follow the common envelope below (ELEMENT_PRIMITIVES.md §3), one element per
+# file at canon/elements/04_technology/<plural-type>/<ID>.yaml.
+#
+# Until then, do not author technology-layer element files — there is no
+# canonical TYPE prefix to use. (The legacy ArchiMate Node / SystemSoftware /
+# Artifact shape this template previously carried has been removed; it predated
+# the canonical schema and is not part of the registry.)
 
-id: "NODE-XXX-001"
-name: "Infrastructure Node / System / Artifact Name"
-type: "Node"  # Valid types: Node, SystemSoftware, Artifact, Device, CommunicationPath
-layer: "Technology"
-
-metadata:
-  status: "Draft"  # Values: Draft, Active, Deprecated, Archived
-  owner: "firstname.lastname"
-  created_at: "2026-05-03"
-  updated_at: "2026-05-03"
-  tags: ["infrastructure", "database"]
-
-properties:
-  description: "Detailed description of the technology element"
-  criticality: "High"  # Values: Critical, High, Medium, Low
-
-  # Infrastructure specifics
-  infrastructure_type: "Compute"  # Values: Compute, Storage, Database, Network, Security, Monitoring
-  deployment_location: "AWS us-east-1"  # Cloud region or data center
-  environment: "Production"  # Values: Development, Staging, Production
-  instance_count: 3
-
-  # Capacity and performance
-  cpu_cores: 8
-  memory_gb: 32
-  storage_gb: 500
-  network_throughput_mbps: 1000
-
-  # Vendor and licensing
-  vendor: "AWS / Azure / GCP / On-Premises"
-  product_name: "RDS PostgreSQL 15.x"
-  license_type: "Commercial"  # Values: Commercial, Open Source, Proprietary, Trial
-  license_expiry: "2027-12-31"
-
-  # Maintenance and support
-  support_level: "Premium"  # Values: Standard, Premium, Enterprise, Community
-  maintenance_window: "Sunday 02:00-06:00 UTC"
-  end_of_life: "2028-12-31"
-
-  # Security and compliance
-  encryption_at_rest: true
-  encryption_in_transit: true
-  security_certifications: ["ISO27001", "SOC2"]
-  backup_strategy: "Daily incremental, weekly full"
-  disaster_recovery_plan: "RTO: 4h, RPO: 1h"
-
-# Capacity planning
-capacity:
-  current_utilization_percent: 0
-  max_capacity_threshold_percent: 80
-  growth_projection_percent_per_year: 15
-
-# Operational metadata
-operations:
-  monitoring_tool: "Datadog / Prometheus / CloudWatch"
-  log_retention_days: 90
-  metrics_retention_days: 365
-  alerting_enabled: true
-
-# Cost allocation
-cost_allocation:
-  monthly_cost_usd: 0
-  cost_center: "Infrastructure"
-  chargeback_model: "Shared"  # Values: Shared, Direct, Tiered, Free
-
-# Related elements
-references:
-  parent_node: null  # ID of parent node if hierarchical
-  connected_nodes: []  # IDs of other nodes
-  hosted_applications: []  # IDs of ApplicationComponents running on this node
+# Common envelope to use once a technology TYPE is registered:
+#
+# notation: <type>                     # lowercased registry TYPE
+# id: <TYPE>-EXAMPLE-1                  # canonical ID — IDS_AND_REFERENCES.md §1
+# name: "Human-readable label"
+# description: >
+#   One-paragraph elaboration.
+#
+# # per-TYPE fields per ELEMENT_PRIMITIVES.md §7
+#
+# # Admission record (CONTRACT.md §6)
+# zone: canon
+# admitted_at: "2026-01-01"
+# admitted_by: "firstname.lastname"
+# gate_checks: { uniqueness: pass, consistency: pass, completeness: pass }
+#
+# # Primitive lifecycle (CONTRACT.md §7)
+# valid_from: "2026-01-01"
+# valid_to: null

--- a/organizations/acme_corp/.templates/elements/05_implementation_template.yaml
+++ b/organizations/acme_corp/.templates/elements/05_implementation_template.yaml
@@ -1,0 +1,36 @@
+# Transitrix element-primitive template — Implementation & Migration layer (05_implementation)
+# Canonical schema: notations/ELEMENT_PRIMITIVES.md §3 (common envelope) + §6.1
+# (layer rationale) + the per-TYPE field sets in §7. One element per file, at
+#   canon/elements/05_implementation/<plural-type>/<ID>.yaml
+#
+# TYPEs in this layer:
+#   ACTIVITY  notation: activity  folder activities/  fields: ELEMENT_PRIMITIVES.md §7.4  (ArchiMate Work Package; recursive via parent)
+#   CHANGE    notation: change    folder changes/     fields: §7.3                       (ArchiMate Gap; multi-scale via parent)
+#   MILESTONE folder milestones/ reserved (§6.2) — standalone registration owned by the MILESTONE TYPE task
+#
+# Worked examples: organizations/acme_corp/canon/elements/05_implementation/.
+
+notation: activity                     # element TYPE short name (lowercased TYPE)
+id: ACTIVITY-EXAMPLE-1                  # canonical ID — IDS_AND_REFERENCES.md §1
+name: "Human-readable label"
+description: >
+  One-paragraph elaboration.
+
+# ── per-TYPE fields (ELEMENT_PRIMITIVES.md §7) ──
+# ACTIVITY:  duration_days ; goals: [GOAL-…] ; delivers_changes: [CHANGE-…] ;
+#            predecessors: [ACTIVITY-…] (inline/timeless) ; parent: ACTIVITY-… ;
+#            start_date / end_date (schedule — distinct from valid_from/valid_to)
+# CHANGE:    goals: [GOAL-…] ; parent: CHANGE-… (multi-scale decomposition)
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-01-01"              # quoted ISO 8601 (CONTRACT.md §4)
+admitted_by: "firstname.lastname"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-01-01"
+valid_to: null

--- a/organizations/acme_corp/.templates/relations/relation_template.yaml
+++ b/organizations/acme_corp/.templates/relations/relation_template.yaml
@@ -1,60 +1,27 @@
-# Transitrix Relation Template
-# Purpose: Describe relationships and connections between architecture elements
-# Location: relations/
-# Naming Convention: [SOURCE_TYPE]-[TARGET_TYPE]-[SEQUENCE].yaml (e.g., APP-NODE-001.yaml, PROC-ROLE-001.yaml)
-# Important: Relations are ATOMIC - no relations inside element files, only in this dedicated directory
+# Transitrix relation template — first-class time-aware relation (REL)
+# Canonical schema: notations/elements/17-relations.md §2.
+# Location: canon/relations/<ID>.yaml  (flat folder; one relation per file)
+# Worked examples: organizations/acme_corp/canon/relations/REL-CAP-V11-PARENT-*.yaml
+#
+# A relation is a directed link from `from` to `to`, tagged with a `type` from the
+# closed enum (§3), carrying its own lifecycle window. Re-linking (e.g. a capability
+# re-parented) ends one relation (valid_to set) and starts a new one.
 
-id: "REL-XXX-001"
+notation: relation
+id: REL-EXAMPLE-1                       # canonical ID — IDS_AND_REFERENCES.md §1: REL-[<middle>-]<INTEGER>
+type: parent                            # closed enum (§3): parent | goal_parent | activity_goal | unit_parent
+from: CAPABILITY-V1.1                   # source / child primitive — must resolve in canon (REL-002)
+to: CAPABILITY-V1                       # target / parent primitive — must resolve in canon (REL-002)
 
-# Source and Target MUST reference valid element IDs
-source:
-  id: "APP-SRVC-001"  # ID of source element
-  type: "ApplicationComponent"  # Type helps validate relation logic
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-01-01"               # quoted ISO 8601 (CONTRACT.md §4)
+admitted_by: "firstname.lastname"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
 
-target:
-  id: "NODE-DB-001"  # ID of target element
-  type: "Node"  # Type helps validate relation logic
-
-# Relationship type from ArchiMate 3.2 specification
-# Common types: Serving, Assignment, Realization, Access, Composition, Aggregation,
-#             Triggering, Flow, Specialization, Association, Influence, Junction
-type: "Access"  # Must align with ArchiMate semantics
-
-metadata:
-  status: "Draft"  # Values: Draft, Active, Deprecated
-  created_at: "2026-05-03"
-  updated_at: "2026-05-03"
-  created_by: "firstname.lastname"
-
-# Relationship specifics
-properties:
-  description: "Detailed description of the relationship and its purpose"
-  criticality: "High"  # Values: Critical, High, Medium, Low
-
-  # Communication and protocol details
-  protocol: "TCP/IP"  # e.g., TCP/IP, HTTP/S, gRPC, AMQP, SQL
-  port: 5432
-  encrypted: true
-
-  # Data flow characteristics
-  data_classification: "Internal"  # Values: Public, Internal, Confidential, Restricted
-  data_volume_per_day_gb: 50
-  synchronous: true  # true = synchronous, false = asynchronous
-
-  # Performance characteristics
-  expected_latency_ms: 100
-  throughput_requests_per_second: 1000
-
-# Governance and risk
-governance:
-  change_control_required: true
-  approval_required: false
-  impact_analysis_required: true
-
-# Optional conditional or temporal information
-conditions: []  # e.g., ["Only during business hours", "For audit purposes"]
-
-# References to related relations or dependencies
-references:
-  depends_on: []  # IDs of other relations that must exist first
-  conflicts_with: []  # IDs of incompatible relations
+# Primitive lifecycle (CONTRACT.md §7) — the relation's own window
+valid_from: "2026-01-01"
+valid_to: null


### PR DESCRIPTION
## What

Item 4 of strategy#103 (the F-1 follow-up), **part 1**: reconcile the copy-and-fill **config templates** adopters instantiate to the canonical post-CONTRACT schema. The stale templates used ArchiMate type names (`Goal`, `BusinessRole`, `Node`), zero-padded non-canonical IDs (`GOAL-XXX-001`), and `metadata`/`properties` wrappers — contradicting `ELEMENT_PRIMITIVES.md` (see its §5 reconciliation table).

- **Element templates** (`.templates/elements/`): `01_motivation`, `02_business`, `03_application` rewritten to the §3 envelope (`notation` + canonical `id` + admission record + lifecycle), annotated per layer with each TYPE's `notation`/folder/§7 field-set reference. Added **`05_implementation_template.yaml`** for the new layer (ACTIVITY/CHANGE). **`04_technology_template.yaml`** reduced to a stub — no element TYPE is registered for the technology layer yet (IDS §3.1).
- **`capability-map_template.yaml`**: `PROC-`/`APP-` cross-refs → canonical `PROCESS-`/`APPLICATION-`.
- **`relations/relation_template.yaml`**: rewritten to the canonical REL shape (`17-relations.md` §2 — `notation`/`type`-enum/`from`/`to`/admission/lifecycle), replacing the pre-canon `source`/`target` + ArchiMate-relationship-type model.

## Verification

All touched templates parse; none carries a non-canonical ID, ArchiMate type name, or `metadata`/`properties` wrapper.

## Scope / deferred (part 2)

The remaining item-4 surface — the old-model **teaching docs** (`.templates/EXAMPLES.md` ~560 lines, `CONVENTIONS.md`, `GETTING_STARTED.md`, `README.md`) and the **bpmn templates** — teach the old ArchiMate model end-to-end (relations, technology nodes, old ID convention) and are a near-rewrite, not a cleanup. Deferring to a dedicated task rather than bloating this PR (one-concern rule). Tracked on strategy#103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
