### PR TITLE
docs: ingest vocabulary — clarify field/codex correspondence, do not rename (IG-4)

### DIFF
--- a/docs/decisions/2026-06-07-ingest-vocabulary-clarify-not-rename.md
+++ b/docs/decisions/2026-06-07-ingest-vocabulary-clarify-not-rename.md
@@ -1,0 +1,64 @@
+---
+title: "Ingest vocabulary — clarify the field/codex correspondence, do not rename"
+status: accepted
+date: "2026-06-07"
+scope: methodology
+supersedes: null
+superseded_by: null
+tags: [ingest, codex, field, vocabulary, naming, documentation, provenance]
+---
+
+# ADR: Ingest vocabulary — clarify, do not rename
+
+**Status:** Accepted
+**Date:** 2026-06-07
+**Deciders:** Valerii Korobeinikov
+**Scope:** Repo-local to `methodology`. Refines the "vocabulary alignment / IG-4" action item of [`2026-06-07-ingest-field-codex-two-routes.md`](./2026-06-07-ingest-field-codex-two-routes.md).
+
+---
+
+## Context
+
+The field-vs-codex routing ADR listed a follow-up ("IG-4"): unify the retained-source-copy field name (`raw_source` in the field zone, `snapshot_file` in codex) to a single `source_snapshot`, and rename the codex admission gate-check `gate_checks.source_authority` to `issuing_authority`, plus document the two trust axes.
+
+On investigation across the repo (16 files reference these names), both renames look worse than the one-line action item implied:
+
+- **`gate_checks.source_authority` → `issuing_authority` is wrong.** `source_authority` is the **codex zone's canonical admission gate-check** (`CONTRACT.md` §6: "codex → source_authority: the issuing or authoritative source is identified and the artefact is faithful to it"), parallel to the field zone's `gate_checks.provenance`. Meanwhile `issuing_authority` **already exists** as a distinct top-level field on **internal** codex artefacts (the body that issued a policy/standard, `14-codex.md` §4). Renaming the gate-check to `issuing_authority` collides with that field and conflates a gate-check with a content field.
+- **`raw_source`/`snapshot_file` → `source_snapshot` has marginal benefit and real cost.** `raw_source` is a tooling-only field (ingest CLI + bundle schema). `snapshot_file`/`snapshot_date` is **canon**, with a deep sub-spec (`14-codex.md` §3.1 snapshots, re-snapshotting, the scanner-agent comparison in §3.5, and required-together validation). The two names are also **zone-appropriate**: "snapshot" fits a point-in-time capture of an external, evolving source (a law); "raw source" fits captured field material (an interview). Unifying would worsen the field name, churn embedded canon, and force an adopter data migration — to buy "one word".
+
+The real problem the alignment was chasing is **reader confusion** (two names for a similar concept; `source_quality` vs `source_authority` look alike). Confusion is better fixed by documentation than by a breaking rename.
+
+## Decision
+
+**Decline both renames. Clarify instead.**
+
+1. Keep `raw_source` (field tooling) and `snapshot_file`/`snapshot_date` (codex canon) as the zone-appropriate names for the retained source copy.
+2. Keep `gate_checks.source_authority` as the codex admission gate-check (`CONTRACT.md` §6). Do not rename it.
+3. Add a short clarification to the canon — `14-codex.md` §3.6 — stating:
+   - codex sources are **authoritative by construction** and carry **no** `source_quality`; the graded source-trust scale is a field-zone concept (`CONTRACT.md` §11.2);
+   - `source_quality` (graded trust on a field informant) and `source_authority` (a provenance gate-check on codex input) are **different axes**, deliberately not unified;
+   - the retained source copy is the codex `snapshot_file` and the field analogue is the ingest field artefact's `raw_source` — the same byte-level-copy concept, named per zone.
+4. Note the field↔codex correspondence in the ingest `field-artefact.schema.json` `raw_source` description.
+
+## Options Considered
+
+### Full rename (`source_snapshot` + `issuing_authority`)
+Rejected. `issuing_authority` collides with the existing internal-codex field; the snapshot rename churns deep canon (snapshot sub-spec + scanner) and breaks adopter data; "snapshot" → field worsens the field name.
+
+### Partial rename (`source_snapshot` only)
+Rejected. Same codex-canon + adopter-migration cost, same field-naming regression, for marginal cross-zone tidiness.
+
+### Clarify only (chosen)
+Additive documentation. Zero breakage, no adopter migration, names stay stable, and the actual problem (confusion between similar names and across zones) is addressed where readers meet it (the spec).
+
+## Consequences
+
+- **Easier:** no breaking change; adopters' existing codex data and the ingest CLI keep working; the genuine confusion is resolved in the spec.
+- **Harder:** two names for "the retained source copy" persist across zones — mitigated by the §3.6 correspondence note.
+- **Supersedes:** the IG-4 "rename" action item in the field/codex two-routes ADR is resolved as *clarify, not rename*.
+
+## Action Items
+
+1. [x] Add `14-codex.md` §3.6 (this PR).
+2. [x] Add the field↔codex correspondence line to `field-artefact.schema.json` (this PR).
+3. [ ] Mark IG-4 done-as-clarify in `win-claude/tasks.md`.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -10,3 +10,4 @@ Format: dated `YYYY-MM-DD-slug.md`, front-matter (`status`, `date`, `scope`, `su
 | 2026-06-07 | [Ingest — one skill, two routes (field + codex), shared vocabulary](./2026-06-07-ingest-field-codex-two-routes.md) | Accepted | methodology (ingest skill + CLI) |
 | 2026-06-07 | [Retire the model-side ISSUE type; no bespoke replacement](./2026-06-07-retire-model-issue-type.md) | Accepted | methodology (ISSUE TYPE + issues view) |
 | 2026-06-07 | [Entity classification axis is the ArchiMate layer; governance docs are cross-cutting](./2026-06-07-entity-classification-axis-archimate-layers.md) | Accepted | methodology (notations vocabulary + root docs) |
+| 2026-06-07 | [Ingest vocabulary — clarify the field/codex correspondence, do not rename](./2026-06-07-ingest-vocabulary-clarify-not-rename.md) | Accepted | methodology (ingest docs / 14-codex) |

--- a/notations/elements/14-codex.md
+++ b/notations/elements/14-codex.md
@@ -225,6 +225,12 @@ scan:
 
 The `scan` block is optional — a brand-new live artefact that no scanner has touched yet legitimately has no `scan` block. Once a scanner runs against it the block appears and is maintained on subsequent scans.
 
+### 3.6 Trust and provenance — vs the field zone
+
+A codex source is **authoritative by construction**: it is *given to* the organisation by an outside or issuing authority, so a codex artefact carries **no** `source_quality`. The graded source-trust scale (`authoritative` / `corroborated` / `single_source` / `unverified`, [CONTRACT.md](../CONTRACT.md) §11.2) is a **field-zone** concept — it scores how far to trust an *informant or observation*. A codex source has nothing to grade: `gate_checks.source_authority` records **who** the authoritative source is (provenance), not **how much** to trust it. `source_quality` and `source_authority` are therefore **different axes** — one a graded trust label on field input, the other a provenance gate-check on codex input — and are deliberately *not* unified despite the similar names.
+
+The **retained copy of the source** is likewise the same concept under a zone-appropriate name. In codex it is the `snapshot_file` (a point-in-time capture of an external, possibly-evolving document, held in `sources/`, §3.1); in the **field** zone it is the ingest pipeline's field-artefact `raw_source` (the raw input bytes, retained in `_intake/processed/`). Both are a byte-level copy kept for traceability and fingerprinted by a `source_hash`; they are named per zone — "snapshot" fits an external evolving source, "raw source" fits captured field material — rather than unified. See the decision record [`docs/decisions/2026-06-07-ingest-vocabulary-clarify-not-rename.md`](../../docs/decisions/2026-06-07-ingest-vocabulary-clarify-not-rename.md).
+
 ---
 
 ## 4. Frontmatter — internal codex artefacts

--- a/transitrix/skills/ingest/schemas/field-artefact.schema.json
+++ b/transitrix/skills/ingest/schemas/field-artefact.schema.json
@@ -39,7 +39,7 @@
     },
     "source_quality": {
       "type": "string",
-      "description": "PROPOSED trust in the source (CONTRACT.md §11.2). Closed ordinal set; weight is informational. A human confirms at admission. Absent ⇒ downstream confidence scoring treats the source as `unverified`.",
+      "description": "PROPOSED trust in the source (CONTRACT.md §11.2). Closed ordinal set; weight is informational. A human confirms at admission. Absent ⇒ downstream confidence scoring treats the source as `unverified`. Field-zone only: codex sources are authoritative by construction and carry no source_quality (14-codex.md §3.6).",
       "enum": ["authoritative", "corroborated", "single_source", "unverified"]
     },
     "source_quality_proposed_by": {
@@ -60,7 +60,7 @@
     },
     "raw_source": {
       "type": "string",
-      "description": "Path, relative to the org root, to the retained raw file in _intake/processed/ — the byte-level source this artefact was derived from, kept for traceability."
+      "description": "Path, relative to the org root, to the retained raw file in _intake/processed/ — the byte-level source this artefact was derived from, kept for traceability. The field-zone analogue of a codex artefact's `snapshot_file` (14-codex.md §3.6): the same retained-source-copy concept, named per zone."
     },
     "source_hash": {
       "type": "string",


### PR DESCRIPTION
## What

Resolves **IG-4** (the "vocabulary alignment" follow-up from the field/codex two-routes ADR) as **clarify, not rename**.

Investigation across the repo showed both proposed renames are unwise:
- **`gate_checks.source_authority` → `issuing_authority`** collides with the existing top-level `issuing_authority` field on internal codex artefacts (`14-codex.md §4`) and conflates a canon gate-check (`CONTRACT.md §6`) with a content field.
- **`raw_source`/`snapshot_file` → `source_snapshot`** churns deep codex canon (snapshot sub-spec + scanner-agent §3.5) and breaks adopter data for a zone-inappropriate single name (`raw_source` ≠ "snapshot" for captured field material).

## Decision

Keep the zone-appropriate names; **document** the distinction instead.

- **ADR** `docs/decisions/2026-06-07-ingest-vocabulary-clarify-not-rename.md` (+ INDEX row) — records the rename considered and declined, with the reasoning.
- **`14-codex.md` §3.6** (new) — the two trust axes (codex is authoritative-by-construction, **no** `source_quality`; `source_quality` vs `source_authority` are different axes) and the field↔codex correspondence (`raw_source` ≈ `snapshot_file` = the retained source copy, named per zone).
- **`field-artefact.schema.json`** — one-line note on `raw_source` (and `source_quality` is field-zone only) pointing at §3.6.

## Notes

Zero behaviour/breaking change — additive documentation only. Base `main` (not stacked). Per the new git-hygiene rules.