### PR TITLE
docs: redact internal agent topology from DQ ADR deciders

### DIFF
--- a/docs/decisions/2026-06-05-data-quality-source-trust-and-freshness.md
+++ b/docs/decisions/2026-06-05-data-quality-source-trust-and-freshness.md
@@ -12,7 +12,7 @@ tags: [confidence, provenance, freshness, zones, views, data-quality]
 
 **Status:** Accepted
 **Date:** 2026-06-05
-**Deciders:** Valerii Korobeinikov; Win-Claude (Transitrix-family coordinator — decided at family level per the escalation policy)
+**Deciders:** Valerii Korobeinikov
 **Scope:** Repo-local to `methodology` (canonical owner of notation semantics). Consumed by `transitrix-dsm` (entry + storage) and `transitrix-studio` (view render). Those repos align as consumers per their standing "methodology is canon" rules; this ADR does not change their internal architecture.
 
 ---


### PR DESCRIPTION
## What

The **Deciders** line of `docs/decisions/2026-06-05-data-quality-source-trust-and-freshness.md` named an internal coordinating agent ("Win-Claude") and an internal "escalation policy" on this **public** repository. This replaces it with the human decider only.

```diff
-**Deciders:** Valerii Korobeinikov; Win-Claude (Transitrix-family coordinator — decided at family level per the escalation policy)
+**Deciders:** Valerii Korobeinikov
```

## Why

Internal agent topology / operating process should not surface on a public OSS repo — same class of rule as keeping internal project codes off public surfaces. Not a credential or security leak; a hygiene fix.

## Scope

- One line changed. The ADR is immutable point-in-time; **the decision itself is unchanged** — only the deciders attribution is corrected.
- No other occurrences found: a code search for the agent name across `org:transitrix` returned only this file.

Open PR, do not merge — Valerii gates.