### PR TITLE
feat(ingest-cli): codex-artefact emitter — the codex route (IG-2)

### DIFF
--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -8,8 +8,8 @@
 //
 // Exit codes:  0 = ok  ·  1 = usage / findings that need review  ·  2 = error
 //
-// Implemented: --version, scaffold-intake, convert, field-artefact.
-// emit-candidates / validate / review-queue land next.
+// Implemented: --version, scaffold-intake, convert, field-artefact, codex-artefact,
+// emit-candidates, validate, review-queue.
 
 import { readFile, access } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -22,6 +22,7 @@ import { validateCandidate, loadCandidates } from './src/validate.mjs';
 import { readCoverageProfile } from './src/coverage.mjs';
 import { buildReviewQueue, writeReviewQueue } from './src/review-queue.mjs';
 import { emitCandidates } from './src/emit-candidates.mjs';
+import { emitCodexArtefact } from './src/codex-artefact.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -58,6 +59,10 @@ function usage() {
     '  field-artefact <md> --type T --role R --date YYYY-MM-DD [--setting S]',
     '                 [--captured-by X] [--source-quality Q] [--slug SL] [--admitted-at A]',
     '                                 Emit a field artefact with a proposed source_quality',
+    '  codex-artefact <md> --type LAW|REGULATION|POLICY|INTERNAL_STANDARD',
+    '                 --effective-date YYYY-MM-DD [--jurisdiction J] [--source-authority A]',
+    '                 [--issuing-authority A] [--slug SL] [--monitoring] [--name N] [--admitted-at A]',
+    '                                 Admit a faithful codex (law/policy) source artefact',
     '  emit-candidates <field-artefact> --from <result.json> [--candidates-dir <dir>]',
     '                                 Shape the agent extraction result into candidates',
     '  validate <candidates-dir>      Validate candidate *.json against the contract + coverage profile',
@@ -135,6 +140,44 @@ async function cmdFieldArtefact(args) {
     return 0;
   } catch (err) {
     console.error(`field-artefact: ${err.message}`);
+    return 2;
+  }
+}
+
+async function cmdCodexArtefact(args) {
+  const { _, flags } = parseArgs(args);
+  const md = _[0];
+  if (!md) { console.error('codex-artefact: missing <md> (a converted file in _intake/processing/)'); return 1; }
+  const mdPath = resolve(md);
+  try { await access(mdPath); } catch { console.error(`codex-artefact: file not found: ${md}`); return 2; }
+  if (!flags.type || !flags['effective-date']) {
+    console.error('codex-artefact: --type and --effective-date are required');
+    return 1;
+  }
+  const orgRoot = await findOrgRoot(mdPath);
+  if (!orgRoot) { console.error(`codex-artefact: "${md}" is not inside an _intake/ workspace.`); return 2; }
+
+  try {
+    const res = await emitCodexArtefact({
+      orgRoot, mdPath,
+      type: String(flags.type).toUpperCase(),
+      jurisdiction: flags.jurisdiction,
+      effectiveDate: flags['effective-date'],
+      sourceAuthority: flags['source-authority'],
+      issuingAuthority: flags['issuing-authority'],
+      admittedAt: flags['admitted-at'] || today(),
+      admittedBy: flags['admitted-by'] || '@transitrix/ingest-cli',
+      monitoring: flags.monitoring === true || flags.monitoring === 'true',
+      slug: flags.slug,
+      name: flags.name,
+    });
+    console.log(`codex artefact  ${res.id}  ->  ${res.outPath}`);
+    console.log(`  zone: codex (${res.scope}) — authoritative by construction; derive obligations as REQUIREMENT + ASSERTION candidates`);
+    if (res.snapshotFile) console.log(`  snapshot retained: ${res.snapshotFile}`);
+    if (res.sourceHash) console.log(`  source_hash:       ${res.sourceHash}`);
+    return 0;
+  } catch (err) {
+    console.error(`codex-artefact: ${err.message}`);
     return 2;
   }
 }
@@ -226,6 +269,7 @@ async function main(argv) {
     case 'scaffold-intake': return cmdScaffoldIntake(args);
     case 'convert':         return cmdConvert(args);
     case 'field-artefact':  return cmdFieldArtefact(args);
+    case 'codex-artefact':  return cmdCodexArtefact(args);
     case 'emit-candidates': return cmdEmitCandidates(args);
     case 'validate':        return cmdValidate(args);
     case 'review-queue':    return cmdReviewQueue(args);

--- a/packages/ingest-cli/src/codex-artefact.mjs
+++ b/packages/ingest-cli/src/codex-artefact.mjs
@@ -1,0 +1,138 @@
+// `codex-artefact` — admit a converted external law/regulation or internal policy /
+// standard into the CODEX zone as a FAITHFUL source artefact (14-codex.md §3/§4).
+//
+// Unlike a FIELD artefact, a codex artefact:
+//   - carries NO source_quality — a codex source is authoritative by construction;
+//   - embeds NO extracted content — it records the source's identity + admission
+//     record + a snapshot pointer to the retained raw bytes (the source text stays in
+//     _intake/processing/ for the extraction step).
+//
+// Obligations are derived downstream as REQUIREMENT (element) + ASSERTION candidates
+// via `emit-candidates`, each citing this artefact through derived_from. Admission to
+// codex/ is a zone admission (gate_checks.source_authority), parallel to the field
+// flow's admission to field/. This command NEVER writes canon/.
+
+import { readFile, writeFile, mkdir, readdir, rename, access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, resolve, basename, extname } from 'node:path';
+import { isValidId, makeId, slugSegment, parseId } from './ids.mjs';
+import { dump } from './yaml.mjs';
+import { stageDir } from './intake.mjs';
+
+// CODEX TYPE -> sub-zone (14-codex.md §2).
+const TYPE_INFO = {
+  LAW:               { scope: 'external' },
+  REGULATION:        { scope: 'external' },
+  POLICY:            { scope: 'internal' },
+  INTERNAL_STANDARD: { scope: 'internal' },
+};
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+// Next free ordinal for IDs sharing a TYPE + middle prefix in a codex folder.
+async function nextOrdinal(dir, type, middle) {
+  if (!(await exists(dir))) return 1;
+  const want = [type, ...middle].join('-');
+  let max = 0;
+  for (const name of await readdir(dir)) {
+    if (!name.endsWith('.yaml')) continue;
+    const p = parseId(basename(name, '.yaml'));
+    if (!p) continue;
+    if ([p.type, ...p.middle].join('-') === want) max = Math.max(max, p.ordinal);
+  }
+  return max + 1;
+}
+
+// Find the raw source in inbox/ matching a converted md by basename stem.
+async function findRaw(orgRoot, mdPath) {
+  const inbox = stageDir(orgRoot, 'inbox');
+  if (!(await exists(inbox))) return null;
+  const stem = basename(mdPath, extname(mdPath));
+  for (const name of await readdir(inbox)) {
+    if (basename(name, extname(name)) === stem) return join(inbox, name);
+  }
+  return null;
+}
+
+export async function emitCodexArtefact(opts) {
+  const {
+    orgRoot, mdPath, type, jurisdiction, effectiveDate, sourceAuthority,
+    issuingAuthority, admittedAt, admittedBy, monitoring, slug, name,
+  } = opts;
+
+  const info = TYPE_INFO[type];
+  if (!info) throw new Error(`unknown --type ${type}; expected one of ${Object.keys(TYPE_INFO).join(', ')}`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(effectiveDate || '')) throw new Error('--effective-date must be YYYY-MM-DD');
+
+  let codexDir;
+  let frontJurisdiction = null;
+  if (info.scope === 'external') {
+    if (!jurisdiction) throw new Error(`--jurisdiction is required for ${type} (codex/external/<jurisdiction>/, CODEX-001)`);
+    frontJurisdiction = String(jurisdiction).toLowerCase();
+    codexDir = join(resolve(orgRoot), 'codex', 'external', frontJurisdiction);
+  } else {
+    if (!issuingAuthority) throw new Error(`--issuing-authority is required for ${type} (codex/internal/)`);
+    codexDir = join(resolve(orgRoot), 'codex', 'internal');
+  }
+
+  const seg = slug ? slugSegment(slug) : slugSegment(name);
+  if (!seg) throw new Error('could not derive an ID segment from --slug/--name; pass --slug');
+  const middle = [seg];
+  const ordinal = await nextOrdinal(codexDir, type, middle);
+  const id = makeId(type, middle, ordinal);
+  if (!isValidId(id)) throw new Error(`generated an invalid ID: ${id}`);
+
+  // Snapshot the raw bytes into the codex sources/ subfolder (audit trail) + fingerprint.
+  const raw = await findRaw(orgRoot, mdPath);
+  let snapshotFile = null;
+  let snapshotDate = null;
+  let sourceHash = null;
+  if (raw) {
+    const bytes = await readFile(raw);
+    sourceHash = `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+    snapshotDate = admittedAt;
+    const sourcesDir = join(codexDir, 'sources');
+    await mkdir(sourcesDir, { recursive: true });
+    const snapName = `snapshot_${id}_${snapshotDate}${extname(raw)}`;
+    await rename(raw, join(sourcesDir, snapName));
+    snapshotFile = `sources/${snapName}`;
+  }
+
+  const common = {
+    id,
+    name: name || `${type} — ${seg}`,
+    type,
+    zone: 'codex',
+    admitted_at: admittedAt,
+    admitted_by: admittedBy,
+  };
+  const snapshot = {
+    ...(snapshotFile ? { snapshot_file: snapshotFile, snapshot_date: snapshotDate } : {}),
+    ...(sourceHash ? { source_hash: sourceHash } : {}),
+  };
+
+  const artefact = info.scope === 'external'
+    ? {
+        ...common,
+        gate_checks: { source_authority: sourceAuthority || 'recorded' },
+        jurisdiction: frontJurisdiction,
+        effective_date: effectiveDate,
+        ...snapshot,
+        monitoring_needed: Boolean(monitoring),
+      }
+    : {
+        ...common,
+        gate_checks: { source_authority: issuingAuthority },
+        issuing_authority: issuingAuthority,
+        effective_date: effectiveDate,
+        ...snapshot,
+      };
+
+  await mkdir(codexDir, { recursive: true });
+  const outPath = join(codexDir, `${id}.yaml`);
+  await writeFile(outPath, dump(artefact), 'utf8');
+
+  return { id, outPath, snapshotFile, sourceHash, scope: info.scope };
+}
+
+export { TYPE_INFO };

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """From-scratch pipeline test for the Transitrix Ingest skill + @transitrix/ingest-cli.
 
-Deterministic, no-API-key guard. Four parts:
+Deterministic, no-API-key guard. Five parts:
 
   A. Bundle integrity — SKILL.md frontmatter, the three JSON schemas parse, the
      three layer prompts + READMEs exist, the _intake template is present.
@@ -15,6 +15,8 @@ Deterministic, no-API-key guard. Four parts:
      accepted, a non-closed rel_kind is flagged, derived_from merges across sources.
   D. IG-1 assertion candidate — emit shapes an assertion; a valid one passes,
      bad subject TYPE / status / non-REQUIREMENT about are flagged.
+  E. IG-2 codex artefact — codex-artefact emits a faithful law/policy source
+     artefact (no source_quality); downstream REQUIREMENT/ASSERTION candidates cite it.
 
 This is the PR-CI guard. The LLM-driven walk-through lives in drive_ingest_e2e.py,
 gated to the weekly cron. See tests/README.md.
@@ -62,7 +64,7 @@ def frontmatter(path):
     return yaml.safe_load(m.group(1)) if m else None
 
 
-# ── Part A — bundle integrity ───────────────────────────────────
+# ── Part A — bundle integrity ────────────────────────────────────
 
 def part_a_bundle():
     skill = os.path.join(SKILL_DIR, "SKILL.md")
@@ -180,7 +182,7 @@ def part_b_pipeline():
         shutil.rmtree(work, ignore_errors=True)
 
 
-# ── Part C — IG-5 regressions (rehearsal-found defects) ──────────────────
+# ── Part C — IG-5 regressions (rehearsal-found defects) ──────────────
 
 def part_c_ig5():
     """Capability V/H ID accepted, closed-REL-kind flag, derived_from merge."""
@@ -249,7 +251,7 @@ def part_c_ig5():
         shutil.rmtree(work, ignore_errors=True)
 
 
-# ── Part D — IG-1 assertion candidate kind ───────────────────────────────────
+# ── Part D — IG-1 assertion candidate kind ───────────────────────
 
 def part_d_ig1():
     """Assertion candidate: emit shaping, valid passes, bad subject/status/about flagged."""
@@ -309,10 +311,83 @@ def part_d_ig1():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part E — IG-2 codex artefact emitter ─────────────────────────
+
+def part_e_ig2():
+    """Faithful codex LAW artefact + downstream REQUIREMENT/ASSERTION candidates citing it."""
+    if not shutil.which("node"):
+        print("SKIP Part E: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-ig2-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+
+        inbox = os.path.join(org, "_intake", "inbox")
+        proc = os.path.join(org, "_intake", "processing")
+        raw = os.path.join(inbox, "LAW-conveyor.txt")
+        with open(raw, "wb") as fh:
+            fh.write(b"Article 3 - certification required before market placement.\n")
+        expected_hash = "sha256:" + hashlib.sha256(open(raw, "rb").read()).hexdigest()
+        with open(os.path.join(proc, "LAW-conveyor.md"), "w", encoding="utf-8") as fh:
+            fh.write("# Regulation\nArticle 3 - certification required before market placement.\n")
+
+        r = run_cli("codex-artefact", os.path.join(proc, "LAW-conveyor.md"),
+                    "--type", "LAW", "--jurisdiction", "eu", "--effective-date", "2026-01-01",
+                    "--source-authority", "FICTIONAL", "--slug", "conveyor-safety",
+                    "--admitted-at", "2026-06-07", "--monitoring")
+        check(r.returncode == 0, "IG-2: codex-artefact failed: %s" % (r.stderr or r.stdout))
+
+        art = os.path.join(org, "codex", "external", "eu", "LAW-conveyor_safety-1.yaml")
+        if check(os.path.isfile(art), "IG-2: codex artefact not written under codex/external/eu/"):
+            d = yaml.safe_load(open(art, encoding="utf-8"))
+            check(d.get("zone") == "codex", "IG-2: codex artefact zone is not 'codex'")
+            check(d.get("type") == "LAW", "IG-2: codex artefact type")
+            check(d.get("jurisdiction") == "eu", "IG-2: jurisdiction must match the folder (CODEX-001)")
+            check(d.get("effective_date") == "2026-01-01", "IG-2: effective_date")
+            check(d.get("gate_checks", {}).get("source_authority") == "FICTIONAL", "IG-2: gate_checks.source_authority")
+            check("source_quality" not in d, "IG-2: a codex artefact must NOT carry source_quality (authoritative by construction)")
+            check(d.get("source_hash") == expected_hash, "IG-2: source_hash mismatch")
+            check(str(d.get("snapshot_file", "")).startswith("sources/snapshot_"), "IG-2: snapshot_file under sources/")
+            check(d.get("monitoring_needed") is True, "IG-2: monitoring_needed")
+
+        check(os.path.isdir(os.path.join(org, "codex", "external", "eu", "sources")), "IG-2: codex sources/ folder missing")
+        check(not os.path.exists(raw), "IG-2: raw source was not moved into codex sources/")
+        check(not os.path.exists(os.path.join(org, "canon")), "IG-2: codex emit must not create canon/")
+
+        # Downstream: derive REQUIREMENT + ASSERTION candidates that cite the codex LAW.
+        res = os.path.join(work, "res.json")
+        with open(res, "w", encoding="utf-8") as fh:
+            json.dump({"elements": [{"id": "REQUIREMENT-CONVEYOR-CERT-1", "name": "Hold a certificate",
+                                     "element_type": "REQUIREMENT", "extraction_confidence": "high"}],
+                       "relations": [],
+                       "assertions": [{"id": "ASSERTION-FLEXLINE-CERT-1", "about": "REQUIREMENT-CONVEYOR-CERT-1",
+                                       "subject": "PRODUCT-FLEXLINE-1", "status": "under_review",
+                                       "extraction_confidence": "medium"}]}, fh)
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        r = run_cli("emit-candidates", art, "--from", res, "--candidates-dir", cdir)
+        check(r.returncode == 0, "IG-2: emit-candidates from a codex artefact failed: %s" % (r.stderr or r.stdout))
+
+        req = json.load(open(os.path.join(cdir, "REQUIREMENT-CONVEYOR-CERT-1.json"), encoding="utf-8"))
+        ass = json.load(open(os.path.join(cdir, "ASSERTION-FLEXLINE-CERT-1.json"), encoding="utf-8"))
+        check(req.get("derived_from") == ["LAW-conveyor_safety-1"],
+              "IG-2: REQUIREMENT candidate does not cite the codex LAW: %r" % req.get("derived_from"))
+        check(ass.get("kind") == "assertion" and ass.get("derived_from") == ["LAW-conveyor_safety-1"],
+              "IG-2: ASSERTION candidate does not cite the codex LAW: %r" % ass.get("derived_from"))
+        r = run_cli("validate", cdir)
+        check(r.returncode == 0, "IG-2: codex-derived candidates did not validate clean: %s" % (r.stdout + r.stderr))
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
 part_d_ig1()
+part_e_ig2()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## What

Adds the **`codex-artefact`** command — the codex half of the field-vs-codex split the acme rehearsal exposed. It admits a converted law/regulation/policy/standard into the **CODEX zone** as a faithful source artefact (`14-codex.md §3/§4`), parallel to `field-artefact` for the field zone. IG-2 of ADR `2026-06-07-ingest-field-codex-two-routes`.

A codex artefact differs from a field artefact **by design**:
- **no `source_quality`** — a codex source is authoritative by construction;
- **no embedded content** — it records identity + admission record (`gate_checks.source_authority`) + a snapshot pointer + `source_hash`; the source text stays in `_intake/processing/` for extraction;
- **external** (`LAW`/`REGULATION`) → `codex/external/<jurisdiction>/` with `jurisdiction` (CODEX-001) + `effective_date` + `monitoring_needed`; **internal** (`POLICY`/`INTERNAL_STANDARD`) → `codex/internal/` with `issuing_authority`.

The downstream derivation reuses the existing `emit-candidates` unchanged: it reads the codex artefact's `id` for `derived_from`, so a law flows **law → codex artefact → REQUIREMENT + ASSERTION candidates**, all human-gated. `canon/` is never written.

## Files
- `src/codex-artefact.mjs` (new) — the emitter.
- `ingest.mjs` — wire the `codex-artefact` command + usage.
- `tests/test_ingest_integrity.py` — **Part E**: faithful LAW under `codex/external/eu/` (jurisdiction/effective_date/source_authority/snapshot/source_hash/monitoring, **no** source_quality), raw snapshotted into `sources/`, `canon/` untouched, and REQUIREMENT+ASSERTION candidates citing the LAW. Full A+B+C+D+E suite passes locally (`PASS`).

## Stacking
**Stacked on #133** (assertion candidate kind), which is stacked on #132 (rehearsal-found defects). Base is `feat/ingest-assertion-candidate`; retarget down the chain as each merges. Merge order: **#132 → #133 → this**. Ingest remains tooling flagged for extraction (IG-7); the unified `admit-source --zone` rename is IG-3 (separate). **Do not merge — Valerii gates;** clean squash.