### PR TITLE
ci+docs(notations): front-door doc-lint + tracked NOTATIONS_VALIDATION.md (+ 26 link repairs)

### DIFF
--- a/.github/workflows/notations-doc-lint.yml
+++ b/.github/workflows/notations-doc-lint.yml
@@ -1,0 +1,33 @@
+name: Notations doc-lint
+
+# Mechanical front-door rot checks for the notations docs: example file
+# extensions + `notation:` headers, internal Markdown link resolution, and
+# methodology_version pin consistency. Implementation:
+# scripts/check-notations.mjs. The tracked audit NOTATIONS_VALIDATION.md holds
+# the judgement calls a linter can't make.
+#
+# CI is red on drift — the script exits non-zero and the job fails. Fix the
+# offending file, or — if an invariant is wrong — change the check and say why.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Mondays 09:00 UTC — weekly safety net for drift introduced via
+    # direct-commit changes to main that bypass PR review.
+    - cron: '0 9 * * 1'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run notations doc-lint
+        run: node scripts/check-notations.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -180,7 +180,6 @@ CLAUDE.md
 !organizations/*/CLAUDE.md
 roadmap.md
 PROJECT_RULES.md
-NOTATIONS_VALIDATION.md
 
 # Local development tool worktrees
 .claude/

--- a/NOTATIONS_VALIDATION.md
+++ b/NOTATIONS_VALIDATION.md
@@ -1,0 +1,97 @@
+# Notations / examples validation — audit
+
+**Status:** tracked (was a gitignored local snapshot until 2026-05-30).
+**Last full review:** 2026-05-30.
+**Scope:** conformance of `notations/examples/**` and the per-notation specs in
+`notations/` to the canonical contract. Excludes `0. archive/`.
+
+This file is the **judgement half** of the front-door rot defence. The
+**mechanical half** is automated: `scripts/check-notations.mjs` (run in CI by
+`.github/workflows/notations-doc-lint.yml`) checks the things a script can
+decide — example file extensions, `notation:` headers, internal-link
+resolution, and `methodology_version` pin consistency. Keep the two disjoint:
+anything a linter can verify belongs in the script, not here; anything needing
+human judgement (conceptual drift, an unresolved shape decision) belongs here.
+
+> History: the 2026-05-19/20 snapshot that used to live here (gitignored)
+> flagged a list of example-drift items — flat-vs-nested FGA/Goals, the
+> capability `type`/ID migration, BPMN extension/header/boolean drift, the
+> `order-fulfillment`/`order-processing` duplicate. **Every one of those is now
+> resolved** (verified 2026-05-30 against the files on `main`). That snapshot is
+> superseded by this audit; do not act on it.
+
+---
+
+## 1. Mechanical conformance — clean (and now CI-guarded)
+
+Re-verified 2026-05-30 by reading the files directly; now also enforced by the
+doc-lint so it cannot silently rot:
+
+- **BPMN examples** — all use the canonical `*.bpmn.transitrix.yaml` extension
+  and carry a `notation: bpmn` header. Boolean conditions are quoted
+  (`condition: "yes"`/`"no"`). No `order-processing` duplicate exists.
+- **FGA / Goals** — flat shape, consistent with the strategy-chain form rule.
+- **Capability-map** — every node carries `type`; IDs use canonical
+  `CAPABILITY-V…` / `CAPABILITY_MAP-…` (the 2026-05-28 migration is in).
+- **products / applications** — canonical `PRODUCT-…` / `APP-…` / `ROLE-…` /
+  `CAPABILITY-V…` IDs throughout, no display-name-as-ID.
+- **Internal links** — the doc-lint's first run surfaced 26 broken relative
+  links that had silently rotted: `CONTRACT.md` dropped the `elements/` / `views/`
+  path segment for `15-requirement` / `16-assertion` / `05-capability-map` /
+  `10-applications`, and seven example READMEs dropped the `views/` segment (and
+  one pointed at a never-created `docs/repo-layout.md`). **All repaired in the
+  same change that added the lint** — links now resolve and the lint is green.
+- **Example extensions, `notation:` headers, version pins** — all consistent
+  (the four doc-lint checks pass on a clean checkout).
+
+---
+
+## 2. Open judgement items (a linter cannot decide these)
+
+These are unresolved **decisions**, not regressions. Each needs Valerii's
+direction before any file moves.
+
+1. **Catalogue-root prefix — `elements/…` vs `canon/elements/…`.**
+   `IDS_AND_REFERENCES.md` §3.1/§4 mix `elements/02_business/…` with
+   `canon/elements/…` / `canon/relations/` / `canon/assertions/`;
+   `CONTRACT.md` §7.1 and `notations/README.md` use `canon/elements/…`.
+   Settling the root prefix and sweeping it is a canon change — not yet made.
+
+2. **ArchiMate element IDs — prefix-IDs vs full-word TYPE-IDs.**
+   `method/methodology.md` §3a historically used legacy prefix tables
+   (`GOAL-`, `APP-`, `ACTR-`, …); `IDS_AND_REFERENCES.md` uses full-word TYPEs
+   (`ACTOR`, `CAPABILITY-V…`). The front-door reconcile made IDS authoritative
+   and pointed §3a at it, but the underlying scheme choice is unresolved.
+
+3. **SCENARIO / ISSUE reclassification** (`ELEMENT_PRIMITIVES.md` §4.2).
+   Both are tagged `view-defined` but are content, not presentation — in tension
+   with the reconstruction invariant §1.1. The reclassification (content element
+   + report-config view) is a family-wide shape decision; proposal filed,
+   awaiting direction. Tracked as its own task.
+
+---
+
+## 3. Minor nits (flagged, not auto-fixed)
+
+Surfaced but left for Valerii — examples are not edited unilaterally.
+
+- `notations/examples/capability-map/northbay-retail.capability-map.transitrix.yaml`:
+  capability `V1.2.1` (In-store Retail) has `owner_role: Director of Retail
+  Operations` (a display name) where every other node uses a `ROLE-…` ID.
+  One-line inconsistency, not structural drift.
+
+- `organizations/acme_corp/NEW_ORGANIZATION_TEMPLATE.md` is stale more broadly —
+  still describes the pre-zone `elements/01–04` layout and references
+  `create_organization.sh`. Worth a dedicated rewrite to the
+  `canon`/`field`/`codex` model rather than a one-line patch.
+
+---
+
+## 4. Coverage honesty
+
+The 2026-05-30 pass verified every family that carried a substantive prior
+claim (bpmn, fga, goals, capability-map, products, applications, process-map).
+The specs **not** re-walked schema-line-by-line this pass: `fgca`, `blocks`,
+`activities`, `process-blueprint`, `activity-card`. The doc-lint covers their
+mechanical invariants (extension / header / links / version) continuously; a
+deeper schema re-walk of those five is the next manual audit's job.

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -162,23 +162,23 @@ The lifecycle fields are required on every canonical primitive once a notation s
 
 ## 8. Compliance-domain rules
 
-The compliance domain spans two notations — **`REQUIREMENT`** (motivation-layer element, [15-requirement.md](15-requirement.md)) and **`ASSERTION`** (canon-zone primitive linking a requirement to a subject, [16-assertion.md](16-assertion.md)). For discoverability, the validation rules for both are aggregated below in a single table. The per-notation specs remain the authoritative source for the rule definitions; this table is an index.
+The compliance domain spans two notations — **`REQUIREMENT`** (motivation-layer element, [15-requirement.md](elements/15-requirement.md)) and **`ASSERTION`** (canon-zone primitive linking a requirement to a subject, [16-assertion.md](elements/16-assertion.md)). For discoverability, the validation rules for both are aggregated below in a single table. The per-notation specs remain the authoritative source for the rule definitions; this table is an index.
 
 | Rule | Severity | Notation | Short description | Authoritative spec |
 |---|---|---|---|---|
-| `REQ-001` | error | REQUIREMENT | `id` grammar invalid, or any required field missing | [15-requirement.md](15-requirement.md) §4 |
-| `REQ-002` | error | REQUIREMENT | `derived_from` references an ID that does not resolve | [15-requirement.md](15-requirement.md) §4 |
-| `REQ-003` | error | REQUIREMENT | `derived_from` ID is not of TYPE `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD` | [15-requirement.md](15-requirement.md) §4 |
-| `REQ-COVERAGE-001` | warning | REQUIREMENT (cross-cutting) | REQUIREMENT has no ASSERTION targeting it — compliance gap | [15-requirement.md](15-requirement.md) §4 |
-| `ASSERT-001` | error | ASSERTION | a required field is missing, or `id` grammar invalid | [16-assertion.md](16-assertion.md) §5 |
-| `ASSERT-002` | error | ASSERTION | `about` is missing, malformed, or resolves to a non-REQUIREMENT | [16-assertion.md](16-assertion.md) §5 |
-| `ASSERT-003` | error | ASSERTION | `subject` does not resolve, or TYPE not in `{PRODUCT, PROCESS, CAPABILITY}` | [16-assertion.md](16-assertion.md) §5 |
-| `ASSERT-004` | error | ASSERTION | a `realised_via` entry does not resolve | [16-assertion.md](16-assertion.md) §5 |
-| `ASSERT-005` | error | ASSERTION | an `evidence[]` entry with `kind: canonical_ref` has a `ref` that does not resolve | [16-assertion.md](16-assertion.md) §5 |
-| `ASSERT-006` | error | ASSERTION | `status` not in the enum (`compliant` / `partial` / `non_compliant` / `under_review` / `n_a`) | [16-assertion.md](16-assertion.md) §5 |
-| `ASSERT-007` | warning | ASSERTION | `evidence` is empty AND `status` is `compliant` or `partial` — undefended positive claim | [16-assertion.md](16-assertion.md) §5 |
-| `ASSERT-008` | warning | ASSERTION | `next_review_at` is set and is in the past — assertion is stale | [16-assertion.md](16-assertion.md) §5 |
-| `ASSERT-DEAD-LINK-001` | warning | ASSERTION (cross-cutting) | `subject` or `realised_via` references a primitive whose `valid_to` is in the past — bound to a currently-retired element | [16-assertion.md](16-assertion.md) §5 |
+| `REQ-001` | error | REQUIREMENT | `id` grammar invalid, or any required field missing | [15-requirement.md](elements/15-requirement.md) §4 |
+| `REQ-002` | error | REQUIREMENT | `derived_from` references an ID that does not resolve | [15-requirement.md](elements/15-requirement.md) §4 |
+| `REQ-003` | error | REQUIREMENT | `derived_from` ID is not of TYPE `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD` | [15-requirement.md](elements/15-requirement.md) §4 |
+| `REQ-COVERAGE-001` | warning | REQUIREMENT (cross-cutting) | REQUIREMENT has no ASSERTION targeting it — compliance gap | [15-requirement.md](elements/15-requirement.md) §4 |
+| `ASSERT-001` | error | ASSERTION | a required field is missing, or `id` grammar invalid | [16-assertion.md](elements/16-assertion.md) §5 |
+| `ASSERT-002` | error | ASSERTION | `about` is missing, malformed, or resolves to a non-REQUIREMENT | [16-assertion.md](elements/16-assertion.md) §5 |
+| `ASSERT-003` | error | ASSERTION | `subject` does not resolve, or TYPE not in `{PRODUCT, PROCESS, CAPABILITY}` | [16-assertion.md](elements/16-assertion.md) §5 |
+| `ASSERT-004` | error | ASSERTION | a `realised_via` entry does not resolve | [16-assertion.md](elements/16-assertion.md) §5 |
+| `ASSERT-005` | error | ASSERTION | an `evidence[]` entry with `kind: canonical_ref` has a `ref` that does not resolve | [16-assertion.md](elements/16-assertion.md) §5 |
+| `ASSERT-006` | error | ASSERTION | `status` not in the enum (`compliant` / `partial` / `non_compliant` / `under_review` / `n_a`) | [16-assertion.md](elements/16-assertion.md) §5 |
+| `ASSERT-007` | warning | ASSERTION | `evidence` is empty AND `status` is `compliant` or `partial` — undefended positive claim | [16-assertion.md](elements/16-assertion.md) §5 |
+| `ASSERT-008` | warning | ASSERTION | `next_review_at` is set and is in the past — assertion is stale | [16-assertion.md](elements/16-assertion.md) §5 |
+| `ASSERT-DEAD-LINK-001` | warning | ASSERTION (cross-cutting) | `subject` or `realised_via` references a primitive whose `valid_to` is in the past — bound to a currently-retired element | [16-assertion.md](elements/16-assertion.md) §5 |
 
 In addition, the shared header rules (`HDR-001..004`, §2) and primitive-lifecycle rules (`LIFECYCLE-001..004`, §7.3) apply to REQUIREMENT and ASSERTION files as they do to every other canonical artefact.
 
@@ -252,8 +252,8 @@ A notation spec MAY declare specific attributes as `time_varying`. v1 candidate 
 
 | Notation | Candidate `time_varying` attributes |
 |---|---|
-| Capability map ([05-capability-map.md](05-capability-map.md)) | `maturity_level` (current/target), `responsible_role`, `target_date` |
-| Applications catalogue ([10-applications.md](10-applications.md)) | `lifecycle_stage` (planned / active / sunset), `responsible_unit`, `vendor` (when an organisation switches vendors mid-life) |
+| Capability map ([05-capability-map.md](views/05-capability-map.md)) | `maturity_level` (current/target), `responsible_role`, `target_date` |
+| Applications catalogue ([10-applications.md](views/10-applications.md)) | `lifecycle_stage` (planned / active / sunset), `responsible_unit`, `vendor` (when an organisation switches vendors mid-life) |
 | Organisational unit (future) | `headcount`, `head_role` |
 
 Each notation's "Element lifecycle" or "Fields" section will, in a follow-up PR, mark its `time_varying` attributes and remove inline syntax for them. Adopters with existing inline values migrate by moving the value into a single-entry sidecar with `valid_from` set to the primitive's `valid_from`.

--- a/notations/examples/README.md
+++ b/notations/examples/README.md
@@ -24,5 +24,3 @@ Each folder contains a `README.md` with format documentation and the list of exa
 1. Install the **Transitrix Studio** extension in VS Code.
 2. Open any example file — the preview panel opens automatically beside the editor.
 3. Edit and save the file to refresh the preview.
-
-For how `examples/` fits into the broader repo layout, see [`docs/repo-layout.md`](../docs/repo-layout.md).

--- a/notations/examples/activities/README.md
+++ b/notations/examples/activities/README.md
@@ -1,6 +1,6 @@
 # Activity network diagram (AoN / PSND) and Gantt projection
 
-Activity-on-Node precedence diagram showing activities, durations, dependencies, and the computed critical path. Activities also project to a Gantt timeline when the schedule is anchored on a calendar — see §9 of the [Activities spec](../../07-activities.md).
+Activity-on-Node precedence diagram showing activities, durations, dependencies, and the computed critical path. Activities also project to a Gantt timeline when the schedule is anchored on a calendar — see §9 of the [Activities spec](../../views/07-activities.md).
 
 The critical path is highlighted automatically in both views.
 
@@ -59,7 +59,7 @@ author: "Your Name"
 
 ## Gantt projection — when it renders
 
-A document renders as a Gantt chart when **either** (per [07-activities.md §9](../../07-activities.md)):
+A document renders as a Gantt chart when **either** (per [07-activities.md §9](../../views/07-activities.md)):
 
 - **Computed mode** — every leaf activity has a `duration`, predecessors form a DAG, and a top-level `project.start_date` is present (an optional `project.calendar` controls working-day projection). CPM offsets project onto the calendar.
 - **Pinned mode** — every leaf activity carries both `start_date` and `end_date`.

--- a/notations/examples/blocks/README.md
+++ b/notations/examples/blocks/README.md
@@ -4,7 +4,7 @@ Structured YAML model of a multi-level container layout — a recursive tree of 
 
 **File extension:** `*.blocks.transitrix.yaml`
 
-See [`../../08-blocks.md`](../../08-blocks.md) for the full notation reference.
+See [`../../views/08-blocks.md`](../../views/08-blocks.md) for the full notation reference.
 
 ## How to model a diagram
 

--- a/notations/examples/bpmn/README.md
+++ b/notations/examples/bpmn/README.md
@@ -4,7 +4,7 @@ Business Process Model and Notation 2.0 diagrams defined as compact YAML — one
 
 **File extension:** `*.bpmn.transitrix.yaml`
 
-See the canonical spec: [`../../01-bpmn.md`](../../01-bpmn.md).
+See the canonical spec: [`../../views/01-bpmn.md`](../../views/01-bpmn.md).
 
 ## Minimal structure
 

--- a/notations/examples/fga/README.md
+++ b/notations/examples/fga/README.md
@@ -5,7 +5,7 @@ Use this format when you want a direct mapping from goals to activities without 
 
 **File extension:** `*.fga.transitrix.yaml`
 
-See the canonical spec: [`../../03-fga.md`](../../03-fga.md).
+See the canonical spec: [`../../views/03-fga.md`](../../views/03-fga.md).
 
 ## Minimal structure
 

--- a/notations/examples/fgca/README.md
+++ b/notations/examples/fgca/README.md
@@ -5,7 +5,7 @@ Shows how external factors drive goals, which require changes, which are deliver
 
 **File extension:** `*.fgca.transitrix.yaml`
 
-See the canonical spec: [`../../02-fgca.md`](../../02-fgca.md).
+See the canonical spec: [`../../views/02-fgca.md`](../../views/02-fgca.md).
 
 ## Minimal structure
 
@@ -56,7 +56,7 @@ author: "Your Name"
 - A goal MAY reference multiple factors via `factors: [FACTOR-…, FACTOR-…]`.
 - A change MAY reference multiple goals via `goals: [GOAL-…, GOAL-…]`.
 - An activity MAY reference multiple changes via `changes: [CHANGE-…, CHANGE-…]`.
-- For degenerate paths where a change layer adds no information, an activity MAY link directly via `goals: [GOAL-…]` — see [`../../02-fgca.md`](../../02-fgca.md) §Fields.
+- For degenerate paths where a change layer adds no information, an activity MAY link directly via `goals: [GOAL-…]` — see [`../../views/02-fgca.md`](../../views/02-fgca.md) §Fields.
 
 ## Examples in this folder
 

--- a/notations/examples/issues/README.md
+++ b/notations/examples/issues/README.md
@@ -31,4 +31,4 @@ notation: issues
 | `issues[].name` | One-line summary of the issue |
 | `issues[].status` | One of `open`, `in_progress`, `blocked`, `resolved`, `closed` |
 
-See [`../../12-issues.md`](../../12-issues.md) for the full specification.
+See [`../../views/12-issues.md`](../../views/12-issues.md) for the full specification.

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+// Notations doc-lint — mechanical front-door rot checks.
+//
+// Companion to the tracked audit NOTATIONS_VALIDATION.md: the audit holds the
+// judgement calls a linter can't make (conceptual drift, open shape decisions);
+// this script holds the mechanical invariants that silently rot. Keep them
+// disjoint — if a check here starts needing human judgement, it belongs in the
+// audit, not here.
+//
+// Checks:
+//   E1  extension + location — every notations/examples/**/*.yaml is named
+//       <name>.<short>.transitrix.yaml where <short> is a notation in the
+//       catalogue (notations/README.md §Views), and its parent dir is <short>.
+//       Catches `.bpmn.yaml`-style drift and misfiled examples.
+//   E2  header — each example carries a top-level `notation: <short>` whose
+//       value matches its file extension.
+//   L1  links — every relative Markdown link in notations/**/*.md resolves to
+//       an existing file (anchors and external URLs are skipped).
+//   V1  version — every concrete `methodology_version:` pin in the repo equals
+//       the single source of truth (organizations/acme_corp/transitrix.yaml,
+//       per CONTRACT.md §10), except explicitly allowlisted placeholders.
+//
+// Exit codes:
+//   0 — clean
+//   1 — findings
+//   2 — script-internal error (file missing, parse failure)
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative, resolve, posix } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = join(dirname(__filename), '..');
+const CATALOGUE_PATH = join(REPO_ROOT, 'notations', 'README.md');
+const EXAMPLES_DIR = join(REPO_ROOT, 'notations', 'examples');
+const NOTATIONS_DIR = join(REPO_ROOT, 'notations');
+const VERSION_SOT = join(REPO_ROOT, 'organizations', 'acme_corp', 'transitrix.yaml');
+
+// Files that legitimately carry a non-SoT methodology_version (placeholders).
+const VERSION_PIN_ALLOWLIST = new Set([
+  'skills/onboarding/templates/transitrix.yaml', // "pin a real release once the adopter chooses one"
+]);
+
+// Directories never walked.
+const SKIP_DIRS = new Set(['.git', 'node_modules', '0. archive']);
+
+// --- fs helpers ------------------------------------------------------------
+
+async function walk(dir, filterExt) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      out.push(...(await walk(full, filterExt)));
+    } else if (!filterExt || e.name.endsWith(filterExt)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function relPosix(absPath) {
+  return relative(REPO_ROOT, absPath).split('\\').join('/');
+}
+
+// --- catalogue parse -------------------------------------------------------
+
+// Pull the view-notation catalogue from notations/README.md §Views.
+// Returns Map<short, extension>.
+async function parseCatalogue() {
+  const text = await readFile(CATALOGUE_PATH, 'utf8');
+  const lines = text.split('\n');
+  const headingIdx = lines.findIndex(l => /^##\s+Views\s*$/.test(l));
+  if (headingIdx < 0) throw new Error('notations/README.md: "## Views" section not found');
+
+  const out = new Map();
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    if (/^##\s/.test(lines[i])) break; // next section
+    const line = lines[i];
+    if (!line.startsWith('| [')) continue; // catalogue data row
+    const codes = [...line.matchAll(/`([^`]+)`/g)].map(m => m[1]);
+    const short = codes.find(c => /^[a-z][a-z0-9-]*$/.test(c));
+    const ext = codes.find(c => /^\*\.[a-z0-9-]+\.transitrix\.yaml$/.test(c));
+    if (short && ext) out.set(short, ext.slice(1)); // strip leading '*'
+  }
+  if (out.size === 0) throw new Error('notations/README.md: catalogue table parsed empty');
+  return out;
+}
+
+// --- checks ----------------------------------------------------------------
+
+// E1 + E2: example files.
+async function checkExamples(catalogue, failures) {
+  const files = (await walk(EXAMPLES_DIR, '.yaml'));
+  for (const abs of files) {
+    const rel = relPosix(abs);
+    const base = posix.basename(rel);
+    const parentDir = posix.basename(posix.dirname(rel));
+
+    // E1 — name must be <name>.<short>.transitrix.yaml with a known short.
+    const m = base.match(/^[^.]+\.([a-z0-9-]+)\.transitrix\.yaml$/);
+    if (!m) {
+      failures.push({
+        check: 'E1',
+        message: `${rel}: not named <name>.<short>.transitrix.yaml (non-canonical extension).`,
+      });
+      continue;
+    }
+    const short = m[1];
+    if (!catalogue.has(short)) {
+      failures.push({
+        check: 'E1',
+        message: `${rel}: extension short "${short}" is not a notation in notations/README.md §Views.`,
+      });
+      continue;
+    }
+    if (parentDir !== short) {
+      failures.push({
+        check: 'E1',
+        message: `${rel}: filed under "${parentDir}/" but its notation is "${short}" — move it to examples/${short}/.`,
+      });
+    }
+
+    // E2 — top-level `notation:` must equal the extension short.
+    const text = await readFile(abs, 'utf8');
+    const nm = text.match(/^notation:\s*"?([a-z0-9-]+)"?\s*$/m);
+    if (!nm) {
+      failures.push({
+        check: 'E2',
+        message: `${rel}: missing a top-level \`notation:\` header (expected \`notation: ${short}\`).`,
+      });
+    } else if (nm[1] !== short) {
+      failures.push({
+        check: 'E2',
+        message: `${rel}: \`notation: ${nm[1]}\` does not match the file extension (expected \`${short}\`).`,
+      });
+    }
+  }
+}
+
+// L1: relative markdown links in notations/**/*.md must resolve.
+async function checkLinks(failures) {
+  const files = await walk(NOTATIONS_DIR, '.md');
+  // Inline links only: no newline in the link text or the target, so we never
+  // splice an unrelated `[` and `](…)` across prose into a phantom link.
+  const linkRe = /\[[^\]\n]*\]\(([^)\n]+)\)/g;
+  for (const abs of files) {
+    const rel = relPosix(abs);
+    const text = await readFile(abs, 'utf8');
+    let m;
+    while ((m = linkRe.exec(text)) !== null) {
+      let target = m[1].trim();
+      // Skip external, anchor-only, mailto, and template placeholders.
+      if (/^(https?:|mailto:|#|<)/.test(target)) continue;
+      target = target.split('#')[0]; // drop anchor
+      if (!target) continue; // was anchor-only
+      if (target.includes('<') || target.includes('>')) continue; // placeholder like <id>.yaml
+      // Only validate things that look like a local file/dir reference — a path
+      // segment (`/`) or a file extension. Bare words in parenthetical prose
+      // (`(factor)`, `(set_name)`) are not links.
+      if (!target.includes('/') && !/\.[a-z0-9]+$/i.test(target)) continue;
+      const resolved = resolve(dirname(abs), target);
+      if (!existsSync(resolved)) {
+        failures.push({
+          check: 'L1',
+          message: `${rel}: broken relative link → \`${m[1]}\` (resolves to ${relPosix(resolved)}, not found).`,
+        });
+      }
+    }
+  }
+}
+
+// V1: concrete methodology_version pins must equal the SoT.
+async function checkVersion(failures) {
+  const sotText = await readFile(VERSION_SOT, 'utf8');
+  const sotMatch = sotText.match(/^methodology_version:\s*"?([^"\s#]+)"?/m);
+  if (!sotMatch) throw new Error(`${relPosix(VERSION_SOT)}: methodology_version (source of truth) not found`);
+  const sot = sotMatch[1];
+
+  const files = (await walk(REPO_ROOT, '.yaml')).concat(await walk(REPO_ROOT, '.md'));
+  // A concrete pin is a value assignment, not prose; match `methodology_version: "X"`.
+  const pinRe = /^[ \t]*methodology_version:\s*"([^"]+)"/m;
+  for (const abs of files) {
+    const rel = relPosix(abs);
+    if (VERSION_PIN_ALLOWLIST.has(rel)) continue;
+    const text = await readFile(abs, 'utf8');
+    const pm = text.match(pinRe);
+    if (!pm) continue;
+    if (pm[1] !== sot) {
+      failures.push({
+        check: 'V1',
+        message: `${rel}: methodology_version "${pm[1]}" ≠ source of truth "${sot}" (${relPosix(VERSION_SOT)}). ` +
+          `Bump it, or allowlist the file in scripts/check-notations.mjs if it is an intentional placeholder.`,
+      });
+    }
+  }
+}
+
+// --- main ------------------------------------------------------------------
+
+async function main() {
+  const failures = [];
+  let catalogue;
+  try {
+    catalogue = await parseCatalogue();
+    await checkExamples(catalogue, failures);
+    await checkLinks(failures);
+    await checkVersion(failures);
+  } catch (e) {
+    console.error(`error: ${e.message}`);
+    process.exit(2);
+  }
+
+  if (failures.length > 0) {
+    console.error(`\nNotations doc-lint — ${failures.length} finding(s):\n`);
+    for (const f of failures.sort((a, b) => a.check.localeCompare(b.check))) {
+      console.error(`  - [${f.check}] ${f.message}`);
+    }
+    console.error(
+      `\nThese are mechanical invariants. Fix the offending file, or — if the ` +
+      `invariant itself is wrong — change the check and say why in the PR.\n`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Notations doc-lint clean — ${catalogue.size} view notations; examples, ` +
+    `internal links, and methodology_version pins all consistent.`
+  );
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error(`error: ${e.message}`);
+  process.exit(2);
+});


### PR DESCRIPTION
Closes the remainder of #114 (item 9). You chose **both** defences — a CI doc-lint *and* a refreshed tracked audit. Three commits, one concern each.

## 1. CI doc-lint (mechanical invariants)
`scripts/check-notations.mjs` + `.github/workflows/notations-doc-lint.yml` (PR + weekly cron, matching the existing `check-skill-cheatsheet` pattern). Checks:
- **E1** every `notations/examples/**/*.yaml` is `<name>.<short>.transitrix.yaml` with a catalogued short name, filed under `examples/<short>/`;
- **E2** each example's top-level `notation:` matches its extension;
- **L1** every relative Markdown link in `notations/**/*.md` resolves;
- **V1** every concrete `methodology_version` pin equals the source of truth (`organizations/acme_corp/transitrix.yaml`), bar one allowlisted placeholder.

## 2. 26 broken-link repairs (the lint earned its keep on run #1)
The lint's first run found 26 relative links that had silently rotted — exactly the failure mode #114 exists to stop:
- `CONTRACT.md` dropped the `elements/` / `views/` segment for `15-requirement`, `16-assertion`, `05-capability-map`, `10-applications`;
- seven example READMEs dropped the `views/` segment;
- `examples/README.md` pointed at a never-created `docs/repo-layout.md` (dangling ref removed).

All repaired (targets only; display text preserved). **`node scripts/check-notations.mjs` is green** after this commit.

## 3. Tracked, refreshed audit (judgement calls)
Un-gitignored `NOTATIONS_VALIDATION.md` and rewrote it to the 2026-05-30 state. The old gitignored snapshot was stale — every example-drift item it flagged is resolved. The tracked audit now holds only what a linter can't decide: the `elements/` vs `canon/elements/` root-prefix decision, the ArchiMate ID scheme, the SCENARIO/ISSUE reclassification, plus minor nits, a coverage-honesty note, and the link-repair record.

## BPMN re-check
Re-confirmed all resolved: canonical extension, `notation: bpmn` header, quoted boolean conditions, no `order-processing` duplicate.

## Held back — needs your authorisation
`CLAUDE.md`'s "Known issue" section still points readers at the old gitignored 2026-05-19 snapshot and should be repointed to this tracked audit + the lint. I did **not** include that edit: changing `CLAUDE.md` (the agent's own config) is gated and needs your explicit OK. Say the word and I'll add it as a follow-up commit here.

Do not merge — gated by Valerii.