### PR TITLE
docs: reconcile front-door docs with the 0.5/0.6 model

### DIFF
--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -1,370 +1,77 @@
 # Transitrix Project Index & Navigation
 
-Complete guide to the Transitrix project structure and where to find everything.
+A map of the repository and where to find things. For the methodology itself, start with [`method/methodology.md`](method/methodology.md); for the notation specs, start with [`notations/README.md`](notations/README.md).
 
 ---
 
-## 🏠 Project Root Level
+## Repository root
 
-### Core Files
-
-| File | Purpose | When to Use |
-|------|---------|------------|
-| **README.md** | Main project overview | Starting point - explains multi-tenant architecture |
-| **PROJECT_INDEX.md** | This file - navigation guide | Need to find something in the project |
-| **method/** | Methodology documentation | Understanding the core concepts and principles |
-| **TOOLING.md** | Tools & integrations guide | Setting up Transitrix Studio or other tooling |
-| **glossary.md** | Project terminology | Looking up standardized terms |
-| **organizations/** | All organization directories | Main working area |
-| **create_organization.sh** | Script to add new organizations | Adding a new company/team to the project |
-
-### Scripts
-
-```bash
-./create_organization.sh <name>     # Create new organization quickly
-```
+| Path | What it is |
+|---|---|
+| [`README.md`](README.md) | Project overview and quick start. |
+| [`method/methodology.md`](method/methodology.md) | Methodology overview — principles, zones, repository structure, change lifecycle. |
+| [`notations/`](notations/) | The canonical model: notation specs, shared contract, ID grammar, examples. |
+| [`glossary.md`](glossary.md) | Standardised terminology. |
+| [`CHANGELOG.md`](CHANGELOG.md) | Release history (Keep a Changelog; SemVer with pre-1.0 caveats). |
+| [`RELEASING.md`](RELEASING.md) | Per-release operational checklist for the maintainer. |
+| [`integration/`](integration/) | Tooling, Studio, and CI integration notes. |
+| [`migrations/`](migrations/) | Per-release migration recipes (e.g. `0.4-to-0.5/`, `0.5-to-0.6/`). |
+| [`skills/`](skills/) | Onboarding and per-layer extraction skills. |
+| [`organizations/`](organizations/) | Adopter organisations — the worked example `acme_corp/` lives here. |
+| [`LICENSE`](LICENSE), [`CONTRIBUTING.md`](CONTRIBUTING.md) | MIT licence; contribution guide. |
 
 ---
 
-## 📁 organizations/ Directory
+## `notations/` — the canonical model
 
-Multi-tenant structure where each company/team has its own folder.
+| Path | What it is |
+|---|---|
+| [`notations/README.md`](notations/README.md) | Index of every notation (view + element), with short names, extensions, and spec-maturity status. **Single source of truth for the notation set.** |
+| [`notations/CONTRACT.md`](notations/CONTRACT.md) | Shared rules: file header, zones (§5), admission record (§6), primitive lifecycle (§7), compliance-domain rule index (§8), versioned-attribute sidecar (§9), versioning policy (§10). |
+| [`notations/IDS_AND_REFERENCES.md`](notations/IDS_AND_REFERENCES.md) | Canonical ID grammar and the full TYPE registry. |
+| [`notations/ELEMENT_PRIMITIVES.md`](notations/ELEMENT_PRIMITIVES.md) | The element-primitive file schema common to all standalone elements. |
+| [`notations/MANIFEST.md`](notations/MANIFEST.md) | The adopter manifest (`transitrix.yaml`) specification. |
+| [`notations/views/`](notations/views/) | View-notation specs — BPMN, FGCA, FGA, goals, capability-map, process-map, activities, blocks, products, applications, scenarios, issues, process-blueprint, activity-card. |
+| [`notations/elements/`](notations/elements/) | Element-notation specs — codex, requirement, assertion, relations, actors, stakeholders. |
+| [`notations/examples/`](notations/examples/) | Worked example files for each notation. |
 
-### Example Organization: acme_corp
+---
+
+## An organisation — `organizations/<org>/`
+
+Each organisation splits its content into three parallel **zones** (see `CONTRACT.md` §5): `canon` (validated, authoritative model), `field` (raw source material), and `codex` (externally-given laws and internal policies). Zones are parallel, not stacked.
 
 ```
 organizations/acme_corp/
-├── elements/                    # Architecture elements by ArchiMate layer
-│   ├── 01_motivation/          # Goals, principles, constraints
-│   ├── 02_business/            # Roles, processes, functions
-│   ├── 03_application/         # Services, components, interfaces
-│   └── 04_technology/          # Infrastructure, nodes, deployments
-├── relations/                   # Relationships between elements (ATOMIC)
-├── .templates/                  # Starting templates for new elements
-│   ├── elements/               # Element templates per layer
-│   ├── relations/              # Relation template
-│   ├── bpmn/                   # BPMN process template
-│   └── EXAMPLES.md             # Detailed real-world examples
-├── .validators/                 # Validation and linting tools
-│   └── lint.py                 # Main validator script
-├── views/                       # Diagram generation configurations
-│   └── README.md               # How to configure views
-├── README.md                    # Organization overview & key info
-├── GETTING_STARTED.md          # Step-by-step tutorial for team members
-└── CONVENTIONS.md              # Naming standards & best practices
+├── transitrix.yaml         # Adopter manifest — pinned methodology version, notations, zones
+├── README.md               # Organisation overview
+├── GETTING_STARTED.md      # Onboarding for the team
+├── CONVENTIONS.md          # Local naming overrides
+├── AGENTS.md               # Assistant-neutral agent guide
+├── canon/                  # Zone: validated model
+│   ├── elements/           # Atomic elements by ArchiMate layer (01_motivation … 05_implementation)
+│   ├── relations/          # First-class, time-aware relations (1 per file)
+│   ├── assertions/         # Compliance assertions (REQUIREMENT ↔ subject)
+│   └── views/              # Composite diagrams and aggregations over elements
+├── field/                  # Zone: interviews, surveys, observations, drafts
+├── codex/                  # Zone: external/<jurisdiction>/ laws + internal/ policies
+├── .templates/             # Copy-and-fill templates
+└── .validators/            # Lint and schema scripts (lint.py)
 ```
 
-### Adding a New Organization
+### Reading order
 
-**Option 1: Use the script**
-```bash
-./create_organization.sh my_company
-```
-
-**Option 2: Copy existing organization**
-```bash
-cp -r organizations/acme_corp organizations/my_company
-```
-
-**Option 3: Manual creation**
-```bash
-mkdir -p organizations/my_company/{elements/{01_motivation,02_business,03_application,04_technology},relations,.templates,.validators,views}
-cp organizations/acme_corp/{README.md,GETTING_STARTED.md,CONVENTIONS.md} organizations/my_company/
-cp -r organizations/acme_corp/.templates organizations/my_company/
-cp organizations/acme_corp/.validators/lint.py organizations/my_company/.validators/
-```
-
-See: `organizations/NEW_ORGANIZATION_TEMPLATE.md`
+- **First time:** `organizations/<org>/README.md` → `GETTING_STARTED.md` → `CONVENTIONS.md`.
+- **Creating an element:** copy a template from `.templates/elements/` into the right `canon/elements/<layer>/` folder, fill it in, then `python3 .validators/lint.py`.
+- **Bootstrapping a new organisation:** `organizations/NEW_ORGANIZATION_TEMPLATE.md`, or copy `acme_corp/` as a starting reference.
 
 ---
 
-## 📖 Documentation Map
+## Validation
 
-### **For Project Managers / Architects**
-1. Start: `README.md` (root level)
-2. Then: `method/Transitrix Методология...` (full methodology)
-3. Reference: `PROJECT_INDEX.md` (this file)
-
-### **For Team Members (First Time)**
-1. Start: `organizations/[your_org]/README.md`
-2. Tutorial: `organizations/[your_org]/GETTING_STARTED.md`
-3. Reference: `organizations/[your_org]/CONVENTIONS.md`
-
-### **For Creating Elements**
-1. Review: `organizations/[your_org]/.templates/EXAMPLES.md`
-2. Copy: `organizations/[your_org]/.templates/elements/[layer]_template.yaml`
-3. Follow: Naming conventions in `CONVENTIONS.md`
-
-### **For Understanding Methodology**
-1. Core: `method/Transitrix Методология...`
-2. Examples: `organizations/[your_org]/.templates/EXAMPLES.md`
-3. Best Practices: `organizations/[your_org]/CONVENTIONS.md`
-
-### **For CI/CD Integration**
-1. Reference: `.github_workflows_example.yaml` (root level)
-2. Linter: `organizations/[your_org]/.validators/lint.py`
-3. Setup: Include linter validation in your pipeline
+Every change runs through the validator (`.validators/lint.py`) and the CI gate: YAML syntax, atomicity (no relations inside element files), referential integrity, ArchiMate semantics, and policy (Active status requires an owner). A pull request that breaks validation cannot be merged. See `method/methodology.md` §8 for the rule categories and `notations/CONTRACT.md` for the shared validation codes.
 
 ---
 
-## 🗂️ Organization-Specific Directories
-
-### elements/ - Architecture Elements
-
-**01_motivation/** - Strategic layer
-```
-Elements you might create:
-- GOAL-REV-001.yaml          # Revenue growth goal
-- PRIN-SCALE-001.yaml        # Scalability principle
-- CONS-COMPLIANCE-001.yaml   # Regulatory constraint
-```
-
-**02_business/** - Business layer
-```
-Elements you might create:
-- ROLE-SALES-001.yaml                   # Sales manager role
-- PROC-ORD-FULFILL.bpmn.transitrix.yaml           # Order fulfillment process
-- FUNC-CUSTOMER-MGT-001.yaml           # Customer management function
-```
-
-**03_application/** - Application layer
-```
-Elements you might create:
-- ORDER_API.yaml             # REST API microservice
-- PAYMENT_SERVICE.yaml       # Payment processing
-- CUSTOMER_DB.yaml           # Data object/database
-- API_GATEWAY.yaml           # API interface
-```
-
-**04_technology/** - Technology layer
-```
-Elements you might create:
-- POSTGRES_PRIMARY.yaml      # PostgreSQL database node
-- KUBERNETES_CLUSTER.yaml    # Kubernetes infrastructure
-- REDIS_CACHE.yaml           # Redis cache node
-```
-
-### relations/ - Relationships
-
-```
-Files you create:
-- APP_TO_DB_001.yaml         # Application accesses database
-- PROC_TO_APP_001.yaml       # Process uses application
-- ROLE_TO_PROC_001.yaml      # Role performs process
-```
-
-**Key Rule:** All relations go here, NEVER inside element files.
-
-### .templates/ - Starting Templates
-
-Ready-to-use templates:
-```
-.templates/
-├── elements/
-│   ├── 01_motivation_template.yaml
-│   ├── 02_business_template.yaml
-│   ├── 03_application_template.yaml
-│   └── 04_technology_template.yaml
-├── relations/
-│   └── relation_template.yaml
-├── bpmn/
-│   └── process_template.bpmn.transitrix.yaml
-└── EXAMPLES.md               # Real-world e-commerce example
-```
-
-**How to use:**
-```bash
-cp .templates/elements/03_application_template.yaml \
-   elements/03_application/MY_SERVICE.yaml
-# Then edit the file
-```
-
-### .validators/ - Quality Assurance
-
-```
-lint.py                      # Main validation script
-```
-
-**Run validation:**
-```bash
-cd organizations/[your_org]
-python3 .validators/lint.py
-```
-
-**What it checks:**
-- YAML syntax validity
-- Atomicity (no relations in elements)
-- Referential integrity (all IDs exist)
-- Policy compliance (active elements have owners)
-
-### views/ - Diagram Configuration
-
-```
-README.md                    # How to configure views
-```
-
-**Purpose:** Define which diagrams to generate (PlantUML, Mermaid, SVG)
-
----
-
-## 📋 Quick Reference
-
-### Creating Your First Element
-
-```bash
-# 1. Navigate to organization
-cd organizations/my_company
-
-# 2. Choose layer and template
-cp .templates/elements/03_application_template.yaml \
-   elements/03_application/MY_FIRST_SERVICE.yaml
-
-# 3. Edit file (your editor)
-vim elements/03_application/MY_FIRST_SERVICE.yaml
-
-# 4. Validate
-python3 .validators/lint.py
-
-# 5. Commit to Git
-git add elements/03_application/MY_FIRST_SERVICE.yaml
-git commit -m "docs(arch): add first service element"
-```
-
-### Creating Your First Relationship
-
-```bash
-# 1. In same organization directory
-cp .templates/relations/relation_template.yaml \
-   relations/SERVICE_TO_DATABASE.yaml
-
-# 2. Edit with source and target IDs
-vim relations/SERVICE_TO_DATABASE.yaml
-
-# 3. Validate
-python3 .validators/lint.py
-
-# 4. Commit
-git add relations/
-git commit -m "docs(arch): add service-to-database relationship"
-```
-
-### Validating All Organizations
-
-```bash
-# Validate each organization
-for org in organizations/*/; do
-  echo "Validating $(basename $org)..."
-  cd "$org"
-  python3 .validators/lint.py
-  cd ../..
-done
-```
-
-### Adding New Organization
-
-```bash
-# Using script (recommended)
-./create_organization.sh new_company_name
-
-# Or manually
-cp -r organizations/acme_corp organizations/new_company_name
-```
-
----
-
-## 🎯 Common Tasks & Where to Find Guidance
-
-| Task | See File |
-|------|----------|
-| Understand the methodology | `method/Transitrix Методология...` |
-| Add new organization | `organizations/NEW_ORGANIZATION_TEMPLATE.md` |
-| Create first element | `organizations/[org]/GETTING_STARTED.md` |
-| Learn naming conventions | `organizations/[org]/CONVENTIONS.md` |
-| See real examples | `organizations/[org]/.templates/EXAMPLES.md` |
-| Understand relationships | `organizations/[org]/.templates/relations/relation_template.yaml` |
-| Learn BPMN format | `organizations/[org]/.templates/bpmn/process_template.bpmn.transitrix.yaml` |
-| Set up CI/CD | `.github_workflows_example.yaml` |
-| Troubleshoot validation | `organizations/[org]/.validators/lint.py` |
-
----
-
-## 📊 File Statistics
-
-### Template Files
-- **Element Templates:** 4 (by layer)
-- **Relation Template:** 1
-- **BPMN Template:** 1
-- **Examples:** 1 comprehensive doc with e-commerce case study
-
-### Documentation Files
-- **Per Organization:** 3 (README, GETTING_STARTED, CONVENTIONS)
-- **Root Level:** 2 (main README, PROJECT_INDEX)
-- **Methodology:** 1 (Russian, comprehensive)
-
-### Scripts
-- **create_organization.sh** - Automated setup for new organizations
-
-### Validators
-- **lint.py** - Python validator (copied to each organization)
-
----
-
-## 🔀 Organization Dependencies
-
-```
-Root Level
-    ↓
-method/
-    ↓ (references)
-    ├── README.md
-    └── organizations/[name]/
-            ↓
-            ├── .templates/ (references methodology)
-            ├── .validators/ (enforces methodology)
-            ├── elements/ (created from templates)
-            ├── relations/ (created from templates)
-            └── documentation (explains templates & validators)
-```
-
----
-
-## ✅ Checklist: Project Setup
-
-- [ ] Read `README.md` (root level)
-- [ ] Choose organization name or use existing `acme_corp`
-- [ ] Read `organizations/[org]/README.md`
-- [ ] Read `organizations/[org]/GETTING_STARTED.md`
-- [ ] Create first element from template
-- [ ] Run validator: `python3 .validators/lint.py`
-- [ ] Review naming in `CONVENTIONS.md`
-- [ ] Look at examples in `.templates/EXAMPLES.md`
-- [ ] Commit first element to Git
-- [ ] Add more elements following the pattern
-
----
-
-## 🚀 Next Steps
-
-**Just starting?**
-→ Go to `organizations/acme_corp/GETTING_STARTED.md`
-
-**Adding new organization?**
-→ Run `./create_organization.sh your_name`
-
-**Need examples?**
-→ See `organizations/acme_corp/.templates/EXAMPLES.md`
-
-**Want to understand methodology?**
-→ Read `method/Transitrix Методология...`
-
-**Setting up CI/CD?**
-→ Check `.github_workflows_example.yaml`
-
----
-
-**Project Version:** 1.0.0  
-**Last Updated:** May 3, 2026  
-**Multi-Tenant:** Yes ✓  
-**Organizations:** 1 example (acme_corp), extensible to many
-
-Happy Architecting! 🏗️
+**Status:** maintained alongside the `notations/` specs. The methodology's version is tracked in [`CHANGELOG.md`](CHANGELOG.md); the methodology is **pre-1.0**.
+**Last updated:** 2026-05-30

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ It builds on **ArchiMate 3.2**, **BPMN 2.0**, and the **Capability Maturity Mode
 
 Start here:
 
-- **[`method/methodology.md`](method/methodology.md)** — the canonical methodology specification. Read this first.
+- **[`method/methodology.md`](method/methodology.md)** — the methodology overview. Read this first for the model and principles.
+- **[`notations/README.md`](notations/README.md)** — the canonical notation index; [`notations/CONTRACT.md`](notations/CONTRACT.md) and the per-notation specs are the authoritative source for the model in detail.
 - **[`glossary.md`](glossary.md)** — standardised terminology.
 - **[`PROJECT_INDEX.md`](PROJECT_INDEX.md)** — navigation guide.
 
 Tooling:
 
-- **[`TOOLING.md`](TOOLING.md)** — how to use Transitrix Studio (the reference VS Code extension and CLI for editing all Transitrix custom formats).
+- **[`integration/studio.md`](integration/studio.md)** — how to use Transitrix Studio (the reference VS Code extension and CLI for editing all Transitrix custom formats).
+- **[`integration/tooling.md`](integration/tooling.md)** — broader tooling and ecosystem notes.
 
 Per-organisation:
 
@@ -29,44 +31,36 @@ Per-organisation:
 
 CI:
 
-- **[`.github_workflows_example.yaml`](.github_workflows_example.yaml)** — GitHub Actions template for the validators.
+- **[`integration/ci-example.yaml`](integration/ci-example.yaml)** — CI template for the validators.
 
 ## Repository structure
 
 ```
 transitrix/methodology/
-├── method/                          # Methodology spec
-│   ├── methodology.md               # Canonical methodology document
-│   ├── notations/                   # ArchiMate / PlantUML reference materials
-│   └── bpmn-notation-kit/           # BPMN DSL spec, rules, examples
+├── method/
+│   └── methodology.md               # Canonical methodology overview
+├── notations/                       # Notation specs — the canonical model
+│   ├── README.md                    # Index of all notations (view + element)
+│   ├── CONTRACT.md                  # Shared header / zones / lifecycle / versioning
+│   ├── IDS_AND_REFERENCES.md        # ID grammar + TYPE registry
+│   ├── ELEMENT_PRIMITIVES.md        # Element-primitive file schema
+│   ├── MANIFEST.md                  # Adopter manifest (transitrix.yaml) spec
+│   ├── views/                       # View-notation specs (BPMN, FGCA, goals, …)
+│   ├── elements/                    # Element-notation specs (codex, requirement, …)
+│   └── examples/                    # Worked example files per notation
 ├── organizations/
 │   ├── acme_corp/                   # Worked example organisation
-│   │   ├── elements/                # Architecture elements by ArchiMate layer
-│   │   │   ├── 01_motivation/
-│   │   │   ├── 02_business/
-│   │   │   ├── 03_application/
-│   │   │   └── 04_technology/
-│   │   ├── relations/               # Edges of the architecture graph
-│   │   ├── views/                   # Composite diagrams and aggregations over elements
-│   │   │   ├── goals/               # Goals trees
-│   │   │   ├── capabilities/        # Capability maps + maturity
-│   │   │   ├── processmap/          # Process landscape maps
-│   │   │   ├── bpmn/                # Process flow diagrams (BPMN)
-│   │   │   ├── fgca/                # Factor → Goal → Change → Activity chains
-│   │   │   ├── fga/                 # Factor → Goal → Activity chains
-│   │   │   ├── blocks/              # Nested block diagrams (Svgbob)
-│   │   │   ├── activities/          # Mermaid activity diagrams
-│   │   │   ├── products/            # Filtered views over Product elements
-│   │   │   └── applications/        # Filtered views over Application elements
-│   │   ├── .templates/              # Element / relation / view templates
-│   │   ├── .validators/             # Lint scripts (lint.py)
-│   │   ├── README.md
-│   │   ├── GETTING_STARTED.md
-│   │   └── CONVENTIONS.md
+│   │   ├── canon/                   # Zone: validated model — elements, relations, assertions, views
+│   │   ├── field/                   # Zone: raw material — interviews, surveys, observations
+│   │   ├── codex/                   # Zone: external laws + internal policies
+│   │   ├── .templates/  .validators/
+│   │   ├── transitrix.yaml          # Adopter manifest
+│   │   └── README.md  GETTING_STARTED.md  CONVENTIONS.md  AGENTS.md
 │   └── NEW_ORGANIZATION_TEMPLATE.md # How to bootstrap a new organisation
-├── glossary.md
-├── PROJECT_INDEX.md
-├── TOOLING.md
+├── migrations/                      # Per-release migration recipes (0.4→0.5, 0.5→0.6)
+├── integration/                     # Studio / tooling / CI integration notes
+├── skills/                          # Onboarding + extraction skills
+├── glossary.md  PROJECT_INDEX.md  CHANGELOG.md  RELEASING.md
 ├── README.md                        # This file
 ├── LICENSE                          # MIT
 └── CONTRIBUTING.md                  # How to contribute
@@ -83,8 +77,8 @@ $EDITOR organizations/your_company/CONVENTIONS.md
 
 # 3. Create your first element from a template
 cp organizations/your_company/.templates/elements/03_application_template.yaml \
-   organizations/your_company/elements/03_application/MY_SERVICE.yaml
-$EDITOR organizations/your_company/elements/03_application/MY_SERVICE.yaml
+   organizations/your_company/canon/elements/03_application/MY_SERVICE.yaml
+$EDITOR organizations/your_company/canon/elements/03_application/MY_SERVICE.yaml
 
 # 4. Validate
 python3 organizations/your_company/.validators/lint.py
@@ -104,20 +98,9 @@ git commit -m "docs(arch): add MY_SERVICE for your_company"
 
 ## Notations supported
 
-Transitrix defines text-native notations for the most common enterprise-architecture artefacts. Each has a per-format extension. See [`notations/README.md`](notations/README.md) for the canonical index of all eleven notations and [methodology.md §6](method/methodology.md#6-notation-kit) for the rationale.
+Transitrix defines text-native notations for the most common enterprise-architecture artefacts — process diagrams (BPMN), goals trees, capability maps, the FGCA / FGA strategy chains, activities networks, process maps, blocks, products and applications catalogues, scenarios, issues, and process blueprints — plus element notations for the codex, requirements, assertions, relations, actors, and stakeholders. Each view notation has a `*.<short-name>.transitrix.yaml` extension and a `notation:` header.
 
-| Notation | Extension | Purpose | Status |
-| --- | --- | --- | --- |
-| Process diagram (BPMN 2.0) | `*.bpmn.transitrix.yaml` | Process flow with lanes, KPIs | Implemented |
-| Nested block diagrams | `*.blocks.transitrix.yaml` | Multi-level container layouts — recursive `block` tree | Documented |
-| Goals tree | `*.goals.transitrix.yaml` | Hierarchical goals | Planned |
-| Capabilities map | `*.capmap.transitrix.yaml` | Capabilities + maturity | Planned |
-| Process landscape map | `*.processmap.transitrix.yaml` | Top-level process catalogue | Planned |
-| FGCA | `*.fgca.transitrix.yaml` | Strategy-to-execution chain (Factor → Goal → Change → Activity) | Documented |
-| FGA | `*.fga.transitrix.yaml` | Simplified strategy chain (Factor → Goal → Activity) | Planned |
-| Activities | Mermaid (`.mmd`) | Quick activity / sequence diagrams | External standard |
-| Products | YAML element catalogue | Product / service inventory | Planned |
-| Applications | YAML element catalogue | Application portfolio | Planned |
+See **[`notations/README.md`](notations/README.md)** for the canonical index of every notation — short names, file extensions, and spec-maturity status (`draft` / `documented` / `stable`) — and [`method/methodology.md` §6](method/methodology.md#6-notation-kit) for the rationale. The catalogue is not duplicated here, to keep a single source of truth.
 
 ## Validation in one paragraph
 
@@ -142,5 +125,5 @@ Transitrix — including the FGCA / FGA notations that form part of it — is au
 
 ---
 
-**Methodology version:** 1.0
-**Last updated:** 2026-05-07
+**Methodology status:** pre-1.0 — see [`CHANGELOG.md`](CHANGELOG.md) for the current release and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10 for the compatibility policy.
+**Last updated:** 2026-05-30

--- a/method/methodology.md
+++ b/method/methodology.md
@@ -1,7 +1,7 @@
 ---
 title: Transitrix — Methodology for Enterprise Architecture as Code
-status: v1.0_draft
-last_reviewed: 2026-05-26
+status: active
+last_reviewed: 2026-05-30
 audience: public
 license: MIT
 tags: [transitrix, methodology, enterprise_architecture, architecture_as_code, archimate, bpmn]
@@ -53,22 +53,23 @@ Transitrix does not invent semantics where they already exist. It builds on:
 
 Transitrix adds value at the layer above these standards: how the model is **stored**, **versioned**, **validated**, **rendered**, and **acted upon** by both humans and software agents.
 
-> **Editorial note (2026-05-08):** the ArchiMate vocabulary reference below was ported in from a standalone file. Section numbering is not yet harmonised — to be folded into §3 / §4 in a later pass.
-
 ## 3a. ArchiMate vocabulary reference
 
 Transitrix uses ArchiMate 3.2 as the vocabulary for architectural elements. Every YAML element file carries a `type` field drawn from this vocabulary. Relations between elements use ArchiMate relation types. The subset documented here covers what is actively used in the methodology — it is not a replacement for the full Open Group standard.
 
+> **Canonical ID authority.** The ID grammar and the full TYPE registry are defined once in [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md). Where the prefix tables below differ from that registry, the registry wins — the tables here describe the ArchiMate element *vocabulary*, not the canonical ID forms.
+
 ### 3a.1 Layer mapping
 
-ArchiMate organises elements across four layers. In Transitrix these map directly to the folder structure under `elements/`:
+ArchiMate organises elements across layers. In Transitrix these map directly to the folder structure under `canon/elements/`:
 
 | ArchiMate Layer | Transitrix folder | Contents |
 |---|---|---|
-| Motivation | `elements/01_motivation/` | Goals, principles, drivers, constraints |
-| Business | `elements/02_business/` | Roles, actors, processes, functions, products |
-| Application | `elements/03_application/` | Components, services, data objects, interfaces |
-| Technology | `elements/04_technology/` | Nodes, system software, artefacts, devices |
+| Motivation | `canon/elements/01_motivation/` | Goals, constraints, requirements, stakeholders |
+| Business | `canon/elements/02_business/` | Roles, actors, processes, products, rules |
+| Application | `canon/elements/03_application/` | Components, services, data objects, interfaces |
+| Technology | `canon/elements/04_technology/` | Nodes, system software, artefacts, devices |
+| Implementation & Migration | `canon/elements/05_implementation/` | Activities, changes |
 
 ### 3a.2 Motivation layer elements
 
@@ -140,7 +141,7 @@ name: "Order API"              # Human-readable name
 type: "ApplicationComponent"   # ArchiMate 3.2 type (see tables above)
 layer: "Application"           # Motivation | Business | Application | Technology
 metadata:
-  status: "Active"             # Draft | Active | Deprecated | Archived
+  status: "Active"             # Draft | Active | Deprecated
   owner: "firstname.lastname"
   created_at: "2026-05-08"
   updated_at: "2026-05-08"
@@ -177,7 +178,7 @@ properties:
 
 ## 4. Repository structure
 
-A Transitrix-managed repository organises content in a predictable, ArchiMate-aligned hierarchy. Multiple organisations can coexist in a single repository (multi-tenant structure).
+A Transitrix-managed repository organises content per organisation. Multiple organisations can coexist in a single repository (multi-tenant structure). Each organisation's content is split into three parallel **zones** — `canon`, `field`, and `codex` — defined in [`notations/CONTRACT.md`](../notations/CONTRACT.md) §5. The zones are parallel, not stacked: validated truth (`canon`), raw source material (`field`), and externally-given constraints (`codex`) sit side by side.
 
 ```
 organizations/
@@ -185,32 +186,34 @@ organizations/
 │   ├── README.md                  # Organisation overview
 │   ├── GETTING_STARTED.md         # Onboarding for the team
 │   ├── CONVENTIONS.md             # Local naming conventions and overrides
-│   ├── elements/                  # Atomic ArchiMate elements (1 element = 1 file)
-│   │   ├── 01_motivation/         # Goals, principles, drivers, constraints
-│   │   ├── 02_business/           # Roles, actors, processes, functions, products
-│   │   ├── 03_application/        # Components, services, data objects
-│   │   └── 04_technology/         # Nodes, system software, artefacts
-│   ├── relations/                 # Edges of the architecture graph (1 relation = 1 file)
-│   ├── views/                     # Composite diagrams and aggregations over elements
-│   │   ├── goals/                 # Goals trees
-│   │   ├── capabilities/          # Capability maps + maturity
-│   │   ├── processmap/            # Process landscape maps
-│   │   ├── bpmn/                  # Process flow diagrams (BPMN)
-│   │   ├── fgca/                  # Factor → Goal → Change → Activity chains
-│   │   ├── fga/                   # Factor → Goal → Activity chains
-│   │   ├── blocks/                # Nested block diagrams (ASCII / Svgbob)
-│   │   ├── activities/            # Activity schedule networks
-│   │   ├── products/              # Filtered views over Product elements
-│   │   └── applications/          # Filtered views over Application elements
+│   ├── AGENTS.md                  # Assistant-neutral agent guide
+│   ├── transitrix.yaml            # Adopter manifest — pinned methodology version, notations, zones
+│   ├── canon/                     # Zone: validated, authoritative model
+│   │   ├── elements/              # Atomic elements by ArchiMate layer (1 element = 1 file)
+│   │   │   ├── 01_motivation/     # Goals, constraints, requirements, stakeholders
+│   │   │   ├── 02_business/       # Roles, actors, processes, products, rules
+│   │   │   ├── 03_application/    # Components, services, data objects
+│   │   │   └── 05_implementation/ # Activities, changes
+│   │   ├── relations/             # First-class, time-aware relations (1 relation = 1 file)
+│   │   ├── assertions/            # Compliance assertions (REQUIREMENT ↔ subject)
+│   │   └── views/                 # Composite diagrams and aggregations over elements
+│   │       ├── goals/  capabilities/  processmap/  bpmn/  fgca/  fga/
+│   │       └── blocks/  activities/  products/  applications/  scenarios/  …
+│   ├── field/                     # Zone: raw material — interviews, surveys, observations, drafts
+│   ├── codex/                     # Zone: external laws / regulations + internal policies / standards
+│   │   ├── external/<jurisdiction>/
+│   │   └── internal/
 │   ├── .templates/                # Copy-and-fill templates for elements / relations / views
-│   ├── .validators/               # Lint and schema scripts
+│   └── .validators/               # Lint and schema scripts
 └── NEW_ORGANIZATION_TEMPLATE.md   # How to bootstrap a new organisation
 ```
 
-Two-layer separation matters:
+Two layers stay separate inside `canon/`:
 
-- **`elements/`** holds atomic ArchiMate-typed objects. Each file describes exactly one element — its identity, type, properties, and metadata. No aggregation, no flow, no list of related items.
-- **`views/`** holds compositions over elements. A goals tree is a hierarchy referencing many Goal elements. A BPMN diagram is a detailed flow over a single BusinessProcess element. A products list is a filtered view over all elements of type Product. Views aggregate; elements stay atomic.
+- **`canon/elements/`** holds atomic ArchiMate-typed objects. Each file describes exactly one element — its identity, type, properties, metadata, admission record, and lifecycle. No aggregation, no flow, no list of related items.
+- **`canon/views/`** holds compositions over elements. A goals tree is a hierarchy referencing many Goal elements. A BPMN diagram is a detailed flow over a single BusinessProcess element. A products list is a filtered view over all elements of type Product. Views aggregate; elements stay atomic.
+
+Every canonical artefact carries an **admission record** and a **primitive lifecycle** (`valid_from` / `valid_to`) — both defined in [`notations/CONTRACT.md`](../notations/CONTRACT.md) §6–7. Attributes that change over time live in `*.history.yaml` sidecars (§9), not inline.
 
 Why multi-tenant: a single repository can hold an entire portfolio of organisations (parent group plus subsidiaries; advisory relationships; multiple business units). Each organisation has full structural isolation while sharing methodology and validators.
 
@@ -257,31 +260,17 @@ Transitrix supports a set of **notations** for describing different aspects of a
 
 Every notation is specified in its own file under `notations/`. The file-header rules common to all of them — the required `notation:` field, the reserved `spec_version:` field, validator behaviour, and the extension/content match guarantee — are defined once in `notations/CONTRACT.md`. The cross-notation ID grammar and TYPE registry live in `notations/IDS_AND_REFERENCES.md`.
 
-The table below is the canonical Transitrix notation set. Every notation file follows the extension convention `*.<short-name>.transitrix.yaml` and begins with a `notation: <short-name>` header. The `Status` column reflects the maturity of the notation **specification** (`draft`, `documented`, or `stable`), not whether a tool implements it; tool support is tracked per spec in its `dsm_status:` field.
+The **canonical index of all notations** — view notations and element notations alike, with their short names, file extensions, and spec-maturity status — lives in [`notations/README.md`](../notations/README.md). That index is the single source of truth for the notation set; this document does not restate the catalogue (a duplicate would drift). The `Status` column there reflects the maturity of the notation **specification** (`draft`, `documented`, or `stable`), not whether a tool implements it; tool support is tracked per spec in its `dsm_status:` field.
 
-| # | Notation | File extension | Purpose | Status |
-| --- | --- | --- | --- | --- |
-| 01 | **BPMN process diagram** | `*.bpmn.transitrix.yaml` | BPMN 2.0 process flow — lanes, gateways, sequence flows. | documented |
-| 02 | **FGCA** | `*.fgca.transitrix.yaml` | Four-layer strategy-to-execution chain: Factor → Goal → Change → Activity. | documented |
-| 03 | **FGA** | `*.fga.transitrix.yaml` | Simplified strategy-to-execution chain: Factor → Goal → Activity (no Changes layer). | draft |
-| 04 | **Goals tree** | `*.goals.transitrix.yaml` | Hierarchy of strategic and tactical goals as a tree. | documented |
-| 05 | **Capabilities map** | `*.capability-map.transitrix.yaml` | Capability hierarchy with CMMI V2.0 maturity, addressing, and vertical / horizontal orientation. | documented |
-| 06 | **Process landscape map** | `*.process-map.transitrix.yaml` | Top-level catalogue of processes grouped into Operating, Supporting, and Management. | draft |
-| 07 | **Activities** | `*.activities.transitrix.yaml` | Project schedule as an Activity-on-Node network, with an optional Gantt timeline projection. | documented |
-| 08 | **Nested block diagrams** | `*.blocks.transitrix.yaml` | Multi-level container layouts for deep architectural overviews — recursive `block` tree rendered as nested boxes. | documented |
-| 09 | **Products** | `*.products.transitrix.yaml` | Inventory of products and services — text-and-table catalogue, no diagram. | draft |
-| 10 | **Applications** | `*.applications.transitrix.yaml` | Inventory of applications and integrations — text-and-table catalogue, no diagram. | draft |
-| 11 | **Scenarios** | `*.scenarios.transitrix.yaml` | Alternative strategic development paths — each scenario scopes its own goals, capabilities, activities, products, processes, and applications. | documented |
-| 12 | **Issues register** | `*.issues.transitrix.yaml` | Register of issues — problems, defects, open questions — in a parent/child tree, complementing the activities plan. | draft |
-| 13 | **Process Blueprint** | `*.process-blueprint.transitrix.yaml` | Wide blueprint of a value chain — stages laid out left-to-right, each carrying its goal, result, and supporting systems / actors / equipment / information entities. | draft |
+A few cross-cutting notes:
 
-Gantt is not a separate notation — the calendar-timeline view ships as the Gantt projection of the Activities notation (07).
-
-Notations 09 (Products) and 10 (Applications) are **catalogue** forms — they render as text and tables rather than as a custom diagram. Every other notation is a diagram, rendered through Transitrix Studio's shared diagram engine.
+- Every view notation follows the extension convention `*.<short-name>.transitrix.yaml` and begins with a `notation: <short-name>` header (see [`notations/CONTRACT.md`](../notations/CONTRACT.md) §1–3). Element notations are addressed by ID and governed by per-notation file-location rules.
+- Gantt is not a separate notation — the calendar-timeline view ships as the Gantt projection of the Activities notation.
+- Products and Applications are **catalogue** forms — they render as text and tables rather than as a custom diagram. Every other view notation is a diagram, rendered through Transitrix Studio's shared diagram engine.
 
 ### 6.1 Where each notation lives in the repository
 
-Diagrams and aggregations live under `views/`. Atomic ArchiMate elements live under `elements/`. The two layers stay separate (see §4).
+Diagrams and aggregations live under `canon/views/`. Atomic ArchiMate elements live under `canon/elements/`. The two layers stay separate (see §4). The per-notation paths in the table below are shown relative to the organisation's `canon/` zone.
 
 | Notation | Typical location | What it is |
 | --- | --- | --- |
@@ -299,7 +288,7 @@ Diagrams and aggregations live under `views/`. Atomic ArchiMate elements live un
 | Issues register | `views/issues/<NAME>.issues.transitrix.yaml` | Register of issues — problems, defects, open questions — in a parent/child tree, complementing the activities plan |
 | Process Blueprint | `views/process-blueprint/<DOMAIN>.process-blueprint.transitrix.yaml` | Wide value-chain blueprint referencing stage aspects (systems, actors, equipment, information entities) |
 
-Individual product and application instances are still stored as **atomic elements** in their respective ArchiMate-layer folders — `elements/02_business/<PRODUCT_ID>.yaml` (with `type: Product`) and `elements/03_application/<APP_ID>.yaml` (with `type: ApplicationComponent`). The "view" file in `views/products/` or `views/applications/` defines how to filter, group, and present those elements (e.g., "all active Products grouped by category").
+Individual product and application instances are still stored as **atomic elements** in their respective ArchiMate-layer folders — `canon/elements/02_business/<PRODUCT_ID>.yaml` (with `type: Product`) and `canon/elements/03_application/<APP_ID>.yaml` (with `type: ApplicationComponent`). The "view" file in `views/products/` or `views/applications/` defines how to filter, group, and present those elements (e.g., "all active Products grouped by category").
 
 Inline diagrams (Mermaid blocks in markdown, embedded ASCII block diagrams) are explicitly allowed when the diagram is bound to one specific document and has no independent life. Use stand-alone files in `views/` when the diagram is a first-class artefact of the model.
 
@@ -347,7 +336,7 @@ The two notations are complementary — most organisations need both.
 
 Working with the Transitrix repository is structurally identical to working with a software codebase:
 
-1. **Create.** Copy a template from `.templates/` into the appropriate `elements/` or `relations/` folder.
+1. **Create.** Copy a template from `.templates/` into the appropriate `canon/elements/` or `canon/relations/` folder.
 2. **Describe.** Fill in the YAML — element attributes or relation endpoints. Add metadata (owner, status, dates).
 3. **Validate.** Run the linter (`.validators/lint.py`) locally. Fix syntax, integrity, and policy errors.
 4. **Review.** Open a pull request. Reviewers see the change as a Git diff — the same review surface as for code.
@@ -365,7 +354,7 @@ The linter applies five categories of rules. Each category has progressively-dee
 | **Atomicity** | Element files contain no relations section; relation files contain no element fields beyond endpoints. |
 | **Referential integrity** | Every `source` and `target` in a relation refers to an existing element id. |
 | **Semantics** | Relations conform to ArchiMate 3.2 layer rules (e.g., a BusinessRole cannot be served by an ApplicationComponent without an intermediate ApplicationService). |
-| **Policy** | Active / Production status requires an `owner` field; recent updates require an `updated_at` date; deprecated elements must reference a successor. |
+| **Policy** | Active status requires an `owner` field; recent updates require an `updated_at` date; deprecated elements must reference a successor. |
 
 Validators run locally on save and as a CI gate on every pull request. A pull request that breaks the validation matrix cannot be merged.
 
@@ -383,19 +372,7 @@ Consistency in names is a small thing that pays back daily during diff review an
 
 ### 9.1 Element id type prefixes
 
-| Prefix | ArchiMate type |
-| --- | --- |
-| `ROLE` | BusinessRole |
-| `ACTOR` | BusinessActor |
-| `PROC` | BusinessProcess |
-| `FUNC` | BusinessFunction |
-| `CAP` | Capability |
-| `APP` | ApplicationComponent |
-| `SVC` | ApplicationService |
-| `DATA` | DataObject |
-| `NODE` | Node (infrastructure) |
-| `SYS` | SystemSoftware |
-| `EXT` | External system |
+The canonical ID grammar and the full TYPE registry (`FACTOR`, `GOAL`, `ACTOR`, `CAPABILITY-V…`, `REQUIREMENT`, …) are defined once in [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md). Refer to it rather than to a local prefix list — a duplicate would drift from the registry.
 
 ### 9.2 Mandatory metadata
 
@@ -410,7 +387,7 @@ metadata:
   tags: ["tag1", "tag2"]
 ```
 
-`owner` is mandatory for any element with status `Active` or `Production`. Without an owner, the linter blocks the change.
+`owner` is mandatory for any element with status `Active`. Without an owner, the linter blocks the change.
 
 ## 10. Documentation hierarchy
 
@@ -419,7 +396,7 @@ A Transitrix repository carries documentation at three levels:
 **Repository root:**
 
 - `README.md` — overview and quick start
-- `methodology.md` (this document) — canonical methodology spec
+- `method/methodology.md` (this document) — canonical methodology overview
 - `glossary.md` — standard terminology
 - `LICENSE`, `CONTRIBUTING.md` — open-source artefacts
 
@@ -445,16 +422,16 @@ For organisations integrating Transitrix into existing pipelines, the linter (`.
 
 ## 12. Getting started
 
-### 13.1 For a new organisation
+### 12.1 For a new organisation
 
 1. Read `organizations/NEW_ORGANIZATION_TEMPLATE.md`.
 2. Create `organizations/<your_org_slug>/`.
 3. Copy structure from `organizations/acme_corp/` as a starting reference.
 4. Adapt `.templates/` to local conventions and overrides.
-5. Add the first elements to `elements/`.
+5. Add the first elements to `canon/elements/`.
 6. Open a pull request to introduce the organisation; the validators check the structure.
 
-### 13.2 For modelling capabilities
+### 12.2 For modelling capabilities
 
 1. Open `<org>/.templates/capability-map_template.yaml`.
 2. Define vertical (V) and horizontal (H) capabilities.
@@ -463,7 +440,7 @@ For organisations integrating Transitrix into existing pipelines, the linter (`.
 5. Set target maturity and a target date.
 6. Commit and open a PR.
 
-### 13.3 For modelling complex processes
+### 12.3 For modelling complex processes
 
 Use Transitrix Studio for BPMN authoring with lanes, stages, and KPIs.
 
@@ -483,7 +460,7 @@ This methodology document follows semantic versioning at the methodology level:
 - **Minor** — new notations, new validation rules, additive schema changes.
 - **Patch** — wording, examples, clarifications.
 
-Current methodology version: **1.0**. Tooling versions (Transitrix Studio, etc.) advance independently and declare their compatible methodology version range.
+The methodology is **pre-1.0** — see [`notations/CONTRACT.md`](../notations/CONTRACT.md) §10 for the full compatibility policy (pre-1.0 MINOR bumps may carry breaking changes). The current release is recorded in [`CHANGELOG.md`](../CHANGELOG.md) and pinned per adopter repository via `methodology_version` in `transitrix.yaml` (see [`notations/MANIFEST.md`](../notations/MANIFEST.md)); this document does not restate a version number. Tooling versions (Transitrix Studio, etc.) advance independently and declare their compatible methodology version range.
 
 ## 14. License and contributing
 
@@ -497,5 +474,5 @@ Transitrix is authored by **Valerii Korobeinikov**. The methodology — includin
 
 ---
 
-**Document version:** 1.0 (initial English canonical, 2026-05-07).
+**Last reviewed:** 2026-05-30. The methodology's own versioning is tracked in [`CHANGELOG.md`](../CHANGELOG.md); this document is maintained alongside the `notations/` specs.
 **Status:** Active.

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -29,7 +29,7 @@ In this methodology repo the worked example lives at `organizations/acme_corp/tr
 
 ```yaml
 transitrix: 1                       # manifest schema version (integer)
-methodology_version: "0.4.x"        # the methodology release this repo conforms to
+methodology_version: "0.5.0"        # the methodology release this repo conforms to
 notations: [fgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```
@@ -38,7 +38,7 @@ zones: [canon, field, codex]
 |---|---|---|---|
 | `transitrix` | yes | integer | Manifest schema version. `1` today. Identifies the file as a Transitrix adopter manifest. |
 | `methodology_version` | yes | string | The methodology release this repository pins to. Adopters follow the published specs at this version rather than vendoring `notations/`. |
-| `notations` | yes | list | Short names of the notations the repository uses, from the catalogue in [README.md](README.md) — plus `codex` for the codex zone (see [14-codex.md](14-codex.md)). |
+| `notations` | yes | list | Short names of the notations the repository uses, from the catalogue in [README.md](README.md) — plus `codex` for the codex zone (see [14-codex.md](elements/14-codex.md)). |
 | `zones` | yes | list | Which zones the repository maintains — any subset of `canon`, `field`, `codex`. A repo MAY start canon-only and add `field` / `codex` later. |
 
 No validator enforces the manifest yet; it is declarative. Tooling MAY read it to discover the pinned methodology version and the active notations and zones.
@@ -49,4 +49,4 @@ No validator enforces the manifest yet; it is declarative. Tooling MAY read it t
 
 - Zone model and admission record: [CONTRACT.md](CONTRACT.md) §5–6.
 - Notation catalogue (short names): [README.md](README.md).
-- Codex zone: [14-codex.md](14-codex.md).
+- Codex zone: [14-codex.md](elements/14-codex.md).


### PR DESCRIPTION
Reconciles the repository's entry-point documents with the current (0.5.0 / 0.6.0) model. The `notations/` core had advanced to zones / lifecycle / compliance / actors while `method/methodology.md`, `README.md`, `PROJECT_INDEX.md`, and `notations/MANIFEST.md` were frozen at the "1.0 / 2026-05-07" snapshot and actively contradicted the canon.

Addresses **vkgeorgia/strategy#114** (audit + plan in that issue).

### Scope of this PR (front-door docs only)

**`method/methodology.md`**
- Version: dropped "Current methodology version: **1.0**" → states pre-1.0 and defers to `CHANGELOG.md` + `transitrix.yaml` + `CONTRACT.md` §10 (frontmatter `status`/`last_reviewed` too).
- §4 Repository structure: rewritten to the zoned `canon` / `field` / `codex` layout (was flat `elements/01–04` + `relations/` + `views/`); adds admission-record + primitive-lifecycle + sidecar pointers to `CONTRACT.md` §6–7, §9.
- §3a.1 layer map: paths → `canon/elements/`, added the Implementation & Migration layer (05).
- §3a + §9.1: `IDS_AND_REFERENCES.md` marked the canonical ID/TYPE authority; the second, conflicting prefix table in §9.1 replaced by a pointer (was `ACTR`/`SVC` vs the canonical `ACTOR`/`CAPABILITY-V…`).
- §6 notation table: the in-doc 13-row table (which duplicated and drifted from the canonical index) replaced by a pointer to `notations/README.md`.
- Status enum unified to `Draft | Active | Deprecated`; dropped the undefined `Production` from the Policy rule (§8, §9.2) and `Archived` from §3a.7.
- §12 "Getting started": fixed the mis-numbered 13.1/13.2/13.3 → 12.x.
- Removed the unresolved 2026-05-08 "section numbering not harmonised" editorial TODO.

**`README.md`** — pre-1.0 version statement; repo-structure block rewritten to the real `notations/` + zoned `acme_corp/`; broken links fixed (`TOOLING.md` → `integration/studio.md` + `integration/tooling.md`; `.github_workflows_example.yaml` → `integration/ci-example.yaml`); the 10-row notation table (wrong status vocabulary, Activities mislabelled "Mermaid external") replaced by a pointer to `notations/README.md`; quick-start element path → `canon/elements/`; dropped hardcoded "eleven notations".

**`PROJECT_INDEX.md`** — replaced the stale guide (old `elements/` layout, a deleted Russian methodology file, missing `TOOLING.md` / workflow refs) with a concise, accurate navigation map of the zoned model and the `notations/` canon.

**`notations/MANIFEST.md`** — relative links to `elements/14-codex.md` were one level off (fixed); stale example pin `methodology_version` `0.4.x` → `0.5.0`.

### Deliberately out of scope (trivial mechanical follow-up)

Kept out to keep this PR one concern (and reviewable). A tiny separate PR can:
- Drop the remaining hardcoded "eleven notations" in `notations/CONTRACT.md`, `notations/IDS_AND_REFERENCES.md`, and 8 per-spec headers under `notations/views/` (README's instance is fixed here).
- Refresh two more `methodology_version: "0.4.x"` example pins (`organizations/acme_corp/AGENTS.md`, `skills/onboarding/templates/AGENTS.md`) and one `.github_workflows_example.yaml` reference in `organizations/NEW_ORGANIZATION_TEMPLATE.md`.
- Refresh / retire the gitignored `NOTATIONS_VALIDATION.md` (2026-05-19 snapshot; several items already fixed) and re-check the BPMN examples.

**Do not merge — Valerii gates.** Docs-only; no schema or validator changes.