### PR TITLE
docs(organizations): refresh 0.4.x→0.5.0 version pins + dead CI ref (strategy#114)

### DIFF
--- a/organizations/NEW_ORGANIZATION_TEMPLATE.md
+++ b/organizations/NEW_ORGANIZATION_TEMPLATE.md
@@ -207,7 +207,7 @@ Transitrix/
 │   ├── your_company/           # Your new organization
 │   └── another_org/            # Another organization
 ├── method/
-├── .github_workflows_example.yaml
+├── integration/ci-example.yaml
 └── README.md
 ```
 

--- a/organizations/acme_corp/AGENTS.md
+++ b/organizations/acme_corp/AGENTS.md
@@ -120,7 +120,7 @@ The root `transitrix.yaml` pins which methodology release this repo conforms to 
 
 ```yaml
 transitrix: 1
-methodology_version: "0.4.x"
+methodology_version: "0.5.0"
 notations: [fgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```

--- a/skills/onboarding/templates/AGENTS.md
+++ b/skills/onboarding/templates/AGENTS.md
@@ -116,7 +116,7 @@ The root `transitrix.yaml` pins which methodology release this repo conforms to 
 
 ```yaml
 transitrix: 1
-methodology_version: "0.4.x"
+methodology_version: "0.5.0"
 notations: [fgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```


### PR DESCRIPTION
Mechanical follow-up to #96 (front-door reconcile). Addresses **vkgeorgia/strategy#114**.

Refreshes two stale `0.4.x` example version pins and one dead file reference.

### Changes
- `organizations/acme_corp/AGENTS.md` — `methodology_version: "0.4.x"` → `"0.5.0"`
- `skills/onboarding/templates/AGENTS.md` — `methodology_version: "0.4.x"` → `"0.5.0"`
- `organizations/NEW_ORGANIZATION_TEMPLATE.md` — structure-tree line `.github_workflows_example.yaml` → `integration/ci-example.yaml` (the workflow file doesn't exist; the CI template lives at `integration/ci-example.yaml`)

`0.5.0` is the latest released methodology version per `CHANGELOG.md`.

> **Note — left in scope deliberately:** `skills/onboarding/templates/transitrix.yaml` also pins `methodology_version: "0.4.x"`, but there it is an intentional placeholder ("pin a real release once the adopter chooses one"), not a stale fact, so it is left as-is.
>
> **Note — flagged separately (not free-handed here):** `NEW_ORGANIZATION_TEMPLATE.md` is stale more broadly — it still describes the pre-zone `elements/01–04` layout and references `create_organization.sh`. A full rewrite to the `canon`/`field`/`codex` zoned model is worth a dedicated task rather than bundling it into this one-line fix.

One commit = one concern. Docs-only; no schema or validator changes.

**Do not merge — Valerii gates.**
