### PR TITLE
docs(acme): worked ACTOR + STAKEHOLDER examples (strategy#98/#99)

### DIFF
--- a/organizations/acme_corp/canon/elements/01_motivation/stakeholders/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/stakeholders/README.md
@@ -1,0 +1,31 @@
+# `canon/elements/01_motivation/stakeholders/`
+
+Stakeholder element primitives — the motivation-layer **interest** primitive (ArchiMate Stakeholder): *whose interests are at stake*. A stakeholder carries the stake profile (`concern` / `interest` / `influence`) and a `type` (`internal` / `external`); it **references an `ACTOR` for identity** (`actor:` REQUIRED) — identity is never duplicated here.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`STAKEHOLDER`). Full spec: [`notations/elements/20-stakeholders.md`](../../../../../../notations/elements/20-stakeholders.md).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows `STAKEHOLDER-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `STAKEHOLDER-DPA-1.yaml`.
+
+## Schema
+
+Defined in [`notations/elements/20-stakeholders.md`](../../../../../../notations/elements/20-stakeholders.md) §2 + [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.15 over the common envelope §3:
+
+- Fields: `notation: stakeholder`, `id`, `name`, `type` (`internal` | `external`, required), `actor: ACTOR-…` (**required**), optional `concern` / `interest` / `influence` / `description`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+Stake in a specific `GOAL` / `ACTIVITY` / `CAPABILITY` is a `stakeholding` `REL` ([`17-relations.md`](../../../../../../notations/elements/17-relations.md) §3), not an inline field.
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `STAKEHOLDER-DPA-1.yaml` | `external` — the data-protection regulator; identity `ACTOR-DPA-1`; stakes the EU goal via `REL-STK-DPA-GOAL-EU-1` |
+| `STAKEHOLDER-OPS-1.yaml` | `internal` — Operations; identity `ACTOR-OPS-1` (same actor is also a doer) |
+
+## See also
+
+- Stakeholders notation: [`notations/elements/20-stakeholders.md`](../../../../../../notations/elements/20-stakeholders.md).
+- Identity primitives referenced here: [`../../02_business/actors/`](../../02_business/actors/).
+- `stakeholding` relations: [`../../../relations/`](../../../relations/).

--- a/organizations/acme_corp/canon/elements/01_motivation/stakeholders/STAKEHOLDER-DPA-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/stakeholders/STAKEHOLDER-DPA-1.yaml
@@ -1,0 +1,28 @@
+# Worked example — STAKEHOLDER element primitive (external regulator).
+# Schema: notations/elements/20-stakeholders.md + ELEMENT_PRIMITIVES.md §7.15.
+# Identity lives in ACTOR-DPA-1; this record carries only the stake profile.
+
+notation: stakeholder
+id: STAKEHOLDER-DPA-1
+name: "Data Protection Authority"
+type: external                          # internal | external
+actor: ACTOR-DPA-1                      # REQUIRED — identity binding
+concern: "Lawful processing and timely erasure of EU customer personal data."
+interest: high
+influence: high
+description: >
+  External oversight stakeholder. Its stake in specific objects (e.g. the EU
+  expansion goal) is carried by `stakeholding` relations, not here.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2018-05-25"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/stakeholders/STAKEHOLDER-OPS-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/stakeholders/STAKEHOLDER-OPS-1.yaml
@@ -1,0 +1,26 @@
+# Worked example — STAKEHOLDER element primitive (internal).
+# Schema: notations/elements/20-stakeholders.md + ELEMENT_PRIMITIVES.md §7.15.
+# The same Operations unit is both an ACTOR (it performs work) and a
+# STAKEHOLDER (it has an interest) — one identity (ACTOR-OPS-1), two records.
+
+notation: stakeholder
+id: STAKEHOLDER-OPS-1
+name: "Operations"
+type: internal
+actor: ACTOR-OPS-1                      # REQUIRED — identity binding
+concern: "Operational efficiency and support response time."
+interest: high
+influence: medium
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2024-01-01"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/actors/ACTOR-DPA-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/actors/ACTOR-DPA-1.yaml
@@ -1,0 +1,27 @@
+# Worked example — ACTOR element primitive (external organisation, business_unit).
+# Schema: notations/elements/19-actors.md + ELEMENT_PRIMITIVES.md §7.10.
+# The "external" nature of this body is recorded on the STAKEHOLDER that
+# references it (STAKEHOLDER-DPA-1, type: external) — ACTOR is identity only.
+
+notation: actor
+id: ACTOR-DPA-1
+name: "National Data Protection Authority"
+type: business_unit                     # an external organisation modelled as a business_unit actor
+description: >
+  The national data-protection regulator with oversight of personal-data
+  processing. Modelled as an identity so stakeholders / relations can point
+  at it; its external standing is carried on the referencing STAKEHOLDER.
+external_ref: "https://example.gov/data-protection-authority"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2018-05-25"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/actors/ACTOR-OPS-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/actors/ACTOR-OPS-1.yaml
@@ -1,0 +1,25 @@
+# Worked example — ACTOR element primitive (business_unit).
+# Schema: notations/elements/19-actors.md + ELEMENT_PRIMITIVES.md §7.10.
+# Identity only — engagement and org hierarchy are REL records, not fields here.
+
+notation: actor
+id: ACTOR-OPS-1
+name: "Operations"
+type: business_unit                     # person | business_unit | system
+description: >
+  The operations organisation — owns order-fulfilment operations and the
+  related processes / capabilities.
+contact: "ops@acme.example"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2024-01-01"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/actors/ACTOR-PERSON-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/actors/ACTOR-PERSON-1.yaml
@@ -1,0 +1,30 @@
+# Worked example — ACTOR element primitive (person).
+# Schema: notations/elements/19-actors.md + ELEMENT_PRIMITIVES.md §7.10.
+#
+# Identity only. This person's employment by ACTOR-OPS-1 (and the ROLE they
+# hold) is recorded as a separate `employment` REL — see
+# canon/relations/REL-EMP-PERSON-OPS-1.yaml — NOT as fields here. The split
+# lets the same identity be a candidate / employee / alumnus over time.
+#
+# Name is a synthetic placeholder — `person` actors name real people in a live
+# repo; the worked-example org redacts real names (CONTRACT.md §5).
+
+notation: actor
+id: ACTOR-PERSON-1
+name: "Alex Doe (example)"
+type: person
+description: "Synthetic person actor demonstrating identity-vs-engagement."
+contact: "alex.doe@acme.example"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2025-03-01"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/actors/README.md
+++ b/organizations/acme_corp/canon/elements/02_business/actors/README.md
@@ -1,0 +1,32 @@
+# `canon/elements/02_business/actors/`
+
+Actor element primitives — the active-structure **identity** primitive on the ArchiMate 3.2 **business** layer: *who or what exists and performs work*. One TYPE with a `type` discriminator covers a `person`, a `business_unit`, or a `system`. Actors are the single home for identity — activity ownership, stakeholders, employment, and org hierarchy all *reference* an actor rather than re-declaring who someone is.
+
+TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`ACTOR`). Full spec: [`notations/elements/19-actors.md`](../../../../../../notations/elements/19-actors.md). `ACTOR` replaced the briefly-registered `UNIT` / `EMPLOYEE` TYPEs (2026-05-29).
+
+## File convention
+
+`<id>.yaml`, where `<id>` follows `ACTOR-[<middle>-]<INTEGER>` from [`IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §1. Examples: `ACTOR-OPS-1.yaml`.
+
+## Schema
+
+Defined in [`notations/elements/19-actors.md`](../../../../../../notations/elements/19-actors.md) §2 + [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.10 over the common envelope §3:
+
+- Identity fields: `notation: actor`, `id`, `name`, `type` (`person` | `business_unit` | `system`, required), `description`, optional `contact` / `external_ref`.
+- Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
+
+**Identity only.** No engagement / role / ownership / hierarchy fields on the actor — those are first-class `REL` records ([`17-relations.md`](../../../../../../notations/elements/17-relations.md) §3): `employment`, `candidacy`, `alumni_membership`, `community_membership`, `contracting`, `unit_parent`. A `person` actor names a real person in a live repo; this worked-example org uses synthetic names ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §5).
+
+## Examples in this folder
+
+| File | Notes |
+|---|---|
+| `ACTOR-OPS-1.yaml` | `business_unit` — the Operations organisation |
+| `ACTOR-DPA-1.yaml` | `business_unit` — an external regulator (its external standing is on `STAKEHOLDER-DPA-1`) |
+| `ACTOR-PERSON-1.yaml` | `person` — synthetic identity; employed via `REL-EMP-PERSON-OPS-1` (employment ≠ identity) |
+
+## See also
+
+- Actors notation: [`notations/elements/19-actors.md`](../../../../../../notations/elements/19-actors.md).
+- Engagement / hierarchy relations: [`../../../relations/`](../../../relations/) and [`notations/elements/17-relations.md`](../../../../../../notations/elements/17-relations.md) §3.
+- Stakeholders that reference these actors: [`../../01_motivation/stakeholders/`](../../01_motivation/stakeholders/).

--- a/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-SUPPORT-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-SUPPORT-1.yaml
@@ -7,6 +7,7 @@ id: ACTIVITY-SUPPORT-1
 name: "Add second-shift coverage in EU timezone"
 goals:
   - GOAL-OPS-1
+owner: ACTOR-OPS-1                       # accountable ACTOR (ELEMENT_PRIMITIVES.md §7.4; was unit/employee)
 description: >
   Operational workstream to add second-shift support coverage, serving the
   response-time goal.

--- a/organizations/acme_corp/canon/relations/REL-EMP-PERSON-OPS-1.yaml
+++ b/organizations/acme_corp/canon/relations/REL-EMP-PERSON-OPS-1.yaml
@@ -1,0 +1,30 @@
+# Worked example — employment REL (ACTOR(person) → ACTOR(business_unit)).
+# Schema: notations/elements/17-relations.md §2–3.
+# Demonstrates identity-vs-engagement: the person (ACTOR-PERSON-1) exists as one
+# identity; this relation records that they are employed by Operations and hold
+# the Operations Lead role — replacing the old EMPLOYEE primitive.
+
+notation: relation
+id: REL-EMP-PERSON-OPS-1
+type: employment
+from: ACTOR-PERSON-1
+to: ACTOR-OPS-1
+
+# Per-engagement attributes (employment)
+contract_type: permanent
+roles:
+  - ROLE-OPS-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — the employment window; within both
+# endpoints' lifecycles (REL-003). The person identity took effect 2025-03-01.
+valid_from: "2025-03-01"
+valid_to: null

--- a/organizations/acme_corp/canon/relations/REL-STK-DPA-GOAL-EU-1.yaml
+++ b/organizations/acme_corp/canon/relations/REL-STK-DPA-GOAL-EU-1.yaml
@@ -1,0 +1,27 @@
+# Worked example — stakeholding REL (STAKEHOLDER → GOAL).
+# Schema: notations/elements/17-relations.md §2–3.
+# The DPA's stake in the EU-expansion goal; per-stake concern/influence on the relation.
+
+notation: relation
+id: REL-STK-DPA-GOAL-EU-1
+type: stakeholding
+from: STAKEHOLDER-DPA-1
+to: GOAL-EU-1
+
+# Per-stake attributes (stakeholding)
+concern: "EU personal-data residency and erasure as the EU market is entered."
+influence: high
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7) — within both endpoints' windows (REL-003);
+# GOAL-EU-1 took effect 2026-05-26, so the stake cannot predate that.
+valid_from: "2026-05-26"
+valid_to: null


### PR DESCRIPTION
## What

Worked examples for the new identity model (epics #98 Actors / #99 Stakeholders) in the `acme_corp` repo — demonstrating identity-vs-engagement and identity-vs-interest end to end.

## Added

**Actors** (`canon/elements/02_business/actors/`) — identity only:
- `ACTOR-OPS-1` (`business_unit`), `ACTOR-DPA-1` (external regulator, `business_unit`), `ACTOR-PERSON-1` (`person`, synthetic name per data-protection redaction).

**Stakeholders** (`canon/elements/01_motivation/stakeholders/`) — stake profile + required `actor:` ref:
- `STAKEHOLDER-DPA-1` (external regulator → `ACTOR-DPA-1`); `STAKEHOLDER-OPS-1` (internal → `ACTOR-OPS-1` — same identity is both a doer and a stakeholder).

**Relations** (`canon/relations/`):
- `REL-STK-DPA-GOAL-EU-1` — `stakeholding`, `STAKEHOLDER-DPA-1 → GOAL-EU-1`.
- `REL-EMP-PERSON-OPS-1` — `employment`, `ACTOR-PERSON-1 → ACTOR-OPS-1`, `roles: [ROLE-OPS-1]` (the former EMPLOYEE primitive = `ACTOR(person)` + an `employment` REL).

Plus per-folder READMEs (`actors/`, `stakeholders/`) and `owner: ACTOR-OPS-1` on `ACTIVITY-SUPPORT-1` (end-to-end ownership).

## Verification

All carry the canonical envelope; every cross-reference (`actor` / `from` / `to` / `roles` / `owner`) resolves to a real file (45 known IDs, 0 dangling); REL windows respect both endpoints' lifecycles (`REL-003`); README links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
