### PR TITLE
docs(notations): drop stale "eleven notations" count (strategy#114)

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -1,10 +1,10 @@
 # Notation contract — shared header rules
 
-All eleven Transitrix notations share the same file-header contract: the same required field, the same reserved field, the same validator rules, and the same extension/content match guarantee. This document defines those shared rules once. Each notation spec links here and lists only its per-notation values (the `notation:` short name and the file extension).
+All Transitrix notations share the same file-header contract: the same required field, the same reserved field, the same validator rules, and the same extension/content match guarantee. This document defines those shared rules once. Each notation spec links here and lists only its per-notation values (the `notation:` short name and the file extension).
 
 This document also defines four organisation-level contracts shared across all notations: the **zone model** (§5), the **admission record** (§6), the **primitive lifecycle** (§7), and the **versioned-attribute sidecar** (§9) — the four shared shapes every organisation artefact may carry. §8 aggregates the validation rules of the compliance domain (REQUIREMENT + ASSERTION) for discoverability — the per-notation specs remain authoritative for the rule definitions themselves. §10 sets the **versioning and compatibility policy** for the methodology itself — what kind of change each SemVer bump may carry, and what adopters can rely on across releases.
 
-A change to the rules below applies to all eleven notations simultaneously — they should be edited here, not duplicated into each spec.
+A change to the rules below applies to all notations simultaneously — they should be edited here, not duplicated into each spec.
 
 ---
 

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -1,6 +1,6 @@
 # IDs and cross-references — canonical grammar
 
-This appendix defines the ID grammar used across all eleven Transitrix notations and enumerates the TYPE registry. Every element ID and every cross-reference in any notation file follows this grammar.
+This appendix defines the ID grammar used across all Transitrix notations and enumerates the TYPE registry. Every element ID and every cross-reference in any notation file follows this grammar.
 
 Recorded 2026-05-20 as the canonical decision for the methodology.
 
@@ -209,6 +209,6 @@ The TYPE registry above was confirmed 2026-05-20. Several notations and example 
 
 ## 7. References
 
-- Notation catalogue and the index of all eleven notations: [`README.md`](README.md).
+- Notation catalogue and the index of all notations: [`README.md`](README.md).
 - Capability addressing (the V/H system that the `CAPABILITY` exception relies on): [`05-capability-map.md`](views/05-capability-map.md) §4–5.
 - Methodology: `method/methodology.md`.

--- a/notations/views/01-bpmn.md
+++ b/notations/views/01-bpmn.md
@@ -17,7 +17,7 @@ file_extension: "*.bpmn.transitrix.yaml"
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|

--- a/notations/views/02-fgca.md
+++ b/notations/views/02-fgca.md
@@ -12,7 +12,7 @@ dsm_status: "implemented — F, G, C, A layers active; column selection via loca
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|

--- a/notations/views/05-capability-map.md
+++ b/notations/views/05-capability-map.md
@@ -21,7 +21,7 @@ dsm_status: "implemented — Capabilities page, Editor (C), BCM tab"
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|

--- a/notations/views/06-process-map.md
+++ b/notations/views/06-process-map.md
@@ -16,7 +16,7 @@ file_extension: "*.process-map.transitrix.yaml"
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|

--- a/notations/views/07-activities.md
+++ b/notations/views/07-activities.md
@@ -17,7 +17,7 @@ dsm_status: "partially implemented — Activities page; multi-value fields (pred
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|

--- a/notations/views/09-products.md
+++ b/notations/views/09-products.md
@@ -16,7 +16,7 @@ file_extension: "*.products.transitrix.yaml"
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|

--- a/notations/views/10-applications.md
+++ b/notations/views/10-applications.md
@@ -16,7 +16,7 @@ file_extension: "*.applications.transitrix.yaml"
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|

--- a/notations/views/11-scenarios.md
+++ b/notations/views/11-scenarios.md
@@ -21,7 +21,7 @@ dsm_status: "implemented — Scenarios page; scenario-scoped entities planned in
 
 ## File header
 
-Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all eleven Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
 
 | Field | Value |
 |---|---|


### PR DESCRIPTION
Mechanical follow-up to #96 (front-door reconcile). Addresses **vkgeorgia/strategy#114**.

There are 14 view + 6 element notations, not eleven. This drops the stale hardcoded "eleven notations" count, replacing it with neutral phrasing.

### Changes
- `notations/CONTRACT.md` — "All eleven Transitrix notations…" → "All Transitrix notations…" (L3); "…applies to all eleven notations…" → "…all notations…" (L7)
- `notations/IDS_AND_REFERENCES.md` — "…across all eleven Transitrix notations…" → "…all Transitrix notations…" (L3); "…index of all eleven notations…" → "…index of all notations…" (L212)
- `notations/views/{01-bpmn,02-fgca,05-capability-map,06-process-map,07-activities,09-products,10-applications,11-scenarios}.md` — each per-spec header "…shared across all eleven Transitrix notations and defined in CONTRACT.md…" → "…all Transitrix notations…"

README's instance was already fixed in #96. After this PR, `git grep eleven` (excluding `0. archive/`) returns nothing.

One commit = one concern. Docs-only; no schema or validator changes.

**Do not merge — Valerii gates.**
