### PR TITLE
feat(ingest): deterministic TYPE → materialisation mode + layer placement (ELEMENT_PRIMITIVES §4)

### DIFF
--- a/packages/ingest-cli/README.md
+++ b/packages/ingest-cli/README.md
@@ -28,7 +28,9 @@ transitrix-ingest <command> [args]
 | `field-artefact <md> --type --role --date` | ✅ | Emit a field artefact with provenance + proposed `source_quality`; retain the raw source in `_intake/processed/`. |
 | `emit-candidates <field-artefact> --from <result.json>` | ✅ | Shape the agent's extraction result into candidates (entity-strong, relation-conservative; non-`high` relations become suggestions). |
 | `validate <candidates-dir>` | ✅ | Validate candidate `*.json` against the contract (in code) + coverage profile; flags, never drops. |
-| `review-queue <candidates-dir>` | ✅ | Stage the human review queue (`review-queue.yaml`); `gate.admits_to_canon: false`. |
+| `review-queue <candidates-dir>` | ✅ | Stage the human review queue (`review-queue.yaml`); `gate.admits_to_canon: false`; annotates each element candidate with its §4 `placement`. |
+| `resolve-placement <TYPE>` | ✅ | Print a TYPE's `ELEMENT_PRIMITIVES.md` §4 materialisation mode + layer + folder. |
+| `check-placement [org-root]` | ✅ | Flag admitted elements sitting outside their §4 folder (read-only over `canon/`). |
 
 ## Layout
 
@@ -43,6 +45,7 @@ packages/ingest-cli/
     field-artefact.mjs # emit a field artefact + proposed source_quality
     coverage.mjs       # resolve coverage_profile (preset/custom) + classify in/out
     coverage-presets.mjs # shipped preset membership (COVERAGE_PROFILES §3/§3.1)
+    placement.mjs      # TYPE -> materialisation mode/layer/folder (ELEMENT_PRIMITIVES §4)
     validate.mjs       # candidate contract checks (in code) + candidate loader
     review-queue.mjs   # assemble + emit the human review queue
     emit-candidates.mjs# shape the agent extraction result into candidates

--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -24,6 +24,7 @@ import { readCoverageProfile } from './src/coverage.mjs';
 import { buildReviewQueue, writeReviewQueue } from './src/review-queue.mjs';
 import { emitCandidates } from './src/emit-candidates.mjs';
 import { emitCodexArtefact } from './src/codex-artefact.mjs';
+import { resolvePlacement, checkCanonPlacement } from './src/placement.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -68,6 +69,8 @@ function usage() {
     '  validate <candidates-dir>      Validate candidate *.json against the contract + coverage profile',
     '  review-queue <candidates-dir>  Assemble the human review queue (writes review-queue.yaml)',
     '                 [--out <path>]',
+    '  check-placement [org-root]     Flag admitted elements sitting outside their ELEMENT_PRIMITIVES §4 folder',
+    '  resolve-placement <TYPE>       Print a TYPE\'s §4 materialisation mode + layer + folder',
     '  --version, -v                  Print the CLI version',
     '  --help, -h                     Show this help',
   ].join('\n');
@@ -277,6 +280,35 @@ async function cmdEmitCandidates(args) {
   }
 }
 
+// Print the canonical §4 placement (mode + layer + folder) for a TYPE.
+async function cmdResolvePlacement(args) {
+  const { _ } = parseArgs(args);
+  const type = _[0] ? String(_[0]).toUpperCase() : null;
+  if (!type) { console.error('resolve-placement: missing <TYPE>'); return 1; }
+  const p = resolvePlacement(type);
+  if (!p) { console.error(`resolve-placement: ${type} has no ELEMENT_PRIMITIVES §4 placement (not a catalogue element TYPE).`); return 1; }
+  console.log(`${type}  mode: ${p.mode}  layer: ${p.layer ?? '—'}  folder: ${p.folder ?? '(inline — no catalogue folder)'}${p.promotable ? '  (promotable, §1 rule)' : ''}`);
+  return 0;
+}
+
+// Flag admitted elements sitting outside their §4 folder (read-only over canon/).
+async function cmdCheckPlacement(args) {
+  const { _ } = parseArgs(args);
+  const orgRoot = _[0]
+    ? (await findOrgRoot(resolve(_[0])) || resolve(_[0]))
+    : (await findOrgRoot(process.cwd()));
+  if (!orgRoot) { console.error('check-placement: not inside a Transitrix workspace (no _intake/ found); pass <org-root>.'); return 2; }
+
+  const { scanned, findings } = await checkCanonPlacement(orgRoot);
+  if (findings.length === 0) {
+    console.log(`check-placement  ${scanned} catalogue element(s) scanned — all sit in their ELEMENT_PRIMITIVES §4 folder.`);
+    return 0;
+  }
+  console.error(`check-placement  ${findings.length} of ${scanned} element(s) misplaced (ELEMENT_PRIMITIVES §4):`);
+  for (const f of findings) console.error(`  FLAG  ${f.id}\n          - ${f.reason}`);
+  return 1;
+}
+
 async function main(argv) {
   const [cmd, ...args] = argv;
 
@@ -292,6 +324,8 @@ async function main(argv) {
     case 'emit-candidates': return cmdEmitCandidates(args);
     case 'validate':        return cmdValidate(args);
     case 'review-queue':    return cmdReviewQueue(args);
+    case 'check-placement': return cmdCheckPlacement(args);
+    case 'resolve-placement': return cmdResolvePlacement(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);
       return 1;

--- a/packages/ingest-cli/src/placement.mjs
+++ b/packages/ingest-cli/src/placement.mjs
@@ -1,0 +1,128 @@
+// Materialisation / placement resolver — the deterministic TYPE → {mode, layer,
+// folder} map the ingest pipeline needs to decide where an admitted element lands
+// (its own per-TYPE catalogue file vs inline in a catalogue/view document) and to
+// flag an admitted element sitting in the wrong place.
+//
+// SOURCE OF TRUTH: ELEMENT_PRIMITIVES.md §4 (the mode table) — mode, layer, plural
+// folder. This table mirrors §4 verbatim and MUST track it: when §4 changes (a TYPE
+// promoted, a folder renamed), update this file in lockstep, the same discipline as
+// coverage-presets.mjs against COVERAGE_PROFILES §3.
+//
+// Modes (ELEMENT_PRIMITIVES §1):
+//   - standalone   — own element file in its per-TYPE folder; org-wide-unique id.
+//   - view-defined — authored inline in a view/catalogue document; promotable.
+//   - contained    — inline in a host element (e.g. STEP in PROCESS.flow); promotable.
+// `promotable: true` means the TYPE starts inline and gains its own standalone file
+// only when a SECOND document references it (§1 promotion rule) — the id never changes.
+//
+// THE ONE RULE still holds: this module only READS canon to check placement; it never
+// writes a zone.
+
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join, resolve, dirname } from 'node:path';
+
+// TYPE → placement. `folder` is relative to the elements root, exactly as §4 prints it
+// (no `elements/` or `canon/` prefix — the catalogue-root prefix is a separate open
+// item, so we match on the folder SUFFIX and stay prefix-agnostic). `folder: null`
+// means the TYPE has no own catalogue folder (view-defined, document-local).
+export const PLACEMENT = {
+  // 01_motivation
+  FACTOR:             { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/factors/' },
+  GOAL:               { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/goals/' },
+  CONSTRAINT:         { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/constraints/' },
+  REQUIREMENT:        { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/requirements/' },
+  STAKEHOLDER:        { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/stakeholders/' },
+  ASSESSMENT:         { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/assessments/' },
+  // 02_business
+  CAPABILITY:         { mode: 'standalone',   layer: '02_business',      folder: '02_business/capabilities/' },
+  PROCESS:            { mode: 'standalone',   layer: '02_business',      folder: '02_business/processes/' },
+  STEP:               { mode: 'contained',    layer: '02_business',      folder: '02_business/steps/', promotable: true },
+  PRODUCT:            { mode: 'standalone',   layer: '02_business',      folder: '02_business/products/' },
+  ROLE:               { mode: 'standalone',   layer: '02_business',      folder: '02_business/roles/' },
+  ACTOR:              { mode: 'standalone',   layer: '02_business',      folder: '02_business/actors/' },
+  RULE:               { mode: 'standalone',   layer: '02_business',      folder: '02_business/rules/' },
+  REGISTRY:           { mode: 'standalone',   layer: '02_business',      folder: '02_business/registries/', promotable: true },
+  // 03_application
+  APPLICATION:        { mode: 'standalone',   layer: '03_application',   folder: '03_application/applications/' },
+  INTEGRATION:        { mode: 'view-defined', layer: '03_application',   folder: '03_application/integrations/', promotable: true },
+  // 05_implementation
+  CHANGE:             { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/changes/' },
+  ACTIVITY:           { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/activities/' },
+  TARGET_STATE:       { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/target-states/' },
+  SCENARIO:           { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/scenarios/' },
+  // view-defined, document-local (no own catalogue folder in v1)
+  EQUIPMENT:          { mode: 'view-defined', layer: null,               folder: null, promotable: true },
+  INFORMATION_ENTITY: { mode: 'view-defined', layer: null,               folder: null, promotable: true },
+};
+
+// TYPE prefix of an id (the segment before the first '-'). Capability V/H addresses
+// (CAPABILITY-V1.2) still split on '-' to 'CAPABILITY', so this is safe for them too.
+export function typeOfId(id) {
+  return typeof id === 'string' && id.includes('-') ? id.split('-')[0] : null;
+}
+
+// Resolve placement for an element TYPE. Returns the §4 entry (with `type` echoed) or
+// null for an unknown / non-element TYPE (e.g. a field or codex TYPE has no §4 row).
+export function resolvePlacement(type) {
+  const p = type && PLACEMENT[type];
+  if (!p) return null;
+  return { type, mode: p.mode, layer: p.layer, folder: p.folder, promotable: !!p.promotable };
+}
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+// Recursively collect every *.yaml under dir (relative paths, posix separators).
+async function walkYaml(root, dir = root, out = []) {
+  let entries;
+  try { entries = await readdir(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    const abs = join(dir, e.name);
+    if (e.isDirectory()) await walkYaml(root, abs, out);
+    else if (e.isFile() && e.name.endsWith('.yaml')) out.push(abs);
+  }
+  return out;
+}
+
+// Scan canon/ (read-only) and flag any admitted element file sitting in the wrong §4
+// place. Returns { scanned, findings: [{ id, type, file, expected, reason }] }.
+// A finding is raised when a `standalone` TYPE's file is NOT under its §4 folder, or a
+// `view-defined` TYPE that has no catalogue folder appears as its own canon file.
+// Folder match is by SUFFIX so it is agnostic to the canon-root prefix (open item).
+export async function checkCanonPlacement(orgRoot) {
+  const canonDir = join(resolve(orgRoot), 'canon');
+  const findings = [];
+  let scanned = 0;
+  if (!(await exists(canonDir))) return { scanned, findings };
+
+  for (const file of await walkYaml(canonDir)) {
+    let text;
+    try { text = await readFile(file, 'utf8'); } catch { continue; }
+    // id is the basename without extension, or the top-level `id:` scalar.
+    const idLine = text.match(/^id:[ \t]*["']?([A-Za-z0-9_.\-]+)/m);
+    const id = idLine ? idLine[1] : file.split(/[\\/]/).pop().replace(/\.yaml$/, '');
+    const type = typeOfId(id);
+    const place = type && PLACEMENT[type];
+    if (!place) continue; // not a §4 element TYPE (REL/ASSERTION have fixed homes) — skip
+    scanned++;
+    const dirPosix = dirname(file).replace(/\\/g, '/');
+
+    if (place.folder) {
+      const want = place.folder.replace(/\/$/, '');
+      if (!dirPosix.endsWith(want)) {
+        findings.push({
+          id, type, file,
+          expected: place.folder,
+          reason: `${place.mode} TYPE ${type} must live in its §4 folder ${place.folder}; found at ${dirPosix}/`,
+        });
+      }
+    } else {
+      // view-defined, document-local: no own catalogue file expected.
+      findings.push({
+        id, type, file,
+        expected: '(inline — view-defined, no catalogue folder)',
+        reason: `${type} is view-defined (ELEMENT_PRIMITIVES §4) — it has no catalogue folder; found as a standalone canon file at ${dirPosix}/`,
+      });
+    }
+  }
+  return { scanned, findings };
+}

--- a/packages/ingest-cli/src/review-queue.mjs
+++ b/packages/ingest-cli/src/review-queue.mjs
@@ -9,6 +9,7 @@ import { join, resolve } from 'node:path';
 import { dump, readTopScalar } from './yaml.mjs';
 import { validateCandidate, loadCandidates } from './validate.mjs';
 import { buildCanonIndex, admittedMatch } from './canon.mjs';
+import { resolvePlacement } from './placement.mjs';
 import { parseId } from './ids.mjs';
 import { TYPE_INFO } from './field-artefact.mjs';
 
@@ -49,12 +50,16 @@ export async function buildReviewQueue({ orgRoot, candidatesDir, profile, sugges
     if (already) { excluded_admitted.push({ ref, matched: already }); continue; }
     const v = validateCandidate(candidate, profile);
     for (const d of candidate.derived_from || []) fieldIds.add(d);
+    // Surface the deterministic §4 placement (mode + layer + folder) for an element
+    // candidate, so the human gate places it consistently instead of by judgement.
+    const place = candidate.kind === 'element' ? resolvePlacement(candidate.element_type) : null;
     candidates.push({
       ref,
       kind: candidate.kind,
       extraction_confidence: candidate.extraction_confidence ?? null,
       coverage_flag: v.coverage_flag,
       ...(v.coverage_reason ? { coverage_reason: v.coverage_reason } : {}),
+      ...(place ? { placement: { mode: place.mode, layer: place.layer, folder: place.folder, ...(place.promotable ? { promotable: true } : {}) } } : {}),
       validation_flags: v.validation_flags,
     });
   }

--- a/packages/ingest-cli/src/yaml.mjs
+++ b/packages/ingest-cli/src/yaml.mjs
@@ -36,10 +36,16 @@ function dumpMap(obj, indent) {
       lines.push(`${pad}${k}:`);
       for (const item of v) {
         if (isPlainObject(item)) {
-          const sub = dumpMap(item, indent + 1);
-          // First entry shares the "- " marker; subsequent entries align under it.
-          lines.push(`${pad}  - ${sub[0].trimStart()}`);
-          for (let i = 1; i < sub.length; i++) lines.push(`${pad}    ${sub[i].trimStart()}`);
+          // Render the item one list-level deep so its keys (and any NESTED maps) keep
+          // their relative indentation; the first key shares the "- " marker. Earlier
+          // this trimStart()ed every sub-line and re-padded flat, which collapsed a
+          // nested object inside a list item — fine for scalar-only items, wrong once
+          // an item carries a sub-map (e.g. a candidate's `placement`).
+          const itemIndent = indent + 2;
+          const sub = dumpMap(item, itemIndent);
+          const childPad = '  '.repeat(itemIndent);
+          lines.push(`${pad}  - ${sub[0].slice(childPad.length)}`);
+          for (let i = 1; i < sub.length; i++) lines.push(sub[i]);
         } else {
           lines.push(`${pad}  - ${scalar(item)}`);
         }

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **front door** to a Transitrix repository: it turns raw material into `field`-zone artefacts and typed `canon` *candidates*, at scale, and routes everything through a human review gate. It is the operational counterpart to the per-layer extraction prompts — the part that converts documents, scores source trust, runs the validators, and stages a review queue.
 
-> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`, see [§ The CLI](#the-cli)) implements every subcommand below — `scaffold-intake`, `convert`, `admit-source` (field + codex routes), `emit-candidates`, `validate`, `review-queue` — and is exercised end-to-end by the bundle's integrity test. Run the **CLI-presence pre-check** (Step 0) first; if the CLI is not on PATH in this install, install it before proceeding.
+> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`, see [§ The CLI](#the-cli)) implements every subcommand below — `scaffold-intake`, `convert`, `admit-source` (field + codex routes), `emit-candidates`, `validate`, `review-queue`, `check-placement`, `resolve-placement` — and is exercised end-to-end by the bundle's integrity test. Run the **CLI-presence pre-check** (Step 0) first; if the CLI is not on PATH in this install, install it before proceeding.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the field→canon pipeline against it. It runs **agent-neutrally** under Claude and GitHub Copilot — all heavy logic is in the CLI, and this `SKILL.md` only sequences it.
 
@@ -147,13 +147,22 @@ The queue is the human gate. It lists every field artefact (with its proposed `s
 
 **Nothing lands in `canon/` from this skill.** A human reviews the queue, confirms or revises each proposed `source_quality`, and runs the canon admission gate (`uniqueness`, `consistency`, `completeness` — [CONTRACT §6](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md)) to admit candidates. When ingest is complete for a source, its raw file moves to `_intake/processed/`.
 
+### Placement is deterministic — pinned to ELEMENT_PRIMITIVES §4
+
+Where an admitted element lands is **not** a judgement call. Every element TYPE has a canonical **materialisation mode + layer + folder** in [`ELEMENT_PRIMITIVES.md` §4](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md); the CLI resolves it so equals are treated equally — `ACTOR`, `ROLE`, `PROCESS`, `PRODUCT`, `APPLICATION` are all `standalone` and each gets its own per-TYPE folder, never inline-by-accident.
+
+- The review queue annotates each element candidate with its resolved `placement` (`mode`, `layer`, `folder`). Admit a `standalone` element to exactly that folder, one file per element.
+- Check any TYPE on demand: `npx @transitrix/ingest-cli resolve-placement <TYPE>`.
+- **Honour the §1 promotion rule explicitly.** A `view-defined` / `contained` TYPE (`INTEGRATION`, `STEP`, `EQUIPMENT`, `INFORMATION_ENTITY`, registry rows) stays **inline** in its host/view document and is promoted to its own catalogue file **only when a second document references it** — the id never changes on promotion. Do not pre-create a standalone file for a still-single-reference element.
+- After admitting, verify placement: `npx @transitrix/ingest-cli check-placement [org-root]` flags any admitted element sitting outside its §4 folder (and any `view-defined` TYPE wrongly given its own catalogue file). Read-only over `canon/`.
+
 ---
 
 ## The CLI
 
 All deterministic behaviour lives in **`@transitrix/ingest-cli`** — document conversion, coverage-profile read, validator pass, field-artefact + candidate emission, and the `_intake/` moves. This keeps the deterministic guarantees independent of which agent drives the skill (the same principle as the methodology's CI validators): neither Claude nor Copilot reimplements the logic, and both get identical results.
 
-The CLI is resolved as a **published package** (installed/invoked via `npx`), not vendored per skill and not referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`.
+The CLI is resolved as a **published package** (installed/invoked via `npx`), not vendored per skill and not referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`, `check-placement`, `resolve-placement`.
 
 ---
 

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """From-scratch pipeline test for the Transitrix Ingest skill + @transitrix/ingest-cli.
 
-Deterministic, no-API-key guard. Eight parts:
+Deterministic, no-API-key guard. Nine parts:
 
   A. Bundle integrity — SKILL.md frontmatter, the three JSON schemas parse, the
      three layer prompts + READMEs exist, the _intake template is present.
@@ -26,6 +26,10 @@ Deterministic, no-API-key guard. Eight parts:
   H. #165 idempotency — review-queue excludes candidates already admitted to canon
      (matched by id for elements/assertions, by (type, from, to) triple for relations),
      so a re-run does not re-list already-admitted items.
+  I. #168 placement — resolve-placement reports a TYPE's ELEMENT_PRIMITIVES §4 mode +
+     layer + folder; review-queue annotates each element candidate with its placement
+     (equals resolve consistently); check-placement flags an admitted element sitting
+     outside its §4 folder.
 
 This is the PR-CI guard. The LLM-driven walk-through lives in drive_ingest_e2e.py,
 gated to the weekly cron. See tests/README.md.
@@ -610,6 +614,94 @@ def part_h_idempotent():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part I — #168 materialisation/placement resolution ────────────
+
+def part_i_placement():
+    """resolve-placement + review-queue placement + check-placement flag misplaced."""
+    if not shutil.which("node"):
+        print("SKIP Part I: `node` not found.")
+        return
+
+    # I1 — resolve-placement reports §4 mode + layer + folder per TYPE.
+    cases = {
+        "PRODUCT": ("standalone", "02_business/products/"),
+        "APPLICATION": ("standalone", "03_application/applications/"),
+        "ACTOR": ("standalone", "02_business/actors/"),
+        "ROLE": ("standalone", "02_business/roles/"),
+        "PROCESS": ("standalone", "02_business/processes/"),
+        "INTEGRATION": ("view-defined", "03_application/integrations/"),
+    }
+    for t, (mode, folder) in cases.items():
+        r = run_cli("resolve-placement", t)
+        out = r.stdout + r.stderr
+        check(r.returncode == 0 and ("mode: " + mode) in out and folder in out,
+              f"I1: resolve-placement {t} should report mode {mode} + folder {folder}; got {out.strip()!r}")
+    # An unknown / non-catalogue TYPE has no §4 placement.
+    r = run_cli("resolve-placement", "INTERVIEW")
+    check(r.returncode == 1, "I1: a non-catalogue TYPE (INTERVIEW) must have no §4 placement")
+
+    # I2 — review-queue annotates element candidates with their §4 placement; equals
+    # of equal standing (actor/role/process/product) resolve consistently (own folders).
+    work = tempfile.mkdtemp(prefix="ingest-place-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        os.makedirs(cdir, exist_ok=True)
+        fid = "INTERVIEW-x-20260101-1"
+        equals = {
+            "ACTOR.json": ("ACTOR-A-1", "ACTOR", "02_business/actors/"),
+            "ROLE.json": ("ROLE-A-1", "ROLE", "02_business/roles/"),
+            "PROC.json": ("PROCESS-A-1", "PROCESS", "02_business/processes/"),
+            "PROD.json": ("PRODUCT-A-1", "PRODUCT", "02_business/products/"),
+        }
+        for name, (eid, etype, _folder) in equals.items():
+            with open(os.path.join(cdir, name), "w", encoding="utf-8") as fh:
+                json.dump({"kind": "element", "id": eid, "name": eid, "element_type": etype,
+                           "derived_from": [fid], "admitted_to": "pending",
+                           "extraction_confidence": "high"}, fh)
+        r = run_cli("review-queue", cdir)
+        check(r.returncode == 0, f"I2: review-queue failed: {r.stderr.strip()}")
+        q = yaml.safe_load(open(os.path.join(org, "_intake", "processing", "review-queue.yaml"), encoding="utf-8"))
+        by = {os.path.basename(c["ref"]): c for c in q["candidates"]}
+        for name, (_eid, _etype, folder) in equals.items():
+            pl = by.get(name, {}).get("placement")
+            check(isinstance(pl, dict) and pl.get("mode") == "standalone" and pl.get("folder") == folder,
+                  f"I2: {name} should carry placement mode=standalone folder={folder}; got {pl!r}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    # I3 — check-placement flags an admitted standalone element outside its §4 folder.
+    work = tempfile.mkdtemp(prefix="ingest-place3-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(os.path.join(org, "_intake", "inbox"), exist_ok=True)
+
+        def admit(rel, fname, body):
+            d = os.path.join(org, "canon", "elements", rel)
+            os.makedirs(d, exist_ok=True)
+            with open(os.path.join(d, fname), "w", encoding="utf-8") as fh:
+                fh.write(body)
+
+        # Correct placements first → clean.
+        admit("02_business/products", "PRODUCT-FLEXLINE-1.yaml", 'id: "PRODUCT-FLEXLINE-1"\n')
+        admit("02_business/actors", "ACTOR-ACME-1.yaml", 'id: "ACTOR-ACME-1"\n')
+        r = run_cli("check-placement", org)
+        check(r.returncode == 0, f"I3: a correctly-placed canon should pass check-placement; got: {(r.stdout + r.stderr).strip()}")
+
+        # Misplace an APPLICATION under products/ → flagged.
+        admit("02_business/products", "APPLICATION-CRM-1.yaml", 'id: "APPLICATION-CRM-1"\n')
+        r = run_cli("check-placement", org)
+        out = r.stdout + r.stderr
+        check(r.returncode == 1 and "APPLICATION-CRM-1" in out and "03_application/applications/" in out,
+              f"I3: a standalone element outside its §4 folder must be flagged; got: {out.strip()!r}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
@@ -618,6 +710,7 @@ part_e_ig2()
 part_f_ig3()
 part_g_coverage()
 part_h_idempotent()
+part_i_placement()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## Problem

The ingest pipeline had **no deterministic resolution** of an element's materialisation mode (`standalone` = own per-TYPE folder vs `view-defined` = inline) or its layer/folder. `emit-candidates` wrote flat candidates carrying only `element_type`; `validate` checked grammar + coverage only — no TYPE→layer map, no standalone-vs-view-defined classifier. So placement was left to the manual admission step with no enforcement → inconsistent outcomes (actors/roles materialised into their own folders while processes/products stayed inline).

## Fix

A deterministic **TYPE → {mode, layer, folder, promotable}** resolver sourced **verbatim from `ELEMENT_PRIMITIVES.md` §4** (`src/placement.mjs`; same discipline as `coverage-presets.mjs` against `COVERAGE_PROFILES` §3), surfaced three ways:

- **`resolve-placement <TYPE>`** — print a TYPE's §4 mode + layer + folder.
- **review-queue** annotates each element candidate with its resolved `placement` (`mode`/`layer`/`folder`, + `promotable`), so the human gate places equals equally instead of by judgement.
- **`check-placement [org-root]`** — read-only scan of `canon/` that flags any admitted element sitting outside its §4 folder (and any `view-defined` TYPE wrongly given its own catalogue file). Folder match is **by suffix**, so it's agnostic to the canon-root prefix (a separate open item). **THE ONE RULE holds** — it only reads.

The **§1 promotion rule** is honoured explicitly: `view-defined` / `contained` TYPEs (`INTEGRATION`, `STEP`, `EQUIPMENT`, `INFORMATION_ENTITY`, registry rows) are marked `promotable` and stay inline until a *second* document references them — the id never changes on promotion. `SKILL.md`'s admission step is now pinned to §4 with this rule spelled out.

Sources the resolver from the canon reconciled in #146 / HUB-167 (`PRODUCT`/`APPLICATION` are `standalone`), so the §4 source is unambiguous. (No file dependency on that branch — §4 itself was already correct on `main`; #167 corrected the lagging IDS §4.)

### Incidental: YAML emitter nesting fix

The zero-dep emitter flattened a **nested map inside a list item** (each sub-line was `trimStart()`ed + re-padded flat) — invisible while list items were scalar-only; the candidate `placement` sub-map is the first such case. Now the item renders one list-level deep so nested maps keep their relative indentation; **scalar-only items are byte-identical to before**.

## Acceptance (HUB-168)

- ✅ Given a candidate of TYPE `T`, the pipeline reports `T`'s §4 materialisation mode + target layer/folder.
- ✅ An admitted `standalone` element placed outside its §4 folder is flagged.
- ✅ Actors, roles, processes, products of equal standing resolve consistently (all to own folders) — no silent asymmetry.

## Verification

`python transitrix/skills/ingest/tests/test_ingest_integrity.py` → **PASS** (all parts incl. new Part I). `node scripts/check-notations.mjs` → clean. New commands smoke-tested (resolve-placement across 6 TYPEs incl. unknown; check-placement on correct + misplaced canon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
