### PR TITLE
feat(ingest-cli): re-land IG-1 + IG-2 + add IG-3 + IG-6 (codex route, assertion kind, admit-source, doc cleanup)

### DIFF
--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -8,8 +8,9 @@
 //
 // Exit codes:  0 = ok  ·  1 = usage / findings that need review  ·  2 = error
 //
-// Implemented: --version, scaffold-intake, convert, field-artefact.
-// emit-candidates / validate / review-queue land next.
+// Implemented: --version, scaffold-intake, convert, admit-source (field + codex;
+// field-artefact / codex-artefact remain as deprecated aliases), emit-candidates,
+// validate, review-queue.
 
 import { readFile, access } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -22,6 +23,7 @@ import { validateCandidate, loadCandidates } from './src/validate.mjs';
 import { readCoverageProfile } from './src/coverage.mjs';
 import { buildReviewQueue, writeReviewQueue } from './src/review-queue.mjs';
 import { emitCandidates } from './src/emit-candidates.mjs';
+import { emitCodexArtefact } from './src/codex-artefact.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -55,9 +57,12 @@ function usage() {
     'Commands:',
     '  scaffold-intake <org-root>     Create _intake/{inbox,processing,processed} (idempotent)',
     '  convert <inbox-file>           Convert a document to Markdown in _intake/processing/',
-    '  field-artefact <md> --type T --role R --date YYYY-MM-DD [--setting S]',
-    '                 [--captured-by X] [--source-quality Q] [--slug SL] [--admitted-at A]',
-    '                                 Emit a field artefact with a proposed source_quality',
+    '  admit-source <md> --zone field|codex   Admit a converted source to the field or codex zone',
+    '                 field: --type INTERVIEW|SURVEY|OBSERVATION|DRAFT --role R --date YYYY-MM-DD',
+    '                        [--captured-by X] [--source-quality Q] [--slug SL] [--admitted-at A]',
+    '                 codex: --type LAW|REGULATION|POLICY|INTERNAL_STANDARD --effective-date YYYY-MM-DD',
+    '                        [--jurisdiction J] [--source-authority A] [--issuing-authority A] [--slug SL] [--monitoring]',
+    '  field-artefact / codex-artefact        Deprecated aliases of admit-source --zone field|codex',
     '  emit-candidates <field-artefact> --from <result.json> [--candidates-dir <dir>]',
     '                                 Shape the agent extraction result into candidates',
     '  validate <candidates-dir>      Validate candidate *.json against the contract + coverage profile',
@@ -137,6 +142,55 @@ async function cmdFieldArtefact(args) {
     console.error(`field-artefact: ${err.message}`);
     return 2;
   }
+}
+
+async function cmdCodexArtefact(args) {
+  const { _, flags } = parseArgs(args);
+  const md = _[0];
+  if (!md) { console.error('codex-artefact: missing <md> (a converted file in _intake/processing/)'); return 1; }
+  const mdPath = resolve(md);
+  try { await access(mdPath); } catch { console.error(`codex-artefact: file not found: ${md}`); return 2; }
+  if (!flags.type || !flags['effective-date']) {
+    console.error('codex-artefact: --type and --effective-date are required');
+    return 1;
+  }
+  const orgRoot = await findOrgRoot(mdPath);
+  if (!orgRoot) { console.error(`codex-artefact: "${md}" is not inside an _intake/ workspace.`); return 2; }
+
+  try {
+    const res = await emitCodexArtefact({
+      orgRoot, mdPath,
+      type: String(flags.type).toUpperCase(),
+      jurisdiction: flags.jurisdiction,
+      effectiveDate: flags['effective-date'],
+      sourceAuthority: flags['source-authority'],
+      issuingAuthority: flags['issuing-authority'],
+      admittedAt: flags['admitted-at'] || today(),
+      admittedBy: flags['admitted-by'] || '@transitrix/ingest-cli',
+      monitoring: flags.monitoring === true || flags.monitoring === 'true',
+      slug: flags.slug,
+      name: flags.name,
+    });
+    console.log(`codex artefact  ${res.id}  ->  ${res.outPath}`);
+    console.log(`  zone: codex (${res.scope}) — authoritative by construction; derive obligations as REQUIREMENT + ASSERTION candidates`);
+    if (res.snapshotFile) console.log(`  snapshot retained: ${res.snapshotFile}`);
+    if (res.sourceHash) console.log(`  source_hash:       ${res.sourceHash}`);
+    return 0;
+  } catch (err) {
+    console.error(`codex-artefact: ${err.message}`);
+    return 2;
+  }
+}
+
+// Unified front door (admit-source --zone). `field-artefact` and `codex-artefact`
+// remain as deprecated aliases for one release; both route through here.
+async function cmdAdmitSource(args) {
+  const { flags } = parseArgs(args);
+  const zone = flags.zone || 'field';
+  if (zone === 'field') return cmdFieldArtefact(args);
+  if (zone === 'codex') return cmdCodexArtefact(args);
+  console.error(`admit-source: --zone must be field|codex (got ${JSON.stringify(zone)})`);
+  return 1;
 }
 
 async function resolveDir(dirArg, label) {
@@ -225,7 +279,9 @@ async function main(argv) {
   switch (cmd) {
     case 'scaffold-intake': return cmdScaffoldIntake(args);
     case 'convert':         return cmdConvert(args);
+    case 'admit-source':    return cmdAdmitSource(args);
     case 'field-artefact':  return cmdFieldArtefact(args);
+    case 'codex-artefact':  return cmdCodexArtefact(args);
     case 'emit-candidates': return cmdEmitCandidates(args);
     case 'validate':        return cmdValidate(args);
     case 'review-queue':    return cmdReviewQueue(args);

--- a/packages/ingest-cli/src/codex-artefact.mjs
+++ b/packages/ingest-cli/src/codex-artefact.mjs
@@ -1,0 +1,138 @@
+// `codex-artefact` — admit a converted external law/regulation or internal policy /
+// standard into the CODEX zone as a FAITHFUL source artefact (14-codex.md §3/§4).
+//
+// Unlike a FIELD artefact, a codex artefact:
+//   - carries NO source_quality — a codex source is authoritative by construction;
+//   - embeds NO extracted content — it records the source's identity + admission
+//     record + a snapshot pointer to the retained raw bytes (the source text stays in
+//     _intake/processing/ for the extraction step).
+//
+// Obligations are derived downstream as REQUIREMENT (element) + ASSERTION candidates
+// via `emit-candidates`, each citing this artefact through derived_from. Admission to
+// codex/ is a zone admission (gate_checks.source_authority), parallel to the field
+// flow's admission to field/. This command NEVER writes canon/.
+
+import { readFile, writeFile, mkdir, readdir, rename, access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, resolve, basename, extname } from 'node:path';
+import { isValidId, makeId, slugSegment, parseId } from './ids.mjs';
+import { dump } from './yaml.mjs';
+import { stageDir } from './intake.mjs';
+
+// CODEX TYPE -> sub-zone (14-codex.md §2).
+const TYPE_INFO = {
+  LAW:               { scope: 'external' },
+  REGULATION:        { scope: 'external' },
+  POLICY:            { scope: 'internal' },
+  INTERNAL_STANDARD: { scope: 'internal' },
+};
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+// Next free ordinal for IDs sharing a TYPE + middle prefix in a codex folder.
+async function nextOrdinal(dir, type, middle) {
+  if (!(await exists(dir))) return 1;
+  const want = [type, ...middle].join('-');
+  let max = 0;
+  for (const name of await readdir(dir)) {
+    if (!name.endsWith('.yaml')) continue;
+    const p = parseId(basename(name, '.yaml'));
+    if (!p) continue;
+    if ([p.type, ...p.middle].join('-') === want) max = Math.max(max, p.ordinal);
+  }
+  return max + 1;
+}
+
+// Find the raw source in inbox/ matching a converted md by basename stem.
+async function findRaw(orgRoot, mdPath) {
+  const inbox = stageDir(orgRoot, 'inbox');
+  if (!(await exists(inbox))) return null;
+  const stem = basename(mdPath, extname(mdPath));
+  for (const name of await readdir(inbox)) {
+    if (basename(name, extname(name)) === stem) return join(inbox, name);
+  }
+  return null;
+}
+
+export async function emitCodexArtefact(opts) {
+  const {
+    orgRoot, mdPath, type, jurisdiction, effectiveDate, sourceAuthority,
+    issuingAuthority, admittedAt, admittedBy, monitoring, slug, name,
+  } = opts;
+
+  const info = TYPE_INFO[type];
+  if (!info) throw new Error(`unknown --type ${type}; expected one of ${Object.keys(TYPE_INFO).join(', ')}`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(effectiveDate || '')) throw new Error('--effective-date must be YYYY-MM-DD');
+
+  let codexDir;
+  let frontJurisdiction = null;
+  if (info.scope === 'external') {
+    if (!jurisdiction) throw new Error(`--jurisdiction is required for ${type} (codex/external/<jurisdiction>/, CODEX-001)`);
+    frontJurisdiction = String(jurisdiction).toLowerCase();
+    codexDir = join(resolve(orgRoot), 'codex', 'external', frontJurisdiction);
+  } else {
+    if (!issuingAuthority) throw new Error(`--issuing-authority is required for ${type} (codex/internal/)`);
+    codexDir = join(resolve(orgRoot), 'codex', 'internal');
+  }
+
+  const seg = slug ? slugSegment(slug) : slugSegment(name);
+  if (!seg) throw new Error('could not derive an ID segment from --slug/--name; pass --slug');
+  const middle = [seg];
+  const ordinal = await nextOrdinal(codexDir, type, middle);
+  const id = makeId(type, middle, ordinal);
+  if (!isValidId(id)) throw new Error(`generated an invalid ID: ${id}`);
+
+  // Snapshot the raw bytes into the codex sources/ subfolder (audit trail) + fingerprint.
+  const raw = await findRaw(orgRoot, mdPath);
+  let snapshotFile = null;
+  let snapshotDate = null;
+  let sourceHash = null;
+  if (raw) {
+    const bytes = await readFile(raw);
+    sourceHash = `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+    snapshotDate = admittedAt;
+    const sourcesDir = join(codexDir, 'sources');
+    await mkdir(sourcesDir, { recursive: true });
+    const snapName = `snapshot_${id}_${snapshotDate}${extname(raw)}`;
+    await rename(raw, join(sourcesDir, snapName));
+    snapshotFile = `sources/${snapName}`;
+  }
+
+  const common = {
+    id,
+    name: name || `${type} — ${seg}`,
+    type,
+    zone: 'codex',
+    admitted_at: admittedAt,
+    admitted_by: admittedBy,
+  };
+  const snapshot = {
+    ...(snapshotFile ? { snapshot_file: snapshotFile, snapshot_date: snapshotDate } : {}),
+    ...(sourceHash ? { source_hash: sourceHash } : {}),
+  };
+
+  const artefact = info.scope === 'external'
+    ? {
+        ...common,
+        gate_checks: { source_authority: sourceAuthority || 'recorded' },
+        jurisdiction: frontJurisdiction,
+        effective_date: effectiveDate,
+        ...snapshot,
+        monitoring_needed: Boolean(monitoring),
+      }
+    : {
+        ...common,
+        gate_checks: { source_authority: issuingAuthority },
+        issuing_authority: issuingAuthority,
+        effective_date: effectiveDate,
+        ...snapshot,
+      };
+
+  await mkdir(codexDir, { recursive: true });
+  const outPath = join(codexDir, `${id}.yaml`);
+  await writeFile(outPath, dump(artefact), 'utf8');
+
+  return { id, outPath, snapshotFile, sourceHash, scope: info.scope };
+}
+
+export { TYPE_INFO };

--- a/packages/ingest-cli/src/emit-candidates.mjs
+++ b/packages/ingest-cli/src/emit-candidates.mjs
@@ -1,18 +1,21 @@
 // `emit-candidates` — take the agent's extraction RESULT (produced by running the
 // prompts/ over a field artefact) and emit typed canon CANDIDATES. The CLI does the
 // deterministic part: it reads derived_from from the field artefact itself, shapes
-// each element/relation into a candidate (admitted_to: pending, the field ID in
-// derived_from, extraction_confidence carried through as a review flag), applies
+// each element/relation/assertion into a candidate (admitted_to: pending, the field ID
+// in derived_from, extraction_confidence carried through as a review flag), applies
 // relation-conservatism, and writes candidate *.json. It never extracts (that is the
 // agent's job) and never writes canon.
 //
 // Relation-conservatism (v0): only HIGH-confidence relations become candidates;
-// medium/low relations are held back as review-queue suggestions. Entities flow
-// through regardless of confidence (the flag rides along for the reviewer).
+// medium/low relations are held back as review-queue suggestions. Entities and
+// assertions flow through regardless of confidence (the flag rides along for the
+// reviewer) — an ASSERTION is a constrained claim (about a REQUIREMENT, restricted
+// subject TYPE, closed status enum), and the human gate adjudicates every one.
 //
-// Corroboration: when the SAME candidate (same element id, or same REL triple) is
-// emitted again from a different field source, derived_from is MERGED (union), not
-// overwritten — a fact confirmed across two sources must accumulate its citations.
+// Corroboration: when the SAME candidate (same element id / same REL triple / same
+// assertion id) is emitted again from a different field source, derived_from is MERGED
+// (union), not overwritten — a fact confirmed across two sources must accumulate its
+// citations.
 
 import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
@@ -71,11 +74,28 @@ export function shapeCandidates(derivedFrom, result) {
     }
   }
 
+  for (const a of result.assertions || []) {
+    const c = {
+      kind: 'assertion',
+      id: a.id,
+      about: a.about,
+      subject: a.subject,
+      status: a.status,
+      derived_from: [derivedFrom],
+      admitted_to: 'pending',
+      extraction_confidence: a.extraction_confidence,
+    };
+    if (a.realised_via !== undefined) c.realised_via = a.realised_via;
+    if (a.evidence !== undefined) c.evidence = a.evidence;
+    if (a.extraction_notes) c.extraction_notes = a.extraction_notes;
+    candidates.push(c);
+  }
+
   return { candidates, suggestions };
 }
 
 function candidateFilename(c, index) {
-  if (c.kind === 'element' && c.id) return `${safeName(c.id)}.json`;
+  if ((c.kind === 'element' || c.kind === 'assertion') && c.id) return `${safeName(c.id)}.json`;
   if (c.kind === 'relation') return `REL_${safeName(c.rel_kind)}__${safeName(c.from)}__${safeName(c.to)}.json`;
   return `candidate-${index}.json`;
 }

--- a/packages/ingest-cli/src/validate.mjs
+++ b/packages/ingest-cli/src/validate.mjs
@@ -26,6 +26,16 @@ const CLOSED_REL_KINDS = new Set([
   'community_membership', 'contracting', 'stakeholding',
 ]);
 
+// ASSERTION contract — notations/elements/16-assertion.md §2/§3. `about` must reference
+// a REQUIREMENT (ASSERT-002 resolution is canon-side; the candidate stage checks the
+// grammar + TYPE prefix); `subject` TYPE is restricted (ASSERT-003); `status` is a
+// closed enum. Cross-document resolution (does `about` resolve to an admitted
+// REQUIREMENT) happens at the human admission gate, not here.
+const ASSERTION_STATUS = new Set(['compliant', 'partial', 'non_compliant', 'under_review', 'n_a']);
+const ASSERTION_SUBJECT_TYPES = new Set(['PRODUCT', 'PROCESS', 'CAPABILITY']);
+
+function typeOf(id) { return typeof id === 'string' ? id.split('-')[0] : null; }
+
 // Validate one candidate against `profile`. Returns
 // { validation_flags: [...], coverage_flag, coverage_reason? }.
 export function validateCandidate(cand, profile) {
@@ -34,8 +44,8 @@ export function validateCandidate(cand, profile) {
     return { validation_flags: ['candidate is not a JSON object'], coverage_flag: 'out_of_profile' };
   }
 
-  if (cand.kind !== 'element' && cand.kind !== 'relation') {
-    flags.push(`kind must be "element" or "relation" (got ${JSON.stringify(cand.kind)})`);
+  if (cand.kind !== 'element' && cand.kind !== 'relation' && cand.kind !== 'assertion') {
+    flags.push(`kind must be "element", "relation" or "assertion" (got ${JSON.stringify(cand.kind)})`);
   }
   if (!Array.isArray(cand.derived_from) || cand.derived_from.length < 1) {
     flags.push('derived_from must cite at least one field artefact ID');
@@ -65,6 +75,18 @@ export function validateCandidate(cand, profile) {
     if (!isValidId(cand.from)) flags.push(`relation "from" violates the ID grammar: ${cand.from}`);
     if (!isValidId(cand.to)) flags.push(`relation "to" violates the ID grammar: ${cand.to}`);
     type = cand.rel_kind;
+  } else if (cand.kind === 'assertion') {
+    if (!isValidId(cand.id)) flags.push(`assertion id violates the ID grammar: ${cand.id}`);
+    if (!isValidId(cand.about)) flags.push(`assertion "about" violates the ID grammar: ${cand.about}`);
+    else if (typeOf(cand.about) !== 'REQUIREMENT') flags.push(`assertion "about" must reference a REQUIREMENT (ASSERT-002): ${cand.about}`);
+    if (!isValidId(cand.subject)) flags.push(`assertion "subject" violates the ID grammar: ${cand.subject}`);
+    else if (!ASSERTION_SUBJECT_TYPES.has(typeOf(cand.subject))) flags.push(`assertion "subject" TYPE must be PRODUCT|PROCESS|CAPABILITY (ASSERT-003): ${cand.subject}`);
+    if (!ASSERTION_STATUS.has(cand.status)) flags.push(`assertion status must be compliant|partial|non_compliant|under_review|n_a (got ${JSON.stringify(cand.status)})`);
+    if (cand.realised_via !== undefined) {
+      if (!Array.isArray(cand.realised_via)) flags.push('assertion realised_via must be an array of typed IDs');
+      else for (const rv of cand.realised_via) if (!isValidId(rv)) flags.push(`assertion realised_via has an invalid ID: ${rv}`);
+    }
+    type = 'ASSERTION';
   }
 
   const cov = classifyCoverage(profile, type);
@@ -89,4 +111,4 @@ export async function loadCandidates(dir) {
   return out;
 }
 
-export { EXTRACTION_CONFIDENCE, CLOSED_REL_KINDS };
+export { EXTRACTION_CONFIDENCE, CLOSED_REL_KINDS, ASSERTION_STATUS, ASSERTION_SUBJECT_TYPES };

--- a/transitrix/skills/ingest/README.md
+++ b/transitrix/skills/ingest/README.md
@@ -4,7 +4,7 @@ The **front door** of a Transitrix repository: it turns raw organisational mater
 
 This directory is the **`ingest` skill** within the `transitrix` plugin (the plugin root is [`transitrix/`](../../), which carries the shared [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) manifest, with one `skills/<name>/` directory per skill). Invoked as `/transitrix:ingest`.
 
-> **Status — skeleton (v0).** This skill ships the agent-facing protocol ([`SKILL.md`](SKILL.md)), the artefact / candidate / review-queue JSON schemas ([`schemas/`](schemas/)), and the `_intake/` convention ([`templates/_intake.README.md`](templates/_intake.README.md)). The deterministic CLI and the extraction prompts land in follow-up increments (see [Roadmap](#roadmap)). Until the CLI is published, `SKILL.md`'s pipeline steps describe the contract, and the skill's Step 0 pre-check stops cleanly if the CLI is absent.
+> **Status — operational.** Beyond the agent-facing protocol ([`SKILL.md`](SKILL.md)), JSON schemas ([`schemas/`](schemas/)), and the `_intake/` convention ([`templates/_intake.README.md`](templates/_intake.README.md)), the deterministic CLI ([`@transitrix/ingest-cli`](../../../packages/ingest-cli/)) implements all subcommands and is covered by a no-API-key integrity test (see [Roadmap](#roadmap)). The skill's Step 0 pre-check still stops cleanly if the CLI is not installed in a given environment.
 
 ---
 
@@ -19,7 +19,7 @@ This directory is the **`ingest` skill** within the `transitrix` plugin (the plu
 
 ## What it ships
 
-- [`SKILL.md`](SKILL.md) — the agent-facing, agent-neutral protocol: a six-step pipeline (`scaffold-intake → convert → field-artefact → emit-candidates → validate → review-queue`) plus the hard constraints.
+- [`SKILL.md`](SKILL.md) — the agent-facing, agent-neutral protocol: a six-step pipeline (`scaffold-intake → convert → admit-source → emit-candidates → validate → review-queue`) plus the hard constraints.
 - [`schemas/`](schemas/) — JSON Schemas for the three artefacts the pipeline produces: a `field` artefact, a canon candidate, and the review queue.
 - [`templates/_intake.README.md`](templates/_intake.README.md) — the documentation the CLI drops into an adopter's `_intake/` folder describing the `inbox → processing → processed` flow.
 
@@ -66,9 +66,9 @@ In v0 this convention is **skill-local** — documented here and in [`templates/
 
 | Increment | Contents |
 |---|---|
-| **Skeleton (this)** | `SKILL.md`, JSON schemas, `_intake/` convention, plugin wiring. |
-| **CLI** | `@transitrix/ingest-cli` — the deterministic subcommands (`scaffold-intake`, `convert`, `field-artefact`, `emit-candidates`, `validate`, `review-queue`) + the forked extraction prompts in `prompts/`. |
-| **Tests + CI** | A no-API-key integrity test (bundle + dry CLI run on a fixture) and a weekly LLM-drive, plus a workflow — mirroring the onboarding skill's test harness. |
+| **Skeleton** ✓ landed | `SKILL.md`, JSON schemas, `_intake/` convention, plugin wiring. |
+| **CLI** ✓ landed | `@transitrix/ingest-cli` — the deterministic subcommands (`scaffold-intake`, `convert`, `admit-source`/`field-artefact`/`codex-artefact`, `emit-candidates`, `validate`, `review-queue`) + the forked extraction prompts in `prompts/`. |
+| **Tests + CI** ✓ landed | A no-API-key integrity test (bundle + dry CLI run on a fixture) and a weekly LLM-drive, plus a workflow — mirroring the onboarding skill's test harness. |
 
 ---
 

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **front door** to a Transitrix repository: it turns raw material into `field`-zone artefacts and typed `canon` *candidates*, at scale, and routes everything through a human review gate. It is the operational counterpart to the per-layer extraction prompts — the part that converts documents, scores source trust, runs the validators, and stages a review queue.
 
-> **Status — skeleton (v0).** This skill ships the agent-facing protocol, the artefact/candidate/review-queue schemas, and the `_intake/` convention. The deterministic logic lives in a separate CLI (`@transitrix/ingest-cli`, see [§ The CLI](#the-cli)) that lands in a follow-up increment. Until that CLI is installed, the pipeline steps below describe the contract rather than an executable path — run the **CLI-presence pre-check** (Step 0) first and stop if it is absent.
+> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`, see [§ The CLI](#the-cli)) implements every subcommand below — `scaffold-intake`, `convert`, `admit-source` (field + codex routes), `emit-candidates`, `validate`, `review-queue` — and is exercised end-to-end by the bundle's integrity test. Run the **CLI-presence pre-check** (Step 0) first; if the CLI is not on PATH in this install, install it before proceeding.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the field→canon pipeline against it. It runs **agent-neutrally** under Claude and GitHub Copilot — all heavy logic is in the CLI, and this `SKILL.md` only sequences it.
 
@@ -30,7 +30,7 @@ npx @transitrix/ingest-cli --version
 ```
 
 - **Present** → proceed.
-- **Absent** → this skill is not yet operational in this install (the CLI ships in a later increment). Stop and tell the user; do not hand-roll the pipeline, because hand-rolled extraction has no deterministic validator gate and risks the one rule above.
+- **Absent** → the CLI is not installed (or not published) in this environment. Stop and tell the user; do not hand-roll the pipeline, because hand-rolled extraction has no deterministic validator gate and risks the one rule above.
 
 Also confirm you are operating inside a Transitrix adopter repository (a `transitrix.yaml` manifest at the repo root; see [MANIFEST](https://raw.githubusercontent.com/transitrix/methodology/main/notations/MANIFEST.md)). If there is no repo yet, the user wants `/transitrix:onboard` first.
 
@@ -74,7 +74,7 @@ If Markitdown is not installed the CLI exits with an actionable message naming t
 Each converted document becomes one `field` artefact carrying a complete **admission record** — provenance (who / when / in what setting) and a **proposed** `source_quality`. The field artefact is what lives in `field/`; the original raw bytes stay in `_intake/processed/` so the artefact is traceable to its source.
 
 ```
-npx @transitrix/ingest-cli field-artefact <processing/file.md> \
+npx @transitrix/ingest-cli admit-source --zone field <processing/file.md> \
     --type INTERVIEW|SURVEY|OBSERVATION|DRAFT --role "<role>" --date YYYY-MM-DD
 ```
 
@@ -90,6 +90,8 @@ The CLI fills the admission record (`zone: field`, `gate_checks.provenance`) and
 | Draft, assumption, inference, hearsay | `unverified` | 0.25 |
 
 The skill **proposes**; a human **confirms**. Never silently bake a higher trust than the source warrants.
+
+**Codex sources — laws, regulations, policies, standards — take the parallel `codex` route:** `npx @transitrix/ingest-cli admit-source --zone codex <processing/file.md> --type LAW|REGULATION|POLICY|INTERNAL_STANDARD --effective-date YYYY-MM-DD [--jurisdiction <code>] [--source-authority <who>]`. A codex artefact is *authoritative by construction* — it carries **no** `source_quality`, records a snapshot of the source + a `source_hash`, and lands in `codex/external/<jurisdiction>/` (LAW/REGULATION) or `codex/internal/` (POLICY/INTERNAL_STANDARD) per [14-codex.md](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/14-codex.md). Its obligations are derived in Step 4 as `REQUIREMENT` + `ASSERTION` candidates that cite it via `derived_from`.
 
 ---
 
@@ -147,7 +149,7 @@ The queue is the human gate. It lists every field artefact (with its proposed `s
 
 All deterministic behaviour lives in **`@transitrix/ingest-cli`** — document conversion, coverage-profile read, validator pass, field-artefact + candidate emission, and the `_intake/` moves. This keeps the deterministic guarantees independent of which agent drives the skill (the same principle as the methodology's CI validators): neither Claude nor Copilot reimplements the logic, and both get identical results.
 
-The CLI is resolved as a **published package** (installed/invoked via `npx`), not vendored per skill and not referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `field-artefact`, `emit-candidates`, `validate`, `review-queue`.
+The CLI is resolved as a **published package** (installed/invoked via `npx`), not vendored per skill and not referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`.
 
 ---
 

--- a/transitrix/skills/ingest/schemas/candidate.schema.json
+++ b/transitrix/skills/ingest/schemas/candidate.schema.json
@@ -10,7 +10,7 @@
     "kind": {
       "type": "string",
       "description": "Whether this candidate is an element or a typed relation.",
-      "enum": ["element", "relation"]
+      "enum": ["element", "relation", "assertion"]
     },
     "derived_from": {
       "type": "array",
@@ -87,6 +87,24 @@
         }
       },
       "required": ["rel_kind", "from", "to"]
+    },
+    {
+      "title": "Assertion candidate",
+      "description": "A compliance claim that a subject (PRODUCT/PROCESS/CAPABILITY) satisfies a REQUIREMENT (16-assertion.md). Constrained: about -> REQUIREMENT (ASSERT-002), subject TYPE restricted (ASSERT-003), status a closed enum. Flows as a candidate regardless of confidence; the human gate adjudicates.",
+      "properties": {
+        "kind": { "const": "assertion" },
+        "id": {
+          "type": "string",
+          "description": "Canonical assertion ID: ASSERTION-[<middle>-]<INTEGER>.",
+          "pattern": "^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$"
+        },
+        "about": { "type": "string", "description": "Typed ID of the REQUIREMENT this assertion is about (ASSERT-002)." },
+        "subject": { "type": "string", "description": "Typed ID of the subject element; TYPE in {PRODUCT, PROCESS, CAPABILITY} (ASSERT-003)." },
+        "status": { "type": "string", "enum": ["compliant", "partial", "non_compliant", "under_review", "n_a"] },
+        "realised_via": { "type": "array", "items": { "type": "string" }, "description": "Optional typed IDs of elements that realise the requirement (ASSERT-004)." },
+        "evidence": { "type": "array", "description": "Optional hybrid evidence entries (16-assertion.md §4)." }
+      },
+      "required": ["id", "about", "subject", "status"]
     }
   ]
 }

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """From-scratch pipeline test for the Transitrix Ingest skill + @transitrix/ingest-cli.
 
-Deterministic, no-API-key guard. Three parts:
+Deterministic, no-API-key guard. Six parts:
 
   A. Bundle integrity — SKILL.md frontmatter, the three JSON schemas parse, the
      three layer prompts + READMEs exist, the _intake template is present.
@@ -11,8 +11,14 @@ Deterministic, no-API-key guard. Three parts:
      proposed source_quality, candidate files, a review queue with the gate closed,
      the two-axes rule (a candidate carrying source_quality is flagged), and THE ONE
      RULE — canon/ is never written.
-  C. IG-5 regressions — the three rehearsal-found defects: capability V/H ID is
-     accepted, a non-closed rel_kind is flagged, derived_from merges across sources.
+  C. IG-5 regressions — capability V/H ID is accepted, a non-closed rel_kind is
+     flagged, derived_from merges across sources.
+  D. IG-1 assertion candidate — emit shapes an assertion; a valid one passes,
+     bad subject TYPE / status / non-REQUIREMENT about are flagged.
+  E. IG-2 codex artefact — codex-artefact emits a faithful law/policy source
+     artefact (no source_quality); downstream REQUIREMENT/ASSERTION candidates cite it.
+  F. IG-3 admit-source — admit-source --zone field|codex dispatches; the
+     field-artefact / codex-artefact aliases still work; a bad --zone is rejected.
 
 This is the PR-CI guard. The LLM-driven walk-through lives in drive_ingest_e2e.py,
 gated to the weekly cron. See tests/README.md.
@@ -178,7 +184,7 @@ def part_b_pipeline():
         shutil.rmtree(work, ignore_errors=True)
 
 
-# ── Part C — IG-5 regressions (rehearsal-found defects) ──────────────────
+# ── Part C — IG-5 regressions ──────────────────────────────────
 
 def part_c_ig5():
     """Capability V/H ID accepted, closed-REL-kind flag, derived_from merge."""
@@ -247,9 +253,199 @@ def part_c_ig5():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part D — IG-1 assertion candidate kind ───────────────────────
+
+def part_d_ig1():
+    """Assertion candidate: emit shaping, valid passes, bad subject/status/about flagged."""
+    if not shutil.which("node"):
+        print("SKIP Part D: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-ig1-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+
+        fdir = os.path.join(org, "field", "interviews")
+        os.makedirs(fdir, exist_ok=True)
+        fid = "INTERVIEW-law-20260101-1"
+        with open(os.path.join(fdir, fid + ".yaml"), "w", encoding="utf-8") as fh:
+            fh.write('id: "%s"\nname: "x"\ntype: "INTERVIEW"\nzone: "field"\nnotes: "x"\n' % fid)
+
+        res = os.path.join(work, "res.json")
+        with open(res, "w", encoding="utf-8") as fh:
+            json.dump({"elements": [], "relations": [],
+                       "assertions": [{"id": "ASSERTION-FLEXLINE-CERT-1",
+                                       "about": "REQUIREMENT-CERT-1", "subject": "PRODUCT-FLEXLINE-1",
+                                       "status": "under_review", "realised_via": ["CAPABILITY-V1.2"],
+                                       "extraction_confidence": "medium"}]}, fh)
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        run_cli("emit-candidates", os.path.join(fdir, fid + ".yaml"), "--from", res, "--candidates-dir", cdir)
+
+        shaped = json.load(open(os.path.join(cdir, "ASSERTION-FLEXLINE-CERT-1.json"), encoding="utf-8"))
+        check(shaped.get("kind") == "assertion" and shaped.get("admitted_to") == "pending"
+              and shaped.get("derived_from") == [fid] and shaped.get("subject") == "PRODUCT-FLEXLINE-1",
+              "IG-1: emit-candidates did not shape an assertion candidate correctly: %r" % shaped)
+
+        # A valid assertion (PRODUCT subject, closed status, REQUIREMENT about) validates clean.
+        r = run_cli("validate", cdir)
+        check(r.returncode == 0, "IG-1: a valid assertion candidate was flagged: %s" % (r.stdout + r.stderr))
+
+        def cand(name, obj):
+            with open(os.path.join(cdir, name), "w", encoding="utf-8") as fh:
+                json.dump(obj, fh)
+        base = {"kind": "assertion", "derived_from": [fid], "admitted_to": "pending",
+                "extraction_confidence": "high"}
+        cand("A_badsubj.json", {**base, "id": "ASSERTION-X-1", "about": "REQUIREMENT-C-1",
+                                "subject": "GOAL-Z-1", "status": "compliant"})
+        cand("A_badstatus.json", {**base, "id": "ASSERTION-Y-1", "about": "REQUIREMENT-C-1",
+                                  "subject": "PROCESS-P-1", "status": "maybe"})
+        cand("A_badabout.json", {**base, "id": "ASSERTION-W-1", "about": "GOAL-G-1",
+                                 "subject": "CAPABILITY-V1", "status": "compliant"})
+        r = run_cli("validate", cdir)
+        out = r.stdout + r.stderr
+        check("ASSERT-003" in out, "IG-1: bad assertion subject TYPE not flagged (ASSERT-003)")
+        check("assertion status must be" in out, "IG-1: bad assertion status not flagged")
+        check("ASSERT-002" in out, "IG-1: assertion about non-REQUIREMENT not flagged (ASSERT-002)")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+# ── Part E — IG-2 codex artefact emitter ─────────────────────────
+
+def part_e_ig2():
+    """Faithful codex LAW artefact + downstream REQUIREMENT/ASSERTION candidates citing it."""
+    if not shutil.which("node"):
+        print("SKIP Part E: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-ig2-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+
+        inbox = os.path.join(org, "_intake", "inbox")
+        proc = os.path.join(org, "_intake", "processing")
+        raw = os.path.join(inbox, "LAW-conveyor.txt")
+        with open(raw, "wb") as fh:
+            fh.write(b"Article 3 - certification required before market placement.\n")
+        expected_hash = "sha256:" + hashlib.sha256(open(raw, "rb").read()).hexdigest()
+        with open(os.path.join(proc, "LAW-conveyor.md"), "w", encoding="utf-8") as fh:
+            fh.write("# Regulation\nArticle 3 - certification required before market placement.\n")
+
+        r = run_cli("codex-artefact", os.path.join(proc, "LAW-conveyor.md"),
+                    "--type", "LAW", "--jurisdiction", "eu", "--effective-date", "2026-01-01",
+                    "--source-authority", "FICTIONAL", "--slug", "conveyor-safety",
+                    "--admitted-at", "2026-06-07", "--monitoring")
+        check(r.returncode == 0, "IG-2: codex-artefact failed: %s" % (r.stderr or r.stdout))
+
+        art = os.path.join(org, "codex", "external", "eu", "LAW-conveyor_safety-1.yaml")
+        if check(os.path.isfile(art), "IG-2: codex artefact not written under codex/external/eu/"):
+            d = yaml.safe_load(open(art, encoding="utf-8"))
+            check(d.get("zone") == "codex", "IG-2: codex artefact zone is not 'codex'")
+            check(d.get("type") == "LAW", "IG-2: codex artefact type")
+            check(d.get("jurisdiction") == "eu", "IG-2: jurisdiction must match the folder (CODEX-001)")
+            check(d.get("effective_date") == "2026-01-01", "IG-2: effective_date")
+            check(d.get("gate_checks", {}).get("source_authority") == "FICTIONAL", "IG-2: gate_checks.source_authority")
+            check("source_quality" not in d, "IG-2: a codex artefact must NOT carry source_quality (authoritative by construction)")
+            check(d.get("source_hash") == expected_hash, "IG-2: source_hash mismatch")
+            check(str(d.get("snapshot_file", "")).startswith("sources/snapshot_"), "IG-2: snapshot_file under sources/")
+            check(d.get("monitoring_needed") is True, "IG-2: monitoring_needed")
+
+        check(os.path.isdir(os.path.join(org, "codex", "external", "eu", "sources")), "IG-2: codex sources/ folder missing")
+        check(not os.path.exists(raw), "IG-2: raw source was not moved into codex sources/")
+        check(not os.path.exists(os.path.join(org, "canon")), "IG-2: codex emit must not create canon/")
+
+        # Downstream: derive REQUIREMENT + ASSERTION candidates that cite the codex LAW.
+        res = os.path.join(work, "res.json")
+        with open(res, "w", encoding="utf-8") as fh:
+            json.dump({"elements": [{"id": "REQUIREMENT-CONVEYOR-CERT-1", "name": "Hold a certificate",
+                                     "element_type": "REQUIREMENT", "extraction_confidence": "high"}],
+                       "relations": [],
+                       "assertions": [{"id": "ASSERTION-FLEXLINE-CERT-1", "about": "REQUIREMENT-CONVEYOR-CERT-1",
+                                       "subject": "PRODUCT-FLEXLINE-1", "status": "under_review",
+                                       "extraction_confidence": "medium"}]}, fh)
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        r = run_cli("emit-candidates", art, "--from", res, "--candidates-dir", cdir)
+        check(r.returncode == 0, "IG-2: emit-candidates from a codex artefact failed: %s" % (r.stderr or r.stdout))
+
+        req = json.load(open(os.path.join(cdir, "REQUIREMENT-CONVEYOR-CERT-1.json"), encoding="utf-8"))
+        ass = json.load(open(os.path.join(cdir, "ASSERTION-FLEXLINE-CERT-1.json"), encoding="utf-8"))
+        check(req.get("derived_from") == ["LAW-conveyor_safety-1"],
+              "IG-2: REQUIREMENT candidate does not cite the codex LAW: %r" % req.get("derived_from"))
+        check(ass.get("kind") == "assertion" and ass.get("derived_from") == ["LAW-conveyor_safety-1"],
+              "IG-2: ASSERTION candidate does not cite the codex LAW: %r" % ass.get("derived_from"))
+        r = run_cli("validate", cdir)
+        check(r.returncode == 0, "IG-2: codex-derived candidates did not validate clean: %s" % (r.stdout + r.stderr))
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+# ── Part F — IG-3 admit-source unify + aliases ─────────────────────
+
+def part_f_ig3():
+    """admit-source --zone field|codex dispatch; field-artefact alias still works."""
+    if not shutil.which("node"):
+        print("SKIP Part F: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-ig3-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+        inbox = os.path.join(org, "_intake", "inbox")
+        proc = os.path.join(org, "_intake", "processing")
+
+        def drop(stem, body):
+            with open(os.path.join(inbox, stem + ".txt"), "w", encoding="utf-8") as fh:
+                fh.write(body + "\n")
+            with open(os.path.join(proc, stem + ".md"), "w", encoding="utf-8") as fh:
+                fh.write("# " + stem + "\n" + body + "\n")
+
+        drop("INT", "note")
+        r = run_cli("admit-source", "--zone", "field", os.path.join(proc, "INT.md"),
+                    "--type", "INTERVIEW", "--role", "Ops", "--date", "2026-01-01",
+                    "--slug", "ops", "--admitted-at", "2026-01-02")
+        check(r.returncode == 0, "IG-3: admit-source --zone field failed: %s" % (r.stderr or r.stdout))
+        check(os.path.isfile(os.path.join(org, "field", "interviews", "INTERVIEW-ops-20260101-1.yaml")),
+              "IG-3: admit-source --zone field did not write a field artefact")
+
+        drop("LAW", "law")
+        r = run_cli("admit-source", "--zone", "codex", os.path.join(proc, "LAW.md"),
+                    "--type", "LAW", "--jurisdiction", "eu", "--effective-date", "2026-01-01",
+                    "--slug", "road", "--admitted-at", "2026-01-02")
+        check(r.returncode == 0, "IG-3: admit-source --zone codex failed: %s" % (r.stderr or r.stdout))
+        check(os.path.isfile(os.path.join(org, "codex", "external", "eu", "LAW-road-1.yaml")),
+              "IG-3: admit-source --zone codex did not write a codex artefact")
+
+        drop("INT2", "note2")
+        r = run_cli("field-artefact", os.path.join(proc, "INT2.md"),
+                    "--type", "INTERVIEW", "--role", "Ops2", "--date", "2026-01-01",
+                    "--slug", "ops2", "--admitted-at", "2026-01-02")
+        check(r.returncode == 0, "IG-3: deprecated field-artefact alias broke: %s" % (r.stderr or r.stdout))
+        check(os.path.isfile(os.path.join(org, "field", "interviews", "INTERVIEW-ops2-20260101-1.yaml")),
+              "IG-3: field-artefact alias did not write a field artefact")
+
+        r = run_cli("admit-source", "--zone", "bogus", os.path.join(proc, "INT.md"),
+                    "--type", "INTERVIEW", "--role", "x", "--date", "2026-01-01")
+        check(r.returncode == 1 and "zone must be field|codex" in (r.stdout + r.stderr),
+              "IG-3: a bad --zone was not rejected")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
+part_d_ig1()
+part_e_ig2()
+part_f_ig3()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## Why this PR exists (recovery)

PRs **#133 (IG-1)** and **#134 (IG-2)** show *merged*, but their content **never reached `main`**: under **auto-merge + auto-delete-branch**, each stacked PR merged into its *declared base* (a sibling feature branch, not `main`), and those branches were then auto-deleted. `main` ended up with only **#132 (IG-5)**. This PR re-lands the orphaned IG-1 + IG-2 cleanly off `main`, and adds IG-3 + IG-6 in the same drop (they touch the same files, so a single base-`main` PR avoids re-tangling under auto-merge).

## What it lands

- **IG-1 — assertion candidate kind.** `candidate.schema.json` gains the `assertion` variant; `validate` adds the `kind:assertion` branch (ASSERT-002 about→REQUIREMENT, ASSERT-003 subject TYPE, closed status enum); `emit-candidates` shapes `result.assertions[]`.
- **IG-2 — codex route.** New `codex-artefact.mjs`: a faithful `LAW/REGULATION/POLICY/INTERNAL_STANDARD` emitter (jurisdiction/effective_date/source_authority/snapshot/source_hash/monitoring; **no** `source_quality`). Downstream `emit-candidates` derives REQUIREMENT + ASSERTION candidates citing it.
- **IG-3 — `admit-source --zone field|codex`** unified front door; `field-artefact` / `codex-artefact` kept as deprecated aliases for one release. SKILL.md Step 3 + codex note updated.
- **IG-6 — docs.** Stale "skeleton (v0)" banner removed from SKILL.md + README.md; roadmap marked landed.

## Tests

Integrity test grows to **Parts A–F** (adds D assertion, E codex, F admit-source). Full suite passes locally (`PASS`). `canon/` is never written in any path.

## Notes

Base is **`main`** (not stacked) — deliberately, so auto-merge lands it on `main` directly. Ingest stays tooling flagged for extraction to its own repo ~1.0 (IG-7). Per ADR `2026-06-07-ingest-field-codex-two-routes`.