### PR TITLE
docs(notations): bpmn templates → canonical structure + role/system carve-out (strategy#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The Actors / Stakeholders identity model (epics #98 / #99). Unifies active-struc
 - **New canonical TYPEs in `notations/IDS_AND_REFERENCES.md` §3.1:** `ACTOR`, `STAKEHOLDER`. New folders `canon/elements/02_business/actors/` and `canon/elements/01_motivation/stakeholders/`.
 - **acme_corp worked examples** — `ACTOR` (business_unit / external regulator / person), `STAKEHOLDER` (internal + external), and `stakeholding` / `employment` RELs, with folder READMEs. (#98/#99)
 - **`migrations/0.5-to-0.6/`** migration recipe — codemod + validate + fixtures for the UNIT/EMPLOYEE retirement.
+- **BPMN role / system cross-references** (`notations/views/01-bpmn.md` §7.2): optional `performed_by_role: ROLE-…` and `supported_by_application: APPLICATION-…` on lanes (default) and elements (override), with explicit precedence and validator rule `BPMN-XREF-001`. Inline view→canon cross-reference (not a `REL`); the principle is noted in `17-relations.md` §3. Both `.templates/bpmn/` templates rewritten from the legacy `activities[]` shape to the canonical `process`/`pools`/`lanes`/`elements`/`flows` structure. (#110)
 
 ### Changed
 

--- a/notations/elements/17-relations.md
+++ b/notations/elements/17-relations.md
@@ -88,6 +88,7 @@ Adding a new `type` value is a non-backwards-compatible methodology revision —
 
 - **`applies_to` (Codex → Canon).** Retired entirely in the compliance epic ([14-codex.md](14-codex.md) §8) — bindings now live as REQUIREMENT.`derived_from` plus ASSERTION; no `applies_to` relation kind is needed.
 - **Inline relations.** Each notation spec declares which of its relation kinds stay inline (timeless within their host file) versus which become first-class REL files. The per-notation declarations are added in subsequent Wave 3 PRs.
+- **View-document inline cross-references.** A view document may include inline cross-references to canon primitives via documented fields (e.g. capability-map `business_process`, process-map `capability`, BPMN `performed_by_role` / `supported_by_application`), distinct from `REL` element files. Such references are subject to canon-existence validation (per the view's own validator codes) but are **not** subject to `REL-002`, because the referring endpoint (a view-local node or label) is not itself a canon primitive — the link is one-way, and canon never points back at a view-local label.
 
 ---
 

--- a/notations/views/01-bpmn.md
+++ b/notations/views/01-bpmn.md
@@ -139,6 +139,8 @@ lanes:
 | `id` | string | Identifier pattern; must differ from pool id and from any element id |
 | `name` | string | Non-empty, free-form (rendered as the lane caption) |
 | `elements` | array | At least one element required |
+| `performed_by_role` | string | Optional. `ROLE-…` responsible for the work in this lane — the default for every element in it (see §7.2). |
+| `supported_by_application` | string | Optional. `APPLICATION-…` used for the work in this lane — the default for every element in it (see §7.2). |
 
 Order of lanes in the YAML determines the vertical order of swimlanes in the rendered diagram (top to bottom).
 
@@ -165,6 +167,8 @@ Each element is an object with these fields:
 | `id` | string | Identifier pattern; globally unique within the document |
 | `type` | string | One of the seven enum values above |
 | `name` | string | Required for tasks and gateways (non-empty); optional for events |
+| `performed_by_role` | string | Optional. `ROLE-…` responsible for this task — overrides the lane default (see §7.2). |
+| `supported_by_application` | string | Optional. `APPLICATION-…` used for this task — overrides the lane default (see §7.2). |
 
 Example:
 
@@ -193,6 +197,23 @@ Events (`startEvent`, `endEvent`) may omit `name` because their visual represent
 - **`parallelGateway`** — AND fork/join. When splitting, all outgoing flows are activated simultaneously; outgoing flows must not carry conditions. When joining, the gateway waits for all incoming tokens before proceeding.
 
 A gateway with exactly one incoming and one outgoing flow is forbidden — use a sequence flow instead.
+
+### 7.2. Role and system association (cross-references to canon)
+
+A BPMN document may record **who** performs each piece of work and **which system** supports it, by referencing canon primitives from two optional fields:
+
+- `performed_by_role: ROLE-…` — the responsible business role ([elements/19-actors.md](../elements/19-actors.md) defines `ROLE`; `ACTOR` is the identity that fills it).
+- `supported_by_application: APPLICATION-…` — the supporting application ([10-applications.md](10-applications.md)).
+
+Both may appear at **lane** level (the default for every element in the lane — the standard swimlane-is-a-role reading) and at **element** level (an override for one task). Precedence, per element:
+
+1. Element-level value wins.
+2. Otherwise the enclosing lane's value applies.
+3. If neither is present, no role / system is declared for that element.
+
+This keeps a 10-task lane from repeating the field ten times while still allowing a single automated task inside a human lane to point at a system.
+
+These are **inline cross-references from a BPMN-local label to a canon primitive**, not `REL` files: a BPMN task / lane id is a document-local label ([IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.3), not a canon primitive, so the link is one-way (canon never points back at a local label) and is validated by canon-existence (`BPMN-XREF-001`, §11), not by the `REL` rules. This is the same view-references-canon pattern used by capability-map (`business_process`), process-map (`capability`), and the products / applications catalogues — see [elements/17-relations.md](../elements/17-relations.md) §3.
 
 ---
 
@@ -354,6 +375,12 @@ In addition, anti-pattern checks (warnings, not errors) flag suspicious-but-vali
 | ID | Rule |
 |---|---|
 | **POOL-05** | Exactly one pool per document. |
+
+**Cross-references to canon**
+
+| ID | Rule |
+|---|---|
+| **BPMN-XREF-001** | A `performed_by_role` / `supported_by_application` value (on a lane or an element, §7.2) must resolve to an admitted primitive in canon: `ROLE-…` in `canon/elements/02_business/roles/`, `APPLICATION-…` in `canon/elements/03_application/applications/`. Same canon-existence bar as `REL-002`, applied at parse time when the catalogue is loaded. |
 
 ### Warnings (non-blocking)
 

--- a/organizations/acme_corp/.templates/bpmn/advanced-process-with-lanes.bpmn.transitrix.yaml
+++ b/organizations/acme_corp/.templates/bpmn/advanced-process-with-lanes.bpmn.transitrix.yaml
@@ -1,324 +1,130 @@
-# Transitrix Advanced BPMN Process Template with Lanes & Stages
-# Purpose: Model complex business processes with multiple actors/lanes
-# Location: canon/views/bpmn/ (as <DOMAIN>.bpmn.transitrix.yaml)
+# Transitrix BPMN process template — multi-lane (copy-and-fill)
+# Spec:      notations/views/01-bpmn.md
+# Extension: *.bpmn.transitrix.yaml
+# Location:  canon/views/bpmn/   (one pool; lanes partition it; file-local node labels)
 #
-# ⚠ PENDING STRUCTURAL RECONCILIATION. This template predates the canonical BPMN
-# notation and uses an old shape (activities[]/UserTask/ServiceTask, assigned_role/
-# supporting_system, business_capability/related_processes). The canonical notation
-# (notations/views/01-bpmn.md) is process -> pools -> lanes -> elements + flows, with
-# file-local node labels (IDS_AND_REFERENCES.md §3.3) and no notation lifecycle.
-# Legacy element-reference IDs here have been canonicalised (APPLICATION-/PROCESS-/ROLE-),
-# but the document STRUCTURE is still the old shape and will not validate against
-# 01-bpmn.md until rewritten. Tracked as a dedicated bpmn-template rewrite task; use
-# notations/examples/bpmn/ for canonical-shape worked examples in the meantime.
+# Swimlanes are the actors: each lane sets performed_by_role (and optionally
+# supported_by_application) as the default for its tasks; a task overrides with its
+# own performed_by_role / supported_by_application (01-bpmn.md §7.2). These reference
+# canon primitives (ROLE-… / APPLICATION-…) and are validated by BPMN-XREF-001.
+#
+# Worked order-fulfilment flow: place → validate → (reject | fulfil) → pick/pack →
+# QC (with a rework loop) → ship → deliver → confirm.
 
-id: "PROCESS-XXX-1"
-name: "Process Name with Multiple Actors"
-type: "BusinessProcess"
-layer: "Business"
+notation: bpmn
+spec_version: "0.1"
 
-metadata:
-  status: "Draft"
-  owner: "firstname.lastname"
-  created_at: "2026-05-03"
-  updated_at: "2026-05-03"
-  tags: ["multi-actor", "structured"]
+process:
+  id: order-fulfilment
+  name: "Order Fulfilment"
+  pools:
+    - id: acme
+      name: "Acme Corp"
+      lanes:
+        - id: customer
+          name: "Customer"
+          performed_by_role: ROLE-CUSTOMER-1
+          elements:
+            - id: start
+              type: startEvent
+              name: "Order placed"
+            - id: confirm-delivery
+              type: task
+              name: "Confirm delivery"
+            - id: end-delivered
+              type: endEvent
+              name: "Order delivered"
 
-properties:
-  description: "Process description with clear scope and actors involved"
-  scope: "Business area or organization unit"
-  frequency: "Daily"
-  avg_duration_minutes: 480
-  criticality: "High"
+        - id: sales
+          name: "Sales Team"
+          performed_by_role: ROLE-SALES-1
+          supported_by_application: APPLICATION-CRM-1     # lane default system
+          elements:
+            - id: receive-order
+              type: task
+              name: "Receive order"
+            - id: validate-order
+              type: serviceTask
+              name: "Validate order"
+            - id: order-valid
+              type: exclusiveGateway
+              name: "Order valid?"
+            - id: notify-rejected
+              type: serviceTask
+              name: "Notify customer — rejected"
+              supported_by_application: APPLICATION-NOTIFICATION-1   # override the lane CRM default
+            - id: end-rejected
+              type: endEvent
+              name: "Order rejected"
+            - id: send-to-warehouse
+              type: task
+              name: "Send order to warehouse"
+              supported_by_application: APPLICATION-WMS-1
+            - id: notify-shipped
+              type: serviceTask
+              name: "Notify customer — shipped"
+              supported_by_application: APPLICATION-NOTIFICATION-1
 
-# BPMN Process Definition with Lanes and Stages
-bpmn:
-  # Organizational lanes (actors/roles)
-  lanes:
-    - id: "lane_customer"
-      name: "Customer"
-      actor_role: "ROLE-CUSTOMER-1"  # Reference to BusinessRole
+        - id: warehouse
+          name: "Warehouse"
+          performed_by_role: ROLE-WAREHOUSE-MANAGER-1
+          supported_by_application: APPLICATION-WMS-1
+          elements:
+            - id: pick-items
+              type: userTask
+              name: "Pick items"
+              performed_by_role: ROLE-WAREHOUSE-PICKER-1    # override the lane manager default
+            - id: pack-items
+              type: userTask
+              name: "Pack items"
+              performed_by_role: ROLE-WAREHOUSE-PACKER-1
+            - id: ready-for-qc
+              type: exclusiveGateway
+              name: "Ready for QC"                          # join: first pack, or a repack loop-back
+            - id: quality-check
+              type: serviceTask
+              name: "Quality check"
+              supported_by_application: APPLICATION-QMS-1
+            - id: package-approved
+              type: exclusiveGateway
+              name: "Package approved?"
+            - id: repack
+              type: userTask
+              name: "Repack package"
+              performed_by_role: ROLE-WAREHOUSE-PACKER-1
+            - id: handoff-logistics
+              type: task
+              name: "Hand off to logistics"
 
-    - id: "lane_sales"
-      name: "Sales Team"
-      actor_role: "ROLE-SALES-1"  # Reference to BusinessRole
-      responsible_system: "APPLICATION-CRM-1"  # Supporting system
+        - id: logistics
+          name: "Logistics Partner"
+          performed_by_role: ROLE-LOGISTICS-PROVIDER-1
+          supported_by_application: APPLICATION-LOGISTICS-1
+          elements:
+            - id: ship-package
+              type: task
+              name: "Ship package"
+            - id: deliver-package
+              type: task
+              name: "Deliver package"
 
-    - id: "lane_warehouse"
-      name: "Warehouse"
-      actor_role: "ROLE-WAREHOUSE-MANAGER-1"
-      responsible_system: "APPLICATION-WMS-1"  # Warehouse Management System
-
-    - id: "lane_logistics"
-      name: "Logistics Partner"
-      actor_role: "ROLE-LOGISTICS-PROVIDER-1"
-      responsible_system: "EXT-LOGISTICS-API"  # External system
-
-  # Process stages (logical grouping)
-  stages:
-    # STAGE 1: Initiation
-    - stage_id: "S1"
-      stage_name: "Order Placement & Validation"
-      description: "Customer initiates order, system validates"
-      duration_minutes: 30
-
-      steps:
-        - id: "S1_start"
-          type: "startEvent"
-          label: "Customer Initiates Order"
-          lane: "lane_customer"
-          next: "S1_receive"
-
-        - id: "S1_receive"
-          type: "task"
-          label: "Receive Order"
-          lane: "lane_sales"
-          description: "Order received in CRM system"
-          supporting_system: "APPLICATION-CRM-1"
-          required_data: ["CUSTOMER_ID", "ORDER_ITEMS"]
-          output_data: ["ORDER_ID"]
-          next: "S1_validate"
-
-        - id: "S1_validate"
-          type: "serviceTask"
-          label: "Validate Order"
-          lane: "lane_sales"
-          description: "Check inventory, pricing, customer credit"
-          supporting_system: "APPLICATION-CRM-1"
-          checks:
-            - "Inventory availability"
-            - "Customer creditworthiness"
-            - "Price accuracy"
-          required_data: ["ORDER_ID", "PRODUCT_IDS"]
-          next: "S1_decision"
-
-        - id: "S1_decision"
-          type: "exclusiveGateway"
-          label: "Order Valid?"
-          decision_logic: "Validation passed all checks"
-          true_path: "S2_start"  # Go to next stage
-          false_path: "S1_reject"  # Rejection path
-
-        - id: "S1_reject"
-          type: "task"
-          label: "Notify Customer - Order Rejected"
-          lane: "lane_sales"
-          supporting_system: "APPLICATION-NOTIFICATION-1"
-          next: "S1_end"
-
-        - id: "S1_end"
-          type: "endEvent"
-          label: "Order Rejected"
-          lane: "lane_sales"
-
-    # STAGE 2: Processing & Fulfillment
-    - stage_id: "S2"
-      stage_name: "Order Processing & Fulfillment"
-      description: "Warehouse picks and packs order"
-      duration_minutes: 240
-
-      steps:
-        - id: "S2_start"
-          type: "task"
-          label: "Send Order to Warehouse"
-          lane: "lane_sales"
-          description: "Order routed to fulfillment center"
-          supporting_system: "APPLICATION-WMS-1"
-          output_data: ["SHIPMENT_ID"]
-          next: "S2_pick"
-
-        - id: "S2_pick"
-          type: "userTask"
-          label: "Pick Items from Inventory"
-          lane: "lane_warehouse"
-          description: "Warehouse staff picks items"
-          assigned_role: "ROLE-WAREHOUSE-PICKER-1"
-          required_data: ["ORDER_ID", "PRODUCT_LOCATIONS"]
-          output_data: ["PICKED_ITEMS"]
-          next: "S2_pack"
-
-        - id: "S2_pack"
-          type: "userTask"
-          label: "Pack Items"
-          lane: "lane_warehouse"
-          description: "Items packaged for shipment"
-          assigned_role: "ROLE-WAREHOUSE-PACKER-1"
-          quality_checks:
-            - "Item count verification"
-            - "Packaging integrity"
-          output_data: ["PACKAGE_ID", "WEIGHT", "DIMENSIONS"]
-          next: "S2_quality"
-
-        - id: "S2_quality"
-          type: "serviceTask"
-          label: "Quality Check"
-          lane: "lane_warehouse"
-          description: "Verify package meets quality standards"
-          supporting_system: "APPLICATION-QMS-1"  # Quality Management System
-          checks: ["Correct items", "Proper packaging", "Label accuracy"]
-          next: "S2_decision"
-
-        - id: "S2_decision"
-          type: "exclusiveGateway"
-          label: "Package Approved?"
-          true_path: "S3_start"
-          false_path: "S2_repack"
-
-        - id: "S2_repack"
-          type: "userTask"
-          label: "Repack Package"
-          lane: "lane_warehouse"
-          assigned_role: "ROLE-WAREHOUSE-PACKER-1"
-          next: "S2_quality"  # Loop back to quality check
-
-    # STAGE 3: Shipping & Delivery
-    - stage_id: "S3"
-      stage_name: "Shipping & Delivery"
-      description: "Package handed to logistics provider"
-      duration_minutes: 1440  # Up to 24+ hours depending on location
-
-      steps:
-        - id: "S3_start"
-          type: "task"
-          label: "Hand Off to Logistics"
-          lane: "lane_warehouse"
-          description: "Package ready for pickup by logistics"
-          supporting_system: "APPLICATION-WMS-1"
-          output_data: ["TRACKING_NUMBER"]
-          next: "S3_ship"
-
-        - id: "S3_ship"
-          type: "task"
-          label: "Ship Package"
-          lane: "lane_logistics"
-          description: "Logistics provider ships package"
-          supporting_system: "EXT-LOGISTICS-API"
-          output_data: ["TRACKING_DETAILS"]
-          next: "S3_notify_customer"
-
-        - id: "S3_notify_customer"
-          type: "serviceTask"
-          label: "Notify Customer - Shipment Sent"
-          lane: "lane_sales"
-          supporting_system: "APPLICATION-NOTIFICATION-1"
-          notification_type: "Email + SMS"
-          next: "S3_deliver"
-
-        - id: "S3_deliver"
-          type: "task"
-          label: "Deliver Package"
-          lane: "lane_logistics"
-          description: "Package delivered to customer"
-          supporting_system: "EXT-LOGISTICS-API"
-          next: "S3_confirm"
-
-        - id: "S3_confirm"
-          type: "task"
-          label: "Confirm Delivery"
-          lane: "lane_customer"
-          description: "Customer confirms receipt"
-          next: "S3_end"
-
-        - id: "S3_end"
-          type: "endEvent"
-          label: "Order Delivered"
-          lane: "lane_customer"
-
-# Key Performance Indicators
-kpis:
-  - name: "Order-to-Delivery Time"
-    target: "48 hours"
-    measurement_unit: "hours"
-    calculated_from: ["S1_start", "S3_end"]
-
-  - name: "First-Pass Quality Rate"
-    target: "98%"
-    measurement_unit: "percentage"
-    related_step: "S2_decision"
-
-  - name: "Order Acceptance Rate"
-    target: "95%"
-    measurement_unit: "percentage"
-    related_step: "S1_decision"
-
-# Resource Requirements
-resources:
-  required_roles:
-    - "ROLE-SALES-1"
-    - "ROLE-WAREHOUSE-PICKER-1"
-    - "ROLE-WAREHOUSE-PACKER-1"
-
-  required_systems:
-    - "APPLICATION-CRM-1"
-    - "APPLICATION-WMS-1"
-    - "APPLICATION-NOTIFICATION-1"
-    - "EXT-LOGISTICS-API"
-
-  required_data_entities:
-    - "Customer"
-    - "Order"
-    - "Inventory Item"
-    - "Package"
-    - "Shipment"
-
-# Governance
-governance:
-  audit_required: true
-  audit_frequency: "Monthly"
-  change_control_required: true
-  approval_required: false
-
-# References
-references:
-  business_capability: "PROCESS-ORD-FULFILL-1"  # Capability this process supports
-  supporting_goals:
-    - "GOAL-DELIVERY-SPEED-001"
-    - "GOAL-CUSTOMER-SATISFACTION-001"
-  related_processes:
-    - "PROCESS-RETURNS-1"
-    - "PROCESS-CUSTOMER-SERVICE-1"
-
-# Versioning
-versioning:
-  current_version: "1.0.0"
-  last_review_date: "2026-05-03"
-  next_review_date: "2026-08-03"
-  last_updated_by: "firstname.lastname"
-
----
-
-## Lane & Stage Guidance
-
-### When to Use Lanes
-- Multiple actors/roles involved
-- Cross-functional process
-- Need clear responsibility assignment
-- Want to show who does what
-
-### When to Use Stages
-- Long processes that naturally divide into phases
-- Want to group related steps logically
-- Need SLA/timing by stage
-- Want to show progression through phases
-
-### Data Flow
-- Each task shows `required_data` (inputs) and `output_data` (outputs)
-- Links tasks in the flow with `next` field
-- Makes data dependencies explicit
-
-### System Integration
-- Every task that uses a system shows `supporting_system`
-- Reference to ApplicationComponent elements (APPLICATION-XXX-1)
-- External systems prefixed with EXT-
-
-### Quality & Control
-- Include quality checkpoints (S2_quality example)
-- Show decision gateways
-- Document decision criteria
-- Include loops for rework (S2_repack example)
-
----
-
-**Template Version:** 1.0.0
-**Created:** May 3, 2026
-**Based On:** Segments project BPMN format + Transitrix ArchiMate integration
+  flows:
+    - { from: start, to: receive-order }
+    - { from: receive-order, to: validate-order }
+    - { from: validate-order, to: order-valid }
+    - { from: order-valid, to: send-to-warehouse, condition: "order_valid == true" }
+    - { from: order-valid, to: notify-rejected, default: true }
+    - { from: notify-rejected, to: end-rejected }
+    - { from: send-to-warehouse, to: pick-items }
+    - { from: pick-items, to: pack-items }
+    - { from: pack-items, to: ready-for-qc }
+    - { from: repack, to: ready-for-qc }
+    - { from: ready-for-qc, to: quality-check }
+    - { from: quality-check, to: package-approved }
+    - { from: package-approved, to: handoff-logistics, condition: "package_approved == true" }
+    - { from: package-approved, to: repack, default: true }
+    - { from: handoff-logistics, to: ship-package }
+    - { from: ship-package, to: notify-shipped }
+    - { from: notify-shipped, to: deliver-package }
+    - { from: deliver-package, to: confirm-delivery }
+    - { from: confirm-delivery, to: end-delivered }

--- a/organizations/acme_corp/.templates/bpmn/process_template.bpmn.transitrix.yaml
+++ b/organizations/acme_corp/.templates/bpmn/process_template.bpmn.transitrix.yaml
@@ -1,144 +1,61 @@
-# Transitrix BPMN Process Template
-# Purpose: Describe business processes in text-first format with automatic layout
-# Location: canon/views/bpmn/ (as <DOMAIN>.bpmn.transitrix.yaml)
+# Transitrix BPMN process template — copy-and-fill
+# Spec:      notations/views/01-bpmn.md
+# Extension: *.bpmn.transitrix.yaml
+# Location:  canon/views/bpmn/   (one pool per document; file-local node labels)
 #
-# ⚠ PENDING STRUCTURAL RECONCILIATION. This template predates the canonical BPMN
-# notation and uses an old shape (activities[] with UserTask/ServiceTask,
-# assigned_role/required_system). The canonical notation (notations/views/01-bpmn.md)
-# is process -> pools -> lanes -> elements + flows, with file-local node labels
-# (POOL-/LANE-/TASK-/GW-/SF-…, IDS_AND_REFERENCES.md §3.3) and no notation lifecycle.
-# Legacy element-reference IDs here have been canonicalised (APPLICATION-/PROCESS-/ROLE-),
-# but the document STRUCTURE is still the old shape and will not validate against
-# 01-bpmn.md until rewritten. Tracked as a dedicated bpmn-template rewrite task; use
-# notations/examples/bpmn/ for canonical-shape worked examples in the meantime.
+# Role / system association is expressed with the optional cross-reference fields
+# performed_by_role: ROLE-… and supported_by_application: APPLICATION-… — set them
+# at the lane level as a default, override per task where it differs (01-bpmn.md §7.2).
+# They reference canon primitives and are validated by BPMN-XREF-001.
 
-id: "PROCESS-XXX-1"
-name: "Business Process Name"
-type: "BusinessProcess"
-layer: "Business"
+notation: bpmn
+spec_version: "0.1"
 
-metadata:
-  status: "Draft"  # Values: Draft, Active, Deprecated, Archived
-  owner: "firstname.lastname"
-  created_at: "2026-05-03"
-  updated_at: "2026-05-03"
-  tags: ["core-process", "customer-facing"]
+process:
+  id: process-template
+  name: "Business Process Name"
+  pools:
+    - id: company
+      name: "Company"
+      lanes:
+        - id: handling-team
+          name: "Handling Team"
+          performed_by_role: ROLE-SALES-1        # lane default — the role for every task below
+          elements:
+            - id: start
+              type: startEvent
 
-properties:
-  description: "High-level description of what this process accomplishes"
-  scope: "End-to-end process scope"
-  frequency: "Daily"  # Values: Continuous, Hourly, Daily, Weekly, Monthly, Ad-hoc
-  avg_duration_minutes: 120
-  criticality: "High"  # Values: Critical, High, Medium, Low
+            - id: receive-request
+              type: userTask
+              name: "Receive request"
 
-# BPMN Process Definition in text-first format
-# This structure enables:
-# 1. Human-readable YAML description
-# 2. Automatic BPMN 2.0 XML generation
-# 3. Automatic layout calculation (ELK.js)
-# 4. VS Code interactive preview
+            - id: validate-request
+              type: serviceTask
+              name: "Validate request"
+              supported_by_application: APPLICATION-VALIDATOR-1   # task override: a system, not the lane role
 
-bpmn:
-  # Start event
-  start_event:
-    id: "START_001"
-    name: "Process Started"
-    event_type: "None"  # Values: None, Message, Timer, Signal, Error, Escalation, etc.
+            - id: request-valid
+              type: exclusiveGateway
+              name: "Request valid?"
 
-  # Main flow definition
-  activities:
-    - id: "TASK_001"
-      name: "Task 1: Receive Request"
-      type: "UserTask"  # Values: UserTask, ServiceTask, ManualTask, ScriptTask
-      assigned_role: "ROLE-SALES-1"  # Reference to BusinessRole
-      required_system: null  # Reference to ApplicationComponent if system-supported
+            - id: process-request
+              type: serviceTask
+              name: "Process approved request"
+              supported_by_application: APPLICATION-PROCESSOR-1
 
-    - id: "TASK_002"
-      name: "Task 2: Validate Request"
-      type: "ServiceTask"
-      assigned_role: null
-      required_system: "APPLICATION-VALIDATOR-1"
+            - id: notify-rejected
+              type: serviceTask
+              name: "Notify requester — rejected"
+              supported_by_application: APPLICATION-NOTIFICATION-1
 
-    - id: "GATEWAY_001"
-      name: "Decision: Request Valid?"
-      type: "ExclusiveGateway"  # Values: ExclusiveGateway, ParallelGateway, InclusiveGateway
+            - id: end
+              type: endEvent
 
-    - id: "TASK_003"
-      name: "Task 3: Process Approved Request"
-      type: "ServiceTask"
-      assigned_role: null
-      required_system: "APPLICATION-PROCESSOR-1"
-
-    - id: "TASK_004"
-      name: "Task 4: Notify Requester - Rejected"
-      type: "ServiceTask"
-      assigned_role: null
-      required_system: "APPLICATION-NOTIFICATION-1"
-
-  # Sequence flows (connections between activities)
-  sequences:
-    - id: "FLOW_001"
-      source_id: "START_001"
-      target_id: "TASK_001"
-      name: ""  # Typically empty for default flow
-
-    - id: "FLOW_002"
-      source_id: "TASK_001"
-      target_id: "TASK_002"
-      name: ""
-
-    - id: "FLOW_003"
-      source_id: "TASK_002"
-      target_id: "GATEWAY_001"
-      name: ""
-
-    - id: "FLOW_004"
-      source_id: "GATEWAY_001"
-      target_id: "TASK_003"
-      name: "Valid"  # Condition label
-
-    - id: "FLOW_005"
-      source_id: "GATEWAY_001"
-      target_id: "TASK_004"
-      name: "Invalid"  # Condition label
-
-  # End event
-  end_event:
-    id: "END_001"
-    name: "Process Completed"
-    event_type: "None"
-
-  # Connect activities to end event (this would be defined as additional sequences in actual implementation)
-
-# KPI and metrics
-metrics:
-  sla_completion_hours: 24
-  target_completion_rate_percent: 95
-  average_processing_time_minutes: 120
-  bottleneck_activity: "TASK_002"  # ID of slowest step
-
-# Resource requirements
-resources:
-  required_roles: ["ROLE-SALES-1"]
-  required_systems: ["APPLICATION-VALIDATOR-1", "APPLICATION-PROCESSOR-1", "APPLICATION-NOTIFICATION-1"]
-  required_data: ["Customer Data", "Request Details"]
-
-# Compliance and governance
-governance:
-  audit_required: true
-  audit_frequency: "Monthly"
-  compliance_frameworks: ["GDPR", "ISO27001"]
-  change_control_required: true
-
-# Version and lifecycle
-versioning:
-  current_version: "1.0.0"
-  last_review_date: "2026-05-03"
-  next_review_date: "2026-08-03"
-
-# References to supporting documentation
-references:
-  related_goals: []  # IDs of Goal elements this process supports
-  related_roles: ["ROLE-SALES-1"]  # IDs of BusinessRole elements
-  related_systems: ["APPLICATION-VALIDATOR-1"]  # IDs of ApplicationComponent elements
-  documentation_url: null  # Link to detailed SOPs or wiki
+  flows:
+    - { from: start, to: receive-request }
+    - { from: receive-request, to: validate-request }
+    - { from: validate-request, to: request-valid }
+    - { from: request-valid, to: process-request, condition: "valid == true" }
+    - { from: request-valid, to: notify-rejected, default: true }
+    - { from: process-request, to: end }
+    - { from: notify-rejected, to: end }


### PR DESCRIPTION
## What

Completes the bpmn-template rewrite approved on strategy#110, using the inline cross-reference carve-out decided on strategy#113 (Decision A). The old `.templates/bpmn/` templates used a pre-canonical shape (`activities[]` / `UserTask` / `assigned_role` / `supporting_system`) that wouldn't validate against `01-bpmn.md`.

## Spec changes

- **`01-bpmn.md` §7.2** — optional `performed_by_role: ROLE-…` and `supported_by_application: APPLICATION-…` on **lanes** (default for the lane's tasks) and **elements** (per-task override), with explicit precedence (task > lane > none). Inline view→canon cross-references — BPMN tasks are document-local labels (`IDS §3.3`), so they can't be `REL` endpoints. New rule **`BPMN-XREF-001`** (value must resolve to an admitted `ROLE-`/`APPLICATION-` in canon). Fields added to the §6 lane and §7 element tables.
- **`17-relations.md` §3** — one sentence formalizing the inline-view-cross-reference pattern (distinct from `REL`, not subject to `REL-002`).

## Template rewrites

- `process_template` and `advanced-process-with-lanes` rewritten to canonical `process` / `pools` / `lanes` / `elements` / `flows`. Role/system associations moved to the inline fields (lane defaults + task overrides — e.g. picker/packer overriding the warehouse-manager default, QMS overriding the lane WMS). `PENDING` notes, the trailing markdown-after-`---`, and all non-notation metadata removed.

## Not added (per #113)

`task_role` / `task_application` REL TYPEs (the inline carve-out replaces them); `process_capability` / `process_related` (already expressible via capability-map / process-map).

## Verification

Both templates parse; exactly one pool each; all flow endpoints resolve to declared elements; ids match the §9 pattern; canon xrefs correctly prefixed; no old-model residue; spec links resolve (9 in 01-bpmn, 21 in 17-relations). CHANGELOG `[0.6.0]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
