### PR TITLE
fix(ingest-cli): rehearsal-found validator + emitter defects

### DIFF
--- a/packages/ingest-cli/src/emit-candidates.mjs
+++ b/packages/ingest-cli/src/emit-candidates.mjs
@@ -9,12 +9,17 @@
 // Relation-conservatism (v0): only HIGH-confidence relations become candidates;
 // medium/low relations are held back as review-queue suggestions. Entities flow
 // through regardless of confidence (the flag rides along for the reviewer).
+//
+// Corroboration: when the SAME candidate (same element id, or same REL triple) is
+// emitted again from a different field source, derived_from is MERGED (union), not
+// overwritten — a fact confirmed across two sources must accumulate its citations.
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { readTopScalar } from './yaml.mjs';
 
 const REL_THRESHOLD = 'high';
+const CONFIDENCE_RANK = { low: 0, medium: 1, high: 2 };
 
 function safeName(s) {
   return String(s).replace(/[^A-Za-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '');
@@ -75,6 +80,32 @@ function candidateFilename(c, index) {
   return `candidate-${index}.json`;
 }
 
+async function fileExists(p) { try { await access(p); return true; } catch { return false; } }
+
+// Merge a freshly-shaped candidate with one already on disk for the same key:
+// union derived_from (dedup, order-preserving), keep the STRONGER extraction_confidence
+// (corroboration raises confidence), and concatenate distinct extraction_notes.
+export function mergeCandidates(existing, fresh) {
+  const derived_from = Array.isArray(existing.derived_from) ? [...existing.derived_from] : [];
+  for (const d of fresh.derived_from || []) if (!derived_from.includes(d)) derived_from.push(d);
+
+  const rank = (v) => (v in CONFIDENCE_RANK ? CONFIDENCE_RANK[v] : -1);
+  const extraction_confidence =
+    rank(fresh.extraction_confidence) >= rank(existing.extraction_confidence)
+      ? fresh.extraction_confidence : existing.extraction_confidence;
+
+  const merged = { ...existing, ...fresh, derived_from, extraction_confidence };
+
+  const notes = [];
+  for (const n of [existing.extraction_notes, fresh.extraction_notes]) {
+    if (n && !notes.includes(n)) notes.push(n);
+  }
+  if (notes.length) merged.extraction_notes = notes.join(' | ');
+  else delete merged.extraction_notes;
+
+  return merged;
+}
+
 export async function emitCandidates({ orgRoot, fieldArtefactPath, resultPath, candidatesDir }) {
   const fieldText = await readFile(fieldArtefactPath, 'utf8');
   const derivedFrom = readTopScalar(fieldText, 'id');
@@ -90,7 +121,15 @@ export async function emitCandidates({ orgRoot, fieldArtefactPath, resultPath, c
   await mkdir(dir, { recursive: true });
   let i = 0;
   for (const c of candidates) {
-    await writeFile(join(dir, candidateFilename(c, i++)), JSON.stringify(c, null, 2) + '\n', 'utf8');
+    const out = join(dir, candidateFilename(c, i++));
+    let toWrite = c;
+    if (await fileExists(out)) {
+      try {
+        const existing = JSON.parse(await readFile(out, 'utf8'));
+        toWrite = mergeCandidates(existing, c);   // corroboration — accumulate derived_from
+      } catch { /* unparseable existing file — overwrite with the fresh candidate */ }
+    }
+    await writeFile(out, JSON.stringify(toWrite, null, 2) + '\n', 'utf8');
   }
 
   // Suggestions feed the review queue (loaded by `review-queue` when present).

--- a/packages/ingest-cli/src/ids.mjs
+++ b/packages/ingest-cli/src/ids.mjs
@@ -4,11 +4,18 @@
 
 export const ID_RE = /^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$/;
 
+// Capability V/H diagram-address exception (IDS_AND_REFERENCES.md §1): a capability
+// is addressed by a vertical/horizontal diagram path instead of a terminal integer —
+// CAPABILITY-V1, CAPABILITY-V1.2, CAPABILITY-H1.2.3 — capped at three levels, each
+// level a positive integer with no leading zeros. The general ID_RE rejects this form
+// (no terminal -<INTEGER>), so isValidId accepts it explicitly.
+export const CAPABILITY_ADDRESS_RE = /^CAPABILITY-[VH][1-9][0-9]*(?:\.[1-9][0-9]*){0,2}$/;
+
 // A bare TYPE prefix: uppercase, letter-led.
 export const TYPE_RE = /^[A-Z][A-Z0-9_]*$/;
 
 export function isValidId(id) {
-  return typeof id === 'string' && ID_RE.test(id);
+  return typeof id === 'string' && (ID_RE.test(id) || CAPABILITY_ADDRESS_RE.test(id));
 }
 
 export function isValidType(type) {
@@ -16,8 +23,11 @@ export function isValidType(type) {
 }
 
 // Split an ID into { type, middle: [...], ordinal }. Returns null if invalid.
+// Tests the integer-ordinal grammar only: capability V/H addresses are valid IDs but
+// carry no terminal ordinal, so they (correctly) return null here — the ID-generation
+// paths (field-artefact ordinals, compareIds) never operate on capability addresses.
 export function parseId(id) {
-  if (!isValidId(id)) return null;
+  if (typeof id !== 'string' || !ID_RE.test(id)) return null;
   const parts = id.split('-');
   const ordinal = Number(parts[parts.length - 1]);
   const type = parts[0];

--- a/packages/ingest-cli/src/validate.mjs
+++ b/packages/ingest-cli/src/validate.mjs
@@ -15,6 +15,17 @@ import { classifyCoverage } from './coverage.mjs';
 
 const EXTRACTION_CONFIDENCE = new Set(['high', 'medium', 'low']);
 
+// Closed REL `type` enum — notations/elements/17-relations.md §3. The enum is closed
+// in v1; adding a kind is a non-backwards-compatible methodology revision. The CLI
+// tracks it (like ID_RE) so a rel_kind outside the enum is FLAGGED for review — never
+// silently emitted, never dropped. This completes the candidate contract: the bundle's
+// candidate.schema.json names "closed REL kinds" among what validation_flags covers.
+const CLOSED_REL_KINDS = new Set([
+  'parent', 'goal_parent', 'target_state_satisfies_goal', 'assessment_influences_goal',
+  'activity_goal', 'unit_parent', 'employment', 'candidacy', 'alumni_membership',
+  'community_membership', 'contracting', 'stakeholding',
+]);
+
 // Validate one candidate against `profile`. Returns
 // { validation_flags: [...], coverage_flag, coverage_reason? }.
 export function validateCandidate(cand, profile) {
@@ -50,6 +61,7 @@ export function validateCandidate(cand, profile) {
     type = cand.element_type;
   } else if (cand.kind === 'relation') {
     if (!cand.rel_kind) flags.push('relation is missing rel_kind');
+    else if (!CLOSED_REL_KINDS.has(cand.rel_kind)) flags.push(`rel_kind is not a closed REL kind (17-relations.md §3): ${cand.rel_kind}`);
     if (!isValidId(cand.from)) flags.push(`relation "from" violates the ID grammar: ${cand.from}`);
     if (!isValidId(cand.to)) flags.push(`relation "to" violates the ID grammar: ${cand.to}`);
     type = cand.rel_kind;
@@ -77,4 +89,4 @@ export async function loadCandidates(dir) {
   return out;
 }
 
-export { EXTRACTION_CONFIDENCE };
+export { EXTRACTION_CONFIDENCE, CLOSED_REL_KINDS };

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """From-scratch pipeline test for the Transitrix Ingest skill + @transitrix/ingest-cli.
 
-Deterministic, no-API-key guard. Two parts:
+Deterministic, no-API-key guard. Three parts:
 
   A. Bundle integrity — SKILL.md frontmatter, the three JSON schemas parse, the
      three layer prompts + READMEs exist, the _intake template is present.
@@ -11,6 +11,8 @@ Deterministic, no-API-key guard. Two parts:
      proposed source_quality, candidate files, a review queue with the gate closed,
      the two-axes rule (a candidate carrying source_quality is flagged), and THE ONE
      RULE — canon/ is never written.
+  C. IG-5 regressions — the three rehearsal-found defects: capability V/H ID is
+     accepted, a non-closed rel_kind is flagged, derived_from merges across sources.
 
 This is the PR-CI guard. The LLM-driven walk-through lives in drive_ingest_e2e.py,
 gated to the weekly cron. See tests/README.md.
@@ -58,7 +60,7 @@ def frontmatter(path):
     return yaml.safe_load(m.group(1)) if m else None
 
 
-# ── Part A — bundle integrity ────────────────────────────────────────────────
+# ── Part A — bundle integrity ───────────────────────────────────
 
 def part_a_bundle():
     skill = os.path.join(SKILL_DIR, "SKILL.md")
@@ -86,7 +88,7 @@ def part_a_bundle():
     check(os.path.isfile(CLI), "CLI entry point missing: packages/ingest-cli/ingest.mjs")
 
 
-# ── Part B — CLI pipeline drive ──────────────────────────────────────────────
+# ── Part B — CLI pipeline drive ──────────────────────────────────
 
 def run_cli(*args):
     return subprocess.run(["node", CLI, *args], capture_output=True, text=True)
@@ -176,8 +178,78 @@ def part_b_pipeline():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part C — IG-5 regressions (rehearsal-found defects) ──────────────────
+
+def part_c_ig5():
+    """Capability V/H ID accepted, closed-REL-kind flag, derived_from merge."""
+    if not shutil.which("node"):
+        print("SKIP Part C: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-ig5-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        os.makedirs(cdir, exist_ok=True)
+
+        def cand(name, obj):
+            with open(os.path.join(cdir, name), "w", encoding="utf-8") as fh:
+                json.dump(obj, fh)
+
+        fid = "INTERVIEW-x-20260101-1"
+        cand("CAP.json", {"kind": "element", "id": "CAPABILITY-V1.2", "name": "Cap",
+                          "element_type": "CAPABILITY", "derived_from": [fid],
+                          "admitted_to": "pending", "extraction_confidence": "high"})
+        cand("RELbad.json", {"kind": "relation", "rel_kind": "contributes_to",
+                             "from": "FACTOR-A-1", "to": "GOAL-B-1", "derived_from": [fid],
+                             "admitted_to": "pending", "extraction_confidence": "high"})
+        cand("RELok.json", {"kind": "relation", "rel_kind": "stakeholding",
+                            "from": "STAKEHOLDER-A-1", "to": "GOAL-B-1", "derived_from": [fid],
+                            "admitted_to": "pending", "extraction_confidence": "high"})
+
+        r = run_cli("validate", cdir)
+        out = r.stdout + r.stderr
+        check("violates the ID grammar: CAPABILITY-V1.2" not in out,
+              "IG-5a: capability V/H address (CAPABILITY-V1.2) wrongly flagged for ID grammar")
+        check("contributes_to" in out and "closed REL kind" in out,
+              "IG-5c: a non-closed rel_kind (contributes_to) was not flagged")
+        check("stakeholding" not in out,
+              "IG-5c: a valid closed rel_kind (stakeholding) was wrongly flagged")
+
+        fdir = os.path.join(org, "field", "interviews")
+        os.makedirs(fdir, exist_ok=True)
+        for f in ("INTERVIEW-a-20260101-1", "INTERVIEW-b-20260101-1"):
+            with open(os.path.join(fdir, f + ".yaml"), "w", encoding="utf-8") as fh:
+                fh.write('id: "%s"\nname: "x"\ntype: "INTERVIEW"\nzone: "field"\nnotes: "x"\n' % f)
+        res = os.path.join(work, "res.json")
+        mdir = os.path.join(org, "_intake", "processing", "merge")
+
+        def emit(field_id, conf):
+            with open(res, "w", encoding="utf-8") as fh:
+                json.dump({"elements": [{"id": "GOAL-SHARED-1", "name": "Shared",
+                                         "element_type": "GOAL", "extraction_confidence": conf}],
+                           "relations": []}, fh)
+            return run_cli("emit-candidates", os.path.join(fdir, field_id + ".yaml"),
+                           "--from", res, "--candidates-dir", mdir)
+
+        emit("INTERVIEW-a-20260101-1", "medium")
+        emit("INTERVIEW-b-20260101-1", "high")
+        merged = json.load(open(os.path.join(mdir, "GOAL-SHARED-1.json"), encoding="utf-8"))
+        check(sorted(merged.get("derived_from", [])) == ["INTERVIEW-a-20260101-1", "INTERVIEW-b-20260101-1"],
+              "IG-5b: derived_from not merged across two sources: %r" % merged.get("derived_from"))
+        check(merged.get("extraction_confidence") == "high",
+              "IG-5b: merge did not keep the stronger extraction_confidence: %r" % merged.get("extraction_confidence"))
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
+part_c_ig5()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## What

Three correctness fixes in `@transitrix/ingest-cli`, surfaced by rehearsing the ingest pipeline on a synthetic acme corpus (see ADR `docs/decisions/2026-06-07-ingest-field-codex-two-routes.md`). One commit per concern + a test commit.

- **`ids`** — accept the canonical **CAPABILITY V/H diagram address** (`CAPABILITY-V1`, `-V1.2`, `-H1.2.3`) per `IDS_AND_REFERENCES.md §1`. The general `ID_RE` requires a terminal integer, so every capability candidate was wrongly flagged for "ID grammar". `parseId` still returns `null` for these (no terminal ordinal) — only `isValidId` learns the exception; the ID-generation paths never touch capability addresses.
- **`validate`** — flag a relation candidate whose `rel_kind` is **not in the closed REL enum** (`17-relations.md §3`). This completes the candidate contract: `candidate.schema.json` already lists "closed REL kinds" among what `validation_flags` covers, but the check was missing. Soft flag for review, never a drop.
- **`emit-candidates`** — **merge `derived_from`** (union, dedup) and keep the **stronger `extraction_confidence`** when the same candidate (same element id / same REL triple) is emitted again from another source, instead of overwriting. Corroboration across sources must accumulate citations, not lose them.

## Tests

Adds **Part C** to the integrity test (`test_ingest_integrity.py`) covering all three: `CAPABILITY-V1.2` validates clean, `contributes_to` is flagged while `stakeholding` stays clean, and a `GOAL-SHARED-1` emitted from two field artefacts ends with both in `derived_from` at the higher confidence. Full A+B+C suite passes locally (`PASS`).

## Notes

Scope-limited to the unambiguous defects. The remaining two rehearsal findings are deliberately **not** in this PR: the field-artefact-schema-vs-acme-example reconcile and the structured-import `source_quality` default are judgement calls left for a separate decision (the CLI's conservative default is arguably correct by design). **Do not merge — Valerii gates;** prefer a clean squash message.