### PR TITLE
feat(methodology): Team Operations convention — operational layer for adopter teams (strategy#133)

### DIFF
--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -10,6 +10,7 @@ A map of the repository and where to find things. For the methodology itself, st
 |---|---|
 | [`README.md`](README.md) | Project overview and quick start. |
 | [`method/methodology.md`](method/methodology.md) | Methodology overview — principles, zones, repository structure, change lifecycle. |
+| [`method/team-operations.md`](method/team-operations.md) | Team Operations convention — `operations/` folder, ADR + Work Item shapes; operational layer alongside the model (not a zone). |
 | [`notations/`](notations/) | The canonical model: notation specs, shared contract, ID grammar, examples. |
 | [`glossary.md`](glossary.md) | Standardised terminology. |
 | [`CHANGELOG.md`](CHANGELOG.md) | Release history (Keep a Changelog; SemVer with pre-1.0 caveats). |
@@ -55,6 +56,7 @@ organizations/acme_corp/
 │   └── views/              # Composite diagrams and aggregations over elements
 ├── field/                  # Zone: interviews, surveys, observations, drafts
 ├── codex/                  # Zone: external/<jurisdiction>/ laws + internal/ policies
+├── operations/             # Operational layer (NOT a zone) — team's ADRs + Work Items
 ├── .templates/             # Copy-and-fill templates
 └── .validators/            # Lint and schema scripts (lint.py)
 ```

--- a/method/methodology.md
+++ b/method/methodology.md
@@ -203,6 +203,9 @@ organizations/
 │   ├── codex/                     # Zone: external laws / regulations + internal policies / standards
 │   │   ├── external/<jurisdiction>/
 │   │   └── internal/
+│   ├── operations/                # Operational layer (NOT a zone) — team's own ADRs + Work Items (§4.1)
+│   │   ├── decisions/             #   ADR-NNNN-<slug>.md
+│   │   └── work-items/            #   WI-NNNN-<slug>.md
 │   ├── .templates/                # Copy-and-fill templates for elements / relations / views
 │   └── .validators/               # Lint and schema scripts
 └── NEW_ORGANIZATION_TEMPLATE.md   # How to bootstrap a new organisation
@@ -214,6 +217,16 @@ Two layers stay separate inside `canon/`:
 - **`canon/views/`** holds compositions over elements. A goals tree is a hierarchy referencing many Goal elements. A BPMN diagram is a detailed flow over a single BusinessProcess element. A products list is a filtered view over all elements of type Product. Views aggregate; elements stay atomic.
 
 Every canonical artefact carries an **admission record** and a **primitive lifecycle** (`valid_from` / `valid_to`) — both defined in [`notations/CONTRACT.md`](../notations/CONTRACT.md) §6–7. Attributes that change over time live in `*.history.yaml` sidecars (§9), not inline.
+
+### 4.1 Operational layer — Team Operations (`operations/`)
+
+Alongside the model zones, an adopter team optionally keeps an **operational layer** — its own decision log and in-flight work — at `organizations/<org>/operations/`. This is the **Team Operations** convention: a sibling folder containing `decisions/` (Architecture Decision Records, `ADR-…`) and `work-items/` (Work Items, `WI-…`), plus a one-screen local README.
+
+`operations/` is **not** a zone. It sits outside `canon` / `field` / `codex`, is not admitted through the zone gates, and its IDs (`ADR-NNNN`, `WI-NNNN`) are deliberately outside the canonical TYPE registry. It exists to keep the team's own working artefacts under the same version control and review surface as the model, without leaking into the model.
+
+The convention is **distinct from the model-side `issues` notation** ([`notations/views/12-issues.md`](../notations/views/12-issues.md)): that catalogue records architectural issues (defects, open questions, risks in the model or the system being modelled) and is part of canon; Team Operations Work Items record what the team itself is doing, deliberately not called "issues" to prevent collision.
+
+Full convention: [`method/team-operations.md`](team-operations.md). Worked example: [`organizations/acme_corp/operations/`](../organizations/acme_corp/operations/).
 
 Why multi-tenant: a single repository can hold an entire portfolio of organisations (parent group plus subsidiaries; advisory relationships; multiple business units). Each organisation has full structural isolation while sharing methodology and validators.
 

--- a/method/team-operations.md
+++ b/method/team-operations.md
@@ -1,0 +1,182 @@
+---
+title: Team Operations — operational layer convention
+status: draft
+last_reviewed: 2026-06-03
+audience: public
+license: MIT
+tags: [transitrix, methodology, operations, adr, work-items]
+---
+
+# Team Operations — operational layer convention
+
+> Lightweight convention for the **work an adopter team does to run itself** — its decisions and its in-flight tasks — kept alongside the architectural model in the same repository, but strictly separate from it.
+
+## 1. What this is — and what it is not
+
+The Transitrix model (`canon/`, `field/`, `codex/`) describes the **enterprise** an organisation is steering: its goals, capabilities, processes, applications, and the changes/activities that move it forward. Those are statements *about the business*.
+
+A team applying Transitrix also accumulates a second, smaller body of artefacts that describe how **the team itself** is operating: the choices it has made about its own setup, and the units of work it currently has in flight. Those are statements *about the team*.
+
+This is the **Team Operations** convention. It defines a folder, two file shapes, and one linking rule — nothing more.
+
+**Hard distinctions to preserve:**
+
+- **Operational ≠ Model.** Team-operations artefacts are not part of `canon/`. They do not describe the enterprise. They are not subject to the zone admission gates (see [`notations/CONTRACT.md`](../notations/CONTRACT.md) §5–6) and they are not in the ID grammar registry (see [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md)). They live in a sibling folder, `operations/`, deliberately outside the zone model.
+- **Operational ≠ `ISSUE` notation.** The model already has an [`issues`](../notations/views/12-issues.md) view notation, which catalogues **architectural** issues — defects, open questions, and risks *in the model or in the system being modelled*. That is part of canon. Team Operations uses **Work Items (`WI-…`)** for what the team is doing day to day, deliberately not the word "issue", to keep the two from colliding. An adopter who needs to track an architectural problem files an `ISSUE` under `canon/views/issues/`; an adopter who needs to track a piece of their own workstream files a `WI` under `operations/work-items/`.
+
+The convention is intentionally minimal: a folder, two templates, and a one-screen rules doc. Adopters who want a heavier process should keep their existing tracker — this convention is for teams that want their decision log and work queue under the same version control and review surface as the model itself.
+
+## 2. Folder layout
+
+The adopter instantiates the convention at:
+
+```
+organizations/<org>/operations/
+├── README.md                      # Local rules (~1 screen)
+├── decisions/                     # Architecture decision records
+│   ├── ADR-0001-<slug>.md
+│   ├── ADR-0002-<slug>.md
+│   └── …
+└── work-items/                    # Team work items
+    ├── WI-0001-<slug>.md
+    ├── WI-0002-<slug>.md
+    └── …
+```
+
+`operations/` is a **sibling** of `canon/`, `field/`, and `codex/` — not a zone. It is excluded from canon validation: the linter does not walk it, and `transitrix.yaml`'s `zones:` list does not include it.
+
+## 3. The two file shapes
+
+### 3.1 Architecture Decision Record (`ADR-…`)
+
+A short, append-only record of a decision the team has made about how it runs the model, the repository, or its working setup. ADRs are immutable once accepted: a later decision that changes course supersedes the earlier one rather than overwriting it.
+
+Filename: `ADR-NNNN-<short-slug>.md` (`NNNN` is a four-digit zero-padded sequence, monotonically increasing within `operations/decisions/`).
+
+Front-matter:
+
+```yaml
+---
+id: ADR-0001
+title: "Adopt Transitrix methodology 0.5.x for the enterprise model"
+status: accepted            # proposed | accepted | superseded
+date: "2026-06-03"
+relates_to:                 # optional — model IDs the decision concerns
+  - CAPABILITY-V1
+  - GOAL-EU-1
+superseded_by: null         # ADR-… ID if this decision has been replaced
+---
+```
+
+Body — three short sections:
+
+```markdown
+## Context
+Why a decision was needed; the constraints in play.
+
+## Decision
+What the team decided, stated as a single declarative sentence followed by any
+necessary qualifiers.
+
+## Consequences
+What this commits the team to; what it rules out; what becomes easier or harder.
+```
+
+### 3.2 Work Item (`WI-…`)
+
+A short record of a piece of work the team has in flight or has queued. Work Items are mutable — `status` and the body are updated as work progresses — and short-lived: when the work is done the item is `closed`, not deleted.
+
+Filename: `WI-NNNN-<short-slug>.md` (`NNNN` is a four-digit zero-padded sequence, monotonically increasing within `operations/work-items/`).
+
+Front-matter:
+
+```yaml
+---
+id: WI-0001
+title: "Capture the first capability assessments for V1.1"
+status: in_progress          # proposed | in_progress | blocked | done | closed
+opened: "2026-06-03"
+closed: null                 # ISO date when status → done/closed; null otherwise
+owner: "v.korobeinikov"      # optional — the person carrying the item
+relates_to:                  # optional — model IDs the work concerns
+  - CAPABILITY-V1.1
+  - ACTIVITY-DISCOVERY-1
+---
+```
+
+Body — free-form Markdown. A short outcome statement and a checklist is usually enough; substantive discussion that leads to a course change is captured as an ADR, not as a long Work Item description.
+
+## 4. The linking rule — `relates_to:`
+
+Both file shapes carry an optional `relates_to:` list of **model entity IDs** the artefact concerns — Goals, Capabilities, Activities, Changes, Roles, and so on, drawn from the canonical TYPE registry in [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md) §3.
+
+`relates_to:` is the only link from operations into the model. The model does **not** link back: nothing inside `canon/` references an ADR or a Work Item, by design. The model describes the enterprise; the operations layer describes the team. The dependency is one-directional — operations → model.
+
+If a Work Item or ADR references a model ID that does not resolve (typo, deleted element, future plan), the convention treats it as a warning, not an error. The canonical doc-lint (`scripts/check-notations.mjs`) does not validate `operations/` — it is outside the linter's scope, on purpose.
+
+## 5. IDs — distinct namespace from the model
+
+`ADR-` and `WI-` are deliberately **outside** the canonical ID grammar. The TYPE registry in [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md) governs model IDs only; `ADR-…` and `WI-…` carry zero-padded four-digit sequences (`ADR-0001`, `WI-0042`) and are unique within their own folder, not globally. They cannot be cross-referenced from inside the model.
+
+This is intentional: the team-operations namespace is a different *kind* of identifier than a model entity ID, and keeping them mechanically distinguishable (four-digit padded sequence with no domain segment) prevents accidental collisions.
+
+## 6. Status vocabularies
+
+### 6.1 ADR `status:`
+
+| Value | Meaning |
+|---|---|
+| `proposed` | The decision is drafted but not yet committed by the team. |
+| `accepted` | The decision is in force. ADR body is immutable from here. |
+| `superseded` | Replaced by a later ADR. `superseded_by:` names the successor. |
+
+### 6.2 Work Item `status:`
+
+| Value | Meaning |
+|---|---|
+| `proposed` | The item is registered but not yet being worked. |
+| `in_progress` | The item is actively being worked. |
+| `blocked` | The item cannot progress until something external is resolved. |
+| `done` | The work is complete; outcome is recorded in the body. |
+| `closed` | No longer tracked — done-and-archived, withdrawn, or a "won't do". |
+
+## 7. The 1-screen rules doc — `operations/README.md`
+
+Each adopter writes a short local README inside `operations/` covering:
+
+- The two file shapes the convention provides (ADR, WI) — point at this canonical doc rather than restating the schema.
+- The team's local **decision-making process** — when an ADR is required, who signs off, where supersedes are recorded.
+- The team's local **work-item flow** — how items are opened, who reviews, how items move through `proposed → in_progress → done`.
+
+The local README is the team's adaptation; this canonical doc is the convention.
+
+A starter template lives at [`organizations/acme_corp/operations/README.md`](../organizations/acme_corp/operations/README.md).
+
+## 8. Templates
+
+Two starter templates live under `.templates/operations/` in the adopter repository:
+
+- [`organizations/acme_corp/.templates/operations/ADR-template.md`](../organizations/acme_corp/.templates/operations/ADR-template.md)
+- [`organizations/acme_corp/.templates/operations/WI-template.md`](../organizations/acme_corp/.templates/operations/WI-template.md)
+
+Copy a template into the matching subfolder, fill in the front-matter and body, commit.
+
+## 9. What this convention is not (extended)
+
+To keep the layer minimal and prevent it from drifting into a parallel process system:
+
+- **Not a ticket tracker.** Work Items are short, current, and few. A team that needs grooming, sprints, burn-down, and prioritisation has outgrown this convention and should use its existing tracker.
+- **Not a forum.** Long discussions belong in the PR that proposes the ADR, not in the ADR body.
+- **Not a versioned spec.** ADRs are decisions, not contracts; they do not carry `valid_from`/`valid_to` and they are not admitted to canon.
+- **Not a Transitrix Studio-rendered notation.** Operations files are plain Markdown — no rendering pipeline, no notation header, no extension convention.
+
+## 10. References
+
+- Worked example: [`organizations/acme_corp/operations/`](../organizations/acme_corp/operations/).
+- Methodology overview: [`method/methodology.md`](methodology.md) §4 — repository structure.
+- Distinct from the model-side issues catalogue: [`notations/views/12-issues.md`](../notations/views/12-issues.md).
+- Distinct from the canon zones: [`notations/CONTRACT.md`](../notations/CONTRACT.md) §5.
+
+---
+
+**Status:** draft — new in this release. The convention is intentionally small; widen it only when an adopter team demonstrates a recurring need the current shape does not cover.

--- a/organizations/acme_corp/.templates/operations/ADR-template.md
+++ b/organizations/acme_corp/.templates/operations/ADR-template.md
@@ -1,0 +1,35 @@
+---
+id: ADR-NNNN
+title: "FILL-ME — one-line decision title"
+status: proposed            # proposed | accepted | superseded
+date: "YYYY-MM-DD"
+relates_to: []              # optional — model entity IDs this decision concerns
+superseded_by: null         # ADR-NNNN ID if this decision has been replaced
+---
+
+<!--
+ADR template. Convention: method/team-operations.md §3.1.
+
+Naming:    ADR-NNNN-<short-slug>.md  (NNNN = four-digit zero-padded, sequence per
+           operations/decisions/, monotonically increasing).
+
+Status:    proposed   → drafted, not yet committed by the team
+           accepted   → in force; body is immutable from here
+           superseded → replaced by a later ADR; superseded_by names the successor
+
+Once accepted, do not edit the body. If course changes, open a new ADR and set this
+file's status: superseded + superseded_by: ADR-…  in the same PR.
+-->
+
+## Context
+
+Why a decision was needed; the constraints in play; what was tried or considered.
+
+## Decision
+
+What the team decided, stated as a single declarative sentence followed by any
+necessary qualifiers.
+
+## Consequences
+
+What this commits the team to; what it rules out; what becomes easier or harder.

--- a/organizations/acme_corp/.templates/operations/WI-template.md
+++ b/organizations/acme_corp/.templates/operations/WI-template.md
@@ -1,0 +1,35 @@
+---
+id: WI-NNNN
+title: "FILL-ME — one-line work-item title"
+status: proposed            # proposed | in_progress | blocked | done | closed
+opened: "YYYY-MM-DD"
+closed: null                # ISO date when status → done/closed; null otherwise
+owner: "firstname.lastname" # optional — person carrying the item
+relates_to: []              # optional — model entity IDs this work concerns
+---
+
+<!--
+Work Item template. Convention: method/team-operations.md §3.2.
+
+Naming:    WI-NNNN-<short-slug>.md  (NNNN = four-digit zero-padded, sequence per
+           operations/work-items/, monotonically increasing).
+
+Status:    proposed     → registered, not yet being worked
+           in_progress  → actively being worked
+           blocked      → cannot progress until something external is resolved
+           done         → work complete; outcome recorded in body
+           closed       → no longer tracked (done-and-archived / withdrawn / won't do)
+
+Work Items are mutable while active. Keep them short — substantive course-changing
+discussion belongs in an ADR, not in a long Work Item description.
+-->
+
+## Outcome
+
+What this work is meant to land. One or two sentences.
+
+## Checklist
+
+- [ ] First concrete step.
+- [ ] Second concrete step.
+- [ ] …

--- a/organizations/acme_corp/README.md
+++ b/organizations/acme_corp/README.md
@@ -24,10 +24,13 @@ acme_corp/
 ├── codex/                       # external laws/regulations + internal policies/standards, faithful to source
 │   ├── external/<jurisdiction>/ # LAW, REGULATION
 │   └── internal/                # POLICY, INTERNAL_STANDARD
+├── operations/                  # operational layer (NOT a zone) — the team's ADRs + Work Items
+│   ├── decisions/               #   ADR-NNNN-<slug>.md
+│   └── work-items/              #   WI-NNNN-<slug>.md
 └── .templates/                  # copy-and-fill templates for new elements / views / relations
 ```
 
-The three **zones** (`canon` / `field` / `codex`) are parallel, not stacked — see [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §5.
+The three **zones** (`canon` / `field` / `codex`) are parallel, not stacked — see [`notations/CONTRACT.md`](../../notations/CONTRACT.md) §5. The `operations/` folder sits alongside the zones as a separate **operational layer**: it records how the team applying Transitrix runs itself (decisions and work items), not the enterprise being modelled. See [`method/team-operations.md`](../../method/team-operations.md) for the convention and [`operations/README.md`](operations/README.md) for the local rules.
 
 ## 🚀 Quick start
 

--- a/organizations/acme_corp/operations/README.md
+++ b/organizations/acme_corp/operations/README.md
@@ -1,0 +1,45 @@
+# Operations — acme_corp
+
+The **operational layer** for the team applying Transitrix to the `acme_corp` model. Distinct from the model itself (`canon/`, `field/`, `codex/`) — this folder is where the team records the decisions it has made about its own setup and the units of work it currently has in flight.
+
+> Convention canon: [`method/team-operations.md`](../../../method/team-operations.md). This README is the **local** rules — it adapts the convention to how the `acme_corp` team works, and it should fit on one screen.
+
+## Layout
+
+```
+operations/
+├── README.md            # this file — local rules
+├── decisions/           # ADR-NNNN-<slug>.md — Architecture Decision Records
+└── work-items/          # WI-NNNN-<slug>.md — Work Items
+```
+
+## Two file shapes
+
+- **ADR — Architecture Decision Record.** A short, append-only record of a decision about how the team runs the model. Once `status: accepted` the body is immutable; a later decision that changes course is a **new** ADR that names this one in its `superseded_by:` field. Schema: [`method/team-operations.md`](../../../method/team-operations.md) §3.1. Template: [`../.templates/operations/ADR-template.md`](../.templates/operations/ADR-template.md).
+
+- **WI — Work Item.** A short record of a piece of work the team has in flight or queued. Mutable while active; `closed` when done — not deleted. Schema: [`method/team-operations.md`](../../../method/team-operations.md) §3.2. Template: [`../.templates/operations/WI-template.md`](../.templates/operations/WI-template.md).
+
+## What goes where — local rules
+
+| Situation | File shape |
+|---|---|
+| The team agreed on a way the repo or model is set up (a versioning pin, a naming override, a process choice) | **ADR** in `decisions/` |
+| Someone is doing a piece of work that touches one or more model entities (filling in capability assessments, drafting a view, refactoring a relation set) | **WI** in `work-items/` |
+| An architectural problem about the modelled enterprise (e.g. a defect in a process, a risk in a system) | **NOT here** — file an `ISSUE` under `canon/views/issues/` (model-side, see [`notations/views/12-issues.md`](../../../notations/views/12-issues.md)) |
+| A long discussion or proposal that has not landed on a decision | The pull-request that opens the candidate ADR — not a separate file here |
+
+## Linking into the model — `relates_to:`
+
+Both ADR and WI carry an optional `relates_to:` list of model entity IDs (Goals, Capabilities, Activities, …). That is the only link from operations into the model. The model **never** links back — nothing in `canon/` references an ADR or a WI.
+
+`relates_to:` entries use the canonical ID grammar from [`notations/IDS_AND_REFERENCES.md`](../../../notations/IDS_AND_REFERENCES.md) §3. Unresolved IDs are treated as warnings, not errors — the doc-lint does not validate `operations/`.
+
+## Local flow
+
+- **Opening an ADR.** Open a PR with `status: proposed`. Discussion lives on the PR. On merge the status flips to `accepted`. Owner: Valerii (sole maintainer of `acme_corp` today).
+- **Superseding an ADR.** Open a new ADR; in the same PR set the old ADR's `status: superseded` and `superseded_by:`. The old body is otherwise untouched.
+- **Opening a Work Item.** Anyone on the team may open a WI with `status: proposed` or `status: in_progress`. Update the status as the work moves. On completion set `status: done` (outcome recorded in body) or `status: closed` (won't do / withdrawn).
+
+## Numbering
+
+Sequence is per-folder, monotonically increasing, four-digit zero-padded (`ADR-0001`, `WI-0042`). When opening a new file pick the next free number.

--- a/organizations/acme_corp/operations/decisions/ADR-0001-adopt-team-operations-convention.md
+++ b/organizations/acme_corp/operations/decisions/ADR-0001-adopt-team-operations-convention.md
@@ -1,0 +1,25 @@
+---
+id: ADR-0001
+title: "Adopt the Team Operations convention alongside the model"
+status: accepted
+date: "2026-06-03"
+relates_to: []
+superseded_by: null
+---
+
+## Context
+
+The `acme_corp` repository carries a Transitrix architecture model (`canon/` + `field/` + `codex/`) and a small set of team-running artefacts that had no canonical home: notes on which methodology version is pinned, who maintains what, in-flight refactors. Until now those lived as ad-hoc comments on pull requests and were lost as soon as the PR closed.
+
+The methodology now defines a **Team Operations** convention ([`method/team-operations.md`](../../../../method/team-operations.md)): a sibling folder `operations/` with `decisions/` and `work-items/`, deliberately outside the zone model. The convention is minimal — a folder, two file shapes, one linking rule — and intended to live under the same version control as the model.
+
+## Decision
+
+The `acme_corp` worked example adopts the Team Operations convention in full, starting at `operations/`. ADRs and Work Items follow the canonical schema; no local extensions are introduced at this point.
+
+## Consequences
+
+- Future decisions about how the `acme_corp` model is run (version pins, naming overrides, refactor scope) land as ADRs in `operations/decisions/`, not in PR comments.
+- In-flight work that spans several PRs may be tracked as a Work Item in `operations/work-items/` to make the connection explicit.
+- The convention is **not** subject to the doc-lint (`scripts/check-notations.mjs`) — operations files are plain Markdown outside the linter's scope. Drift in this layer is caught at PR review, not by CI.
+- If a heavier process is ever needed (sprints, prioritisation, SLAs), the team will outgrow this convention and move to a dedicated tracker; this ADR will be superseded.

--- a/organizations/acme_corp/operations/work-items/WI-0001-bootstrap-operations-folder.md
+++ b/organizations/acme_corp/operations/work-items/WI-0001-bootstrap-operations-folder.md
@@ -1,0 +1,20 @@
+---
+id: WI-0001
+title: "Bootstrap operations/ folder and seed ADR + Work Item"
+status: done
+opened: "2026-06-03"
+closed: "2026-06-03"
+owner: "v.korobeinikov"
+relates_to: []
+---
+
+## Outcome
+
+`operations/` folder created with the canonical layout (`README.md`, `decisions/`, `work-items/`), the convention adopted via [`ADR-0001`](../decisions/ADR-0001-adopt-team-operations-convention.md), and this seed Work Item closed.
+
+## Checklist
+
+- [x] Create `operations/README.md` (local rules).
+- [x] File `ADR-0001` adopting the convention.
+- [x] Add `.templates/operations/` with ADR + WI templates.
+- [x] Close this WI when the seed is in place.


### PR DESCRIPTION
## Summary

Introduces a lightweight **operational layer** convention sitting alongside the model zones: `organizations/<org>/operations/` with `decisions/` (ADRs) and `work-items/` (WIs). Implements `vkgeorgia/strategy#133`.

The convention is intentionally minimal — a folder, two templates, one linking rule — and exists to keep an adopter team's own decision log and in-flight work under the same version control as the model, without leaking into the model.

## Hard distinctions preserved

- **Operational ≠ Model.** `operations/` is **not** a zone. It sits outside `canon` / `field` / `codex`, is not admitted through the zone gates ([`CONTRACT.md`](../../notations/CONTRACT.md) §5–6), and its IDs (`ADR-NNNN`, `WI-NNNN`) are deliberately outside the canonical TYPE registry ([`IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §3).
- **Operational ≠ `issues` notation.** The model-side [`issues`](notations/views/12-issues.md) catalogue records architectural issues in canon; Team Operations Work Items record what the team itself is doing — deliberately **not** called "issues" to prevent collision.
- **Operational ≠ strategy-hub mechanism.** Stated explicitly in the convention doc — this is for adopter teams, not the `vkgeorgia/strategy` epics/proj:* tasks workflow.

## What landed

- `method/team-operations.md` — canonical convention spec (folder layout, ADR + WI schemas, `relates_to:` linking rule, status vocabularies, the model/operations distinction).
- `method/methodology.md` §4.1 — new operational-layer subsection + tree-diagram update so `operations/` is visible in the canonical repo structure.
- `PROJECT_INDEX.md` — new convention link and tree entry.
- `organizations/acme_corp/operations/` — worked example seeding the layer:
  - `README.md` — local rules (one screen).
  - `decisions/ADR-0001-adopt-team-operations-convention.md` — example ADR.
  - `work-items/WI-0001-bootstrap-operations-folder.md` — example WI.
- `organizations/acme_corp/.templates/operations/{ADR,WI}-template.md` — starter templates.
- `organizations/acme_corp/README.md` — folder-tree update + one-paragraph context.

`acme_corp` is the neutral example throughout — no client-identifiable names.

## Out of scope

- Studio-side paired change for the existing `issues` notation rename (the task notes this is a separate `proj:transitrix-studio` change). Methodology stays canon source.
- DSM first-class entities — explicitly out of scope per the task.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean.
- [x] File integrity verified — all new files end with a newline, no truncation.
- [x] Internal links from the new docs resolve (manually traced).
- [x] `acme_corp/.validators/lint.py` continues to ignore `operations/` (it only walks `canon/elements/` and `canon/relations/`).
- [ ] **Do not merge — Valerii gates.**