### PR TITLE
Ingest skill — source_hash (SHA-256) on field artefacts

### DIFF
--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -131,6 +131,7 @@ async function cmdFieldArtefact(args) {
     console.log(`field artefact  ${res.id}  ->  ${res.outPath}`);
     console.log(`  proposed source_quality: ${res.proposedSQ} (confirm at admission)`);
     if (res.rawMoved) console.log(`  raw source retained: ${res.rawMoved}`);
+    if (res.sourceHash) console.log(`  source_hash:         ${res.sourceHash}`);
     return 0;
   } catch (err) {
     console.error(`field-artefact: ${err.message}`);

--- a/packages/ingest-cli/src/field-artefact.mjs
+++ b/packages/ingest-cli/src/field-artefact.mjs
@@ -7,6 +7,7 @@
 // never touches canon/.
 
 import { readFile, writeFile, mkdir, readdir, rename, access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { join, resolve, basename, extname } from 'node:path';
 import { isValidId, makeId, slugSegment, parseId } from './ids.mjs';
 import { dump } from './yaml.mjs';
@@ -82,10 +83,15 @@ export async function emitFieldArtefact(opts) {
   const body = await readFile(mdPath, 'utf8');
   const proposedSQ = sourceQuality || DEFAULT_SQ[type];
 
-  // Move the raw source into processed/ and record a traceable pointer.
+  // Move the raw source into processed/ and record a traceable pointer + SHA-256.
+  // The hash gives the artefact tamper-evidence (a re-saved "same" file is detected
+  // by mismatch) and a stable provenance fingerprint independent of the path.
   const raw = await findRaw(orgRoot, mdPath);
   let rawSource = null;
+  let sourceHash = null;
   if (raw) {
+    const bytes = await readFile(raw);
+    sourceHash = `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
     const dest = join(stageDir(orgRoot, 'processed'), basename(raw));
     await mkdir(stageDir(orgRoot, 'processed'), { recursive: true });
     await rename(raw, dest);
@@ -109,6 +115,7 @@ export async function emitFieldArtefact(opts) {
       setting: setting || `ingested via @transitrix/ingest-cli from ${basename(mdPath)}`,
     },
     ...(rawSource ? { raw_source: rawSource } : {}),
+    ...(sourceHash ? { source_hash: sourceHash } : {}),
     [info.body]: body,
   };
 
@@ -116,7 +123,7 @@ export async function emitFieldArtefact(opts) {
   const outPath = join(fieldDir, `${id}.yaml`);
   await writeFile(outPath, dump(artefact), 'utf8');
 
-  return { id, outPath, proposedSQ, rawMoved: rawSource };
+  return { id, outPath, proposedSQ, rawMoved: rawSource, sourceHash };
 }
 
 export { TYPE_INFO, SOURCE_QUALITY };

--- a/packages/ingest-cli/src/review-queue.mjs
+++ b/packages/ingest-cli/src/review-queue.mjs
@@ -25,6 +25,7 @@ async function readFieldArtefact(orgRoot, id) {
     id,
     proposed_source_quality: readTopScalar(text, 'source_quality'),
     raw_source: readTopScalar(text, 'raw_source') || undefined,
+    source_hash: readTopScalar(text, 'source_hash') || undefined,
   };
 }
 

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -78,7 +78,7 @@ npx @transitrix/ingest-cli field-artefact <processing/file.md> \
     --type INTERVIEW|SURVEY|OBSERVATION|DRAFT --role "<role>" --date YYYY-MM-DD
 ```
 
-The CLI fills the admission record (`zone: field`, `gate_checks.provenance`) and **proposes** a `source_quality` from the document type. The schema is [`schemas/field-artefact.schema.json`](schemas/field-artefact.schema.json); the canonical contract is [CONTRACT §6](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md) (admission record) and [§11.2](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md) (the source-trust scale).
+The CLI fills the admission record (`zone: field`, `gate_checks.provenance`) and **proposes** a `source_quality` from the document type. It also fingerprints the raw bytes as `source_hash: sha256:<hex>` alongside `raw_source` — tamper-evidence for adopters with audit needs (GDPR / SOX / ISO 27001) and source-replacement detection: a re-saved "same" file is caught by hash mismatch, not by silent drift. The schema is [`schemas/field-artefact.schema.json`](schemas/field-artefact.schema.json); the canonical contract is [CONTRACT §6](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md) (admission record) and [§11.2](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md) (the source-trust scale).
 
 **Proposed `source_quality` by document character** — closed set, the human confirms at admission:
 

--- a/transitrix/skills/ingest/schemas/field-artefact.schema.json
+++ b/transitrix/skills/ingest/schemas/field-artefact.schema.json
@@ -62,6 +62,11 @@
       "type": "string",
       "description": "Path, relative to the org root, to the retained raw file in _intake/processed/ — the byte-level source this artefact was derived from, kept for traceability."
     },
+    "source_hash": {
+      "type": "string",
+      "description": "Content fingerprint of the raw bytes the artefact was derived from. Provides tamper-evidence and source-replacement detection: a re-saved 'same' file is detected by hash mismatch, and adopters with audit needs (GDPR / SOX / ISO 27001) can prove a field record actually derives from this specific source. Format: '<algo>:<hex>', currently 'sha256:<64 lowercase hex>'.",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
     "notes": { "type": "string", "description": "Body block for type INTERVIEW — free-text transcript or notes the extraction step reads." },
     "responses": { "type": "string", "description": "Body block for type SURVEY — structured or free-text answers." },
     "observations": { "type": "string", "description": "Body block for type OBSERVATION — what was directly observed." },

--- a/transitrix/skills/ingest/schemas/review-queue.schema.json
+++ b/transitrix/skills/ingest/schemas/review-queue.schema.json
@@ -39,7 +39,12 @@
             "type": "string",
             "enum": ["authoritative", "corroborated", "single_source", "unverified"]
           },
-          "raw_source": { "type": "string" }
+          "raw_source": { "type": "string" },
+          "source_hash": {
+            "type": "string",
+            "description": "Content fingerprint of the raw bytes, surfaced for the reviewer (e.g. to compare against an inbox copy).",
+            "pattern": "^sha256:[0-9a-f]{64}$"
+          }
         },
         "additionalProperties": true
       }

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -19,6 +19,7 @@ Run:  python transitrix/skills/ingest/tests/test_ingest_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
 """
 
+import hashlib
 import json
 import os
 import re
@@ -39,6 +40,7 @@ CLI = os.path.join(REPO_ROOT, "packages", "ingest-cli", "ingest.mjs")
 FIXTURES = os.path.join(HERE, "fixtures")
 
 ID_RE = re.compile(r"^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$")
+SOURCE_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SOURCE_QUALITY = {"authoritative", "corroborated", "single_source", "unverified"}
 
 _failures = []
@@ -108,8 +110,9 @@ def part_b_pipeline():
         with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
             fh.write("transitrix: 1\nmethodology_version: \"0.5.0\"\ncoverage_profile: full\n")
 
-        shutil.copy(os.path.join(FIXTURES, "raw", "INTERVIEW-sample.md"),
-                    os.path.join(org, "_intake", "inbox", "INTERVIEW-sample.md"))
+        raw_src = os.path.join(FIXTURES, "raw", "INTERVIEW-sample.md")
+        expected_hash = "sha256:" + hashlib.sha256(open(raw_src, "rb").read()).hexdigest()
+        shutil.copy(raw_src, os.path.join(org, "_intake", "inbox", "INTERVIEW-sample.md"))
 
         r = run_cli("convert", os.path.join(org, "_intake", "inbox", "INTERVIEW-sample.md"))
         check(r.returncode == 0, f"convert failed: {r.stderr.strip()}")
@@ -128,6 +131,9 @@ def part_b_pipeline():
             check(d.get("source_quality") in SOURCE_QUALITY, f"source_quality not in the closed set: {d.get('source_quality')}")
             check(isinstance(d.get("notes"), str) and d["notes"].strip(), "field artefact body block (notes) missing")
             check(str(d.get("raw_source", "")).startswith("_intake/processed/"), "raw_source not retained under _intake/processed/")
+            sh = d.get("source_hash", "")
+            check(bool(SOURCE_HASH_RE.match(sh)), f"source_hash missing or malformed: {sh!r}")
+            check(sh == expected_hash, f"source_hash does not match raw bytes: got {sh!r}, expected {expected_hash!r}")
 
         r = run_cli("emit-candidates", art, "--from", os.path.join(FIXTURES, "extraction-result.json"))
         check(r.returncode == 0, f"emit-candidates failed: {r.stderr.strip()}")
@@ -151,6 +157,9 @@ def part_b_pipeline():
             check(q.get("gate", {}).get("admits_to_canon") is False, "review queue gate.admits_to_canon must be False")
             check(isinstance(q.get("candidates"), list) and len(q["candidates"]) >= 1, "review queue lists no candidates")
             check(len(q.get("relation_suggestions", [])) >= 1, "review queue did not carry the held-back suggestion")
+            fas = q.get("field_artefacts") or []
+            check(any(fa.get("source_hash") == expected_hash for fa in fas),
+                  "review queue did not carry the field artefact's source_hash through")
 
         # THE ONE RULE: the pipeline must never create canon/.
         check(not os.path.exists(os.path.join(org, "canon")), "pipeline created canon/ — it must only propose")


### PR DESCRIPTION
## Summary

- Every field artefact now records `source_hash: sha256:<hex>` of the raw bytes alongside `raw_source`.
- Tamper-evidence (GDPR / SOX / ISO 27001 audit trails) + source-replacement detection (a re-saved \"same\" file at the same inbox path is caught by hash mismatch).
- Optional in the schema; surfaced in CLI output and in the review-queue's field-artefact entries so a reviewer can compare it to any inbox copy.

## Scope

One concern. The hash is computed before the raw file is moved into `_intake/processed/`, stored as `sha256:<64 lowercase hex>`, and pattern-validated in the schema. No behaviour changes for `raw_source` or `source_quality`.

## Files

- `packages/ingest-cli/src/field-artefact.mjs` — compute + emit `source_hash`.
- `packages/ingest-cli/ingest.mjs` — surface it in the CLI's output line.
- `packages/ingest-cli/src/review-queue.mjs` — read it back into the queue.
- `transitrix/skills/ingest/schemas/{field-artefact,review-queue}.schema.json` — declare the field.
- `transitrix/skills/ingest/SKILL.md` — Step 3 documents the fingerprint.
- `transitrix/skills/ingest/tests/test_ingest_integrity.py` — asserts the hash matches the fixture bytes and round-trips through the review queue.

## Test plan

- [x] `python transitrix/skills/ingest/tests/test_ingest_integrity.py` — passes locally.
- [x] `node scripts/check-notations.mjs` — clean.
- [x] End-to-end smoke (`scaffold-intake → convert → field-artefact`) on the bundled fixture: artefact carries `source_hash: sha256:ac2ebc8d…`, matches `hashlib.sha256` of the raw bytes.