### PR TITLE
docs(repo): reconcile README and PROJECT_INDEX maps (strategy#146 Part A)

### DIFF
--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -15,9 +15,13 @@ A map of the repository and where to find things. For the methodology itself, st
 | [`glossary.md`](glossary.md) | Standardised terminology. |
 | [`CHANGELOG.md`](CHANGELOG.md) | Release history (Keep a Changelog; SemVer with pre-1.0 caveats). |
 | [`RELEASING.md`](RELEASING.md) | Per-release operational checklist for the maintainer. |
+| [`NOTATIONS_VALIDATION.md`](NOTATIONS_VALIDATION.md) | Maintainer audit — open shape decisions a linter can't make, plus flagged nits. |
 | [`integration/`](integration/) | Tooling, Studio, and CI integration notes. |
 | [`migrations/`](migrations/) | Per-release migration recipes (e.g. `0.5-to-0.6/`). |
-| [`skills/`](skills/) | Onboarding and per-layer extraction skills. |
+| [`transitrix/`](transitrix/) | Claude / Copilot Agent Skills plugin — currently `skills/onboard/` and `skills/ingest/`. |
+| [`packages/`](packages/) | Versioned tooling packages — e.g. `@transitrix/ingest-cli`, the shared CLI invoked by the ingest skill. |
+| [`scripts/`](scripts/) | Repo-level doc-lint scripts (`check-notations.mjs`, `check-skill-cheatsheet.mjs`). |
+| [`docs/`](docs/) | Decision records (`decisions/`) and other maintainer-facing notes. |
 | [`organizations/`](organizations/) | Adopter organisations — the worked example `acme_corp/` lives here. |
 | [`LICENSE`](LICENSE), [`CONTRIBUTING.md`](CONTRIBUTING.md) | MIT licence; contribution guide. |
 
@@ -75,5 +79,5 @@ Every change runs through the validator (`.validators/lint.py`) and the CI gate:
 
 ---
 
-**Status:** maintained alongside the `notations/` specs. The methodology's version is tracked in [`CHANGELOG.md`](CHANGELOG.md); the methodology is **pre-1.0**.
-**Last updated:** 2026-06-02
+**Status:** maintained alongside the `notations/` specs. This file is the single canonical file map for the repository — `README.md` carries only a three-bucket overview that points back here. The methodology's version is tracked in [`CHANGELOG.md`](CHANGELOG.md); the methodology is **pre-1.0**.
+**Last updated:** 2026-06-05

--- a/README.md
+++ b/README.md
@@ -35,36 +35,13 @@ CI:
 
 ## Repository structure
 
-```
-transitrix/methodology/
-├── method/
-│   └── methodology.md               # Canonical methodology overview
-├── notations/                       # Notation specs — the canonical model
-│   ├── README.md                    # Index of all notations (view + element)
-│   ├── CONTRACT.md                  # Shared header / zones / lifecycle / versioning
-│   ├── IDS_AND_REFERENCES.md        # ID grammar + TYPE registry
-│   ├── ELEMENT_PRIMITIVES.md        # Element-primitive file schema
-│   ├── MANIFEST.md                  # Adopter manifest (transitrix.yaml) spec
-│   ├── views/                       # View-notation specs (BPMN, FGCA, goals, …)
-│   ├── elements/                    # Element-notation specs (codex, requirement, …)
-│   └── examples/                    # Worked example files per notation
-├── organizations/
-│   ├── acme_corp/                   # Worked example organisation
-│   │   ├── canon/                   # Zone: validated model — elements, relations, assertions, views
-│   │   ├── field/                   # Zone: raw material — interviews, surveys, observations
-│   │   ├── codex/                   # Zone: external laws + internal policies
-│   │   ├── .templates/  .validators/
-│   │   ├── transitrix.yaml          # Adopter manifest
-│   │   └── README.md  GETTING_STARTED.md  CONVENTIONS.md  AGENTS.md
-│   └── NEW_ORGANIZATION_TEMPLATE.md # How to bootstrap a new organisation
-├── migrations/                      # Per-release migration recipes (0.5→0.6)
-├── integration/                     # Studio / tooling / CI integration notes
-├── skills/                          # Onboarding + extraction skills
-├── glossary.md  PROJECT_INDEX.md  CHANGELOG.md  RELEASING.md
-├── README.md                        # This file
-├── LICENSE                          # MIT
-└── CONTRIBUTING.md                  # How to contribute
-```
+The repository has three buckets:
+
+- **Spec** — what adopters consume: [`notations/`](notations/) (CONTRACT, IDS_AND_REFERENCES, ELEMENT_PRIMITIVES, MANIFEST, COVERAGE_PROFILES, plus `views/`, `elements/`, `examples/`), [`method/`](method/), [`glossary.md`](glossary.md), [`migrations/`](migrations/).
+- **Worked example** — a sample organisation to learn from: [`organizations/acme_corp/`](organizations/acme_corp/).
+- **Tooling** — what you install or run: [`transitrix/skills/`](transitrix/skills/) (Agent Skills — onboard, ingest), [`packages/`](packages/) (CLIs — e.g. `@transitrix/ingest-cli`), [`integration/`](integration/) (Studio / CI), [`scripts/`](scripts/) (doc-lint).
+
+For the full file map, see [`PROJECT_INDEX.md`](PROJECT_INDEX.md) — the single canonical navigation guide.
 
 ## Quick start — for a new organisation
 
@@ -126,4 +103,4 @@ Transitrix — including the FGCA / FGA notations that form part of it — is au
 ---
 
 **Methodology status:** pre-1.0 — see [`CHANGELOG.md`](CHANGELOG.md) for the current release and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10 for the compatibility policy.
-**Last updated:** 2026-05-30
+**Last updated:** 2026-06-05


### PR DESCRIPTION
## Summary

- Drops the embedded ASCII tree from `README.md` — it duplicated ~80% of `PROJECT_INDEX.md` and had drifted (still listed `skills/` although the multi-skill plugin moved to `transitrix/skills/` in #114; missing `transitrix/`, `packages/`, `docs/`, `scripts/`, `NOTATIONS_VALIDATION.md`).
- `README.md` now carries a **three-bucket overview only** — *spec / worked example / tooling* — in current naming, and links to `PROJECT_INDEX.md`.
- `PROJECT_INDEX.md` is now the **single canonical file map**: added rows for `transitrix/`, `packages/`, `scripts/`, `docs/`, and `NOTATIONS_VALIDATION.md`; refreshed the trailing status line.
- Two file maps that could drift are now one.

## Scope — Part A only

This is Part A of the task. The remaining Part A items don't need a code change:

- `notations/examples/.DS_Store` and `notations/examples/bpmn/.DS_Store` — already covered by `.gitignore` (line 102, `.DS_Store`) and not tracked; local copies removed from disk, no repo change required.
- `PROJECT_RULES.md` vs `CONTRIBUTING.md` / `CLAUDE.md` — `PROJECT_RULES.md` is already gitignored (line 182, MAINTAINER-LOCAL FILES) and not in the published repo. Already resolved at the publish boundary.

**Part B is intentionally out of scope** for this PR — per the task's "individually-reviewable PRs, one concern each" instruction. The rename `organizations/ → example/`, quick-start rewrite, validator consolidation, bootstrap-path consolidation, and internal-doc relocation will land as separate PRs.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (14 view notations; examples, internal links, and `methodology_version` pins all consistent).
- [x] Re-read tails of `README.md` and `PROJECT_INDEX.md` — both end with a newline; no truncation.
- [x] Verified the dirs / files newly listed in `PROJECT_INDEX.md` (`transitrix/`, `packages/`, `scripts/`, `docs/`, `NOTATIONS_VALIDATION.md`) all exist as tracked paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)