### PR TITLE
feat(notations): tighten FACTOR to neutral Driver + PESTLE category (strategy#128)

### DIFF
--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -246,10 +246,13 @@ Each subsection lists the per-TYPE fields that sit between the identity block an
 
 ### 7.1 `FACTOR` — `01_motivation/factors/`
 
+ArchiMate **Driver** — a neutral, standing force the organisation acts on (an environmental pressure, a market shift, an internal performance dimension). A FACTOR is the *thing*, not a judgement about its state: it names the dimension the organisation organises around ("EU regulatory window", "Customer churn", "Support response time"). It carries no polarity and no findings. A dated finding/judgement about a driver's current state — a measurement, a trend, an observation — is an `ASSESSMENT` (§7.16) that `assesses` the FACTOR; the assessment is what changes over time, the FACTOR is what persists. Whether a finding reads as a strength, weakness, opportunity, or threat lives on the `assessment_influences_goal` REL ([elements/17-relations.md](elements/17-relations.md) §3), not on the FACTOR or the ASSESSMENT.
+
 | Field | Required | Type | Semantics |
 |---|---|---|---|
 | `type` | no | string | `external` \| `internal`. |
-| `description` | recommended | string | One-paragraph elaboration of the driver. |
+| `category` | no | string | **PESTLE sub-classification** for external drivers — one of `political` \| `economic` \| `social` \| `technological` \| `legal` \| `environmental`. Use on external factors to record which PESTLE class the driver falls into (regulators / public policy → `political`; binding regulations / law → `legal`; markets / costs / demand → `economic`; demographic / cultural → `social`; technology shifts → `technological`; climate / sustainability → `environmental`). Omit on internal factors — PESTLE does not apply. |
+| `description` | recommended | string | One-paragraph elaboration of the driver — what the standing force is, not a finding about it. Keep findings (numbers, trends, observations) out of the FACTOR; put them on an `ASSESSMENT` that `assesses` this factor. |
 | `references_constraint` | no | list | `CONSTRAINT-…` IDs the factor reflects. |
 
 Inline shape: [views/02-fgca.md](views/02-fgca.md) §5.2.

--- a/notations/examples/fga/strategy-2026.fga.transitrix.yaml
+++ b/notations/examples/fga/strategy-2026.fga.transitrix.yaml
@@ -13,9 +13,11 @@ factors:
   - id: FACTOR-MARKET-1
     name: "Market growth opportunity in new geographies"
     type: external
+    category: economic
   - id: FACTOR-REG-1
     name: "Increasing regulatory pressure (GDPR, data residency)"
     type: external
+    category: legal
   - id: FACTOR-TECH-1
     name: "Internal shift to cloud-native architecture"
     type: internal

--- a/notations/examples/fgca/constraint-driven.fgca.transitrix.yaml
+++ b/notations/examples/fgca/constraint-driven.fgca.transitrix.yaml
@@ -16,6 +16,7 @@ factors:
   - id: FACTOR-DATA-RESIDENCY-1
     name: "EU customer personal-data residency obligation"
     type: external
+    category: legal
     references_constraint:
       - CONSTRAINT-GDPR-RESIDENCY-1
 

--- a/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
+++ b/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
@@ -13,9 +13,11 @@ factors:
   - id: FACTOR-1
     name: "Competitive market pressure"
     type: external
+    category: economic
   - id: FACTOR-2
     name: "Digital adoption acceleration"
     type: external
+    category: technological
 
 goals:
   - id: GOAL-1

--- a/notations/views/02-fgca.md
+++ b/notations/views/02-fgca.md
@@ -141,6 +141,7 @@ factors:
   - id: FACTOR-1
     name: "Competitive market pressure"
     type: external          # external | internal
+    category: economic      # PESTLE — external only (political | economic | social | technological | legal | environmental)
 
 goals:
   - id: GOAL-1
@@ -184,13 +185,16 @@ A complete example: [`examples/fgca/strategy-2026.fgca.transitrix.yaml`](../exam
 
 ### `factors[]`
 
+A factor is a **neutral driver** — a standing force the organisation acts on, not a finding about it. Findings about a driver's current state (numbers, trends, observations) live on `ASSESSMENT` records that reference the FACTOR; they are not inline on a factor entry. See [`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §7.1 (FACTOR as ArchiMate Driver) and §7.16 (ASSESSMENT).
+
 | Field | Required | Description |
 |---|---|---|
 | `id` | yes | `FACTOR-[<middle>-]<INTEGER>` |
-| `name` | yes | what the factor is |
+| `name` | yes | what the factor is — the neutral driver, not a finding about it |
 | `type` | no | `external` or `internal` |
+| `category` | no | PESTLE sub-classification for external factors — `political` \| `economic` \| `social` \| `technological` \| `legal` \| `environmental`. Omit on internal factors. See [`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §7.1. |
 | `references_constraint` | no | array of `CONSTRAINT-…` IDs the factor reflects. Cross-document reference into the organisation's constraints catalogue (`elements/01_motivation/constraints/`). Rationale: the existence of a constraint is itself a factor for the organisation that acts on it — the factor is the FGCA driver, the constraint is the binding rule. (Decision recorded 2026-05-26.) |
-| `description` | no | one-paragraph elaboration |
+| `description` | no | one-paragraph elaboration of the driver — keep findings out; emit them as `ASSESSMENT` records |
 
 ### `goals[]`
 

--- a/notations/views/03-fga.md
+++ b/notations/views/03-fga.md
@@ -94,6 +94,7 @@ factors:
   - id: FACTOR-1
     name: "Competitive market pressure"
     type: external          # external | internal
+    category: economic      # PESTLE — external only
 
 goals:
   - id: GOAL-1
@@ -131,12 +132,15 @@ A complete example: [`examples/fga/strategy-2026.fga.transitrix.yaml`](../exampl
 
 ### `factors[]`
 
+A factor is a **neutral driver** — a standing force the organisation acts on, not a finding about it. Findings about a driver's current state live on `ASSESSMENT` records that reference the FACTOR. See [`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §7.1 (FACTOR as ArchiMate Driver) and §7.16 (ASSESSMENT).
+
 | Field | Required | Description |
 |---|---|---|
 | `id` | yes | `FACTOR-[<middle>-]<INTEGER>` |
-| `name` | yes | what the factor is |
+| `name` | yes | what the factor is — the neutral driver, not a finding about it |
 | `type` | no | `external` or `internal` |
-| `description` | no | one-paragraph elaboration |
+| `category` | no | PESTLE sub-classification for external factors — `political` \| `economic` \| `social` \| `technological` \| `legal` \| `environmental`. Omit on internal factors. See [`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §7.1. |
+| `description` | no | one-paragraph elaboration of the driver — keep findings out; emit them as `ASSESSMENT` records |
 
 ### `goals[]`
 

--- a/organizations/acme_corp/canon/elements/01_motivation/assessments/ASSESSMENT-SUPPORT-RESPONSE-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/assessments/ASSESSMENT-SUPPORT-RESPONSE-1.yaml
@@ -1,10 +1,11 @@
 # Worked example — ASSESSMENT element primitive.
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.16 + envelope §3.
 # ArchiMate Assessment over a Driver: a dated finding about the state of
-# FACTOR-COMP-1 ("Support response time degraded over Q1"). No polarity field —
-# whether 8h is "bad" is carried by the assessment_influences_goal REL kind
-# (notations/elements/17-relations.md §3); see canon/relations/REL-ASSMT-SUPP-
-# RESP-GOAL-OPS-1.yaml for the worked negative influence on GOAL-OPS-1.
+# FACTOR-COMP-1 (the neutral driver "Support response time"). No polarity
+# field — whether 8h is "bad" is carried by the assessment_influences_goal
+# REL kind (notations/elements/17-relations.md §3); see canon/relations/
+# REL-ASSMT-SUPP-RESP-GOAL-OPS-1.yaml for the worked negative influence on
+# GOAL-OPS-1.
 
 notation: assessment
 id: ASSESSMENT-SUPPORT-RESPONSE-1

--- a/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
@@ -1,15 +1,25 @@
 # Worked example — FACTOR element primitive (internal driver).
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.1 + envelope §3.
 # Referenced inline from the FGA view (canon/views/fga/).
+#
+# Neutral Driver — the standing internal force ("support response time" as a
+# performance dimension the organisation acts on), not a finding about it.
+# Findings about this driver's current state live on ASSESSMENT records that
+# assesses: FACTOR-COMP-1 — see ../assessments/ASSESSMENT-SUPPORT-RESPONSE-1.yaml
+# for the worked "8h and degrading" finding.
+# No PESTLE category — PESTLE applies to external factors only.
 
 notation: factor
 id: FACTOR-COMP-1
-name: "Support response time degraded over Q1"
+name: "Support response time"
 type: internal
 description: >
-  Internal support response time (P50) drifted upward through Q1 2026.
-  The performance gap is the internal driver behind the operational-
-  improvement goal chain.
+  Standing internal driver — the performance dimension of support first-
+  response time. The organisation organises around this dimension; the
+  operational-improvement goal chain is driven by it. Dated findings about
+  the current state of this dimension (measurements, trends, judgements)
+  live on ASSESSMENT records that reference this FACTOR — they are not
+  inline here.
 
 # Admission record (CONTRACT.md §6)
 zone: canon

--- a/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-EU-REG-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-EU-REG-1.yaml
@@ -1,16 +1,24 @@
-# Worked example — FACTOR element primitive.
+# Worked example — FACTOR element primitive (external driver, PESTLE: legal).
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.1 + envelope §3.
 # Definition home for this factor; referenced inline from the FGCA view
 # (canon/views/fgca/) which is the authoring surface.
+#
+# Neutral Driver — the standing external regulatory force, not a finding about
+# its current state. Dated findings about this driver (e.g. a closing window,
+# a moving timeline) would live on ASSESSMENT records that assesses this FACTOR.
+# `category: legal` per PESTLE — binding regulations / law.
 
 notation: factor
 id: FACTOR-EU-REG-1
-name: "EU regulatory window closing in Q3"
+name: "EU regulatory window for market entry"
 type: external
+category: legal
 description: >
-  A favourable EU market-entry regulatory window is expected to close in
-  Q3 2026. The pressure to act before it closes is the external driver
-  behind the EU-expansion goal chain.
+  Standing external driver — the EU regulatory regime governing market
+  entry for the organisation's product. The organisation's portfolio is
+  subject to it. Findings about its current state (a closing window, a
+  moving timeline, a notified-body bottleneck) belong on ASSESSMENT
+  records that assesses this FACTOR — they are not inline here.
 
 # The factor reflects a standing constraint the organisation must respect.
 references_constraint:

--- a/organizations/acme_corp/canon/elements/01_motivation/factors/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/README.md
@@ -1,6 +1,8 @@
 # `canon/elements/01_motivation/factors/`
 
-Factor element primitives — each file is one strategic driver (external or internal) on the ArchiMate 3.2 **motivation** layer. Factors open the strategy chain: they justify the goals that follow. The FGCA / FGA views (`../../../views/fgca/`, `../../../views/fga/`) are the authoring surface; a factor shared across documents is materialised here as its canonical record.
+Factor element primitives — each file is one **neutral driver** (external or internal) on the ArchiMate 3.2 **motivation** layer (ArchiMate **Driver**). A factor names the standing force the organisation acts on (a regulatory regime, a market shift, an internal performance dimension); it carries no findings and no polarity. Factors open the strategy chain: they justify the goals that follow. The FGCA / FGA views (`../../../views/fgca/`, `../../../views/fga/`) are the authoring surface; a factor shared across documents is materialised here as its canonical record.
+
+**Driver vs finding.** A FACTOR is the *thing* (e.g. "Support response time"), not a statement about its current state. Dated findings about a driver's state — measurements, trends, observations — are `ASSESSMENT` records that `assesses` the FACTOR ([`../assessments/`](../assessments/), schema [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.16). Polarity (whether a finding helps or harms a particular goal) lives on the `assessment_influences_goal` REL ([`17-relations.md`](../../../../../../notations/elements/17-relations.md) §3) — never on the FACTOR or the ASSESSMENT.
 
 TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`FACTOR`).
 
@@ -12,7 +14,7 @@ TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/I
 
 Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.1 (per-TYPE fields) over the common envelope §3:
 
-- Identity + factor fields: `notation: factor`, `id`, `name`, optional `type` (`external` | `internal`), `description`, `references_constraint: [CONSTRAINT-…]`.
+- Identity + factor fields: `notation: factor`, `id`, `name`, optional `type` (`external` | `internal`), optional `category` (PESTLE — external only: `political` | `economic` | `social` | `technological` | `legal` | `environmental`), `description`, `references_constraint: [CONSTRAINT-…]`.
 - Admission record per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
 - Primitive lifecycle per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
 
@@ -20,11 +22,13 @@ Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEME
 
 | File | Notes |
 |---|---|
-| `FACTOR-EU-REG-1.yaml` | External driver — closing EU regulatory window; references `CONSTRAINT-GDPR-RESIDENCY-1` |
-| `FACTOR-COMP-1.yaml` | Internal driver — degraded support response time |
+| `FACTOR-EU-REG-1.yaml` | External driver — EU regulatory regime for market entry; `category: legal`; references `CONSTRAINT-GDPR-RESIDENCY-1` |
+| `FACTOR-COMP-1.yaml` | Internal driver — support response time (the performance dimension); assessed by `ASSESSMENT-SUPPORT-RESPONSE-1` |
 
 ## See also
 
 - Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.1.
+- ASSESSMENT (findings about a driver): [`../assessments/`](../assessments/), [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.16.
+- `assessment_influences_goal` REL (where polarity / SWOT lives): [`notations/elements/17-relations.md`](../../../../../../notations/elements/17-relations.md) §3.
 - FGCA / FGA notations: [`notations/views/02-fgca.md`](../../../../../../notations/views/02-fgca.md), [`notations/views/03-fga.md`](../../../../../../notations/views/03-fga.md).
 - Views over these elements: [`../../../views/fgca/`](../../../views/fgca/), [`../../../views/fga/`](../../../views/fga/).

--- a/organizations/acme_corp/canon/views/fga/README.md
+++ b/organizations/acme_corp/canon/views/fga/README.md
@@ -21,8 +21,8 @@ author: "Acme Ops"
 
 factors:
   - id: FACTOR-COMP-1              # → canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
-    name: "Support response time degraded over Q1"
-    type: internal
+    name: "Support response time"  # neutral driver — the finding "8h and degrading" lives on ASSESSMENT-SUPPORT-RESPONSE-1
+    type: internal                 # internal → no PESTLE category
     valid_from: "2026-05-26"       # CONTRACT.md §7 — required on every inline element
     valid_to: null
 

--- a/organizations/acme_corp/canon/views/fgca/README.md
+++ b/organizations/acme_corp/canon/views/fgca/README.md
@@ -21,8 +21,9 @@ author: "Acme Strategy Office"
 
 factors:
   - id: FACTOR-EU-REG-1           # → canon/elements/01_motivation/factors/FACTOR-EU-REG-1.yaml
-    name: "EU regulatory window closing in Q3"
+    name: "EU regulatory window for market entry"   # neutral driver — findings live on ASSESSMENTs
     type: external
+    category: legal               # PESTLE — external only
     references_constraint: [CONSTRAINT-GDPR-RESIDENCY-1]   # → canon/elements/01_motivation/constraints/
     valid_from: "2026-05-26"      # CONTRACT.md §7 — required on every inline element
     valid_to: null

--- a/skills/onboarding/extraction/01_motivation.md
+++ b/skills/onboarding/extraction/01_motivation.md
@@ -46,7 +46,7 @@ You produce draft primitives of these TYPEs:
 
 | TYPE | What it represents | When to extract |
 |---|---|---|
-| `FACTOR` | Strategic driver — external or internal — that shapes the organisation's direction | The source names a **driver**: a standing thing the organisation acts on — an environmental pressure ("EU regulatory window closing"), a market shift ("customer demand growing 30% YoY"), an internal concern ("support response time"), or any cause the organisation organises around |
+| `FACTOR` | **Neutral driver** (ArchiMate Driver) — external or internal — a standing force the organisation acts on | The source names a **driver**: a standing thing the organisation acts on — an environmental pressure ("EU regulatory window"), a market shift ("customer demand"), an internal performance dimension ("support response time"), or any cause the organisation organises around. Extract the *driver itself*, not a finding about its current state — findings go on an `ASSESSMENT` (below). For external drivers, also extract the PESTLE `category` (`political` \| `economic` \| `social` \| `technological` \| `legal` \| `environmental`) when the source supports the classification. Internal drivers carry no category. |
 | `GOAL` | Strategic or tactical objective the organisation commits to | The source names a desired outcome, a target the organisation is aiming at, or an explicit objective for a period |
 | `CONSTRAINT` | Restriction or prohibition the organisation must not cross | The source names a boundary using "must not", "cannot exceed", "is limited to", "is classified as" — the form of the obligation is a restriction |
 | `REQUIREMENT` | Positive obligation the organisation must fulfil | The source names an obligation using "must", "shall", "must submit", "must register", "must obtain" — the form is a positive action ([15-requirement.md](../../../notations/elements/15-requirement.md) §1) |
@@ -54,7 +54,7 @@ You produce draft primitives of these TYPEs:
 
 **`REQUIREMENT` vs `CONSTRAINT` boundary:** form of the obligation. Positive action ("must do X") → REQUIREMENT. Restriction ("must not do X" / "X cannot exceed Y") → CONSTRAINT. The same regulatory source may produce both; emit both when both forms appear ([15-requirement.md](../../../notations/elements/15-requirement.md) §1 has worked boundary examples).
 
-**`FACTOR` vs `ASSESSMENT` boundary:** the *driver* vs a *finding about it*. The neutral, standing thing the organisation acts on is the `FACTOR` (e.g. "Support response time" / "Customer churn"). A dated, observed statement about that thing's current state — a number, a trend, a judgement — is an `ASSESSMENT` that `assesses` the factor. When the source gives both ("our support response time" + "it's 8h and degrading"), emit a `FACTOR` and an `ASSESSMENT` referencing it. An assessment records **what was found, never whether it is good or bad** — emit no polarity / strength-weakness-opportunity-threat label; that judgement is established later, separately. If the source states a finding but names no underlying driver, emit the `FACTOR` you infer the finding is about and set `confidence: low` with a note.
+**`FACTOR` vs `ASSESSMENT` boundary:** the *driver* vs a *finding about it*. The neutral, standing thing the organisation acts on is the `FACTOR` (e.g. "Support response time" / "Customer churn" / "EU regulatory window"). A dated, observed statement about that thing's current state — a number, a trend, a judgement — is an `ASSESSMENT` that `assesses` the factor. When the source gives both ("our support response time" + "it's 8h and degrading"), emit a `FACTOR` and an `ASSESSMENT` referencing it; **never collapse the finding into the FACTOR name or description**. A FACTOR like "Support response time degraded over Q1" is wrong — the FACTOR is "Support response time" (the dimension), and "degraded over Q1" is the ASSESSMENT. An assessment records **what was found, never whether it is good or bad** — emit no polarity / strength-weakness-opportunity-threat label; that judgement is established later, separately. If the source states a finding but names no underlying driver, emit the `FACTOR` you infer the finding is about and set `confidence: low` with a note.
 
 `derived_from` on a REQUIREMENT cites the Field artefact ID, **not** a codex source. Codex sources are admitted separately; the connection between REQUIREMENT and its codex source (`LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`) is established at admission time, after this prompt has run.
 
@@ -76,12 +76,15 @@ You emit a list of draft primitives. Each draft is a valid YAML document in **ca
 
 ```yaml
 id: FACTOR-EU-REGULATORY-WINDOW-1
-name: "EU regulatory window for medical-device manufacturers closing in Q3 2027"
+name: "EU regulatory window for medical-device manufacturers"
 type: external                          # external | internal
+category: legal                         # PESTLE — external only; political | economic | social | technological | legal | environmental
 description: >
-  Regulatory framework changes in the EU will introduce stricter
-  conformity-assessment timelines, taking effect Q3 2027. The
-  organisation's product portfolio is affected.
+  Standing external driver — the EU regulatory regime for medical-device
+  manufacturers. The organisation's product portfolio is subject to it.
+  Findings about its current state (a closing window, a moving timeline,
+  a notified-body bottleneck) live on ASSESSMENT records that assess
+  this FACTOR — they are not inline here.
 
 # Provenance — cites the Field source(s)
 derived_from:

--- a/skills/onboarding/templates/fga.fga.transitrix.yaml
+++ b/skills/onboarding/templates/fga.fga.transitrix.yaml
@@ -14,8 +14,9 @@ author: "FILL-ME"
 
 factors:
   - id: FACTOR-1
-    name: "FILL-ME factor"
+    name: "FILL-ME factor — neutral driver (the standing force, not a finding about it)"
     type: external           # external | internal
+    # category: economic     # PESTLE — external only: political | economic | social | technological | legal | environmental
 
 goals:
   - id: GOAL-1

--- a/skills/onboarding/templates/fgca.fgca.transitrix.yaml
+++ b/skills/onboarding/templates/fgca.fgca.transitrix.yaml
@@ -15,8 +15,9 @@ author: "FILL-ME"
 
 factors:
   - id: FACTOR-1
-    name: "FILL-ME factor — strategic driver"
+    name: "FILL-ME factor — neutral driver (the standing force, not a finding about it)"
     type: external           # external | internal
+    # category: economic     # PESTLE — external only: political | economic | social | technological | legal | environmental
 
 goals:
   - id: GOAL-1


### PR DESCRIPTION
## Summary

Closes sub-task 2 of the Motivation-layer epic (strategy#121): split FACTOR from "driver doing double duty" into a clean ArchiMate **Driver**, with optional PESTLE `category`. Findings about a driver's current state live on `ASSESSMENT` records that `assesses` the FACTOR; polarity lives on `assessment_influences_goal` (landed via #105). Acme worked factors that named findings ("...degraded over Q1", "...closing in Q3") are migrated to the neutral driver form — the assessment record for the support-response finding already exists from sub-task 1 (#102).

## What changed

- **Spec.** `ELEMENT_PRIMITIVES.md` §7.1 rewords FACTOR as neutral Driver, adds optional PESTLE `category` (external only), tightens the `description` rule (no inline findings).
- **View shapes.** `views/02-fgca.md` and `views/03-fga.md` mirror the rule in the inline FGCA / FGA `factors[]` schema, with `category` in the worked snippet.
- **Examples.** `examples/fga/strategy-2026`, `examples/fgca/strategy-2026`, `examples/fgca/constraint-driven` backfill PESTLE `category` on the external factors (economic / legal / technological).
- **Extraction agent.** `skills/onboarding/extraction/01_motivation.md` reframes the FACTOR row, sharpens the FACTOR-vs-ASSESSMENT boundary with a wrong-shape example, and rewrites the worked emit-block to the neutral form.
- **Templates.** `skills/onboarding/templates/fga.fga.transitrix.yaml` and `fgca.fgca.transitrix.yaml` switch FILL-ME wording to "neutral driver" and include a commented PESTLE category hint.
- **Acme canon migration.** `FACTOR-COMP-1` "Support response time degraded over Q1" → neutral "Support response time" (the existing `ASSESSMENT-SUPPORT-RESPONSE-1` carries the "8h and degrading" finding); `FACTOR-EU-REG-1` "...closing in Q3" → "EU regulatory window for market entry" + `category: legal`; canon FGA / FGCA view READMEs refreshed to match.

## Out of scope

- `assessment_influences_goal` REL — already landed via #105.
- SWOT view (sub-task 4 of #121).

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (14 view notations; examples, internal links, methodology_version pins consistent).
- [x] Re-read tails of all 15 edited files to confirm no truncation.
- [ ] Reviewer: confirm migration story (FACTOR + ASSESSMENT split, FACTOR-COMP-1 rename) matches strategy#128 intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)