### PR TITLE
docs(canon): reconcile PRODUCT/APPLICATION materialisation mode — IDS §4 vs ELEMENT_PRIMITIVES §4

### DIFF
--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -165,7 +165,8 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | `CAPABILITY` | within the capability set (`set_name`, per [`05-capability-map.md`](views/05-capability-map.md) §5). |
 | `PROCESS` | within the organisation's element catalogue (`elements/02_business/`). |
 | `STEP` | within its `PROCESS` element while inline (canonical-by-containment); once promoted, within the organisation's element catalogue (`elements/02_business/steps/`), one file per promoted STEP. The id is unchanged by promotion (no rename). |
-| `PRODUCT`, `APPLICATION`, `INTEGRATION` | within the catalogue document. |
+| `PRODUCT`, `APPLICATION` | within the organisation's element catalogue (`elements/02_business/` for `PRODUCT`, `elements/03_application/` for `APPLICATION`), one file per element. Both are `standalone` ([ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §4), so their IDs are org-wide-unique from creation (not document-scoped) — the §1 promotion rule does not apply (they are first-class catalogue elements, never inline). |
+| `INTEGRATION` | within the catalogue document while `view-defined` (nested in an application's `integrations[]`, [`10-applications.md`](views/10-applications.md)); once promoted (§1 promotion rule), within the organisation's element catalogue (`elements/03_application/integrations/`), one file per promoted INTEGRATION. The id is unchanged by promotion (no rename). |
 | `ROLE`, `ACTOR` | within the organisation's element catalogue (`elements/02_business/`). |
 | `SCENARIO` | within the organisation's element catalogue (`elements/05_implementation/scenarios/`), one file per SCENARIO. |
 | `EQUIPMENT`, `INFORMATION_ENTITY` | within the notation document that defines them (today: a Process Blueprint). No organisation-wide catalogue is mandated yet; the TYPEs are registered so the IDs already conform to the canonical grammar and can be promoted to a future catalogue without renaming. |


### PR DESCRIPTION
## Problem

Two canon tables disagreed on `PRODUCT` / `APPLICATION`:

- **`IDS_AND_REFERENCES.md` §4** (uniqueness scope): `PRODUCT, APPLICATION, INTEGRATION` were "within the catalogue document" — a document-scoped placement.
- **`ELEMENT_PRIMITIVES.md` §4** (materialisation mode, + §4.1 rationale): `PRODUCT` and `APPLICATION` are **`standalone`** with their own per-element folders (`02_business/products/`, `03_application/applications/`); only `INTEGRATION` is `view-defined`.

A `standalone` TYPE needs **org-wide-unique** IDs to be referenced cross-document, so "unique within the catalogue document" cannot hold for PRODUCT/APPLICATION.

## Decision & fix

`ELEMENT_PRIMITIVES.md` §4/§4.1 is the **authoritative** source — it's settled, with detailed rationale, and matches the grain already in canon (the capability-map / products / applications catalogues reference `PRODUCT-…` / `APPLICATION-…` *elements*). So this corrects the lagging **IDS §4** table to agree (no change to ELEMENT_PRIMITIVES, which was already right). The IDS §4 row is split:

- **`PRODUCT`, `APPLICATION`** → org-wide element-catalogue uniqueness (`elements/02_business/`, `elements/03_application/`), one file per element; `standalone`, org-wide-unique **from creation**, the §1 promotion rule does **not** apply (they are never inline). Wording mirrors the existing `ROLE`/`ACTOR`/`PROCESS` rows.
- **`INTEGRATION`** → unchanged in substance ("leave as is" per the issue) but the **§1 promotion interaction is now explicit**: document-scoped while `view-defined`, org-wide element-catalogue scope once promoted, id unchanged — mirroring the `STEP` row and ELEMENT_PRIMITIVES §4 (`view-defined → standalone`).

Uses the table's existing `elements/…` prefix convention — the catalogue-root prefix question (`elements/` vs `canon/elements/`) is a separate open item in `NOTATIONS_VALIDATION.md` and is left untouched.

## Acceptance (HUB-167)

- ✅ IDS §4 and ELEMENT_PRIMITIVES §4 state the same mode + uniqueness scope for `PRODUCT` and `APPLICATION` (standalone, org-wide catalogue).
- ✅ No TYPE is `standalone` in one table and catalogue-document-scoped in the other.

## Verification

`node scripts/check-notations.mjs` → clean (examples, internal links, version pins consistent). Data-free, docs-only — one-line table change.

This unblocks the dependent ingest resolver work (a deterministic TYPE → placement source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
