### PR TITLE
docs(notations): process behaviour is canon — PROCESS gains flow + participants; BPMN becomes a projection (strategy#116)

### DIFF
--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -25,6 +25,17 @@ A `standalone` mode therefore does not forbid inline authoring inside a single v
 
 A `view-defined` TYPE has **no** standalone element-file schema in v1: its only definition home is the view/document that declares it (§4 lists which, and why).
 
+### 1.1 The reconstruction invariant — `Views = render(Elements, view_config)`
+
+The split between `canon/elements/` and `canon/views/` is governed by one invariant: **the elements are the complete and sufficient source of truth for the organisation's behaviour; a view is a projection over them.** Formally, a view is `render(Elements, view_config)` — it takes the canonical elements plus its own *presentation configuration* (which elements to show, grouping, filtering, ordering, display options) and renders them. The two folders own disjoint things:
+
+- **No behaviour lives only in a view.** Every fact about how the organisation works — a process's steps and flow, a goal hierarchy, a capability's maturity — must be reconstructable from `canon/elements/`. Delete `canon/views/` entirely and no knowledge is lost; the views regenerate.
+- **No view configuration lives in `canon/elements/`.** Which rows a Process Blueprint shows, a capability-map's orientation, a saved report's selection and filters — these are the view's own primary data and are not derivable from the elements. They are not behaviour; they stay in the view.
+
+**View-purity corollary.** A view carries *no non-derivable information beyond its configuration* — no hand-tuned layout, no view-only annotations, no canonical content that exists nowhere else. (Layout is already computed deterministically per notation, so it carries no information — consistent with this rule.) BPMN is the case this resolves: a process's flow is behaviour and belongs in the `PROCESS` element (§7.5); the BPMN file is a projection of it.
+
+This invariant scopes the materialisation modes of §4: `view-defined` must never mean "behaviour that lives only in a view" (§4.2).
+
 ---
 
 ## 2. Relationship to the views, the element notations, and `canon/`
@@ -157,6 +168,13 @@ The mode table. For each registry element TYPE: its mode (§1), its `notation` s
 - **`SCENARIO` / `ISSUE` are `view-defined`.** [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §4 scopes `SCENARIO` to "within the organisation" via its scenarios document and `ISSUE` to "within the issues catalogue document." A scenario is itself a container/projection over other elements; an issue register is a document-scoped tree. Neither is materialised as a standalone catalogue element in v1.
 - **`EQUIPMENT` / `INFORMATION_ENTITY` are `view-defined` (document-local).** [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §4 and [views/13](views/13-process-blueprint.md) §5.3 already state these are blueprint-scoped with no organisation-wide catalogue mandated in v1 — "the IDs already conform to the canonical grammar and can be promoted … without renaming." This document leaves that decision unchanged.
 
+### 4.2 `view-defined` is inline-content convenience, never a content home of last resort
+
+Per the reconstruction invariant (§1.1), `view-defined` in the table above is a convenience — a *content* element authored inline inside a view document instead of in its own catalogue file — and it does not license a view to be the **only** home of canonical content. Two distinctions follow:
+
+- **Content vs presentation config.** The element TYPEs in §4 are content (an `EQUIPMENT`, an `INFORMATION_ENTITY` — real things the organisation has). A view document *also* carries presentation configuration — which elements it shows, grouping, filtering, ordering, display options. That configuration is the view's own primary data, is not an element TYPE, and legitimately and permanently lives in the view (out of scope of this element table by construction). The rule: content is promotable to canon; presentation config stays in the view.
+- **`view-defined` content must be promotable.** `EQUIPMENT` / `INFORMATION_ENTITY` already are (§4.1) — inline today, with canonical-grammar IDs ready for promotion. The remaining non-promotable `view-defined` rows (`SCENARIO`, `ISSUE`) sit in tension with §1.1: a register of issues and an alternative-path scenario are content, not presentation. Reconciling each into a content element plus a report-configuration view is filed separately and is out of scope here.
+
 ---
 
 ## 5. Reconciliation with the legacy `.templates/elements/*` shape
@@ -277,13 +295,25 @@ Inline shape: [views/07-activities.md](views/07-activities.md) §5.2, [views/02-
 
 ### 7.5 `PROCESS` — `02_business/processes/`
 
+The `PROCESS` element is the **complete, self-sufficient definition** of a business process. It carries not only the catalogue metadata but the process *behaviour* — the participants and the flow — so the process can be reconstructed without any view. A BPMN diagram is a **projection** of this element, not its definition home (the reconstruction invariant, §1.1; render contract in [views/01-bpmn.md](views/01-bpmn.md)).
+
 | Field | Required | Type | Semantics |
 |---|---|---|---|
-| `owner_role` | no | string | `ROLE-…` accountable for the process. |
+| `owner_role` | no | string | `ROLE-…` accountable for the process as a whole. |
 | `capability` | no | string | `CAPABILITY-…` this process realises. |
 | `maturity` | no | integer | CMM level 1–5. |
-| `bpmn_file` | no | string | Path to the detailed BPMN diagram. |
+| `participants` | no | list | The process's lanes — each a reference to a canonical active-structure element, `ROLE-…` or `ACTOR-…` (person / business_unit / system). A participant's lane caption is **derived** from the referenced element's `name`; no caption text is stored here. List order is the rendered top-to-bottom lane order. |
+| `flow` | no | object | The canonical process graph — steps, gateways, and sequence flows (see below). Sufficient to regenerate a BPMN diagram; the view adds only layout, which is computed deterministically. |
 | `description` | recommended | string | One-paragraph elaboration. |
+
+The former `bpmn_file` pointer ("path to the detailed BPMN diagram") is **removed as a source field**. The flow is no longer authored in a separate `.bpmn` file the element points at; any `.bpmn.transitrix.yaml` is a *derived projection* of `flow` (generated output), never the source — see [views/01-bpmn.md](views/01-bpmn.md).
+
+**`flow` shape.** `flow` reuses the structural vocabulary defined once in [views/01-bpmn.md](views/01-bpmn.md) — the seven element types (`startEvent` / `endEvent` / `task` / `userTask` / `serviceTask` / `exclusiveGateway` / `parallelGateway`) and named sequence flows — but homed here as canon, not in a view. It follows the canon-wide flat-array-with-references form rule ([README](README.md) "Form rule"): a flat `steps` list, with lane membership expressed by reference rather than by nesting.
+
+- `flow.steps` — list of nodes. Each step: `id`, `type` (one of the seven), `name` (required for tasks / gateways; optional for events), `performed_by` (a member of `participants` — `ROLE-…` or `ACTOR-…`), and optional `supported_by_application` (`APPLICATION-…`). Precedence and the "swimlane is a role" default follow [views/01-bpmn.md](views/01-bpmn.md) §7.2; the BPMN projection derives lane grouping from `performed_by`.
+- `flow.sequence` — list of `{ from, to, condition?, default? }` sequence flows between step IDs (projects to the BPMN `flows` array).
+
+Step IDs use the canonical ID grammar ([IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §1), not the file-local BPMN labels of §3.3, so a step is **addressable**: a step-level `CHANGE` (§7.3, §6.1), a `RULE.applies_to`, or an `ACTIVITY` realising a step can reference it. Steps are canonical **by containment** — the PROCESS element carries the single admission record and lifecycle (§1, inline-element rule); a step is **promoted** to its own record only if a second document references it (§1 promotion rule). The file-local-label convention of [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.3 now applies only to a standalone `.bpmn` projection, not to a `flow` authored inside canon.
 
 Inline shape (as referenced from the map): [views/06-process-map.md](views/06-process-map.md) §5. The process-map view references `PROCESS-…` by `process_id`; the element file is the definition home.
 

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -111,9 +111,11 @@ Each notation file carries its own ID using the same grammar; the TYPE names the
 
 BPMN diagrams use their `process.id` as the document identifier; that field is a free-form string defined by the spec, not by this appendix.
 
-### 3.3 File-local labels (out of scope)
+### 3.3 File-local labels (standalone BPMN projection only)
 
-BPMN element IDs inside a single file (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) are local labels, not cross-document references. They identify nodes within one BPMN document and are not part of the TYPE registry above. Each BPMN file may use its own labelling convention.
+In a **standalone `.bpmn.transitrix.yaml` projection** — a generated diagram, not an authored source — the node IDs (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) are local labels, not cross-document references: they identify nodes within that one rendered file and are not part of the TYPE registry above.
+
+This does **not** apply to a process flow authored inside a `PROCESS` element ([ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §7.5). There the flow is canon: each `flow.steps[].id` follows the canonical ID grammar (§1) and is **addressable** — unique within its `PROCESS` and referenceable by a step-level `CHANGE`, a `RULE`, or an `ACTIVITY` — and is promoted to a registered standalone TYPE only if a second document references it (canonical-by-containment + promotion, [ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §1).
 
 ### 3.4 Field artefact types
 

--- a/notations/views/01-bpmn.md
+++ b/notations/views/01-bpmn.md
@@ -26,11 +26,16 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ---
 
-## Element lifecycle
+## Relationship to the PROCESS element — BPMN is a projection
 
-BPMN files use **file-local labels** for the nodes they describe (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`). Per [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.3 these labels are not canonical elements — they identify nodes within one BPMN document only, not artefacts that the organisation registers in its element catalogue. Accordingly, neither the BPMN nodes nor the BPMN document itself carry the canonical primitive lifecycle (`valid_from` / `valid_to`) defined in [CONTRACT.md](../CONTRACT.md) §7.
+A `.bpmn.transitrix.yaml` document is a **projection** of a `PROCESS` element's `flow`, not the definition home of the process. The canonical behaviour — participants, steps, gateways, sequence flows — lives on the `PROCESS-…` element ([ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §7.5); this notation defines how that flow **renders** to BPMN 2.0. A BPMN file is derived output: it can be deleted and regenerated from the element with no loss (the reconstruction invariant, [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1).
 
-The lifecycle of the **process** this BPMN file describes lives on the corresponding `PROCESS-…` element registered in the process landscape map ([06-process-map.md](06-process-map.md)); the BPMN file is the detailed flow representation of that process, not the lifecycle bearer.
+Two consequences:
+
+- **The view stores no behaviour and no captions of its own.** Lane captions are **derived** from each participant's `name`; the role / system bindings are the `PROCESS` `participants` and per-step `performed_by`. The only thing this notation adds on top of the element is layout, and layout is computed deterministically at compile time (§1) — so it carries no information either. The view is `render(PROCESS.flow)` and nothing more.
+- **Lifecycle and identity live on the element.** The node labels in a rendered BPMN file (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) remain file-local labels in the *projection* ([IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.3); the canonical, addressable identity of each step is the `PROCESS` `flow.steps[].id` ([ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §7.5). Neither the BPMN file nor its labels carry the primitive lifecycle (`valid_from` / `valid_to`, [CONTRACT.md](../CONTRACT.md) §7); that lives on the `PROCESS` element registered in the process landscape map ([06-process-map.md](06-process-map.md)).
+
+> **Inversion (this change).** Until now the BPMN file was the detailed flow representation that the `PROCESS` element pointed at via `bpmn_file`. That pointer is inverted: the element's `flow` is the source, the BPMN file is derived. The structural schema in §3–§8 below describes the **projected (serialised) form** the renderer emits and consumes.
 
 ---
 
@@ -40,7 +45,7 @@ A process file describes a BPMN 2.0 process as a structured YAML document. The n
 
 The notation is intentionally minimal. It covers the subset of BPMN 2.0 that maps cleanly to text and produces unambiguous diagrams without manual editing. Element types and structures outside this subset are explicitly out of scope (see §13).
 
-The compiled output is consumable by any BPMN 2.0–conformant tool (Camunda Modeler, bpmn.io, Signavio, etc.) without round-tripping; YAML is the single source of truth.
+The compiled output is consumable by any BPMN 2.0–conformant tool (Camunda Modeler, bpmn.io, Signavio, etc.) without round-tripping. The canonical source of truth is the `PROCESS` element's `flow`, of which this YAML is a projection (see "Relationship to the PROCESS element" above).
 
 ---
 
@@ -120,7 +125,7 @@ The `pools` array must contain exactly one entry. Two or more entries cause a co
 
 ## 6. Lanes
 
-Lanes (a.k.a. swimlanes) partition a pool into horizontal bands, each typically representing a role or responsible system. Every element belongs to exactly one lane.
+Lanes (a.k.a. swimlanes) partition a pool into horizontal bands, each representing one **participant** — a `ROLE-…` or `ACTOR-…` (person / business_unit / system). Every element belongs to exactly one lane. In the canonical form a lane is the projection of one entry in the `PROCESS` `participants` list ([ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §7.5).
 
 ```yaml
 lanes:
@@ -137,12 +142,12 @@ lanes:
 | Field | Type | Constraints |
 |---|---|---|
 | `id` | string | Identifier pattern; must differ from pool id and from any element id |
-| `name` | string | Non-empty, free-form (rendered as the lane caption) |
+| `performed_by` | string | The lane's participant — `ROLE-…` or `ACTOR-…`. The default for every element in the lane (see §7.2). |
+| `name` | string | The rendered lane caption. **Derived** from the participant's `name` — not authored (reconstruction invariant, [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1). Present in the serialised projection only. |
 | `elements` | array | At least one element required |
-| `performed_by_role` | string | Optional. `ROLE-…` responsible for the work in this lane — the default for every element in it (see §7.2). |
 | `supported_by_application` | string | Optional. `APPLICATION-…` used for the work in this lane — the default for every element in it (see §7.2). |
 
-Order of lanes in the YAML determines the vertical order of swimlanes in the rendered diagram (top to bottom).
+Order of participants in the `PROCESS` element determines the vertical order of swimlanes in the rendered diagram (top to bottom).
 
 ---
 
@@ -167,7 +172,7 @@ Each element is an object with these fields:
 | `id` | string | Identifier pattern; globally unique within the document |
 | `type` | string | One of the seven enum values above |
 | `name` | string | Required for tasks and gateways (non-empty); optional for events |
-| `performed_by_role` | string | Optional. `ROLE-…` responsible for this task — overrides the lane default (see §7.2). |
+| `performed_by` | string | Optional. `ROLE-…` or `ACTOR-…` responsible for this step — overrides the lane participant (see §7.2). |
 | `supported_by_application` | string | Optional. `APPLICATION-…` used for this task — overrides the lane default (see §7.2). |
 
 Example:
@@ -200,12 +205,12 @@ A gateway with exactly one incoming and one outgoing flow is forbidden — use a
 
 ### 7.2. Role and system association (cross-references to canon)
 
-A BPMN document may record **who** performs each piece of work and **which system** supports it, by referencing canon primitives from two optional fields:
+A process records **who** performs each piece of work and **which system** supports it by referencing canon primitives. In the canonical form these are the `PROCESS` `participants` and per-step `performed_by` / `supported_by_application` ([ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §7.5); the BPMN projection carries them through:
 
-- `performed_by_role: ROLE-…` — the responsible business role ([elements/19-actors.md](../elements/19-actors.md) defines `ROLE`; `ACTOR` is the identity that fills it).
+- `performed_by: ROLE-…` or `ACTOR-…` — the responsible role or actor ([elements/19-actors.md](../elements/19-actors.md) defines `ROLE` as the position and `ACTOR` as the identity — person / business_unit / system — that fills it).
 - `supported_by_application: APPLICATION-…` — the supporting application ([10-applications.md](10-applications.md)).
 
-Both may appear at **lane** level (the default for every element in the lane — the standard swimlane-is-a-role reading) and at **element** level (an override for one task). Precedence, per element:
+Both may appear at **lane** level (the default for every element in the lane — the standard swimlane-is-a-participant reading) and at **element** level (an override for one task). Precedence, per element:
 
 1. Element-level value wins.
 2. Otherwise the enclosing lane's value applies.
@@ -380,7 +385,7 @@ In addition, anti-pattern checks (warnings, not errors) flag suspicious-but-vali
 
 | ID | Rule |
 |---|---|
-| **BPMN-XREF-001** | A `performed_by_role` / `supported_by_application` value (on a lane or an element, §7.2) must resolve to an admitted primitive in canon: `ROLE-…` in `canon/elements/02_business/roles/`, `APPLICATION-…` in `canon/elements/03_application/applications/`. Same canon-existence bar as `REL-002`, applied at parse time when the catalogue is loaded. |
+| **BPMN-XREF-001** | A `performed_by` / `supported_by_application` value (on a lane or an element, §7.2) must resolve to an admitted primitive in canon: `ROLE-…` in `canon/elements/02_business/roles/` or `ACTOR-…` in `canon/elements/02_business/actors/`; `APPLICATION-…` in `canon/elements/03_application/applications/`. Same canon-existence bar as `REL-002`, applied at parse time when the catalogue is loaded. |
 
 ### Warnings (non-blocking)
 


### PR DESCRIPTION
Addresses **vkgeorgia/strategy#116**.

Enforces the reconstruction invariant: `canon/elements/` is the complete, sufficient source of truth for process behaviour; a view is a projection. Until now a process's flow (tasks, gateways, sequence flows, lanes) lived only inside the BPMN view as file-local, non-canonical nodes — so behaviour never entered canon. This moves the flow onto the `PROCESS` element and reframes BPMN as a projection of it.

### Changes (3 spec files, one concern)

**`notations/ELEMENT_PRIMITIVES.md`**
- **§1.1 (new)** — the reconstruction invariant `Views = render(Elements, view_config)`: no behaviour lives only in a view; no view configuration lives in elements; view-purity corollary (a view carries no non-derivable information beyond its config).
- **§4.2 (new)** — `view-defined` is inline-content convenience, never a content home of last resort. Distinguishes content (promotable) from presentation config (stays in the view); flags `SCENARIO` / `ISSUE` as content in tension with §1.1 (reconciliation filed separately).
- **§7.5 PROCESS** — gains `participants` (lanes → `ROLE-…` / `ACTOR-…` references; captions derived) and `flow` (steps / gateways / sequence flows, flat-array-with-references form). `bpmn_file` removed as a source field — BPMN is derived. Step IDs are canonical-grammar, addressable, canonical-by-containment + promotable.

**`notations/views/01-bpmn.md`**
- "Element lifecycle" → "Relationship to the PROCESS element — BPMN is a projection". A `.bpmn` file is derived output of `PROCESS.flow`; stores no behaviour or captions of its own; `bpmn_file` pointer inverted.
- `performed_by_role` → `performed_by` (accepts `ROLE-…` **or** `ACTOR-…`) at lane and element level; lane `name` is the derived caption; `BPMN-XREF-001` and the "single source of truth" line updated.

**`notations/IDS_AND_REFERENCES.md`**
- §3.3 scoped to standalone `.bpmn` projections; a flow authored inside a `PROCESS` element has addressable canonical step IDs.

### Deliberately out of scope (follow-ups)

- The 4 `PROCESS-*` worked examples + the process-map `bpmn_file` field/examples reconciliation.
- A registered step TYPE in the ID registry (canonical-by-containment covers v1).
- `SCENARIO` / `ISSUE` reclassification (content element + report-config view).

Docs-only; no validator or schema-tool changes. **Do not merge — Valerii gates.**