### PR TITLE
docs(notations): Actors notation + retire UNIT/EMPLOYEE (strategy#98)

### DIFF
--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -1,6 +1,6 @@
 # Element primitives — canonical file schema
 
-This appendix defines the **element-primitive file schema**: what a standalone canon-zone element file looks like, which element TYPEs get one, where each lives on disk, and how the per-TYPE field sets are defined. It is the cross-cutting companion to the view specs (`notations/views/`), the four element notations (`notations/elements/`), the ID grammar ([`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md)), and the shared contracts ([`CONTRACT.md`](CONTRACT.md)).
+This appendix defines the **element-primitive file schema**: what a standalone canon-zone element file looks like, which element TYPEs get one, where each lives on disk, and how the per-TYPE field sets are defined. It is the cross-cutting companion to the view specs (`notations/views/`), the element notations (`notations/elements/`), the ID grammar ([`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md)), and the shared contracts ([`CONTRACT.md`](CONTRACT.md)).
 
 Recorded 2026-05-29 as the canonical decision for the methodology. Status: **documented** — the three decisions this document carries (standalone-vs-view-only mode assignment §4, the new `05_implementation` layer §6, and `name` as the single label field §3) were ratified by canon on 2026-05-29.
 
@@ -27,7 +27,7 @@ A `view-defined` TYPE has **no** standalone element-file schema in v1: its only 
 
 ---
 
-## 2. Relationship to the views, the four element notations, and `canon/`
+## 2. Relationship to the views, the element notations, and `canon/`
 
 ```
 canon/
@@ -42,8 +42,7 @@ canon/
       processes/      PROCESS-*.yaml
       products/       PRODUCT-*.yaml
       roles/          ROLE-*.yaml
-      units/          UNIT-*.yaml
-      employees/      EMPLOYEE-*.yaml
+      actors/         ACTOR-*.yaml           # elements/19-actors.md (person | business_unit | system)
       rules/          RULE-*.yaml             # worked-example precedent
     03_application/
       applications/   APPLICATION-*.yaml
@@ -59,7 +58,7 @@ canon/
   views/              *.<short>.transitrix.yaml   # the render-able projections
 ```
 
-- The **four element notations** (`14-codex` / `15-requirement` / `16-assertion` / `17-relations`) define specific element families with their own per-notation specs. This appendix is the *general* schema those specs specialise: REQUIREMENT (`elements/15`) and the capability element (`views/05` §13) are already-published instances of the `standalone` envelope below. Where an element notation spec exists, it remains authoritative for that TYPE's per-element fields; this document carries the cross-TYPE envelope and the placement/mode decisions, and gives the field set for the TYPEs that have no dedicated spec yet (`FACTOR`, `GOAL`, `CHANGE`, `ACTIVITY`, `PROCESS`, `PRODUCT`, `APPLICATION`, `INTEGRATION`, `ROLE`, `UNIT`, `EMPLOYEE`, `CONSTRAINT`, `RULE`).
+- The **element notations** (`14-codex` / `15-requirement` / `16-assertion` / `17-relations` / `19-actors`) define specific element families with their own per-notation specs. This appendix is the *general* schema those specs specialise: REQUIREMENT (`elements/15`) and the capability element (`views/05` §13) are already-published instances of the `standalone` envelope below. Where an element notation spec exists, it remains authoritative for that TYPE's per-element fields; this document carries the cross-TYPE envelope and the placement/mode decisions, and gives the field set for the TYPEs that have no dedicated spec yet (`FACTOR`, `GOAL`, `CHANGE`, `ACTIVITY`, `PROCESS`, `PRODUCT`, `APPLICATION`, `INTEGRATION`, `ROLE`, `CONSTRAINT`, `RULE`). `ACTOR` additionally has [elements/19-actors.md](elements/19-actors.md).
 - `REL` (`canon/relations/`) and `ASSERTION` (`canon/assertions/`) are canon-zone primitives that deliberately sit **outside** the `elements/` tree (their specs say so); they carry the same admission + lifecycle envelope but are not layer-placed elements. They are out of scope for the §4 element table but listed here for completeness.
 - `codex` artefacts (`LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`) live in the `codex/` zone, not `canon/elements/`, and follow [`elements/14-codex.md`](elements/14-codex.md). They are not `canon` elements and are out of scope here.
 
@@ -99,7 +98,7 @@ valid_to: null
 
 | Field | Required | Type | Semantics |
 |---|---|---|---|
-| `notation` | yes | string | The element TYPE's short name — the lowercased registry TYPE (`factor`, `goal`, `change`, `activity`, `capability`, `process`, `product`, `application`, `integration`, `role`, `unit`, `employee`, `rule`, `constraint`; `requirement` per [elements/15](elements/15-requirement.md)). Machine-readable type tag; redundant with the ID prefix but read by tooling that does not parse IDs. Drives `HDR-002`. |
+| `notation` | yes | string | The element TYPE's short name — the lowercased registry TYPE (`factor`, `goal`, `change`, `activity`, `capability`, `process`, `product`, `application`, `integration`, `role`, `actor`, `rule`, `constraint`; `requirement` per [elements/15](elements/15-requirement.md)). Machine-readable type tag; redundant with the ID prefix but read by tooling that does not parse IDs. Drives `HDR-002`. |
 | `id` | yes | string | Canonical ID per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §1 (and §2 for `CAPABILITY`). The prefix MUST be the element's registry TYPE. |
 | `name` | yes | string | Human-readable label. **Canonical across every element TYPE — no TYPE-specific aliases.** [elements/15-requirement.md](elements/15-requirement.md) historically used `title` (inherited from IEEE/ISO requirements templates — stylistic, not functional); REQUIREMENT migrates `title` → `name` (follow-up F-3, §10). A richer naming structure (e.g. `short_title` + `long_description`) is a separate additive enhancement via *additional fields*, never via an alias for `name`. |
 | `type` | per-TYPE | string | Subtype value from the TYPE's controlled vocabulary (e.g. `external` / `internal` for FACTOR; `domain` / `supporting` for CAPABILITY). Required where §7 defines a subtype vocabulary; omitted where it does not. **`type` carries the *subtype*, never the element TYPE itself** — the element TYPE is carried by `notation` + the ID prefix. |
@@ -135,9 +134,8 @@ The mode table. For each registry element TYPE: its mode (§1), its `notation` s
 | `CAPABILITY` | standalone | `capability` | business | `02_business/capabilities/` | [views/05-capability-map.md](views/05-capability-map.md) §13 |
 | `PROCESS` | standalone | `process` | business | `02_business/processes/` | §7.5 + [views/06-process-map.md](views/06-process-map.md) |
 | `PRODUCT` | standalone | `product` | business | `02_business/products/` | §7.6 + [views/09-products.md](views/09-products.md) |
-| `ROLE` | standalone | `role` | business | `02_business/roles/` | §7.9 (reference-only until now) |
-| `UNIT` | standalone | `unit` | business | `02_business/units/` | §7.10 (reference-only until now) |
-| `EMPLOYEE` | standalone | `employee` | business | `02_business/employees/` | §7.11 (reference-only until now) |
+| `ROLE` | standalone | `role` | business | `02_business/roles/` | §7.9 |
+| `ACTOR` | standalone | `actor` | business | `02_business/actors/` | §7.10 + [elements/19-actors.md](elements/19-actors.md) |
 | `RULE` | standalone | `rule` | business | `02_business/rules/` | §7.12 (worked-example precedent) |
 | `APPLICATION` | standalone | `application` | application | `03_application/applications/` | §7.7 + [views/10-applications.md](views/10-applications.md) |
 | `INTEGRATION` | view-defined → standalone (promotable) | `integration` | application | `03_application/integrations/` | §7.8 + [views/10-applications.md](views/10-applications.md) |
@@ -151,7 +149,7 @@ The mode table. For each registry element TYPE: its mode (§1), its `notation` s
 ### 4.1 Why these assignments
 
 - **The strategy chain (`FACTOR` / `GOAL` / `CHANGE` / `ACTIVITY`) is `standalone`.** All four are referenced across documents (a `GOAL` appears in the Goals tree, FGCA, FGA, Activities, Scenarios, and Issues; a `FACTOR` in FGCA, FGA, and Scenarios), and [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §4 already mandates their catalogue uniqueness when cross-referenced. The flat FGCA/FGA/Goals/Activities documents remain the authoring surface (README "Form rule"); the catalogue file is the canonical record once an element is shared. Defining their element-file shape (§7.1–§7.4) is exactly what unblocks the elements-population that surfaced this task.
-- **The stock business/application elements (`CAPABILITY` / `PROCESS` / `PRODUCT` / `APPLICATION` / `ROLE` / `UNIT` / `EMPLOYEE` / `RULE`) are `standalone`.** This matches the grain already in canon: the capability-map spec states it is "a view over Capability elements stored in `elements/02_business/`" ([views/05](views/05-capability-map.md) §1); the products and applications catalogues say their entries "reference a `PRODUCT-…` / `APPLICATION-…` element"; `RULE` already has a worked element file. `ROLE` / `UNIT` / `EMPLOYEE` were registered TYPEs with no schema and appeared only as cross-references (`owner_role`, `unit`, `employee`) — §7.9–§7.11 give them their first element-file schema.
+- **The stock business/application elements (`CAPABILITY` / `PROCESS` / `PRODUCT` / `APPLICATION` / `ROLE` / `ACTOR` / `RULE`) are `standalone`.** This matches the grain already in canon: the capability-map spec states it is "a view over Capability elements stored in `elements/02_business/`" ([views/05](views/05-capability-map.md) §1); the products and applications catalogues say their entries "reference a `PRODUCT-…` / `APPLICATION-…` element"; `RULE` already has a worked element file. `ROLE` (position) and `ACTOR` (identity — `person` / `business_unit` / `system`) are the active-structure pair settled by the 2026-05-29 Actors decision; `ACTOR` subsumes the former `UNIT` / `EMPLOYEE` TYPEs (§7.10–§7.11).
 - **The motivation obligations (`CONSTRAINT` / `REQUIREMENT`) are `standalone`** — already shipped as element files (`CONSTRAINT-GDPR-RESIDENCY-1`, [elements/15](elements/15-requirement.md)).
 - **`INTEGRATION` is promotable.** The applications spec ([views/10](views/10-applications.md)) currently nests integrations inside an application's `integrations[]`. v1 keeps that nested-in-view form as the definition home; the standalone `03_application/integrations/` schema (§7.8) is defined so an integration that needs its own lifecycle/cross-references can be promoted without renaming.
 - **`SCENARIO` / `ISSUE` are `view-defined`.** [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §4 scopes `SCENARIO` to "within the organisation" via its scenarios document and `ISSUE` to "within the issues catalogue document." A scenario is itself a container/projection over other elements; an issue register is a document-scoped tree. Neither is materialised as a standalone catalogue element in v1.
@@ -194,7 +192,7 @@ canon/elements/<NN>_<layer>/<plural-type>/<ID>.yaml
 | `NN_layer` folder | ArchiMate layer | Element TYPEs placed here |
 |---|---|---|
 | `01_motivation/` | Motivation | `FACTOR` (`factors/`), `GOAL` (`goals/`), `CONSTRAINT` (`constraints/`), `REQUIREMENT` (`requirements/`) |
-| `02_business/` | Business | `CAPABILITY` (`capabilities/`), `PROCESS` (`processes/`), `PRODUCT` (`products/`), `ROLE` (`roles/`), `UNIT` (`units/`), `EMPLOYEE` (`employees/`), `RULE` (`rules/`) |
+| `02_business/` | Business | `CAPABILITY` (`capabilities/`), `PROCESS` (`processes/`), `PRODUCT` (`products/`), `ROLE` (`roles/`), `ACTOR` (`actors/`), `RULE` (`rules/`) |
 | `03_application/` | Application | `APPLICATION` (`applications/`), `INTEGRATION` (`integrations/`, when promoted) |
 | `04_technology/` | Technology | *(no registry element TYPE in §3.1 yet; the layer folder exists for templates / future TYPEs)* |
 | `05_implementation/` | Implementation & Migration | `ACTIVITY` (`activities/`), `CHANGE` (`changes/`), `MILESTONE` (`milestones/` — see 6.2) |
@@ -265,9 +263,7 @@ Inline shape: [views/02-fgca.md](views/02-fgca.md) §5.4. (No subtype vocabulary
 | `predecessors` | no | list | `ACTIVITY-…` IDs that must complete first. **Stays inline/timeless.** |
 | `parent` | no | string | `ACTIVITY-…` — the aggregating work package (recursive: initiative → programme → project → task, all one TYPE; §6.1). Subsumes WBS grouping. |
 | `scenario` | no | string | `SCENARIO-…` this activity belongs to. |
-| `unit` | no | string | `UNIT-…` responsible. |
-| `employee` | no | string | `EMPLOYEE-…` responsible. |
-| `owner` | no | string | Free-text owner (override when no typed `UNIT`/`EMPLOYEE`). |
+| `owner` | no | string | `ACTOR-…` responsible for the activity. Replaces the old parallel `owner`(free-text) / `unit` / `employee` fields, collapsed into one typed reference by the 2026-05-29 Actors decision. |
 | `start_date` / `end_date` | no | string | Planned dates — quoted ISO 8601 ([CONTRACT.md](CONTRACT.md) §4). |
 | `labor_cost` / `resources_cost` / `effort` | no | number | Cost / effort signals. |
 | `score` / `sort` | no | integer | Prioritisation / display ordering. |
@@ -334,37 +330,39 @@ In v1 an integration is a nested entry under its source application's `integrati
 
 ### 7.9 `ROLE` — `02_business/roles/`
 
-First element-file schema for `ROLE` (previously reference-only via `owner_role`).
+`ROLE` is a **position / responsibility** — distinct from the `ACTOR` (§7.10) that fills it (ArchiMate Business Role vs Business Actor).
 
 | Field | Required | Type | Semantics |
 |---|---|---|---|
 | `description` | recommended | string | What the role is accountable for. |
-| `unit` | no | string | `UNIT-…` the role sits in. |
+| `unit` | no | string | `ACTOR-…` of `type: business_unit` the role sits in (was `UNIT-…` before the 2026-05-29 Actors decision). |
 | `responsibility_area` | no | string | Domain / function area. |
 
-### 7.10 `UNIT` — `02_business/units/`
+### 7.10 `ACTOR` — `02_business/actors/`
 
-First element-file schema for `UNIT`.
-
-| Field | Required | Type | Semantics |
-|---|---|---|---|
-| `description` | recommended | string | What the unit does. |
-| `head_role` | no | string | `ROLE-…` that heads the unit. **Time-varying** — sidecar ([CONTRACT.md](CONTRACT.md) §9). |
-| `headcount` | no | integer | **Time-varying** — sidecar. |
-
-**Time-aware:** the `unit_parent` (`UNIT → UNIT`) relation is reserved as first-class ([elements/17-relations.md](elements/17-relations.md) §3); no `UNIT` primitives ship in acme_corp v1.
-
-### 7.11 `EMPLOYEE` — `02_business/employees/`
-
-First element-file schema for `EMPLOYEE`.
+The active-structure identity primitive — *who or what exists and performs work* (ArchiMate Business Actor). A single TYPE with a `type` discriminator unifies the old `owner` / `unit` / `employee` ownership fields. Decided 2026-05-29 (strategy proposal): `ACTOR` is the identity; engagement (employment, candidacy, …) and stakes are separate `REL` records that point at it, never inline.
 
 | Field | Required | Type | Semantics |
 |---|---|---|---|
-| `description` | no | string | Notes on the person's scope. |
-| `unit` | no | string | `UNIT-…` the employee belongs to. |
-| `roles` | no | list | `ROLE-…` IDs the employee holds. |
+| `type` | yes | string | `person` \| `business_unit` \| `system` — the identity discriminator. |
+| `description` | recommended | string | Who / what this actor is. |
+| `contact` | no | string | Contact handle (for `person` / `business_unit`). |
+| `external_ref` | no | string | External identifier or URL — e.g. a `system`'s integration endpoint, or an external organisation's reference. |
 
-> **Note:** `EMPLOYEE` files name real people; adopters apply their own data-protection rules (and the worked-example org redacts real names). See [CONTRACT.md](CONTRACT.md) §5 on the trust contract of canon.
+- **Identity only.** A `person` actor is *who someone is*, independent of engagement. Employment, candidacy, alumni status, community membership, and contracting are **first-class time-aware `REL` records** ([elements/17-relations.md](elements/17-relations.md) §3), not fields here — a person can exist in the org's scope (candidate, alumnus, contractor, community member) without being an employee.
+- **Org hierarchy.** A `business_unit` actor's parent unit is a time-aware `REL` of `type: unit_parent` (`ACTOR(business_unit) → ACTOR(business_unit)`), not an inline field.
+- **Role assignment.** Which `ROLE` an actor fills is carried on the relevant engagement `REL` (e.g. `employment` carries role assignments), not inline on the actor.
+
+> **Note:** `person` actors name real people; adopters apply their own data-protection rules (and the worked-example org redacts real names). See [CONTRACT.md](CONTRACT.md) §5 on the trust contract of canon.
+
+### 7.11 Removed TYPEs — `UNIT`, `EMPLOYEE`
+
+`UNIT` and `EMPLOYEE` were registered (schema-only) on 2026-05-29 and **removed the same day** by the Actors decision, before any primitives were populated:
+
+- `UNIT` → `ACTOR` with `type: business_unit`.
+- `EMPLOYEE` → `ACTOR` with `type: person` **plus** an `employment` `REL` (the employment relationship, with its dates and role assignments). The split keeps identity (the person) separate from engagement (the employment).
+
+The deprecation + mapping is recorded in the `0.5 → 0.6` migration recipe for any adopter who populated these between registration and the next cut.
 
 ### 7.12 `RULE` — `02_business/rules/`
 
@@ -419,8 +417,8 @@ Backfill for existing canon files and downstream tasks. Each is a **separate PR*
 - **F-1 — reconcile `.templates/elements/*_template.yaml`** to the §3 envelope: canonical IDs, `notation:` headers, admission + lifecycle blocks, `type:` for subtype only, dropped `metadata`/`properties` wrappers, one template per element TYPE (or one annotated template per layer). Touches `organizations/acme_corp/`. (§5.)
 - **F-2 — backfill `notation:` + `type:`-as-subtype on the `CONSTRAINT` / `RULE` worked examples.** `CONSTRAINT-GDPR-RESIDENCY-1` and `RULE-DUAL-APPROVAL-1` currently carry `type: constraint` / `type: rule` (TYPE repeated) and no `notation:` header — they pre-date the header contract. Add `notation: constraint` / `notation: rule` and drop or re-purpose `type:`. (§3, §7.12–7.13.)
 - **F-3 — migrate REQUIREMENT `title` → `name`.** Decided: `name` is the single canonical label field, no aliases (§3). [elements/15-requirement.md](elements/15-requirement.md) and the worked-example requirement files migrate via a trivial codemod (`s/^title:/name:/` over `canon/elements/01_motivation/requirements/*.yaml`, plus the field row in the spec). The transform lands in a methodology migration recipe (0.5 → 0.6, or pulled forward into 0.4 → 0.5 if that recipe is still open before tag).
-- **F-4 — acme_corp worked examples** for the newly-schema'd TYPEs (`FACTOR`, `GOAL`, `CHANGE`, `ACTIVITY`, `PROCESS`, `PRODUCT`, `APPLICATION`, `ROLE`, `UNIT`, `EMPLOYEE`) plus per-folder READMEs, created alongside the elements-population wave that surfaced this task.
-- **F-5 — declare `time_varying` fields per notation** (capability `current_maturity`/`owner_role`/`target_date`; application `lifecycle_stage`/`vendor`/`owner_role`/`maturity`; unit `headcount`/`head_role`) in the respective specs, completing the [CONTRACT.md](CONTRACT.md) §9.4 candidate list.
+- **F-4 — acme_corp worked examples** for the newly-schema'd TYPEs (`FACTOR`, `GOAL`, `CHANGE`, `ACTIVITY`, `PROCESS`, `PRODUCT`, `APPLICATION`, `ROLE`) plus per-folder READMEs, created alongside the elements-population wave that surfaced this task. (`ACTOR` examples ship with the Actors notation.)
+- **F-5 — declare `time_varying` fields per notation** (capability `current_maturity`/`owner_role`/`target_date`; application `lifecycle_stage`/`vendor`/`owner_role`/`maturity`) in the respective specs, completing the [CONTRACT.md](CONTRACT.md) §9.4 candidate list.
 
 ---
 

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -53,7 +53,7 @@ CAPABILITY-H<L1[.L2[.L3]]>
 - `CAPABILITY-V1.2.3`
 - `CAPABILITY-H1.2`
 
-The diagram address derives from the V/H positional addressing system documented in [`05-capability-map.md`](05-capability-map.md) §4–5. Capability IDs are the only place the trailing integer is replaced by a multi-component path; every other TYPE follows §1 unchanged.
+The diagram address derives from the V/H positional addressing system documented in [`05-capability-map.md`](views/05-capability-map.md) §4–5. Capability IDs are the only place the trailing integer is replaced by a multi-component path; every other TYPE follows §1 unchanged.
 
 ---
 
@@ -76,18 +76,17 @@ Elements that get referenced across documents.
 | `PRODUCT` | product or service | Products catalogue |
 | `APPLICATION` | application | Applications catalogue |
 | `INTEGRATION` | integration between applications | Applications catalogue |
-| `ROLE` | business role | referenced as `owner_role` across notations |
-| `UNIT` | organisational unit | Activities |
-| `EMPLOYEE` | named employee | Activities |
+| `ROLE` | business role — a position / responsibility, distinct from the `ACTOR` that fills it | referenced as `owner_role` across notations; `role.unit` references an `ACTOR` of `type: business_unit` |
+| `ACTOR` | active-structure identity — `person`, `business_unit`, or `system` (ArchiMate Business Actor). Replaces the former `UNIT` / `EMPLOYEE` TYPEs (removed 2026-05-29). Engagement (employment, candidacy, …) and org hierarchy are first-class `REL` records, not inline fields. | Actors catalogue (`elements/02_business/actors/`); referenced as activity `owner`. Schema: [19-actors.md](elements/19-actors.md). |
 | `SCENARIO` | strategic scenario | Scenarios |
 | `ISSUE` | issue — problem, defect, or open question | Issues register |
 | `EQUIPMENT` | physical instrument, device, or facility a process stage depends on | Process Blueprint |
 | `INFORMATION_ENTITY` | data, document, or record produced or consumed by a process stage | Process Blueprint |
 | `RULE` | business rule (business layer per ArchiMate 3.2) | Rules catalogue (`elements/02_business/rules/`); referenceable from any notation via `applies_to:` |
 | `CONSTRAINT` | design / operating constraint (motivation layer per ArchiMate 3.2) — a restriction or prohibition the organisation must not cross | Constraints catalogue (`elements/01_motivation/constraints/`); referenced from FGCA factors via `references_constraint:` |
-| `REQUIREMENT` | regulatory or organisational requirement (motivation layer per ArchiMate 3.2) — a positive obligation the organisation must fulfil. Distinct from `CONSTRAINT` by **form of the obligation**: REQUIREMENT = positive action ("must submit", "must register", "must obtain approval"); CONSTRAINT = restriction ("must not", "cannot exceed"). | Requirements catalogue (`elements/01_motivation/requirements/`); cites its source via `derived_from:` (codex `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`). Schema: [15-requirement.md](15-requirement.md). |
-| `REL` | first-class time-aware relation between two canonical primitives — `parent`, `activity_goal`, `goal_parent`, etc. Carries its own `valid_from` / `valid_to` so changes to a relation (a capability re-parenting, a goal re-aimed) are first-class temporal events. | Relations catalogue (`canon/relations/`); one file per relation. Schema: [17-relations.md](17-relations.md). |
-| `MILESTONE` | project-narrative milestone — a decision gate, certification date, or programme-level marker that belongs in a Project Card's narrative. Distinct from a "schedule milestone" (a zero-duration activity inside an Activities document, see [07-activities.md](07-activities.md) §5.9), which exists for critical-path computation. | Defined inside a Project Card document (`*.project-card.transitrix.yaml`); scope is the parent card document. Schema: [18-project-card.md](18-project-card.md). |
+| `REQUIREMENT` | regulatory or organisational requirement (motivation layer per ArchiMate 3.2) — a positive obligation the organisation must fulfil. Distinct from `CONSTRAINT` by **form of the obligation**: REQUIREMENT = positive action ("must submit", "must register", "must obtain approval"); CONSTRAINT = restriction ("must not", "cannot exceed"). | Requirements catalogue (`elements/01_motivation/requirements/`); cites its source via `derived_from:` (codex `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`). Schema: [15-requirement.md](elements/15-requirement.md). |
+| `REL` | first-class time-aware relation between two canonical primitives — `parent`, `activity_goal`, `goal_parent`, etc. Carries its own `valid_from` / `valid_to` so changes to a relation (a capability re-parenting, a goal re-aimed) are first-class temporal events. | Relations catalogue (`canon/relations/`); one file per relation. Schema: [17-relations.md](elements/17-relations.md). |
+| `MILESTONE` | project-narrative milestone — a decision gate, certification date, or programme-level marker that belongs in a Project Card's narrative. Distinct from a "schedule milestone" (a zero-duration activity inside an Activities document, see [07-activities.md](views/07-activities.md) §5.9), which exists for critical-path computation. | Defined inside a Project Card document (`*.project-card.transitrix.yaml`); scope is the parent card document. Schema: [18-project-card.md](views/18-project-card.md). |
 
 ### 3.2 Document-level types
 
@@ -128,7 +127,7 @@ Raw, unprocessed material in the **Field** zone (see [CONTRACT.md](CONTRACT.md) 
 
 ### 3.5 Codex artefact types
 
-External constraints and internal authority documents in the **Codex** zone — *given to* the organisation, not authored by it. See [CONTRACT.md](CONTRACT.md) §5 and [14-codex.md](14-codex.md).
+External constraints and internal authority documents in the **Codex** zone — *given to* the organisation, not authored by it. See [CONTRACT.md](CONTRACT.md) §5 and [14-codex.md](elements/14-codex.md).
 
 | TYPE | Sub-zone | What it is |
 |---|---|---|
@@ -139,7 +138,7 @@ External constraints and internal authority documents in the **Codex** zone — 
 
 ### 3.6 Assertion type
 
-Compliance claims linking a `REQUIREMENT` to the elements that realise it. Assertions are canonical (canon zone) but live **outside** the `elements/` tree, under `canon/assertions/`. Schema: [16-assertion.md](16-assertion.md).
+Compliance claims linking a `REQUIREMENT` to the elements that realise it. Assertions are canonical (canon zone) but live **outside** the `elements/` tree, under `canon/assertions/`. Schema: [16-assertion.md](elements/16-assertion.md).
 
 | TYPE | What it is |
 |---|---|
@@ -154,11 +153,11 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | TYPE | Uniqueness scope |
 |---|---|
 | `FACTOR`, `GOAL`, `CHANGE`, `ACTIVITY` | within the FGCA / FGA / Goals / Activities document that defines them. When referenced from across documents, IDs must also be unique within the organisation's element catalogue (`elements/01_motivation/`, `elements/02_business/`). |
-| `CAPABILITY` | within the capability set (`set_name`, per [`05-capability-map.md`](05-capability-map.md) §5). |
+| `CAPABILITY` | within the capability set (`set_name`, per [`05-capability-map.md`](views/05-capability-map.md) §5). |
 | `PROCESS` | within the organisation's element catalogue (`elements/02_business/`). |
 | `PRODUCT`, `APPLICATION`, `INTEGRATION` | within the catalogue document. |
 | `ISSUE` | within the issues catalogue document. |
-| `ROLE`, `UNIT`, `EMPLOYEE` | within the organisation's element catalogue (`elements/02_business/`). |
+| `ROLE`, `ACTOR` | within the organisation's element catalogue (`elements/02_business/`). |
 | `SCENARIO` | within the organisation. |
 | `EQUIPMENT`, `INFORMATION_ENTITY` | within the notation document that defines them (today: a Process Blueprint). No organisation-wide catalogue is mandated yet; the TYPEs are registered so the IDs already conform to the canonical grammar and can be promoted to a future catalogue without renaming. |
 | `RULE` | within the organisation's element catalogue (`elements/02_business/rules/`), one file per RULE. |
@@ -209,5 +208,5 @@ The TYPE registry above was confirmed 2026-05-20. Several notations and example 
 ## 7. References
 
 - Notation catalogue and the index of all eleven notations: [`README.md`](README.md).
-- Capability addressing (the V/H system that the `CAPABILITY` exception relies on): [`05-capability-map.md`](05-capability-map.md) §4–5.
+- Capability addressing (the V/H system that the `CAPABILITY` exception relies on): [`05-capability-map.md`](views/05-capability-map.md) §4–5.
 - Methodology: `method/methodology.md`.

--- a/notations/README.md
+++ b/notations/README.md
@@ -27,18 +27,19 @@ All view notations share the same file-extension convention `.<short-name>.trans
 
 ## Elements
 
-The 4 element notations live under [`elements/`](elements/) — each defines a canon-zone primitive: standalone YAML files admitted to canon and referenced (by ID) from views and other elements. Element primitives carry their own admission record + primitive lifecycle per [`CONTRACT.md`](CONTRACT.md) §6–7.
+The 5 element notations live under [`elements/`](elements/) — each defines a canon-zone primitive: standalone YAML files admitted to canon and referenced (by ID) from views and other elements. Element primitives carry their own admission record + primitive lifecycle per [`CONTRACT.md`](CONTRACT.md) §6–7.
 
 | Spec | Short name | Purpose | File location | Status |
 |---|---|---|---|---|
 | [14-codex.md](elements/14-codex.md) | `codex` | External laws / regulations and internal policies / standards in the codex zone. | `codex/external/<jurisdiction>/<ID>.yaml`, `codex/internal/<ID>.yaml` | documented |
 | [15-requirement.md](elements/15-requirement.md) | `requirement` | Motivation-layer element capturing a positive obligation derived from a codex source. | `canon/elements/01_motivation/requirements/REQUIREMENT-<…>.yaml` | documented |
 | [16-assertion.md](elements/16-assertion.md) | `assertion` | Canon-zone primitive linking a REQUIREMENT to a subject (PRODUCT / PROCESS / CAPABILITY). | `canon/assertions/ASSERTION-<…>.yaml` | documented |
-| [17-relations.md](elements/17-relations.md) | `relation` | First-class, time-aware relation between two canonical primitives — `parent` / `goal_parent` / `activity_goal` / `unit_parent`. | `canon/relations/REL-<…>.yaml` | documented |
+| [17-relations.md](elements/17-relations.md) | `relation` | First-class, time-aware relation between two canonical primitives — `parent` / `goal_parent` / `activity_goal` / `unit_parent` / engagement kinds. | `canon/relations/REL-<…>.yaml` | documented |
+| [19-actors.md](elements/19-actors.md) | `actor` | Active-structure identity primitive — `person` / `business_unit` / `system` (replaces the former UNIT / EMPLOYEE TYPEs). | `canon/elements/02_business/actors/ACTOR-<…>.yaml` | draft |
 
 Element notations don't carry the `*.transitrix.yaml` extension convention — they're addressed by ID, and their file location is governed by the per-notation rule above.
 
-The cross-cutting **element-primitive file schema** — the common envelope every standalone element file carries, which TYPEs get a standalone file vs. live only inline in a view, and where each lives on disk — is defined once in [`ELEMENT_PRIMITIVES.md`](ELEMENT_PRIMITIVES.md). The four element notations above are specialised instances of that envelope.
+The cross-cutting **element-primitive file schema** — the common envelope every standalone element file carries, which TYPEs get a standalone file vs. live only inline in a view, and where each lives on disk — is defined once in [`ELEMENT_PRIMITIVES.md`](ELEMENT_PRIMITIVES.md). The element notations above are specialised instances of that envelope.
 
 ## Status vocabulary
 

--- a/notations/elements/17-relations.md
+++ b/notations/elements/17-relations.md
@@ -72,9 +72,16 @@ The enum is **closed** in v1. Each value names a specific kind of link between t
 | `parent` | child → parent | `CAPABILITY` → `CAPABILITY` (V/H sub-grammar applies) | Child capability sits under its parent in the capability hierarchy. Re-parenting a capability — a re-org or a capability split — produces a new relation with its own window. |
 | `goal_parent` | child → parent | `GOAL` → `GOAL` | A goal's place under another goal in the Goals tree. A goal re-parented mid-stream (a tactical goal moved to a different strategic goal) produces a new relation. |
 | `activity_goal` | activity → goal | `ACTIVITY` → `GOAL` | An activity serves a goal. An activity re-aimed mid-stream produces a new relation. |
-| `unit_parent` *(reserved)* | child → parent | `UNIT` → `UNIT` | Organisational re-parenting. Reserved; no OrgUnit primitives ship in v1. |
+| `unit_parent` | child → parent | `ACTOR(business_unit)` → `ACTOR(business_unit)` | Organisational re-parenting — a business-unit actor moved under a different parent unit. (Was `UNIT → UNIT` before the 2026-05-29 Actors decision folded `UNIT` into `ACTOR`.) |
+| `employment` | person → org | `ACTOR(person)` → `ACTOR(business_unit)` | Employment of a person by a unit / organisation. Time-aware (the employment window); carries the most attributes of the engagement kinds — `contract_type`, role assignments (`roles: [ROLE-…]`). |
+| `candidacy` | person → org | `ACTOR(person)` → `ACTOR(business_unit)` | A person under evaluation (pre-hire). Carries `stage`, `source`. |
+| `alumni_membership` | person → org | `ACTOR(person)` → `ACTOR(business_unit)` | A former employee's continuing relationship; may reference the prior `employment`. |
+| `community_membership` | person → community | `ACTOR(person)` → `ACTOR(business_unit)` | Membership of a community modelled as a `business_unit` actor (e.g. an open-source community, a user group). |
+| `contracting` | contractor → org | `ACTOR(person\|business_unit)` → `ACTOR(business_unit)` | A contracting relationship; carries `contract_terms`. |
 
 Adding a new `type` value is a non-backwards-compatible methodology revision — adopters' validators built against an older enum will reject newer relations.
+
+**Engagement relations (`employment` / `candidacy` / `alumni_membership` / `community_membership` / `contracting`).** Decided 2026-05-29 (Actors): a `person` actor records *identity only*; every kind of engagement with the organisation is its own first-class, time-aware relation, so the same person can be a candidate, then an employee, then an alumnus over time without losing history, and can hold several engagements at once. Each engagement kind carries only the attributes that kind needs; the relation's own `valid_from`/`valid_to` is the engagement window.
 
 **Out of the enum in v1, by deliberate decision:**
 

--- a/notations/elements/19-actors.md
+++ b/notations/elements/19-actors.md
@@ -1,0 +1,139 @@
+---
+title: "Actors — active-structure identity primitive"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-05-29"
+status: "draft"
+---
+
+# Actors — Reference
+
+**Scope:** The `ACTOR` element type — the active-structure **identity** primitive: *who or what exists and performs work* (ArchiMate Business Actor). One TYPE with a `type` discriminator covers a `person`, a `business_unit`, or a `system`. The shared header / zone / admission / lifecycle contracts are defined in [CONTRACT.md](../CONTRACT.md); the common element-primitive envelope is [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §3 (`ACTOR` field set: §7.10); the TYPE registry sits in [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.1.
+
+Actors are **zone primitives**: each actor is a single YAML file under `canon/elements/02_business/actors/`, named by its canonical ID, carrying the admission record ([CONTRACT.md](../CONTRACT.md) §6, `zone: canon`) plus the primitive lifecycle ([CONTRACT.md](../CONTRACT.md) §7) and the actor-specific frontmatter below.
+
+Recorded 2026-05-29 as the canonical decision (strategy proposal): `ACTOR` is the single identity primitive; it replaces the briefly-registered `UNIT` and `EMPLOYEE` TYPEs (removed the same day, before population). Engagement and org hierarchy are first-class relations, not fields here.
+
+---
+
+## 1. ACTOR vs ROLE — identity vs position
+
+The business layer carries two active-structure types with a clean split:
+
+| | ACTOR | ROLE |
+|---|---|---|
+| **What it is** | An identity — who/what exists | A position — a responsibility that can be filled |
+| **ArchiMate** | Business Actor | Business Role |
+| **Examples** | "Acme GmbH" (business_unit), "Jane Doe" (person), "Order Management System" (system) | "Operations Lead", "Data Protection Officer" |
+| **Folder** | `canon/elements/02_business/actors/` | `canon/elements/02_business/roles/` |
+
+The same actor can fill many roles over time; the same role can be filled by different actors. Which actor fills which role is carried on the relevant engagement relation (e.g. `employment` carries role assignments — §3), not inline on either primitive.
+
+### 1.1 Identity vs engagement — why a `person` is not an `employee`
+
+A `person` actor records *identity*, independent of how the organisation engages them. The same person may be a candidate, then an employee, then an alumnus — and may be a contractor or community member alongside. Conflating identity with employment loses that history and forces a person to be re-created per engagement. So engagement is modelled as separate, time-aware `REL` records pointing at the one identity (§3); the `ACTOR` file itself is engagement-free.
+
+This is why the former `EMPLOYEE` TYPE was removed: `EMPLOYEE` = `ACTOR(person)` **+** an `employment` relation.
+
+---
+
+## 2. Frontmatter — canonical schema
+
+```yaml
+notation: actor
+id: ACTOR-OPS-TEAM-1
+name: "Operations Team"
+type: business_unit             # person | business_unit | system  (required)
+description: "The operations organisation responsible for order fulfilment."
+contact: "ops@acme.example"     # optional
+
+# Admission record (CONTRACT.md §6) — required
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — required
+valid_from: "2024-01-01"
+valid_to: null
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | Fixed value `actor`. |
+| `id` | yes | string | Canonical ID per [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §1: `ACTOR-[<middle>-]<INTEGER>`. |
+| `name` | yes | string | Human-readable identity label. |
+| `type` | yes | string | One of `person`, `business_unit`, `system` — the identity discriminator. |
+| `description` | recommended | string | Who / what this actor is. |
+| `contact` | no | string | Contact handle (for `person` / `business_unit`). |
+| `external_ref` | no | string | External identifier or URL — e.g. a `system`'s endpoint, or an external organisation's reference. |
+| `zone` | yes | string | Always `canon` for ACTOR — see [CONTRACT.md](../CONTRACT.md) §6. |
+| `admitted_at` / `admitted_by` / `gate_checks` | yes | — | Admission record — [CONTRACT.md](../CONTRACT.md) §6. |
+| `valid_from` | yes | string | Date the actor became known to the organisation's scope — [CONTRACT.md](../CONTRACT.md) §7. |
+| `valid_to` | yes | string \| null | Date the actor left scope, or `null`. |
+
+No engagement, role, ownership, or org-hierarchy fields appear on the actor — those are relations (§3).
+
+> **Note:** `person` actors name real people; adopters apply their own data-protection rules (and the worked-example org redacts real names). See [CONTRACT.md](../CONTRACT.md) §5.
+
+---
+
+## 3. Relations on an actor
+
+All of an actor's links are first-class, time-aware `REL` records ([17-relations.md](17-relations.md)), never inline fields:
+
+| Relation `type` | From → To | What it records |
+|---|---|---|
+| `unit_parent` | `ACTOR(business_unit)` → `ACTOR(business_unit)` | Org hierarchy — a unit's parent unit. Re-parenting = one ended relation + one new. |
+| `employment` | `ACTOR(person)` → `ACTOR(business_unit)` | Employment window; carries `contract_type` and role assignments (`roles: [ROLE-…]`). |
+| `candidacy` | `ACTOR(person)` → `ACTOR(business_unit)` | Pre-hire evaluation; carries `stage`, `source`. |
+| `alumni_membership` | `ACTOR(person)` → `ACTOR(business_unit)` | Former-employee relationship; may reference the prior `employment`. |
+| `community_membership` | `ACTOR(person)` → `ACTOR(business_unit)` | Membership of a community modelled as a `business_unit` actor. |
+| `contracting` | `ACTOR(person\|business_unit)` → `ACTOR(business_unit)` | Contracting relationship; carries `contract_terms`. |
+
+Activity ownership references an actor by ID: an activity's `owner: ACTOR-…` ([07-activities.md](../views/07-activities.md) §5.6). The Stakeholders notation references an actor for identity (`STAKEHOLDER.actor: ACTOR-…`, REQUIRED) — a stakeholder carries the stake, never the identity.
+
+---
+
+## 4. File location and naming
+
+```
+canon/elements/02_business/actors/<ID>.yaml
+```
+
+One actor per file, named by its canonical ID. Examples: `ACTOR-OPS-TEAM-1.yaml`, `ACTOR-JANE-DOE-1.yaml`, `ACTOR-ORDER-MGMT-SYS-1.yaml`.
+
+A flat catalogue listing (`*.actors.transitrix.yaml`) is an optional **view** over these element files for tooling that wants a single-file roster; the element files are authoritative. A dedicated catalogue-view notation is deferred (not needed for v0.1).
+
+---
+
+## 5. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `ACTOR-001` | error | `id` missing or not matching `ACTOR-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §1); or a required field (`notation`, `name`, `type`, `zone`, `admitted_at`, `admitted_by`, `gate_checks`, `valid_from`, `valid_to`) is missing. |
+| `ACTOR-002` | error | `type` is not one of `person`, `business_unit`, `system`. |
+| `ACTOR-003` | error | An engagement / hierarchy field (`employment`, `unit_parent`, `roles`, `owner`, …) is present inline on the actor file — these belong in `REL-…` files (`REL-004`), not on the identity primitive. |
+
+The shared header (`HDR-001..004`, [CONTRACT.md](../CONTRACT.md) §2) and primitive-lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](../CONTRACT.md) §7.3) rules apply to ACTOR files in addition to the ACTOR-* rules above.
+
+---
+
+## 6. Evolution
+
+- A dedicated `*.actors.transitrix.yaml` catalogue-view notation, if tooling demand emerges (v0.1 ships the element files only).
+- `system` actors may grow structured `external_ref` sub-fields (endpoint, protocol) once an integration register needs them.
+- DSM ownership migration (the `owner` / `unit` / `employee` → `owner_actor_id` collapse) is a `proj:transitrix-dsm` track; this spec defines only the methodology side.
+
+---
+
+## 7. References
+
+- TYPE registry and ID grammar: [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.1 (entry), §1 (grammar), §4 (uniqueness scope).
+- Common element-primitive envelope + `ACTOR` field set: [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §3, §7.10.
+- Engagement / hierarchy relations: [17-relations.md](17-relations.md) §3.
+- Activity ownership (`owner: ACTOR-…`): [07-activities.md](../views/07-activities.md) §5.6.
+- Stakeholder identity binding (`STAKEHOLDER.actor`): the Stakeholders notation (forthcoming, strategy#99).

--- a/notations/examples/activities/office-relocation.activities.transitrix.yaml
+++ b/notations/examples/activities/office-relocation.activities.transitrix.yaml
@@ -35,7 +35,7 @@ activities:
     start_date: "2026-06-01"
     end_date: "2026-06-12"
     goals: [GOAL-RELOC-001]
-    unit: UNIT-FACILITIES
+    owner: ACTOR-FACILITIES-1
     tags: [planning]
 
   - id: A-102
@@ -45,7 +45,7 @@ activities:
     end_date: "2026-07-03"
     predecessors: [A-101]
     goals: [GOAL-RELOC-001]
-    unit: UNIT-FACILITIES
+    owner: ACTOR-FACILITIES-1
     tags: [planning]
 
   - id: A-103
@@ -55,7 +55,7 @@ activities:
     end_date: "2026-07-17"
     predecessors: [A-102]
     goals: [GOAL-RELOC-001]
-    unit: UNIT-LEGAL
+    owner: ACTOR-LEGAL-1
     tags: [planning, legal]
 
   - id: M-LEASE-SIGNED
@@ -74,7 +74,7 @@ activities:
     end_date: "2026-08-14"
     predecessors: [M-LEASE-SIGNED]
     goals: [GOAL-RELOC-001]
-    unit: UNIT-LEGAL
+    owner: ACTOR-LEGAL-1
     tags: [fit-out, legal]
 
   - id: A-202
@@ -84,7 +84,7 @@ activities:
     end_date: "2026-08-07"
     predecessors: [M-LEASE-SIGNED]
     goals: [GOAL-RELOC-002]
-    unit: UNIT-FACILITIES
+    owner: ACTOR-FACILITIES-1
     tags: [fit-out, design]
 
   - id: A-203
@@ -94,7 +94,7 @@ activities:
     end_date: "2026-09-25"
     predecessors: [A-201, A-202]
     goals: [GOAL-RELOC-001]
-    unit: UNIT-FACILITIES
+    owner: ACTOR-FACILITIES-1
     tags: [fit-out]
     delivers_changes: [CHG-WORKSPACE-001]
 
@@ -105,7 +105,7 @@ activities:
     end_date: "2026-10-13"
     predecessors: [A-203]
     goals: [GOAL-RELOC-002]
-    unit: UNIT-IT
+    owner: ACTOR-IT-1
     tags: [fit-out, it]
     delivers_changes: [CHG-WORKSPACE-001]
 
@@ -116,7 +116,7 @@ activities:
     end_date: "2026-10-02"
     predecessors: [A-203]
     goals: [GOAL-RELOC-002]
-    unit: UNIT-FACILITIES
+    owner: ACTOR-FACILITIES-1
     tags: [fit-out]
 
   - id: A-301
@@ -126,7 +126,7 @@ activities:
     end_date: "2026-10-16"
     predecessors: [A-204, A-205]
     goals: [GOAL-RELOC-001]
-    unit: UNIT-FACILITIES
+    owner: ACTOR-FACILITIES-1
     tags: [move]
 
   - id: A-302
@@ -136,7 +136,7 @@ activities:
     end_date: "2026-10-20"
     predecessors: [A-301]
     goals: [GOAL-RELOC-001]
-    unit: UNIT-FACILITIES
+    owner: ACTOR-FACILITIES-1
     tags: [move]
 
   - id: A-303
@@ -146,7 +146,7 @@ activities:
     end_date: "2026-10-23"
     predecessors: [A-302]
     goals: [GOAL-RELOC-001]
-    unit: UNIT-FACILITIES
+    owner: ACTOR-FACILITIES-1
     tags: [move]
 
   - id: M-OPEN-DAY

--- a/notations/examples/activities/platform-launch.activities.transitrix.yaml
+++ b/notations/examples/activities/platform-launch.activities.transitrix.yaml
@@ -17,7 +17,7 @@ activities:
     sort: 10
     goals: [GOAL-CUST-001]
     tags: [q3-priority, discovery]
-    unit: UNIT-PRODUCT
+    owner: ACTOR-PRODUCT-1
     description: |
       Gather and document all requirements for the customer platform.
       Include both functional and non-functional requirements.
@@ -29,8 +29,7 @@ activities:
     predecessors: [A-001]
     goals: [GOAL-CUST-001, GOAL-PLATFORM-002]
     tags: [q3-priority]
-    unit: UNIT-ENGINEERING
-
+    owner: ACTOR-ENGINEERING-1
   - id: A-003
     name: Backend implementation
     duration: 15
@@ -38,7 +37,7 @@ activities:
     predecessors: [A-002]
     goals: [GOAL-PLATFORM-002]
     tags: [q3-priority]
-    unit: UNIT-ENGINEERING
+    owner: ACTOR-ENGINEERING-1
     delivers_changes: [CHG-PLATFORM-001]
 
   - id: A-004
@@ -48,7 +47,7 @@ activities:
     predecessors: [A-002]
     goals: [GOAL-CUST-001]
     tags: [q3-priority]
-    unit: UNIT-ENGINEERING
+    owner: ACTOR-ENGINEERING-1
     delivers_changes: [CHG-UX-001]
 
   - id: A-005
@@ -58,8 +57,7 @@ activities:
     predecessors: [A-002]
     goals: [GOAL-PLATFORM-002]
     tags: [devops]
-    unit: UNIT-INFRA
-
+    owner: ACTOR-INFRA-1
   - id: A-006
     name: Integration testing
     duration: 7
@@ -67,8 +65,7 @@ activities:
     predecessors: [A-003, A-004, A-005]
     goals: [GOAL-CUST-001, GOAL-PLATFORM-002]
     tags: [q3-priority, qa]
-    unit: UNIT-QA
-
+    owner: ACTOR-QA-1
   - id: A-007
     name: Performance testing
     duration: 3
@@ -76,8 +73,7 @@ activities:
     predecessors: [A-006]
     goals: [GOAL-PLATFORM-002]
     tags: [qa]
-    unit: UNIT-QA
-
+    owner: ACTOR-QA-1
   - id: A-008
     name: Security review
     duration: 4
@@ -85,8 +81,7 @@ activities:
     predecessors: [A-006]
     goals: [GOAL-COMPLIANCE-001]
     tags: [security]
-    unit: UNIT-SECURITY
-
+    owner: ACTOR-SECURITY-1
   - id: A-009
     name: Stakeholder sign-off
     duration: 2
@@ -94,8 +89,7 @@ activities:
     predecessors: [A-007, A-008]
     goals: [GOAL-CUST-001]
     tags: [q3-priority]
-    unit: UNIT-PRODUCT
-
+    owner: ACTOR-PRODUCT-1
   - id: A-010
     name: Production deployment
     duration: 1
@@ -103,5 +97,5 @@ activities:
     predecessors: [A-009]
     goals: [GOAL-CUST-001, GOAL-PLATFORM-002]
     tags: [q3-priority, devops]
-    unit: UNIT-INFRA
+    owner: ACTOR-INFRA-1
     delivers_changes: [CHG-PLATFORM-001, CHG-UX-001]

--- a/notations/views/07-activities.md
+++ b/notations/views/07-activities.md
@@ -51,7 +51,7 @@ An **Activities** document describes a directed acyclic graph (DAG) of activitie
 - **Network view** — Project Schedule Network Diagram in Activity-on-Node (AoN) representation: each activity is a node, predecessor relationships are directed edges from predecessor to successor. Always renderable from `activities[]` + `predecessors[]`.
 - **Gantt view** — horizontal-bar timeline: each activity is a bar positioned by computed or pinned dates. Renderable when the schedule is *computable* (durations + predecessors + a project `start_date`) or *pinned* (explicit per-activity dates).
 
-The notation captures **what work is planned** (activities, durations, dependencies), **for what purpose** (goals served), **by whom** (owner / unit / employee), **at what cost** (labor / resources / effort), and **delivering which changes** (BDN linkage). It does **not** track real-time progress against the plan — no `progress` / `% complete` field is part of this notation. Execution tracking is the job of an execution system.
+The notation captures **what work is planned** (activities, durations, dependencies), **for what purpose** (goals served), **by whom** (owner — an `ACTOR`), **at what cost** (labor / resources / effort), and **delivering which changes** (BDN linkage). It does **not** track real-time progress against the plan — no `progress` / `% complete` field is part of this notation. Execution tracking is the job of an execution system.
 
 Critical-path values (early start / early finish / late start / late finish / slack) and computed Gantt dates are **not stored** in the document. They are derived at render time by a forward and backward pass over the network (CPM) and by projecting CPM offsets onto the working calendar (Gantt). Renderers MUST compute them and SHOULD highlight the critical path visually.
 
@@ -81,7 +81,7 @@ Stand-alone activity documents live in:
 organizations/<org>/views/activities/<NAME>.activities.transitrix.yaml
 ```
 
-Activities defined here MAY reference other elements by ID (goals, changes, scenarios, units, employees, activity types) declared elsewhere in the organisation's repository.
+Activities defined here MAY reference other elements by ID (goals, changes, scenarios, actors, activity types) declared elsewhere in the organisation's repository.
 
 ---
 
@@ -122,9 +122,7 @@ activities:
     scenario: SCEN-2026-OPT           # optional, reference to a Scenario element
     parent: A-000                     # optional, hierarchical parent activity (WBS-style)
     predecessors: []                  # optional, array of activity IDs that must complete first
-    owner: alice                      # optional, free-text or reference (see §5.6)
-    unit: UNIT-PRODUCT                # optional, reference to a Unit element
-    employee: EMP-001                 # optional, reference to an Employee element
+    owner: ACTOR-PRODUCT-TEAM-1       # optional, reference to the accountable ACTOR (see §5.6)
     score: 5                          # optional, integer — local prioritisation signal
     sort: 10                          # optional, integer — manual display ordering
     tags: [q3-priority, customer]     # optional, array of free-text tags
@@ -200,9 +198,7 @@ activities:
 | `scenario` | no | string (ID ref) | reference to a Scenario element |
 | `parent` | no | string (ID ref to activity) | hierarchical parent activity (WBS-style, **single** parent only) |
 | `predecessors` | no | array of string (ID refs to activities) | activities that must complete before this one can start |
-| `owner` | no | string | free-text owner identifier (see §5.6) |
-| `unit` | no | string (ID ref) | reference to a Unit element |
-| `employee` | no | string (ID ref) | reference to an Employee element |
+| `owner` | no | string (ID ref) | reference to the accountable `ACTOR-…` (`person` / `business_unit` / `system`); see §5.6 |
 | `score` | no | integer | local prioritisation signal |
 | `sort` | no | integer | manual display ordering |
 | `tags` | no | array of string | free-text tags (M:M) |
@@ -237,14 +233,11 @@ Activities with `start_date` AND `end_date` AND `duration` MUST have `duration` 
 
 All dependencies are interpreted as **Finish-to-Start with zero lag** by renderers and CPM computation. Typed dependencies and lag are reserved for a future version and will be additive (existing documents without these fields will remain valid).
 
-### 5.6 Owner — three optional fields
+### 5.6 Owner — a single Actor reference
 
-DSM today exposes three parallel ownership fields, all optional:
-- `owner` — free-text label (most permissive)
-- `unit` — reference to an organisational unit
-- `employee` — reference to a named employee
+`owner` is an optional reference to the `ACTOR` accountable for the activity — `ACTOR-…` of `type` `person`, `business_unit`, or `system` (see [elements/19-actors.md](../elements/19-actors.md)).
 
-An activity MAY populate any combination. The free-text `owner` is the default surface; `unit` and `employee` are structured alternatives for organisations that want enforced references.
+This collapses the three parallel ownership fields DSM historically exposed (`owner` free-text, `unit` → org unit, `employee` → named employee) into one typed reference, per the 2026-05-29 Actors decision: identity lives in a single `ACTOR` catalogue, so a unit-owner and a person-owner are both just `ACTOR-…` IDs distinguished by the actor's `type`. Legacy free-text `owner` values migrate to an `ACTOR(type: person)` (or `system`) record; the `unit` / `employee` fields are removed (mapping in the `0.5 → 0.6` migration recipe).
 
 ### 5.7 BDN linkage
 


### PR DESCRIPTION
## What

Realizes the **Actors decision** (strategy proposal #111, Q1 = A′) — the methodology side of epic #98. Introduces the `ACTOR` identity primitive and retires the briefly-registered `UNIT` / `EMPLOYEE` TYPEs (schema-only since 2026-05-29; removed same day before any population).

## Decision realized

- **`ACTOR`** (`type ∈ {person, business_unit, system}`) = active-structure **identity**. New element notation `notations/elements/19-actors.md`.
- **`ROLE`** unchanged (position); its `unit` now → `ACTOR(type: business_unit)`.
- **`EMPLOYEE` deleted** → `ACTOR(person)` + an `employment` REL (identity ≠ engagement: a person can be candidate/employee/alumnus/contractor over time).
- **`UNIT` deleted** → `ACTOR(business_unit)`.
- **Engagement = separate REL TYPEs** (`employment` / `candidacy` / `alumni_membership` / `community_membership` / `contracting`) added to `17-relations.md`; `unit_parent` re-typed to `ACTOR(business_unit)`.
- **Activity ownership** collapses `owner`(free-text)/`unit`/`employee` → one `owner: ACTOR-…` (`07-activities.md` §5.6).

## Files

`IDS_AND_REFERENCES.md` §3.1/§4, `ELEMENT_PRIMITIVES.md` (§2/§4/§6/§7.4/§7.9/§7.10/§7.11), `17-relations.md` §3, `07-activities.md` §5.6, the two activities examples (`unit: UNIT-X` → `owner: ACTOR-X-1`), `README.md`, new `elements/19-actors.md`.

## Verification

- All 14 internal links in IDS resolve; 19-actors.md links resolve; activities examples parse.
- No residual `UNIT`/`EMPLOYEE` TYPE references except the intentional "replaces …" notes.

## Bundled cleanup

Fixed pre-existing bare-filename internal links in `IDS_AND_REFERENCES.md` (`05-capability-map.md` → `views/05-capability-map.md`, etc.) that broke when `notations/` split into `views/`+`elements/` (cccbcf1). They were in the file I was already editing.

## Follow-ups (separate PRs, this session)

- #99 Stakeholders notation (`STAKEHOLDER.actor` REQUIRED + `stakeholding` REL).
- acme_corp worked `ACTOR` examples + per-folder README.
- `0.5 → 0.6` migration recipe entry (UNIT/EMPLOYEE deprecation + mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
