### PR TITLE
feat(notations): Confidence and freshness model — source trust, decay, view composite (CONTRACT §11)

### DIFF
--- a/docs/decisions/2026-06-05-data-quality-source-trust-and-freshness.md
+++ b/docs/decisions/2026-06-05-data-quality-source-trust-and-freshness.md
@@ -1,0 +1,101 @@
+---
+title: "Data quality — source trust at entry, freshness decay in canon, composite confidence on views"
+status: accepted
+date: "2026-06-05"
+scope: methodology
+supersedes: null
+superseded_by: null
+tags: [confidence, provenance, freshness, zones, views, data-quality]
+---
+
+# ADR: Data quality — source trust, freshness decay, and view composite confidence
+
+**Status:** Accepted
+**Date:** 2026-06-05
+**Deciders:** Valerii Korobeinikov; Win-Claude (Transitrix-family coordinator — decided at family level per the escalation policy)
+**Scope:** Repo-local to `methodology` (canonical owner of notation semantics). Consumed by `transitrix-dsm` (entry + storage) and `transitrix-studio` (view render). Those repos align as consumers per their standing "methodology is canon" rules; this ADR does not change their internal architecture.
+
+---
+
+## Context
+
+The methodology already separates raw material (`field` zone) from validated truth (`canon` zone), with a `field`-zone admission gate whose contract is `provenance` (§5–6 of `notations/CONTRACT.md`). Two real-work needs were not yet served:
+
+1. **At entry we already know how much to trust a source.** An interview with the accountable owner is not an offhand assumption, and that judgement should be captured at the moment of entry rather than reconstructed later.
+2. **Confidence ages.** A canonical statement last reaffirmed two years ago is less certain than one confirmed last month, even when both are still `valid`. Stale canon should be detectable and surfaced.
+3. **A view should advertise how much to trust it.** When a view is rendered, the reader needs a composite quality signal next to the formation date, not just the date.
+
+Forces at play: canon's trust contract is "authoritative, internally consistent" and must not be undermined; `derived_from` is optional today and making it required would be a breaking change to existing adopter canon; the methodology is pre-1.0, so additive changes are cheap but breaking ones still cost adopters.
+
+## Decision
+
+Add a **Confidence and freshness** model to the shared contract (`CONTRACT.md` §11), built on three principles:
+
+1. **Two independent signals, never collapsed.**
+   - *source trust* — authored at entry as `source_quality` on the `field` artefact's admission record; a closed ordinal set `authoritative` (1.0) / `corroborated` (0.8) / `single_source` (0.5) / `unverified` (0.25); fixed once recorded.
+   - *freshness* — derived, a function of how long ago the canon element was last reaffirmed (`admitted_at`); recomputed on read, never stored.
+2. **Confidence is metadata about certainty, not a contradiction flag.** It never gates admission and never mutates canon. The cure for staleness is **reaffirmation** — re-running the admission gate bumps `admitted_at` and resets freshness; canon content is not edited to refresh a score.
+3. **Composite is computed at render time.** A view surfaces `weakest link` (min over elements — the headline), `mean`, and `coverage` (% of elements with resolvable `derived_from`), mapped to A/B/C/D bands, next to the formation date.
+
+Key formulas (full text in `CONTRACT.md` §11.3–11.6):
+
+```
+freshness            = 1.0 within fresh_days; decays linearly to a floor at stale_days; never 0
+source_trust(elem)   = max source_quality weight over the elem's derived_from field sources
+confidence(elem)     = source_trust(elem) · freshness(elem)
+view weakest link    = min confidence over rendered elements
+```
+
+Decay parameters (`fresh_days`, `stale_days`, `floor`) are configured **per element TYPE** in the adopter manifest (`transitrix.yaml` → `confidence_decay`), because different facts age at different rates; defaults apply to TYPEs not overridden.
+
+A non-mutating scheduled check (`FRESHNESS-001`, warning) reports canon elements past `stale_days` so they can be reaffirmed.
+
+## Options Considered
+
+### Source trust and freshness as one decaying score
+
+| Dimension | Assessment |
+|---|---|
+| Complexity | Low |
+| Honesty of signal | Poor — decay overwrites the authored judgement |
+| Auditability | Poor |
+
+**Pros:** one number, simplest to store and display.
+**Cons:** a stale-but-authoritative source and a fresh-but-unverified one can land on the same value, hiding which problem you have. Rejected.
+
+### Two separate signals combined at read time (chosen)
+
+| Dimension | Assessment |
+|---|---|
+| Complexity | Medium |
+| Honesty of signal | High — entry trust and age stay legible |
+| Auditability | High — `source_quality` is authored and audit-trailed; freshness is a pure function of `admitted_at` |
+
+**Pros:** preserves the authored signal; freshness is derived so nothing in canon mutates; maps cleanly onto the existing zone / admission / lifecycle contracts.
+**Cons:** two concepts to teach; composite needs a documented aggregation.
+
+### Element source trust: weakest source vs best source
+
+Chose **best source (`max`)** at the element level — extra weak corroborating sources should not drag down an element that has at least one authoritative source. The **weakest-link (`min`)** aggregation is applied one level up, at the *view* composite, where a view genuinely is only as trustworthy as its worst element.
+
+### Make `derived_from` required to guarantee provenance
+
+Rejected — a new required field is a breaking (MAJOR) change to existing adopter canon. Instead `derived_from` stays optional; unsourced elements score at the `unverified` floor **and** are counted separately so the gap is visible without being a hard gate.
+
+## Trade-off Analysis
+
+The central trade-off is *simplicity vs. signal fidelity*. A single decaying number is easier to implement but destroys the distinction between "we never trusted this" and "we trusted this but haven't checked lately" — which are different remediation paths (get a better source vs. reaffirm). Keeping the signals separate costs one extra concept and a documented composite, and buys an honest, auditable model that sits naturally on the contract's existing seams (provenance at §6, lifecycle anchor at §7, view render at §11.6). The per-TYPE decay config avoids a one-size half-life that would be wrong for both capability maps and price lists.
+
+## Consequences
+
+- **Easier:** sources can be graded at entry; stale canon becomes detectable and reportable; views carry a trust signal readers can act on; nothing new is persisted in canon, so the audit trail stays clean.
+- **Harder:** adopters must understand two signals; DSM must add a `source_quality` control at field entry and a re-admission ("reaffirm") action; Studio must compute and render the composite; a scheduled freshness pass must be wired somewhere.
+- **To revisit:** persisting the confidence trajectory (would use the §9 sidecar); promoting `source_quality` to a first-class source entity; importance-weighting the view mean; tightening `source_quality` / `derived_from` from optional toward required at the 1.0 cut.
+
+## Action Items
+
+1. [ ] Methodology: land `CONTRACT.md` §11 + §6 `source_quality` + `MANIFEST.md` `confidence_decay` (this PR).
+2. [ ] DSM: add `source_quality` to the field-entry path and a reaffirm (re-admission) action; store on the admission record.
+3. [ ] DSM / validator: implement the `FRESHNESS-001` scheduled, non-mutating check.
+4. [ ] Studio: compute element + view composite confidence and render it next to the view formation date.
+5. [ ] Decide whether the freshness check runs in DSM, the CLI validator, or both.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records — methodology
+
+Repo-local ADRs for the `methodology` repository. Cross-project decisions (affecting ≥2 repos via the strategy hub) live in `vkgeorgia/strategy` under `Architecture/`; the records here are local to methodology — they own notation semantics that other Transitrix repos consume.
+
+Format: dated `YYYY-MM-DD-slug.md`, front-matter (`status`, `date`, `scope`, `supersedes`, `superseded_by`, `tags`), body Context → Decision → Alternatives → Consequences. See `vkgeorgia/strategy` `Architecture/README.md` for the procedure.
+
+| Date | ADR | Status | Scope |
+|---|---|---|---|
+| 2026-06-05 | [Data quality — source trust, freshness decay, view composite confidence](./2026-06-05-data-quality-source-trust-and-freshness.md) | Accepted | methodology (consumed by DSM, Studio) |

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -97,13 +97,14 @@ derived_from:               # optional; typed IDs of the artefacts this one deri
 | `admitted_by` | yes | string | The person handle or tool identifier that ran the admission gate. |
 | `gate_checks` | yes | map | Sub-map keyed by check name; each value records the outcome (`pass`, or a short note). The standard checks per zone are listed below. |
 | `derived_from` | no | list | Typed IDs (per [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md)) of the artefacts this one was derived from. This is how a Canon record cites the Field material behind it (§5) — a citation, never a migration. |
+| `source_quality` | field zone: recommended | string | Authored trust in the *source* of the material, from the closed set `authoritative` / `corroborated` / `single_source` / `unverified` (§11.2). Part of the `field` zone's `provenance` contract (§5). Absent ⇒ downstream confidence scoring (§11) treats the source as `unverified`. Not meaningful on `canon` / `codex` artefacts. |
 
 **Standard `gate_checks` per zone** — the minimum each zone's gate asserts:
 
 | Zone | Standard checks | Meaning |
 |---|---|---|
 | `canon` | `uniqueness`, `consistency`, `completeness` | IDs unique within the catalogue; no contradiction with existing canon; required fields present. |
-| `field` | `provenance` | The source of the material is recorded — who, when, and in what setting. |
+| `field` | `provenance` | The source of the material is recorded — who, when, in what setting, and at what trust (`source_quality`, §11.2). |
 | `codex` | `source_authority` | The issuing or authoritative source is identified and the artefact is faithful to it. |
 
 A zone MAY record additional checks beyond its standard set; codex artefacts additionally carry zone-specific frontmatter defined in the codex notation spec.
@@ -313,3 +314,101 @@ A `MAJOR` release SHOULD ship with a migration recipe under `migrations/<from>-t
 - **The 1.0 cut decision.** Phase 4 of this epic — gated on the in-flight schema epics landing.
 - **Per-notation versioning.** `spec_version` on individual files is informational; only `methodology_version` in `transitrix.yaml` drives compatibility decisions.
 - **Migration for adopter repositories of non-methodology versions** (DSM, Studio, CLI). Those have their own SemVer policies.
+
+---
+
+## 11. Confidence and freshness
+
+Canon is the authoritative model, but not every canonical statement is equally well-sourced, and confidence in a statement *ages* — a fact last reaffirmed two years ago is less certain than one confirmed last month, even when both are still `valid`. This section defines how Transitrix records the trust earned at data entry, how it decays that trust as a statement goes unreaffirmed, and how it surfaces a composite for a rendered view.
+
+Confidence is **metadata about certainty, not a contradiction flag.** A low-confidence canonical element is still canon — internally consistent and authoritative per §5. Confidence never gates admission and never mutates canon; it is computed, reported, and displayed.
+
+### 11.1 Two independent signals
+
+| Signal | Origin | Mutability | Lives in |
+|---|---|---|---|
+| **source trust** | Authored at entry — a judgement about *who or what* the material came from. | Fixed once recorded; a source does not become more or less trustworthy with the passage of time. | `source_quality` on a `field` artefact's admission record (§6). |
+| **freshness** | Derived — a function of how long ago the canonical statement was last reaffirmed. | Changes every day; recomputed at query / render time. | Not stored. Computed from the canon element's `admitted_at` (§6). |
+
+The two are deliberately separate. Collapsing them into one decaying number would erase the authored signal. A statement's overall confidence combines them (§11.4).
+
+### 11.2 Source-trust scale
+
+`source_quality` is a closed ordinal set. The numeric weight is used only for the arithmetic in §11.4–11.6; authors record the label, never the number.
+
+| Label | Weight | Meaning |
+|---|---|---|
+| `authoritative` | 1.0 | Primary source of record: the organisation's system of record, a signed document, or the accountable owner stating it directly. |
+| `corroborated` | 0.8 | Confirmed by triangulation across more than one independent field source. |
+| `single_source` | 0.5 | One uncorroborated informant or observation. |
+| `unverified` | 0.25 | Draft, assumption, inference, or hearsay. The default when `source_quality` is absent. |
+
+### 11.3 Freshness decay
+
+Freshness anchors on the canon element's `admitted_at` (§6) — the date the admission gate last ran for it. Re-running the gate on an unchanged element ("still true as of today") is a **reaffirmation**: it bumps `admitted_at` and resets freshness. This is the maintenance action that cures staleness; canon content is not edited to refresh a score.
+
+```
+age_days  = today − admitted_at
+freshness = 1.0      if age_days ≤ fresh_days
+          = floor    if age_days ≥ stale_days
+          = 1.0 − (1.0 − floor) · (age_days − fresh_days) / (stale_days − fresh_days)   otherwise
+```
+
+Freshness never reaches zero — old canon is less certain, not worthless; it bottoms out at `floor`. The three parameters are configured per element TYPE, because different facts age at different rates (an organisation's capability map ages over years; a price list over weeks). They live in the adopter manifest (`transitrix.yaml`) under `confidence_decay` ([MANIFEST.md](MANIFEST.md) §2); the `defaults` apply to any TYPE not overridden under `by_type`:
+
+```yaml
+confidence_decay:
+  defaults: { fresh_days: 180, stale_days: 730, floor: 0.3 }
+  by_type:
+    CAPABILITY:  { fresh_days: 365, stale_days: 1825 }
+    APPLICATION: { fresh_days: 180, stale_days: 730 }
+```
+
+### 11.4 Element confidence
+
+For one canonical element:
+
+```
+source_trust(element) = max weight over the source_quality of every field artefact
+                        the element cites via derived_from (§6)
+confidence(element)   = source_trust(element) · freshness(element)
+```
+
+Source trust takes the **best** available source (`max`): an element corroborated by an authoritative source is not dragged down by an additional weaker one — extra weak sources add nothing, they do not subtract. Multiplying by freshness then ages that trust: an `authoritative`-but-long-unreaffirmed element scores `1.0 · floor`, while a `single_source`-but-fresh element scores `0.5 · 1.0`.
+
+### 11.5 Unsourced elements
+
+`derived_from` remains optional (§6) — requiring it would break existing canon and is not in scope here. But an element with no resolvable `derived_from` has no authored trust to draw on. For confidence scoring it is treated as `unverified` (0.25) **and counted separately** so the gap is visible rather than hidden. This biases toward filling provenance without making it a hard gate.
+
+### 11.6 View composite
+
+A view renders a set of canonical elements. Its composite confidence is computed at render time and is **not stored** — views carry no lifecycle (§7.1) and no confidence state of their own. Three numbers are surfaced alongside the view's formation date:
+
+| Component | Definition |
+|---|---|
+| **weakest link** | `min` of `confidence(element)` over the rendered elements — a view is only as trustworthy as its weakest element. The headline figure. |
+| **mean** | arithmetic mean of `confidence(element)` over the rendered elements (equal weight per element in v1). |
+| **coverage** | fraction of rendered elements with a resolvable `derived_from`. |
+
+For display, a numeric confidence maps to a band: **A** ≥ 0.8, **B** ≥ 0.6, **C** ≥ 0.4, **D** < 0.4. The headline band is the band of the weakest link. Example render header:
+
+```
+Data confidence (as of 2026-06-05): B (weakest link) · 0.71 mean · 92% sourced
+```
+
+### 11.7 Regular freshness check
+
+A scheduled validator pass computes freshness across canon and **reports** — it never writes. It flags every canonical element whose `age_days ≥ stale_days` for its TYPE (i.e. freshness has bottomed out at `floor`), so they can be reaffirmed. The cure is re-admission (§11.3), not an edit.
+
+| Rule | Severity | Description |
+|---|---|---|
+| `FRESHNESS-001` | warning | A canonical element's `age_days` (today − `admitted_at`) is ≥ `stale_days` for its TYPE. The element is stale and should be reaffirmed. Advisory only — never blocks, never mutates canon. |
+
+`FRESHNESS-001` is cross-cutting in the §8 sense: it needs the element's admission date and the active `confidence_decay` config, not just the file in isolation.
+
+### 11.8 Out of scope (v1)
+
+- **Persisting the confidence trajectory.** Confidence is recomputed on read. If an organisation later needs the history of a confidence value, the versioned-attribute sidecar (§9) is the mechanism — not added here.
+- **`source_quality` as a first-class entity.** Today it is a label on a field artefact's provenance, not a referenced source record. Promoting sources to entities is a later concern.
+- **Automatic reaffirmation.** Bumping `admitted_at` is a deliberate human / tool gate action; nothing reaffirms canon on its own.
+- **Importance-weighting the mean.** v1 weights every rendered element equally; weighting by element importance is deferred.

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -33,6 +33,8 @@ methodology_version: "0.5.0"        # the methodology release this repo conforms
 notations: [fgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md
+confidence_decay:                   # optional — per-TYPE freshness decay; see CONTRACT.md §11.3
+  defaults: { fresh_days: 180, stale_days: 730, floor: 0.3 }
 ```
 
 | Field | Required | Type | Semantics |
@@ -42,6 +44,7 @@ coverage_profile: full              # optional — see COVERAGE_PROFILES.md
 | `notations` | yes | list | Short names of the notations the repository uses, from the catalogue in [README.md](README.md) — plus `codex` for the codex zone (see [14-codex.md](elements/14-codex.md)). |
 | `zones` | yes | list | Which zones the repository maintains — any subset of `canon`, `field`, `codex`. A repo MAY start canon-only and add `field` / `codex` later. |
 | `coverage_profile` | no | string \| map | Which slice of the methodology's vocabulary is in scope for this repo. Short form: a shipped preset name (`minimal` / `core` / `full`). Long form: a custom profile that extends a preset. Defaults to `full` when omitted. Full schema, presets, closure rule, and validation in [COVERAGE_PROFILES.md](COVERAGE_PROFILES.md). |
+| `confidence_decay` | no | map | Per-element-TYPE freshness-decay parameters (`fresh_days`, `stale_days`, `floor`) used by confidence scoring. A `defaults` sub-map applies to any TYPE not listed under `by_type`. Defined in [CONTRACT.md](CONTRACT.md) §11.3. Omitted ⇒ the §11.3 defaults apply. |
 
 No validator enforces the manifest yet; it is declarative. Tooling MAY read it to discover the pinned methodology version and the active notations and zones.
 
@@ -53,3 +56,4 @@ No validator enforces the manifest yet; it is declarative. Tooling MAY read it t
 - Notation catalogue (short names): [README.md](README.md).
 - Codex zone: [14-codex.md](elements/14-codex.md).
 - Coverage Profile (the `coverage_profile:` field): [COVERAGE_PROFILES.md](COVERAGE_PROFILES.md).
+- Confidence and freshness (the `confidence_decay:` field): [CONTRACT.md](CONTRACT.md) §11.


### PR DESCRIPTION
## What

Adds a **data-quality model** to the shared contract: source trust recorded at entry, freshness that decays as a statement goes unreaffirmed, and a composite confidence surfaced on rendered views.

Additive only (MINOR — no existing file changes meaning, nothing becomes required):

- **`CONTRACT.md` §6** — optional `source_quality` on the admission record (extends the `field`-zone `provenance` contract).
- **`CONTRACT.md` §11 (new)** — source-trust scale (`authoritative`/`corroborated`/`single_source`/`unverified`), per-TYPE freshness decay anchored on `admitted_at`, element + view composite confidence, and a non-mutating `FRESHNESS-001` advisory check.
- **`MANIFEST.md`** — optional `confidence_decay` block (per-TYPE `fresh_days`/`stale_days`/`floor`).
- **`docs/decisions/`** — repo-local ADR + INDEX (new).

## Design decisions baked in

- **Two independent signals, never collapsed.** Source trust is authored and fixed; freshness is derived and recomputed on read. Combining them keeps "we never trusted this" distinct from "we haven't checked lately" — different fixes.
- **Confidence never mutates canon.** The cure for staleness is re-admission (reaffirmation), which bumps `admitted_at`. The scheduled check only reports.
- **`max` at the element level, `min` at the view level.** Best source wins per element; weakest element drags the view headline.
- **`derived_from` stays optional.** Unsourced elements score at the `unverified` floor and are counted separately, rather than becoming a breaking required field.

## Open follow-up (not in this PR)

Where the `FRESHNESS-001` scheduled pass runs — DSM, the CLI validator, or both — is left to the consumer side (ADR action item 5).

---

Decided at Transitrix-family level per the escalation policy. **Do not merge — Valerii gates.** Doc-lint (`scripts/check-notations.mjs`) passes clean on the branch.