### PR TITLE
docs(migrations): 0.5→0.6 recipe — UNIT/EMPLOYEE retirement (strategy#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The methodology is **pre-1.0**. MINOR releases (`0.x` → `0.(x+1)`) may carry b
 
 ---
 
+## [0.6.0] — Unreleased
+
+The Actors / Stakeholders identity model (epics #98 / #99). Unifies active-structure identity under one `ACTOR` TYPE and adds the `STAKEHOLDER` interest primitive; retires `UNIT` / `EMPLOYEE`. One pre-1.0 breaking change, called out below.
+
+### Added
+
+- **`notations/elements/19-actors.md`** — `ACTOR` element TYPE: the active-structure identity primitive with `type ∈ {person, business_unit, system}`. Identity only; engagement and hierarchy are relations. Validation codes `ACTOR-001..003`. (#98)
+- **`notations/elements/20-stakeholders.md`** — `STAKEHOLDER` element TYPE (motivation layer): `internal` / `external`, carries the stake profile and **references an `ACTOR` for identity** (`actor:` required). Validation codes `STAKE-001..003`. (#99)
+- **Engagement + stakeholding relations** in `notations/elements/17-relations.md` §3: `employment`, `candidacy`, `alumni_membership`, `community_membership`, `contracting` (person ↔ org), and `stakeholding` (`STAKEHOLDER → GOAL | ACTIVITY | CAPABILITY`). `unit_parent` re-typed to `ACTOR(business_unit)`.
+- **New canonical TYPEs in `notations/IDS_AND_REFERENCES.md` §3.1:** `ACTOR`, `STAKEHOLDER`. New folders `canon/elements/02_business/actors/` and `canon/elements/01_motivation/stakeholders/`.
+- **acme_corp worked examples** — `ACTOR` (business_unit / external regulator / person), `STAKEHOLDER` (internal + external), and `stakeholding` / `employment` RELs, with folder READMEs. (#98/#99)
+- **`migrations/0.5-to-0.6/`** migration recipe — codemod + validate + fixtures for the UNIT/EMPLOYEE retirement.
+
+### Changed
+
+- **BREAKING: `UNIT` and `EMPLOYEE` element TYPEs removed.** `UNIT` → `ACTOR(type: business_unit)`; `EMPLOYEE` → `ACTOR(type: person)` + an `employment` REL. Both were registered schema-only on 2026-05-29 and removed the same day before any population; the `0.5 → 0.6` migration recipe records the mapping. (#98)
+- **BREAKING: activity ownership collapses to one field.** The parallel `owner` (free-text) / `unit` / `employee` fields on activities become a single `owner: ACTOR-…` (`notations/views/07-activities.md` §5.6). `ROLE.unit` now references an `ACTOR(business_unit)`. (#98)
+
+---
+
 ## [0.5.0] — 2026-05-28
 
 A large release covering three completed epics (Compliance & regulation tracking, Temporal model, Per-layer extraction prompts) plus the methodology-upgrade-path policy and the Project Card notation. Adds three shared contracts (primitive lifecycle, compliance-domain rule index, versioned-attribute sidecar) plus a versioning policy. Adds five new notations and seven new element / document TYPEs. Several pre-1.0 breaking changes are called out under Changed.

--- a/migrations/0.5-to-0.6/README.md
+++ b/migrations/0.5-to-0.6/README.md
@@ -1,0 +1,67 @@
+# Migration recipe — methodology 0.5 → 0.6
+
+The on-disk migration recipe an adopter follows when upgrading from methodology version 0.5 to 0.6. Format per [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §10.4 and [`RELEASING.md`](../../RELEASING.md); see also [`CHANGELOG.md`](../../CHANGELOG.md) (0.6.0).
+
+## What this recipe covers — the Actors decision
+
+0.6.0 retires the `UNIT` and `EMPLOYEE` element TYPEs and unifies active-structure **identity** under a single `ACTOR` TYPE (`type ∈ {person, business_unit, system}`), per [`notations/elements/19-actors.md`](../../notations/elements/19-actors.md). Identity (the actor) is separated from engagement and ownership:
+
+| 0.5 form | 0.6 form |
+|---|---|
+| `UNIT-…` element file | `ACTOR-…` with `type: business_unit` (in `canon/elements/02_business/actors/`) |
+| `EMPLOYEE-…` element file | `ACTOR-…` with `type: person` **+** an `employment` REL ([`17-relations.md`](../../notations/elements/17-relations.md) §3) carrying the dates and role assignments |
+| activity `unit:` / `employee:` / free-text `owner:` | one `owner: ACTOR-…` ([`07-activities.md`](../../notations/views/07-activities.md) §5.6) |
+| `ROLE.unit: UNIT-…` | `ROLE.unit: ACTOR-…` (an `ACTOR` of `type: business_unit`) |
+
+**Migration cost is near-zero in practice.** `UNIT` and `EMPLOYEE` were registered schema-only on 2026-05-29 and removed the same day; no adopter had populated them. This recipe exists for any adopter who began populating them between registration and the 0.6 cut.
+
+## What the codemod does (safe, automatic)
+
+- **Transform A — activity ownership collapse.** In `notation: activities | activity` files, rewrites `unit: UNIT-X` and `employee: EMPLOYEE-X | EMP-X` to `owner: ACTOR-<tail>`. Skips (and flags) an entry that already has a sibling `owner:` — that collapse is manual to avoid a duplicate key.
+- **Transform B — `ROLE.unit` retarget.** In `notation: role` files, rewrites `unit: UNIT-X` → `unit: ACTOR-X`.
+
+## What is manual (the codemod flags, does not auto-apply)
+
+- **`UNIT-…` / `EMPLOYEE-…` element files.** These need a move + (for EMPLOYEE) a split that can't be synthesised deterministically:
+  - `UNIT-…` → move to `canon/elements/02_business/actors/`, set `notation: actor` + `type: business_unit`, rename `UNIT-…` → `ACTOR-…`.
+  - `EMPLOYEE-…` → an `ACTOR(type: person)` **plus** an `employment` REL (`canon/relations/`, `type: employment`) carrying the role assignments and employment dates. Splitting identity from engagement is a human judgement (which dates, which roles).
+  
+  The codemod reports each such file with its mapping and **exits non-zero**, leaving the file unchanged so the adopter handles it explicitly.
+
+## Folder shape
+
+```
+migrations/0.5-to-0.6/
+├── README.md         # this file
+├── codemod.mjs       # safe transforms A + B; detection + report for manual cases
+├── validate.mjs      # post-migration check — no UNIT / EMPLOYEE residue
+└── fixtures/
+    ├── before/       # tiny adopter tree on 0.5 form
+    └── after/        # the same tree after the codemod
+```
+
+## Conventions
+
+Pure-Node (≥ 20), idempotent, `[--dry-run] [target-dir]` CLI, diff-style summary, exits non-zero on unsafe ambiguity (leaving the offending file unchanged). Identical to the [`0.4-to-0.5`](../0.4-to-0.5/) recipe.
+
+## Running
+
+```bash
+# preview
+node migrations/0.5-to-0.6/codemod.mjs --dry-run /path/to/adopter-repo
+# apply
+node migrations/0.5-to-0.6/codemod.mjs /path/to/adopter-repo
+# handle any flagged UNIT/EMPLOYEE element files manually (see above), then verify
+node migrations/0.5-to-0.6/validate.mjs /path/to/adopter-repo
+```
+
+A clean run exits `0`; a non-zero exit means UNIT/EMPLOYEE element files still need the manual move + split. After migrating, bump `methodology_version` in the adopter's `transitrix.yaml` to `0.6.x`.
+
+## Self-test
+
+```bash
+cp -r migrations/0.5-to-0.6/fixtures/before /tmp/m && \
+  node migrations/0.5-to-0.6/codemod.mjs /tmp/m && \
+  diff -r /tmp/m migrations/0.5-to-0.6/fixtures/after && \
+  node migrations/0.5-to-0.6/validate.mjs migrations/0.5-to-0.6/fixtures/after
+```

--- a/migrations/0.5-to-0.6/codemod.mjs
+++ b/migrations/0.5-to-0.6/codemod.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// Migration codemod — methodology 0.5 → 0.6.
+//
+// Covers the Actors decision (2026-05-29): the UNIT and EMPLOYEE element TYPEs
+// are removed; identity unifies under ACTOR (person | business_unit | system).
+//   UNIT-…      → ACTOR-… (type: business_unit)
+//   EMPLOYEE-…  → ACTOR-… (type: person) + an `employment` REL (engagement)
+// and the activity ownership fields (owner free-text / unit / employee) collapse
+// to a single `owner: ACTOR-…`.
+//
+// TRANSFORMS (each independent):
+//
+//   A. Activity ownership collapse (notations/views/07-activities.md §5.6).
+//      In files with notation: activities | activity, rewrites inline
+//      `unit: UNIT-X` and `employee: EMPLOYEE-X | EMP-X` to `owner: ACTOR-<tail>`.
+//      Skips (flags) an entry that already carries a sibling `owner:` so the
+//      collapse never produces a duplicate key — that case is manual.
+//
+//   B. ROLE.unit value retarget (notations/ELEMENT_PRIMITIVES.md §7.9).
+//      In files with notation: role, rewrites `unit: UNIT-X` → `unit: ACTOR-X`
+//      (the field stays; it now points at an ACTOR of type business_unit).
+//
+//   C. UNIT / EMPLOYEE element files (detection only — UNSAFE to auto-transform).
+//      A file whose `id:` is UNIT-… or EMPLOYEE-… needs a manual move + split:
+//      UNIT → ACTOR(business_unit); EMPLOYEE → ACTOR(person) + an employment REL
+//      (the engagement data can't be synthesised deterministically). Such files
+//      are reported and left unchanged; the codemod exits non-zero so the adopter
+//      handles them (per the recipe convention).
+//
+// Conventions (canonical for every migration recipe):
+//   - Pure-Node, no native deps; Node ≥ 20.
+//   - Idempotent: a repo already on 0.6 form is a no-op.
+//   - CLI: [--dry-run] [target-dir]. Default target = current working dir.
+//   - Per-transform + overall diff-style summary. Exit non-zero on unsafe
+//     ambiguity, leaving the offending file unchanged.
+//
+// Line-based transformation (not js-yaml roundtrip) to preserve comments,
+// key order, and formatting on untouched lines.
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const target = resolve(args.find(a => !a.startsWith('--')) ?? process.cwd());
+
+if (!existsSync(target)) {
+  console.error(`error: target directory does not exist: ${target}`);
+  process.exit(2);
+}
+
+function walkYaml(dir, out = []) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return out; }
+  for (const ent of entries) {
+    const full = join(dir, ent);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) walkYaml(full, out);
+    else if (st.isFile() && ent.endsWith('.yaml')) out.push(full);
+  }
+  return out;
+}
+
+function notationOf(content) {
+  const m = content.match(/^notation\s*:\s*(\S+)/m);
+  return m ? m[1] : null;
+}
+
+// tail of a typed id: UNIT-FACILITIES -> FACILITIES, EMP-001 -> 001
+function tail(id) {
+  return id.replace(/^(UNIT|EMPLOYEE|EMP)-/, '');
+}
+
+// --- Transform A: activity ownership collapse -------------------------------
+
+function collapseOwnership(content) {
+  if (!['activities', 'activity'].includes(notationOf(content))) {
+    return { content, modified: 0, failed: 0, notes: [] };
+  }
+  const lines = content.split('\n');
+  const out = [];
+  let modified = 0, failed = 0;
+  const notes = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = line.match(/^(\s*)(unit|employee)\s*:\s*["']?((?:UNIT|EMPLOYEE|EMP)-[A-Za-z0-9._-]+)["']?\s*(#.*)?$/);
+    if (!m) { out.push(line); continue; }
+    const [, indent, , id, comment] = m;
+    // Guard: don't create a duplicate owner key within the same activity entry.
+    const siblingOwner = lines.some((l, j) => {
+      if (j === i) return false;
+      const om = l.match(/^(\s*)owner\s*:/);
+      return om && om[1].length === indent.length && nearSameEntry(lines, i, j, indent.length);
+    });
+    if (siblingOwner) {
+      failed++;
+      notes.push(`already has a sibling owner: near "${id}" — collapse manually`);
+      out.push(line);
+      continue;
+    }
+    modified++;
+    out.push(`${indent}owner: ACTOR-${tail(id)}${comment ? ' ' + comment : ''}`);
+  }
+  return { content: out.join('\n'), modified, failed, notes };
+}
+
+// crude same-entry check: two sibling-indented keys belong to the same list
+// item if no shallower-or-equal list marker ("- ") sits between them.
+function nearSameEntry(lines, i, j, indent) {
+  const [a, b] = i < j ? [i, j] : [j, i];
+  for (let k = a + 1; k < b; k++) {
+    const lm = lines[k].match(/^(\s*)-\s/);
+    if (lm && lm[1].length < indent) return false;
+  }
+  return true;
+}
+
+// --- Transform B: ROLE.unit value retarget ----------------------------------
+
+function retargetRoleUnit(content) {
+  if (notationOf(content) !== 'role') {
+    return { content, modified: 0, failed: 0, notes: [] };
+  }
+  let modified = 0;
+  const result = content.replace(
+    /^(\s*unit\s*:\s*["']?)UNIT-([A-Za-z0-9._-]+)(["']?\s*(?:#.*)?)$/gm,
+    (_, pre, body, post) => { modified++; return `${pre}ACTOR-${body}${post}`; },
+  );
+  return { content: result, modified, failed: 0, notes: [] };
+}
+
+// --- Detection C: UNIT / EMPLOYEE element files -----------------------------
+
+function isRemovedTypeElement(content) {
+  const m = content.match(/^id\s*:\s*["']?(UNIT|EMPLOYEE)-[A-Za-z0-9._-]+/m);
+  return m ? m[1] : null;
+}
+
+// --- Run --------------------------------------------------------------------
+
+const transforms = [
+  { key: 'A', label: 'activity ownership → owner: ACTOR-…', fn: collapseOwnership },
+  { key: 'B', label: 'ROLE.unit → ACTOR(business_unit)', fn: retargetRoleUnit },
+];
+
+const files = walkYaml(target);
+let totalModified = 0, totalFailed = 0;
+const manualFiles = [];
+
+for (const t of transforms) {
+  let modified = 0, failed = 0;
+  const touched = [];
+  for (const f of files) {
+    const original = readFileSync(f, 'utf8');
+    const r = t.fn(original);
+    if (r.notes?.length) r.notes.forEach(n => console.error(`  ! ${relative(target, f)}: ${n}`));
+    failed += r.failed;
+    if (r.modified > 0 && r.content !== original) {
+      modified += r.modified;
+      touched.push(`${relative(target, f)} (${r.modified})`);
+      if (!dryRun) writeFileSync(f, r.content);
+    }
+  }
+  console.log(`Transform ${t.key} — ${t.label}`);
+  touched.forEach(x => console.log(`  ~ ${x}`));
+  console.log(`  → ${modified} change(s)${dryRun ? ' (dry-run; no files written)' : ''}`);
+  console.log('');
+  totalModified += modified; totalFailed += failed;
+}
+
+// Detection C — UNIT / EMPLOYEE element files (manual)
+for (const f of files) {
+  const kind = isRemovedTypeElement(readFileSync(f, 'utf8'));
+  if (kind) manualFiles.push({ f: relative(target, f), kind });
+}
+
+console.log('Summary:');
+console.log(`  files scanned   ${files.length}`);
+console.log(`  changes applied ${totalModified}${dryRun ? ' (dry-run)' : ''}`);
+if (manualFiles.length) {
+  console.error(`  MANUAL — ${manualFiles.length} removed-TYPE element file(s) need a manual move + split:`);
+  for (const { f, kind } of manualFiles) {
+    const how = kind === 'UNIT'
+      ? 'move to canon/elements/02_business/actors/, set notation: actor + type: business_unit, rename UNIT-… → ACTOR-…'
+      : 'split into ACTOR(type: person) + an employment REL (canon/relations/, type: employment) carrying the role assignments';
+    console.error(`    ✗ ${f}  [${kind}]  → ${how}`);
+  }
+}
+if (totalFailed > 0) console.error(`  flagged (manual collapse) ${totalFailed}`);
+process.exit(manualFiles.length > 0 || totalFailed > 0 ? 1 : 0);

--- a/migrations/0.5-to-0.6/fixtures/after/canon/elements/02_business/roles/ROLE-OPS-1.yaml
+++ b/migrations/0.5-to-0.6/fixtures/after/canon/elements/02_business/roles/ROLE-OPS-1.yaml
@@ -1,0 +1,10 @@
+notation: role
+id: ROLE-OPS-1
+name: "Operations Lead"
+unit: ACTOR-OPS
+zone: canon
+admitted_at: "2026-01-01"
+admitted_by: "x"
+gate_checks: { uniqueness: pass, consistency: pass, completeness: pass }
+valid_from: "2026-01-01"
+valid_to: null

--- a/migrations/0.5-to-0.6/fixtures/after/canon/views/launch.activities.transitrix.yaml
+++ b/migrations/0.5-to-0.6/fixtures/after/canon/views/launch.activities.transitrix.yaml
@@ -1,0 +1,14 @@
+notation: activities
+spec_version: "0.1"
+
+activities:
+  - id: ACTIVITY-BUILD-1
+    name: "Build"
+    owner: ACTOR-PRODUCT # owned by a unit
+    valid_from: "2026-01-01"
+    valid_to: null
+  - id: ACTIVITY-SHIP-1
+    name: "Ship"
+    owner: ACTOR-001
+    valid_from: "2026-01-01"
+    valid_to: null

--- a/migrations/0.5-to-0.6/fixtures/before/canon/elements/02_business/roles/ROLE-OPS-1.yaml
+++ b/migrations/0.5-to-0.6/fixtures/before/canon/elements/02_business/roles/ROLE-OPS-1.yaml
@@ -1,0 +1,10 @@
+notation: role
+id: ROLE-OPS-1
+name: "Operations Lead"
+unit: UNIT-OPS
+zone: canon
+admitted_at: "2026-01-01"
+admitted_by: "x"
+gate_checks: { uniqueness: pass, consistency: pass, completeness: pass }
+valid_from: "2026-01-01"
+valid_to: null

--- a/migrations/0.5-to-0.6/fixtures/before/canon/views/launch.activities.transitrix.yaml
+++ b/migrations/0.5-to-0.6/fixtures/before/canon/views/launch.activities.transitrix.yaml
@@ -1,0 +1,14 @@
+notation: activities
+spec_version: "0.1"
+
+activities:
+  - id: ACTIVITY-BUILD-1
+    name: "Build"
+    unit: UNIT-PRODUCT          # owned by a unit
+    valid_from: "2026-01-01"
+    valid_to: null
+  - id: ACTIVITY-SHIP-1
+    name: "Ship"
+    employee: EMP-001
+    valid_from: "2026-01-01"
+    valid_to: null

--- a/migrations/0.5-to-0.6/validate.mjs
+++ b/migrations/0.5-to-0.6/validate.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Post-migration validation — methodology 0.5 → 0.6 (Actors decision).
+//
+// Asserts the target repo carries no residue of the removed UNIT / EMPLOYEE
+// TYPEs:
+//   - no element file whose id is UNIT-… or EMPLOYEE-…
+//   - no activity `unit:` / `employee:` field referencing UNIT-/EMPLOYEE-/EMP-
+//   - no ROLE `unit:` still pointing at a UNIT-… value
+//
+// Exit 0 = clean (on 0.6 form); exit 1 = residue found (per-file report).
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const target = resolve(process.argv.slice(2).find(a => !a.startsWith('--')) ?? process.cwd());
+if (!existsSync(target)) { console.error(`error: no such dir: ${target}`); process.exit(2); }
+
+function walk(dir, out = []) {
+  let ents; try { ents = readdirSync(dir); } catch { return out; }
+  for (const e of ents) {
+    const f = join(dir, e);
+    let st; try { st = statSync(f); } catch { continue; }
+    if (st.isDirectory()) walk(f, out);
+    else if (st.isFile() && e.endsWith('.yaml')) out.push(f);
+  }
+  return out;
+}
+
+const problems = [];
+for (const f of walk(target)) {
+  const c = readFileSync(f, 'utf8');
+  const rel = relative(target, f);
+  const idm = c.match(/^id\s*:\s*["']?(UNIT|EMPLOYEE)-[A-Za-z0-9._-]+/m);
+  if (idm) problems.push(`${rel}: still a ${idm[1]} element file (should be ACTOR)`);
+  const notation = (c.match(/^notation\s*:\s*(\S+)/m) || [])[1];
+  if (['activities', 'activity'].includes(notation)) {
+    if (/^\s*(unit|employee)\s*:\s*["']?(UNIT|EMPLOYEE|EMP)-/m.test(c))
+      problems.push(`${rel}: activity still has unit:/employee: → should be owner: ACTOR-…`);
+  }
+  if (notation === 'role' && /^\s*unit\s*:\s*["']?UNIT-/m.test(c))
+    problems.push(`${rel}: ROLE.unit still references a UNIT-… (should be ACTOR-…)`);
+}
+
+if (problems.length) {
+  console.error(`FAIL — ${problems.length} 0.5→0.6 residue(s):`);
+  problems.forEach(p => console.error(`  ✗ ${p}`));
+  process.exit(1);
+}
+console.log('PASS — no UNIT / EMPLOYEE residue; repo is on 0.6 form.');
+process.exit(0);


### PR DESCRIPTION
## What

The `0.5 → 0.6` migration recipe for the Actors decision (epic #98) — per `notations/CONTRACT.md` §10.4 / `RELEASING.md`. Records the `UNIT` / `EMPLOYEE` retirement and ships a tested codemod.

## `migrations/0.5-to-0.6/`

- **README.md** — the deprecation + mapping (`UNIT → ACTOR(business_unit)`; `EMPLOYEE → ACTOR(person)` + an `employment` REL; activity `unit`/`employee`/free-text `owner` → one `owner: ACTOR-…`; `ROLE.unit → ACTOR(business_unit)`) + manual steps + run instructions.
- **codemod.mjs** — pure-Node, idempotent. Safe transforms: **(A)** activity ownership collapse → `owner: ACTOR-…`; **(B)** `ROLE.unit` retarget. `UNIT`/`EMPLOYEE` *element files* are detected, reported with their mapping, left unchanged, and the run exits non-zero (the EMPLOYEE→ACTOR+REL split needs human judgement) — per the recipe convention.
- **validate.mjs** — fails on any residual `UNIT`/`EMPLOYEE` element file, `unit`/`employee` activity field, or `UNIT`-referencing `ROLE.unit`.
- **fixtures/before + after** for transforms A & B.

Plus the **CHANGELOG `[0.6.0]` (Unreleased)** section (ACTOR + STAKEHOLDER added; UNIT/EMPLOYEE removed + activity-ownership collapse — both `BREAKING:`).

## Verification (Node ≥ 20)

- `node --check` clean on both scripts.
- codemod on `fixtures/before` → byte-exact `fixtures/after`; second run = 0 changes (idempotent).
- `validate.mjs` PASS on `after/`, FAIL on `before/`; detection-C exits non-zero on a `UNIT-…` element file.

Migration cost is near-zero in practice — `UNIT`/`EMPLOYEE` were schema-only and never populated; the recipe exists for the one-day window.

## Context

Completes the Actors/Stakeholders work this session: #90 (Actors), #91 (Stakeholders), #92 (acme examples), and this recipe. Closes the orchestrator's "fold into the work" checklist from strategy#111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
