### PR TITLE
feat(ingest-cli): assertion candidate kind (codex-route prep, IG-1)

### DIFF
--- a/packages/ingest-cli/src/emit-candidates.mjs
+++ b/packages/ingest-cli/src/emit-candidates.mjs
@@ -1,18 +1,21 @@
 // `emit-candidates` — take the agent's extraction RESULT (produced by running the
 // prompts/ over a field artefact) and emit typed canon CANDIDATES. The CLI does the
 // deterministic part: it reads derived_from from the field artefact itself, shapes
-// each element/relation into a candidate (admitted_to: pending, the field ID in
-// derived_from, extraction_confidence carried through as a review flag), applies
+// each element/relation/assertion into a candidate (admitted_to: pending, the field ID
+// in derived_from, extraction_confidence carried through as a review flag), applies
 // relation-conservatism, and writes candidate *.json. It never extracts (that is the
 // agent's job) and never writes canon.
 //
 // Relation-conservatism (v0): only HIGH-confidence relations become candidates;
-// medium/low relations are held back as review-queue suggestions. Entities flow
-// through regardless of confidence (the flag rides along for the reviewer).
+// medium/low relations are held back as review-queue suggestions. Entities and
+// assertions flow through regardless of confidence (the flag rides along for the
+// reviewer) — an ASSERTION is a constrained claim (about a REQUIREMENT, restricted
+// subject TYPE, closed status enum), and the human gate adjudicates every one.
 //
-// Corroboration: when the SAME candidate (same element id, or same REL triple) is
-// emitted again from a different field source, derived_from is MERGED (union), not
-// overwritten — a fact confirmed across two sources must accumulate its citations.
+// Corroboration: when the SAME candidate (same element id / same REL triple / same
+// assertion id) is emitted again from a different field source, derived_from is MERGED
+// (union), not overwritten — a fact confirmed across two sources must accumulate its
+// citations.
 
 import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
@@ -71,11 +74,28 @@ export function shapeCandidates(derivedFrom, result) {
     }
   }
 
+  for (const a of result.assertions || []) {
+    const c = {
+      kind: 'assertion',
+      id: a.id,
+      about: a.about,
+      subject: a.subject,
+      status: a.status,
+      derived_from: [derivedFrom],
+      admitted_to: 'pending',
+      extraction_confidence: a.extraction_confidence,
+    };
+    if (a.realised_via !== undefined) c.realised_via = a.realised_via;
+    if (a.evidence !== undefined) c.evidence = a.evidence;
+    if (a.extraction_notes) c.extraction_notes = a.extraction_notes;
+    candidates.push(c);
+  }
+
   return { candidates, suggestions };
 }
 
 function candidateFilename(c, index) {
-  if (c.kind === 'element' && c.id) return `${safeName(c.id)}.json`;
+  if ((c.kind === 'element' || c.kind === 'assertion') && c.id) return `${safeName(c.id)}.json`;
   if (c.kind === 'relation') return `REL_${safeName(c.rel_kind)}__${safeName(c.from)}__${safeName(c.to)}.json`;
   return `candidate-${index}.json`;
 }

--- a/packages/ingest-cli/src/validate.mjs
+++ b/packages/ingest-cli/src/validate.mjs
@@ -26,6 +26,16 @@ const CLOSED_REL_KINDS = new Set([
   'community_membership', 'contracting', 'stakeholding',
 ]);
 
+// ASSERTION contract — notations/elements/16-assertion.md §2/§3. `about` must reference
+// a REQUIREMENT (ASSERT-002 resolution is canon-side; the candidate stage checks the
+// grammar + TYPE prefix); `subject` TYPE is restricted (ASSERT-003); `status` is a
+// closed enum. Cross-document resolution (does `about` resolve to an admitted
+// REQUIREMENT) happens at the human admission gate, not here.
+const ASSERTION_STATUS = new Set(['compliant', 'partial', 'non_compliant', 'under_review', 'n_a']);
+const ASSERTION_SUBJECT_TYPES = new Set(['PRODUCT', 'PROCESS', 'CAPABILITY']);
+
+function typeOf(id) { return typeof id === 'string' ? id.split('-')[0] : null; }
+
 // Validate one candidate against `profile`. Returns
 // { validation_flags: [...], coverage_flag, coverage_reason? }.
 export function validateCandidate(cand, profile) {
@@ -34,8 +44,8 @@ export function validateCandidate(cand, profile) {
     return { validation_flags: ['candidate is not a JSON object'], coverage_flag: 'out_of_profile' };
   }
 
-  if (cand.kind !== 'element' && cand.kind !== 'relation') {
-    flags.push(`kind must be "element" or "relation" (got ${JSON.stringify(cand.kind)})`);
+  if (cand.kind !== 'element' && cand.kind !== 'relation' && cand.kind !== 'assertion') {
+    flags.push(`kind must be "element", "relation" or "assertion" (got ${JSON.stringify(cand.kind)})`);
   }
   if (!Array.isArray(cand.derived_from) || cand.derived_from.length < 1) {
     flags.push('derived_from must cite at least one field artefact ID');
@@ -65,6 +75,18 @@ export function validateCandidate(cand, profile) {
     if (!isValidId(cand.from)) flags.push(`relation "from" violates the ID grammar: ${cand.from}`);
     if (!isValidId(cand.to)) flags.push(`relation "to" violates the ID grammar: ${cand.to}`);
     type = cand.rel_kind;
+  } else if (cand.kind === 'assertion') {
+    if (!isValidId(cand.id)) flags.push(`assertion id violates the ID grammar: ${cand.id}`);
+    if (!isValidId(cand.about)) flags.push(`assertion "about" violates the ID grammar: ${cand.about}`);
+    else if (typeOf(cand.about) !== 'REQUIREMENT') flags.push(`assertion "about" must reference a REQUIREMENT (ASSERT-002): ${cand.about}`);
+    if (!isValidId(cand.subject)) flags.push(`assertion "subject" violates the ID grammar: ${cand.subject}`);
+    else if (!ASSERTION_SUBJECT_TYPES.has(typeOf(cand.subject))) flags.push(`assertion "subject" TYPE must be PRODUCT|PROCESS|CAPABILITY (ASSERT-003): ${cand.subject}`);
+    if (!ASSERTION_STATUS.has(cand.status)) flags.push(`assertion status must be compliant|partial|non_compliant|under_review|n_a (got ${JSON.stringify(cand.status)})`);
+    if (cand.realised_via !== undefined) {
+      if (!Array.isArray(cand.realised_via)) flags.push('assertion realised_via must be an array of typed IDs');
+      else for (const rv of cand.realised_via) if (!isValidId(rv)) flags.push(`assertion realised_via has an invalid ID: ${rv}`);
+    }
+    type = 'ASSERTION';
   }
 
   const cov = classifyCoverage(profile, type);
@@ -89,4 +111,4 @@ export async function loadCandidates(dir) {
   return out;
 }
 
-export { EXTRACTION_CONFIDENCE, CLOSED_REL_KINDS };
+export { EXTRACTION_CONFIDENCE, CLOSED_REL_KINDS, ASSERTION_STATUS, ASSERTION_SUBJECT_TYPES };

--- a/transitrix/skills/ingest/schemas/candidate.schema.json
+++ b/transitrix/skills/ingest/schemas/candidate.schema.json
@@ -10,7 +10,7 @@
     "kind": {
       "type": "string",
       "description": "Whether this candidate is an element or a typed relation.",
-      "enum": ["element", "relation"]
+      "enum": ["element", "relation", "assertion"]
     },
     "derived_from": {
       "type": "array",
@@ -87,6 +87,24 @@
         }
       },
       "required": ["rel_kind", "from", "to"]
+    },
+    {
+      "title": "Assertion candidate",
+      "description": "A compliance claim that a subject (PRODUCT/PROCESS/CAPABILITY) satisfies a REQUIREMENT (16-assertion.md). Constrained: about -> REQUIREMENT (ASSERT-002), subject TYPE restricted (ASSERT-003), status a closed enum. Flows as a candidate regardless of confidence; the human gate adjudicates.",
+      "properties": {
+        "kind": { "const": "assertion" },
+        "id": {
+          "type": "string",
+          "description": "Canonical assertion ID: ASSERTION-[<middle>-]<INTEGER>.",
+          "pattern": "^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$"
+        },
+        "about": { "type": "string", "description": "Typed ID of the REQUIREMENT this assertion is about (ASSERT-002)." },
+        "subject": { "type": "string", "description": "Typed ID of the subject element; TYPE in {PRODUCT, PROCESS, CAPABILITY} (ASSERT-003)." },
+        "status": { "type": "string", "enum": ["compliant", "partial", "non_compliant", "under_review", "n_a"] },
+        "realised_via": { "type": "array", "items": { "type": "string" }, "description": "Optional typed IDs of elements that realise the requirement (ASSERT-004)." },
+        "evidence": { "type": "array", "description": "Optional hybrid evidence entries (16-assertion.md §4)." }
+      },
+      "required": ["id", "about", "subject", "status"]
     }
   ]
 }

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """From-scratch pipeline test for the Transitrix Ingest skill + @transitrix/ingest-cli.
 
-Deterministic, no-API-key guard. Three parts:
+Deterministic, no-API-key guard. Four parts:
 
   A. Bundle integrity — SKILL.md frontmatter, the three JSON schemas parse, the
      three layer prompts + READMEs exist, the _intake template is present.
@@ -13,6 +13,8 @@ Deterministic, no-API-key guard. Three parts:
      RULE — canon/ is never written.
   C. IG-5 regressions — the three rehearsal-found defects: capability V/H ID is
      accepted, a non-closed rel_kind is flagged, derived_from merges across sources.
+  D. IG-1 assertion candidate — emit shapes an assertion; a valid one passes,
+     bad subject TYPE / status / non-REQUIREMENT about are flagged.
 
 This is the PR-CI guard. The LLM-driven walk-through lives in drive_ingest_e2e.py,
 gated to the weekly cron. See tests/README.md.
@@ -247,9 +249,70 @@ def part_c_ig5():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part D — IG-1 assertion candidate kind ───────────────────────────────────
+
+def part_d_ig1():
+    """Assertion candidate: emit shaping, valid passes, bad subject/status/about flagged."""
+    if not shutil.which("node"):
+        print("SKIP Part D: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-ig1-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+
+        fdir = os.path.join(org, "field", "interviews")
+        os.makedirs(fdir, exist_ok=True)
+        fid = "INTERVIEW-law-20260101-1"
+        with open(os.path.join(fdir, fid + ".yaml"), "w", encoding="utf-8") as fh:
+            fh.write('id: "%s"\nname: "x"\ntype: "INTERVIEW"\nzone: "field"\nnotes: "x"\n' % fid)
+
+        res = os.path.join(work, "res.json")
+        with open(res, "w", encoding="utf-8") as fh:
+            json.dump({"elements": [], "relations": [],
+                       "assertions": [{"id": "ASSERTION-FLEXLINE-CERT-1",
+                                       "about": "REQUIREMENT-CERT-1", "subject": "PRODUCT-FLEXLINE-1",
+                                       "status": "under_review", "realised_via": ["CAPABILITY-V1.2"],
+                                       "extraction_confidence": "medium"}]}, fh)
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        run_cli("emit-candidates", os.path.join(fdir, fid + ".yaml"), "--from", res, "--candidates-dir", cdir)
+
+        shaped = json.load(open(os.path.join(cdir, "ASSERTION-FLEXLINE-CERT-1.json"), encoding="utf-8"))
+        check(shaped.get("kind") == "assertion" and shaped.get("admitted_to") == "pending"
+              and shaped.get("derived_from") == [fid] and shaped.get("subject") == "PRODUCT-FLEXLINE-1",
+              "IG-1: emit-candidates did not shape an assertion candidate correctly: %r" % shaped)
+
+        # A valid assertion (PRODUCT subject, closed status, REQUIREMENT about) validates clean.
+        r = run_cli("validate", cdir)
+        check(r.returncode == 0, "IG-1: a valid assertion candidate was flagged: %s" % (r.stdout + r.stderr))
+
+        def cand(name, obj):
+            with open(os.path.join(cdir, name), "w", encoding="utf-8") as fh:
+                json.dump(obj, fh)
+        base = {"kind": "assertion", "derived_from": [fid], "admitted_to": "pending",
+                "extraction_confidence": "high"}
+        cand("A_badsubj.json", {**base, "id": "ASSERTION-X-1", "about": "REQUIREMENT-C-1",
+                                "subject": "GOAL-Z-1", "status": "compliant"})
+        cand("A_badstatus.json", {**base, "id": "ASSERTION-Y-1", "about": "REQUIREMENT-C-1",
+                                  "subject": "PROCESS-P-1", "status": "maybe"})
+        cand("A_badabout.json", {**base, "id": "ASSERTION-W-1", "about": "GOAL-G-1",
+                                 "subject": "CAPABILITY-V1", "status": "compliant"})
+        r = run_cli("validate", cdir)
+        out = r.stdout + r.stderr
+        check("ASSERT-003" in out, "IG-1: bad assertion subject TYPE not flagged (ASSERT-003)")
+        check("assertion status must be" in out, "IG-1: bad assertion status not flagged")
+        check("ASSERT-002" in out, "IG-1: assertion about non-REQUIREMENT not flagged (ASSERT-002)")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
+part_d_ig1()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## What

Adds a third candidate `kind`, **`assertion`**, so the field→canon pipeline can shape the `REQUIREMENT`→`ASSERTION` binding the **codex route** needs (`16-assertion.md`). `REQUIREMENT` already flows as an element; this PR adds the binding step that the field candidate schema previously could not represent (the gap the acme rehearsal exposed). IG-1 of ADR `2026-06-07-ingest-field-codex-two-routes`.

- **candidate.schema.json** — `kind` gains `assertion`; new `oneOf` variant (`about` / `subject` / `status` / `realised_via` / `evidence`; required `id`/`about`/`subject`/`status`).
- **validate** — `kind:assertion` branch: `about` must reference a `REQUIREMENT` (ASSERT-002 grammar/TYPE check; canon resolution stays at the human gate), `subject` TYPE ∈ {PRODUCT, PROCESS, CAPABILITY} (ASSERT-003), `status` a closed enum, `realised_via` IDs grammar-checked.
- **emit-candidates** — shape `result.assertions[]` into `kind:assertion` candidates. They flow **regardless of confidence** (a constrained, human-gated claim) — deliberately distinct from relation-conservatism; the `extraction_confidence` flag rides along for the reviewer.
- **tests** — Part D: emit shaping + a valid assertion passes; bad subject TYPE (ASSERT-003), bad status, and a non-`REQUIREMENT` `about` (ASSERT-002) are each flagged. Full A+B+C+D suite passes locally (`PASS`).

## Stacking & scope

**Stacked on #132** (rehearsal-found defects) — base is `fix/ingest-cli-rehearsal-defects`, so this PR shows only the IG-1 diff; retarget to `main` once #132 merges. Decision context: ingest skill+CLI is **tooling, not normative methodology** — kept in-repo for now, flagged as a candidate to extract to its own tooling repo (~1.0), like `@transitrix/diagrams`. IG-2 (the codex artefact emitter / `admit-source --zone codex`) is the follow-up that consumes this. **Do not merge — Valerii gates;** clean squash.