### PR TITLE
test(onboarding): from-scratch install test for the onboarding Skill (strategy#56)

### DIFF
--- a/.github/workflows/onboarding-skill-test.yml
+++ b/.github/workflows/onboarding-skill-test.yml
@@ -1,0 +1,65 @@
+name: Onboarding Skill install test
+
+# From-scratch install test for the Transitrix Onboarding Skill (strategy#56).
+# Proves a first-time user can install the Skill against a clean workspace and
+# end up with a working, canon-valid repo. Implementation + harness rationale:
+# skills/onboarding/tests/README.md.
+#
+# Two jobs:
+#   integrity  — deterministic, no API key. Runs on every PR touching the Skill,
+#                the weekly cron, and manual dispatch. CI is red on any break.
+#   e2e-drive  — true LLM drive (needs ANTHROPIC_API_KEY). Cron / dispatch only;
+#                skips green when the secret is absent.
+
+on:
+  pull_request:
+    paths:
+      - 'skills/onboarding/**'
+      - '.github/workflows/onboarding-skill-test.yml'
+  workflow_dispatch:
+  schedule:
+    # Mondays 09:15 UTC — weekly safety net (incl. the full LLM drive).
+    - cron: '15 9 * * 1'
+
+jobs:
+  integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Run Skill install test (deterministic)
+        run: python skills/onboarding/tests/test_skill_integrity.py
+
+  e2e-drive:
+    # True LLM end-to-end drive — only on the weekly cron and manual dispatch,
+    # never on PRs (no API key in PR CI). Skips green if the secret is absent.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Drive the Skill end-to-end
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: python skills/onboarding/tests/drive_skill_e2e.py

--- a/skills/onboarding/tests/README.md
+++ b/skills/onboarding/tests/README.md
@@ -1,0 +1,56 @@
+# Onboarding Skill — install / end-to-end tests
+
+These tests guard the property the whole onboarding epic exists for: **a first-time
+user can install the Skill against a clean workspace and end up with a working,
+canon-valid Transitrix repo.** If the Skill silently breaks against a clean install
+— a missing template, a header that no longer matches, a starter file that no longer
+parses — the publish-to-marketplace flow would ship a broken artefact. These tests
+fail loudly first.
+
+## Two modes (harness choice)
+
+A true "drive the Skill" run requires an LLM agent (the Skill is an `SKILL.md` protocol
+an agent interprets), which needs an API key. PR CI must run without one. So the suite
+is split:
+
+| Script | What it does | API key | Where it runs |
+|---|---|---|---|
+| `test_skill_integrity.py` | **Deterministic Skill-correctness guard.** Verifies the bundle is intact; every template `SKILL.md` references exists, parses, and carries the matching canonical `notation:` header; then performs a clean install into an ephemeral `HOME` and the representative **Goals** drive (scaffold the zoned skeleton + instantiate the Goals starter) into an empty repo, asserting the result validates. | none | **every PR** touching `skills/onboarding/**`, and the weekly cron |
+| `drive_skill_e2e.py` | **True LLM end-to-end drive.** Installs the bundle, hands an agent a synthetic persona prompt with no human-in-the-loop, lets it run the six-step flow via the `claude` CLI, then runs the same structural assertions against the produced repo. | required | **weekly cron only** (skips gracefully — exit 0 — when the key or CLI is absent) |
+
+**Language: Python (stdlib + PyYAML).** The repo has no Node toolchain, and the test
+needs YAML parsing + structural assertions — Python stdlib covers the clean-workspace /
+install / file-tree work and PyYAML the parsing. No other dependency.
+
+## The `@transitrix/diagrams` validator stand-in
+
+The acceptance criterion asks that authored files "parse cleanly under
+`@transitrix/diagrams/<notation>/validateXxx`". That package ships separately and is
+**not vendored into this repo**, so `test_skill_integrity.py` implements `validate_goals()`
+— a structural check of the invariants the canonical `validateGoals` enforces (header,
+`goal_types`/`goals` shape, type↔level agreement, parent resolution + strict N+1
+`GOALS-012`, canonical ID grammar). When `@transitrix/diagrams` is available in CI,
+swap `validate_goals()` for the real parser; the call site and assertions stay the same.
+
+Per the epic's "one representative path" scope, only the **Goals** notation is driven
+here (the simplest); the other notations are covered by `@transitrix/diagrams`' own
+test suite.
+
+## Run locally
+
+```bash
+pip install pyyaml
+python skills/onboarding/tests/test_skill_integrity.py          # always
+ANTHROPIC_API_KEY=… python skills/onboarding/tests/drive_skill_e2e.py   # full LLM drive
+```
+
+Exit `0` = pass; `1` = a check failed, with the failing assertion (and, for Goals, the
+specific validation error) printed so the problem is localisable without a debugger.
+
+## CI
+
+`.github/workflows/onboarding-skill-test.yml`:
+- **`integrity`** job — runs `test_skill_integrity.py` on every PR touching
+  `skills/onboarding/**`, on the weekly cron, and on manual dispatch.
+- **`e2e-drive`** job — runs `drive_skill_e2e.py` only on the weekly cron / manual
+  dispatch, with `ANTHROPIC_API_KEY` from repo secrets. Absent the secret it skips green.

--- a/skills/onboarding/tests/drive_skill_e2e.py
+++ b/skills/onboarding/tests/drive_skill_e2e.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""True end-to-end LLM drive of the Transitrix Onboarding Skill (strategy#56).
+
+Unlike test_skill_integrity.py (deterministic, no key), this script drives the
+Skill the way a real newcomer would: it installs the bundle into an ephemeral
+HOME, then hands an agent a synthetic persona prompt ("model a Goals tree for a
+2026 strategy") and lets it execute the six-step SKILL.md flow with no
+human-in-the-loop. It then runs the SAME structural assertions as the
+deterministic test against the produced repo.
+
+This is the weekly-cron path — it needs an API key and the `claude` CLI. It is
+NOT run in PR CI (see tests/README.md and the workflow). It skips gracefully —
+exit 0 — when the key or the CLI is absent, so it never red-flags CI for an
+infra reason; the cron run with the secret is where it actually exercises.
+
+Run:  ANTHROPIC_API_KEY=… python skills/onboarding/tests/drive_skill_e2e.py
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import test_skill_integrity as guard  # reuse install layout + validate_goals
+
+PERSONA_PROMPT = (
+    "Use the Transitrix onboarding skill. I'm a first-time user. Set up a new "
+    "Transitrix repo in ./target-repo for an organisation called 'northwind', "
+    "and create a starter Goals tree for our 2026 strategy. Pick sensible "
+    "placeholder goals; don't ask me questions — proceed end to end."
+)
+
+
+def _skip(reason):
+    print(f"SKIP — e2e LLM drive not run: {reason}")
+    print("       (this is expected in PR CI; the weekly cron runs it with the API-key secret.)")
+    return 0
+
+
+def main():
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return _skip("ANTHROPIC_API_KEY not set")
+    if shutil.which("claude") is None:
+        return _skip("`claude` CLI not found on PATH")
+
+    work = tempfile.mkdtemp(prefix="transitrix-e2e-")
+    try:
+        # Clean ephemeral HOME with only the skill installed.
+        home = os.path.join(work, "home")
+        installed = os.path.join(home, ".claude", "skills", "transitrix-onboard")
+        os.makedirs(os.path.dirname(installed), exist_ok=True)
+        shutil.copytree(guard.SKILL_DIR, installed)
+
+        env = dict(os.environ, HOME=home)
+        # Headless, non-interactive run inside the temp workspace.
+        proc = subprocess.run(
+            ["claude", "-p", PERSONA_PROMPT, "--dangerously-skip-permissions"],
+            cwd=work, env=env, capture_output=True, text=True, timeout=900,
+        )
+        sys.stdout.write(proc.stdout[-4000:] if proc.stdout else "")
+        if proc.returncode != 0:
+            print(f"FAIL — agent run exited {proc.returncode}\n{proc.stderr[-2000:]}")
+            return 1
+
+        # Verdict: the agent must have produced a parseable, valid Goals file.
+        repo = os.path.join(work, "target-repo")
+        import glob
+        hits = glob.glob(os.path.join(repo, "**", "*.goals.transitrix.yaml"), recursive=True)
+        if not hits:
+            print(f"FAIL — no *.goals.transitrix.yaml authored under {repo}")
+            return 1
+        errs = guard.validate_goals(guard._load_yaml(hits[0]))
+        if errs:
+            print(f"FAIL — authored Goals file ({hits[0]}) fails validation:")
+            for e in errs:
+                print(f"  ✗ {e}")
+            return 1
+        for root_file in ("transitrix.yaml", "AGENTS.md"):
+            if not os.path.isfile(os.path.join(repo, root_file)):
+                print(f"FAIL — repo skeleton missing {root_file}")
+                return 1
+        print(f"PASS — agent drove the skill end-to-end; valid Goals tree at {hits[0]}")
+        return 0
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/onboarding/tests/test_skill_integrity.py
+++ b/skills/onboarding/tests/test_skill_integrity.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""From-scratch install test for the Transitrix Onboarding Skill (strategy#56).
+
+Deterministic, no-API-key "Skill-correctness" guard. Proves the Skill works
+against a clean install: the bundle is intact, every template the SKILL.md
+references exists / parses / carries the right canonical header, and the
+representative Goals path instantiates into a clean repo and validates.
+
+This is the PR-CI guard. The full LLM-driven persona walk-through (an agent
+reading SKILL.md and producing the repo end-to-end) needs an API key and lives
+in drive_skill_e2e.py, gated to the weekly cron. See tests/README.md for the
+harness-choice rationale and the @transitrix/diagrams stand-in note.
+
+Run:  python skills/onboarding/tests/test_skill_integrity.py
+Exit: 0 = all checks pass; 1 = a check failed (message localises the problem).
+"""
+
+import os
+import re
+import shutil
+import sys
+import tempfile
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.exit("FAIL: PyYAML is required (pip install pyyaml).")
+
+SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The 14 view notations the skill ships a template for (SKILL.md § Templates).
+# Filename convention: <short>.<short>.transitrix.yaml, with `notation: <short>` inside.
+VIEW_NOTATIONS = [
+    "bpmn", "fgca", "fga", "goals", "capability-map", "process-map",
+    "activities", "blocks", "scenarios", "applications", "products",
+    "issues", "process-blueprint", "project-card",
+]
+ROOT_TEMPLATES = ["transitrix.yaml", "AGENTS.md", "copilot-instructions.md"]
+CODEX_TEMPLATES = ["codex-external.yaml", "codex-internal.yaml"]
+EXTRACTION_FILES = ["01_motivation.md", "02_business.md", "03_application.md", "README.md"]
+
+# Canonical ID grammar (IDS_AND_REFERENCES.md §1): <TYPE>-[<middle>-]<INTEGER>,
+# uppercase TYPE, terminal positive integer with no leading zeros.
+ID_RE = re.compile(r"^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$")
+
+_failures = []
+
+
+def check(cond, msg):
+    if not cond:
+        _failures.append(msg)
+    return cond
+
+
+def _load_yaml(path):
+    with open(path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _frontmatter(md_path):
+    """Return the parsed YAML frontmatter of a markdown file (between --- fences)."""
+    text = open(md_path, encoding="utf-8").read()
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+    return yaml.safe_load(m.group(1)) if m else None
+
+
+# ── Part A — bundle integrity (no workspace needed) ──────────────────────────
+
+def check_bundle_integrity():
+    tdir = os.path.join(SKILL_DIR, "templates")
+    edir = os.path.join(SKILL_DIR, "extraction")
+
+    check(os.path.isfile(os.path.join(SKILL_DIR, "SKILL.md")), "SKILL.md missing from bundle")
+    check(os.path.isdir(tdir), "templates/ directory missing from bundle")
+
+    # SKILL.md frontmatter is well-formed and declares the required keys.
+    fm = _frontmatter(os.path.join(SKILL_DIR, "SKILL.md"))
+    if check(isinstance(fm, dict), "SKILL.md frontmatter does not parse"):
+        for key in ("name", "description", "when_to_use", "allowed-tools"):
+            check(key in fm, f"SKILL.md frontmatter missing required key: {key}")
+
+    # Root scaffolding + codex + extraction files exist.
+    for f in ROOT_TEMPLATES + CODEX_TEMPLATES:
+        check(os.path.isfile(os.path.join(tdir, f)), f"template missing: templates/{f}")
+    for f in EXTRACTION_FILES:
+        check(os.path.isfile(os.path.join(edir, f)), f"extraction file missing: extraction/{f}")
+
+    # Every view-notation template exists, parses, and its notation header matches.
+    for short in VIEW_NOTATIONS:
+        fname = f"{short}.{short}.transitrix.yaml"
+        path = os.path.join(tdir, fname)
+        if not check(os.path.isfile(path), f"view template missing: templates/{fname}"):
+            continue
+        try:
+            doc = _load_yaml(path)
+        except yaml.YAMLError as e:
+            check(False, f"view template does not parse: templates/{fname}: {e}")
+            continue
+        check(isinstance(doc, dict), f"view template is not a YAML mapping: templates/{fname}")
+        if isinstance(doc, dict):
+            check(doc.get("notation") == short,
+                  f"templates/{fname}: notation header is {doc.get('notation')!r}, expected {short!r} (HDR-002)")
+
+    # Codex templates parse and carry an admission record (no notation header by design).
+    for f in CODEX_TEMPLATES:
+        path = os.path.join(tdir, f)
+        if os.path.isfile(path):
+            try:
+                doc = _load_yaml(path)
+            except yaml.YAMLError as e:
+                check(False, f"codex template does not parse: templates/{f}: {e}")
+                continue
+            check(isinstance(doc, dict) and doc.get("zone") == "codex",
+                  f"templates/{f}: missing `zone: codex` admission record")
+
+    # The manifest template is a valid adopter manifest (MANIFEST.md schema).
+    man = os.path.join(tdir, "transitrix.yaml")
+    if os.path.isfile(man):
+        doc = _load_yaml(man)
+        for key in ("transitrix", "methodology_version", "notations", "zones"):
+            check(isinstance(doc, dict) and key in doc, f"templates/transitrix.yaml missing key: {key}")
+
+
+# ── Goals structural validation — stand-in for @transitrix/diagrams validateGoals ─
+# @transitrix/diagrams is not vendored into this repo (it ships separately), so we
+# assert the structural invariants the canonical validateGoals enforces. When the
+# package is available in CI, replace this with the real parser (see tests/README.md).
+
+def validate_goals(doc):
+    errs = []
+    if not isinstance(doc, dict):
+        return ["goals document is not a YAML mapping"]
+    if doc.get("notation") != "goals":
+        errs.append(f"notation header is {doc.get('notation')!r}, expected 'goals' (HDR-002)")
+    type_levels = {t["name"]: t["level"] for t in doc.get("goal_types", []) if isinstance(t, dict)}
+    if not type_levels:
+        errs.append("goal_types[] is missing or empty")
+    goals = doc.get("goals", [])
+    if not isinstance(goals, list) or not goals:
+        return errs + ["goals[] is missing or empty"]
+    by_id = {g.get("id"): g for g in goals if isinstance(g, dict)}
+    for g in goals:
+        gid = g.get("id")
+        if not (gid and ID_RE.match(str(gid))):
+            errs.append(f"goal id {gid!r} violates the canonical ID grammar")
+        if not g.get("name"):
+            errs.append(f"goal {gid!r} missing name")
+        gtype, level = g.get("type"), g.get("level")
+        if gtype not in type_levels:
+            errs.append(f"goal {gid!r} type {gtype!r} not declared in goal_types[]")
+        elif level != type_levels[gtype]:
+            errs.append(f"goal {gid!r} level {level} != goal_types[{gtype!r}].level {type_levels[gtype]}")
+        parent = g.get("parent")
+        if parent is not None:
+            if parent not in by_id:
+                errs.append(f"goal {gid!r} parent {parent!r} does not resolve in this document")
+            elif isinstance(level, int) and isinstance(by_id[parent].get("level"), int):
+                if level != by_id[parent]["level"] + 1:
+                    errs.append(f"goal {gid!r} level {level} is not parent level + 1 (GOALS-012)")
+    if not any(g.get("parent") is None for g in goals):
+        errs.append("goals tree has no root (every goal has a parent)")
+    return errs
+
+
+# ── Part B — clean install + representative Goals drive ──────────────────────
+
+ZONE_SKELETON = [
+    "canon/elements/01_motivation", "canon/elements/02_business",
+    "canon/elements/03_application", "canon/elements/04_technology",
+    "canon/views/goals", "field/interviews", "codex/external", "codex/internal",
+]
+
+
+def check_clean_install_goals_path():
+    work = tempfile.mkdtemp(prefix="transitrix-installtest-")
+    try:
+        # 1. Clean ephemeral workspace: a fresh HOME with no ~/.claude state.
+        home = os.path.join(work, "home")
+        os.makedirs(os.path.join(home, ".claude", "skills"), exist_ok=True)
+        check(not os.path.exists(os.path.join(home, ".claude", "skills", "transitrix-onboard")),
+              "precondition: workspace already had the skill installed")
+
+        # 2. Install the skill the way the README documents (cp -r into the
+        #    command-named directory -> the /transitrix-onboard slash command).
+        installed = os.path.join(home, ".claude", "skills", "transitrix-onboard")
+        shutil.copytree(SKILL_DIR, installed)
+        check(os.path.isfile(os.path.join(installed, "SKILL.md")),
+              "install did not place SKILL.md under ~/.claude/skills/transitrix-onboard/")
+
+        # 3. Drive the representative path deterministically: scaffold the zoned
+        #    skeleton (Step 2) and instantiate the Goals starter (Step 3), against
+        #    an empty target repo.
+        repo = os.path.join(work, "target-repo")
+        for d in ZONE_SKELETON:
+            os.makedirs(os.path.join(repo, d), exist_ok=True)
+        tdir = os.path.join(installed, "templates")
+        for f in ROOT_TEMPLATES:
+            dest = os.path.join(repo, ".github") if f == "copilot-instructions.md" else repo
+            os.makedirs(dest, exist_ok=True)
+            shutil.copyfile(os.path.join(tdir, f), os.path.join(dest, f))
+        goals_dest = os.path.join(repo, "canon/views/goals/strategy-2026.goals.transitrix.yaml")
+        shutil.copyfile(os.path.join(tdir, "goals.goals.transitrix.yaml"), goals_dest)
+
+        # 4. Assertions.
+        check(os.path.isfile(os.path.join(repo, "transitrix.yaml")),
+              "skeleton missing transitrix.yaml manifest at repo root")
+        check(os.path.isfile(os.path.join(repo, "AGENTS.md")),
+              "skeleton missing AGENTS.md at repo root")
+        check(os.path.isfile(os.path.join(repo, ".github/copilot-instructions.md")),
+              "skeleton missing .github/copilot-instructions.md")
+        for d in ("canon", "field", "codex"):
+            check(os.path.isdir(os.path.join(repo, d)), f"skeleton missing {d}/ zone")
+        check(os.path.isfile(goals_dest), "starter Goals file was not authored")
+
+        if os.path.isfile(goals_dest):
+            errs = validate_goals(_load_yaml(goals_dest))
+            for e in errs:
+                check(False, f"authored Goals file fails validation: {e}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def main():
+    check_bundle_integrity()
+    check_clean_install_goals_path()
+    if _failures:
+        print(f"FAIL — {len(_failures)} check(s) failed:\n")
+        for f in _failures:
+            print(f"  ✗ {f}")
+        return 1
+    print("PASS — Transitrix Onboarding Skill install test: all checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

A from-scratch install test for the onboarding Skill (strategy#56) — proves a first-time user can install the Skill against a clean workspace and end up with a working, canon-valid repo. Guards the property the publish-to-marketplace task (#23) depends on: that the Skill doesn't silently break (missing template, drifted header, unparseable starter).

## Design — two modes

A true "drive the Skill" run needs an LLM (the Skill is an `SKILL.md` protocol an agent interprets) → an API key, which PR CI must run without. So the suite splits (rationale: `skills/onboarding/tests/README.md`):

| Script | Mode | Key | Runs |
|---|---|---|---|
| `test_skill_integrity.py` | Deterministic Skill-correctness guard — bundle intact; every template `SKILL.md` references exists/parses/has the matching `notation:` header; clean install into an ephemeral `HOME` + representative **Goals** drive (scaffold zoned skeleton + instantiate starter) into an empty repo + validate | none | every PR touching `skills/onboarding/**` + weekly cron |
| `drive_skill_e2e.py` | True LLM end-to-end drive via the `claude` CLI against a synthetic persona, no human-in-the-loop; same assertions on the produced repo | required | weekly cron only; **skips green** without the key/CLI |

**Verified locally:** integrity test passes against the current bundle; the validator catches breaks with specific messages (e.g. `GOALS-012` level violation, dangling parent, non-canonical ID, header mismatch); the e2e script skips green with no key.

## CI

`.github/workflows/onboarding-skill-test.yml` — `integrity` job (PR-on-path + cron + dispatch); `e2e-drive` job (cron/dispatch only, `ANTHROPIC_API_KEY` secret).

## Notes

- **Language:** Python (stdlib + PyYAML) — no Node toolchain in the repo; the test needs YAML parsing + file-tree work.
- **`@transitrix/diagrams` stand-in:** the package isn't vendored here, so the parse assertion uses a structural `validate_goals()` mirroring the canonical `validateGoals` invariants, with a documented swap point for the real parser when it's available in CI.
- **Scope:** one representative notation (Goals, the simplest) per the epic; other notations are covered by `@transitrix/diagrams`' own suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
