### PR TITLE
feat(reg-intel): extraction prompts — SEGMENT + CLASSIFY (#153, increment 2)

### DIFF
--- a/transitrix/skills/reg-intel/prompts/README.md
+++ b/transitrix/skills/reg-intel/prompts/README.md
@@ -1,0 +1,25 @@
+# `prompts/` — reg-intel extraction prompts
+
+The two **agent-facing extraction prompts** the reg-intel pipeline runs over a fetched source snapshot. They are the LLM steps of the [SKILL.md](../SKILL.md) run loop; the deterministic CLI sequences them and shapes their JSON results into `field`-zone `SEGMENT-*` artefacts and `proposed` `REQUIREMENT-*` / `CONSTRAINT-*` candidates. Each prompt is self-contained (it can be fed to an agent independently) and emits a strict JSON result contract — nothing else.
+
+| File | Step | Reads | Emits |
+|---|---|---|---|
+| [`segment.md`](segment.md) | 4 — SEGMENT | normative text of a source snapshot | `segments[]` — obligation-bearing chunks (`locator`, `text_excerpt`, `obligation_signal`, `extraction_confidence`) |
+| [`classify.md`](classify.md) | 5 — CLASSIFY | the SEGMENTs from Step 4 | `candidates[]` — one `requirement`/`constraint` per segment, with `obligation_level` and `derived_from` |
+
+## The rule the CLASSIFY prompt encodes
+
+**Positive obligation → `REQUIREMENT` is the default.** The decision tree distinguishes by the *form* of the obligation, not its topic: a prohibition or a definition/scope boundary is a `CONSTRAINT`; a positive command to act is a `REQUIREMENT`. Encoding this as a deterministic default means the same passage classifies the same way across runs and across agents (Claude and Copilot). Authoring guidance lives in the per-notation spec ([`15-requirement.md`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/15-requirement.md)); the prompt operationalises it.
+
+## Rules both prompts enforce
+
+- **Verbatim, not paraphrased.** Segment text is the source's own words — a later amendment must be provable against the bytes that were read.
+- **Two axes, never merged.** `extraction_confidence` (`high|medium|low`) answers *"did I read / classify correctly"* — a review flag, **separate** from `source_quality` (trust in the source) and **never** persisted into canon.
+- **Ambiguity is surfaced, not resolved.** A passage the classifier cannot confidently place is emitted `extraction_confidence: low` with the alternate classification attached; the human picks.
+- **Propose, never admit.** The prompts emit `proposed` artefacts/candidates only. Admission to canon (`proposed → active | rejected`) is a separate human gate; nothing here writes `canon/`.
+
+## See also
+
+- The skill protocol: [`../SKILL.md`](../SKILL.md) Steps 4–5.
+- SEGMENT / REQUIREMENT TYPEs: [`23-segment.md`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/23-segment.md), [`15-requirement.md`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/15-requirement.md).
+- Admission record + confidence model: [CONTRACT §6, §11](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md).

--- a/transitrix/skills/reg-intel/prompts/classify.md
+++ b/transitrix/skills/reg-intel/prompts/classify.md
@@ -1,0 +1,82 @@
+---
+step: classify
+emits: [REQUIREMENT, CONSTRAINT]
+version: "0.1"
+status: draft
+---
+
+# Reg-Intel extraction prompt — CLASSIFY (Step 5)
+
+You are a classification agent. For each **SEGMENT** produced by the SEGMENT step, you derive exactly one **canon candidate** — a `proposed` `REQUIREMENT` or `CONSTRAINT` — and you map its obligation level. You do not admit anything, and you do not force a deterministic answer on a genuinely ambiguous passage. You propose; a human gates the result.
+
+## Input
+
+One or more SEGMENT artefacts, each with its `SEGMENT-…` id and verbatim obligation text.
+
+## Output
+
+Emit a single JSON object. Nothing else. The CLI assigns each candidate its canonical `REQUIREMENT-…` / `CONSTRAINT-…` id and the admission record — you supply the classification.
+
+```json
+{
+  "candidates": [
+    {
+      "kind": "requirement | constraint",
+      "category": "<see the trees below>",
+      "obligation_level": "SHALL | SHALL_NOT | SHOULD | MAY",
+      "derived_from": ["SEGMENT-<id>"],
+      "source_text": "<verbatim segment text>",
+      "extraction_confidence": "high|medium|low",
+      "extraction_notes": "<optional>",
+      "ambiguous_alt": { "kind": "...", "category": "..." }
+    }
+  ]
+}
+```
+
+`ambiguous_alt` is **only** present when `extraction_confidence: low` — it carries the *other* plausible classification so the digest can show the human both shapes.
+
+## The decision tree — positive obligation → REQUIREMENT is the default
+
+```
+Is the passage establishing a classification, definition, or scope boundary?
+  YES → CONSTRAINT (category: DEFINITIONAL)
+        e.g. "IVDs are devices including when the manufacturer is a laboratory"
+
+Is the passage a prohibition (what the org MUST NOT do)?
+  YES → CONSTRAINT (category: PRODUCT or PROCESS, by subject)
+        e.g. "A device may not be commercially distributed without premarket approval"
+
+Is the passage a positive obligation (something the org MUST actively do)?
+  YES → REQUIREMENT   ←  THE DEFAULT RULE
+        Then, what kind of action?
+          register / list / notify a government body  → REQUIREMENT (ORGANIZATIONAL)
+          submit a report, file, or application       → REQUIREMENT (REPORTING)
+          establish / maintain a process or system    → REQUIREMENT (PROCESS)
+          ensure a product has specific properties    → REQUIREMENT (PRODUCT)
+          keep records / maintain documentation       → REQUIREMENT (DOCUMENTATION)
+```
+
+**Positive obligation → REQUIREMENT is the default.** Distinguish by the *form* of the obligation, not its topic: a REQUIREMENT is a positive action ("must submit", "must register", "must obtain approval"); a CONSTRAINT is a restriction ("must not", "cannot exceed") or a definition/scope boundary. When the passage commands an action, it is a REQUIREMENT unless it is plainly a prohibition or a definition.
+
+## Obligation level (RFC 2119) — mapped from the source language
+
+| Source language | `obligation_level` |
+|---|---|
+| `must` / `shall` / `is required to` | `SHALL` |
+| `must not` / `shall not` / `is prohibited from` | `SHALL_NOT` |
+| `should` / `is expected to` / `recommends` | `SHOULD` |
+| `may` / `at its discretion` | `MAY` |
+
+## Rules every candidate obeys
+
+- **Ambiguity is not silently resolved.** If you cannot confidently place a segment, emit it with `extraction_confidence: low` and fill `ambiguous_alt` with the other classification — the human picks. Forcing a deterministic answer on an ambiguous obligation is the path to a quietly wrong canon.
+- **Cite the segment.** `derived_from` always references the `SEGMENT-…` id (and through it, the codex source). Never classify free-floating text.
+- **Two axes, never merged.** `extraction_confidence` (*"did I classify correctly"*) is a review flag — never `source_quality`, never persisted into canon.
+- **Propose, never admit.** Candidates are written `proposed`; a human flips `proposed → active | rejected`. You never write `canon/`.
+
+## See also
+
+- The skill protocol: [`../SKILL.md`](../SKILL.md) Step 5.
+- REQUIREMENT vs CONSTRAINT authoring guidance: [`15-requirement.md`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/15-requirement.md).
+- The SEGMENT this cites: [`23-segment.md`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/23-segment.md).

--- a/transitrix/skills/reg-intel/prompts/segment.md
+++ b/transitrix/skills/reg-intel/prompts/segment.md
@@ -1,0 +1,57 @@
+---
+step: segment
+emits: [SEGMENT]
+version: "0.1"
+status: draft
+---
+
+# Reg-Intel extraction prompt — SEGMENT (Step 4)
+
+You are a segmentation agent. You read the **normative text of one regulatory source** (a snapshot already fetched and stored by the reg-intel pipeline) and slice it into **obligation-bearing segments**. You do not classify them (that is the CLASSIFY step), you do not admit anything, and you do not interpret legal ambiguity beyond marking your confidence. You propose; a human gates the result.
+
+## Input
+
+The text body of a snapshot of a codex source (`LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`). You are told the source's `CODEX-ID`. Read the **normative text** — skip preambles, comment-and-response sections, tables of contents, and definition-only passages that carry no obligation.
+
+## Output
+
+Emit a single JSON object. Nothing else. The CLI assigns each segment its canonical `SEGMENT-…` id, `source`, `extracted_at`, and the field-zone admission record — you supply only the extractable fields.
+
+```json
+{
+  "segments": [
+    {
+      "locator": "<source-shaped citation, e.g. Art.30(1)(b) or §164.312(a)(1)>",
+      "text_excerpt": "<verbatim text of the obligation passage>",
+      "obligation_signal": "<the primary signal phrase you matched, e.g. shall | must | must not>",
+      "extraction_confidence": "high|medium|low",
+      "extraction_notes": "<optional — ambiguity or boundary judgement for the reviewer>"
+    }
+  ]
+}
+```
+
+If a passage's verbatim text cannot be reproduced (length or licensing), omit `text_excerpt` and add `"text_only_hashable": true`; the CLI will store a `text_hash` instead. At least one of excerpt / hashable must be present per segment.
+
+## What makes a segment
+
+- **Obligation-bearing.** It contains explicit obligation language. Primary signals: `must` / `shall` / `is required to` / `must not` / `shall not` / `is prohibited from`. Secondary signals (`is responsible for`, `may not`, `no person shall`) count, weighted lower — note them in `extraction_notes`.
+- **Self-contained.** It can be read and understood without the surrounding paragraphs.
+- **Atomic — one obligation per segment.** If a paragraph carries three obligations ("must register, must list, and must label"), emit **three** segments. Numbered list items are separate segments when each item is an independent obligation.
+- **Not** a preamble comment, a comment-and-response, or a definition-only passage with no obligation attached.
+
+## Boundaries
+
+Start at the sentence containing the obligation signal (or the section heading that introduces a normative block); end at the last sentence of the same normative thought. Carry the most specific citation the source exposes into `locator`.
+
+## Rules every segment obeys
+
+- **Verbatim, not paraphrased.** `text_excerpt` is the source's own words. Do not summarise, normalise, or "clean up" the text — a later amendment must be provable against the bytes you read.
+- **Confidence is a read-flag, not source trust.** `extraction_confidence` (`high|medium|low`) answers *"did I find a real, atomic obligation and cite it correctly"*. It is **never** `source_quality` (trust in the source), which lives on the field/codex artefact and which you never emit.
+- **Propose, never admit.** You emit segments; the CLI writes them to `_intake/processing/segments/` in the `proposed` state and a human gates them. You never write `canon/` or `field/`.
+
+## See also
+
+- The skill protocol: [`../SKILL.md`](../SKILL.md) Step 4.
+- The SEGMENT TYPE: [`23-segment.md`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/23-segment.md).
+- Two axes of trust: [CONTRACT §11.2, §11.8](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md).

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_prompts.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_prompts.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Bundle test for the Transitrix Reg-Intel extraction prompts (SKILL Steps 4–5).
+
+Deterministic, no-API-key, no-network. Checks the segmentation + classification
+prompts are present, their frontmatter parses, and they encode the contracts the
+SKILL.md run loop depends on — in particular the CLASSIFY default rule
+(positive obligation → REQUIREMENT) that strategy#153 / #152 require.
+
+Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_prompts.py
+Exit: 0 = all pass; 1 = a check failed.
+"""
+
+import os
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.exit("FAIL: PyYAML is required (pip install pyyaml).")
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(HERE)
+PROMPTS = os.path.join(SKILL_DIR, "prompts")
+
+_failures = []
+
+
+def check(cond, msg):
+    if not cond:
+        _failures.append(msg)
+    return cond
+
+
+def read(path):
+    return open(path, encoding="utf-8").read()
+
+
+def frontmatter(text):
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+    return yaml.safe_load(m.group(1)) if m else None
+
+
+# ── presence + frontmatter ───────────────────────────────────────
+
+for name in ("segment.md", "classify.md", "README.md"):
+    check(os.path.isfile(os.path.join(PROMPTS, name)), f"prompts/{name} missing")
+
+for name, step, emits in (("segment.md", "segment", "SEGMENT"), ("classify.md", "classify", "REQUIREMENT")):
+    p = os.path.join(PROMPTS, name)
+    if not os.path.isfile(p):
+        continue
+    fm = frontmatter(read(p))
+    if check(isinstance(fm, dict), f"prompts/{name} frontmatter does not parse"):
+        check(fm.get("step") == step, f"prompts/{name} frontmatter step must be {step!r}")
+        check("version" in fm and "status" in fm, f"prompts/{name} frontmatter missing version/status")
+        check(emits in (fm.get("emits") or []), f"prompts/{name} frontmatter emits must include {emits}")
+
+# ── SEGMENT prompt encodes the segmentation contract ─────────────
+
+if os.path.isfile(os.path.join(PROMPTS, "segment.md")):
+    seg = read(os.path.join(PROMPTS, "segment.md"))
+    check('"segments"' in seg, "segment prompt must emit a segments[] result contract")
+    check("locator" in seg and "text_excerpt" in seg, "segment prompt must carry locator + text_excerpt")
+    for signal in ("shall", "must not", "is required to"):
+        check(signal in seg, f"segment prompt must name the obligation signal {signal!r}")
+    check("atomic" in seg.lower() and "self-contained" in seg.lower(),
+          "segment prompt must require atomic, self-contained segments")
+    check("extraction_confidence" in seg and "source_quality" in seg,
+          "segment prompt must keep the two trust axes distinct")
+
+# ── CLASSIFY prompt encodes the default rule + level mapping ─────
+
+if os.path.isfile(os.path.join(PROMPTS, "classify.md")):
+    cls = read(os.path.join(PROMPTS, "classify.md"))
+    low = cls.lower()
+    check("positive obligation" in low and "default" in low,
+          "classify prompt must state the positive-obligation → REQUIREMENT default")
+    check("REQUIREMENT" in cls and "CONSTRAINT" in cls, "classify prompt must name both kinds")
+    check("DEFINITIONAL" in cls, "classify prompt must include the CONSTRAINT(DEFINITIONAL) branch")
+    for level in ("SHALL", "SHALL_NOT", "SHOULD", "MAY"):
+        check(level in cls, f"classify prompt must map obligation_level {level}")
+    check("derived_from" in cls, "classify prompt must cite the SEGMENT via derived_from")
+    check("ambiguous_alt" in cls and "low" in low,
+          "classify prompt must surface ambiguity (low confidence + alternate classification), not resolve it")
+
+# ── README encodes the default rule too ──────────────────────────
+
+if os.path.isfile(os.path.join(PROMPTS, "README.md")):
+    rd = read(os.path.join(PROMPTS, "README.md")).lower()
+    check("positive obligation" in rd and "default" in rd,
+          "prompts/README must document the positive-obligation → REQUIREMENT default")
+    check("propose, never admit" in rd, "prompts/README must state the propose-never-admit rule")
+
+if _failures:
+    print("FAIL - Transitrix Reg-Intel extraction prompts:")
+    for f in _failures:
+        print(f"  - {f}")
+    sys.exit(1)
+print("PASS - Transitrix Reg-Intel extraction prompts: all checks passed.")
+sys.exit(0)


### PR DESCRIPTION
Second increment of the reg-intel build (HUB-153). The two agent-facing **extraction prompts** — the LLM half of the SKILL.md run loop (Steps 4–5) — mirroring how the ingest skill bundles per-layer extraction prompts.

**Independent of the scheduler-core PR (#148)** — content only, no package code, no `SKILL.md` edit — so it's based on `main` and does **not** stack.

## What ships

- **`prompts/segment.md`** (Step 4) — slices a source snapshot into obligation-bearing, **self-contained, atomic** SEGMENTs; emits a strict `segments[]` JSON contract (`locator`, **verbatim** `text_excerpt`, `obligation_signal`, `extraction_confidence`). The CLI adds the `SEGMENT-…` ids + the field-zone admission record.
- **`prompts/classify.md`** (Step 5) — derives one `REQUIREMENT`/`CONSTRAINT` candidate per SEGMENT and maps the RFC-2119 obligation level. **Encodes the CLASSIFY default — positive obligation → `REQUIREMENT`** (HUB-152) — as the deterministic decision tree, so the same passage classifies the same way across runs and across agents. Ambiguity is **surfaced** (`extraction_confidence: low` + `ambiguous_alt`), never forced.
- **`prompts/README.md`** — index + the rules both prompts enforce (verbatim text, the two-axes trust split, propose-never-admit).

## Tests

`transitrix/skills/reg-intel/tests/test_reg_intel_prompts.py` — deterministic, no-API-key: prompts exist, frontmatter parses, and they encode the contracts the run loop depends on (the positive-obligation default, the obligation-level mapping, ambiguity surfacing). Separate file from the scheduler-core test → no merge collision.

## Scope / #153

Closes the **"Skill (the how) — encodes the CLASSIFY default"** acceptance bullet at the prompt level. **#153 stays open.** Remaining increments (each its own PR): the CLI's `check-signal` / `fetch-snapshot` / `segment` / `classify` / `validate` / `amendment` / `digest` (depend on #148), digest JSON schemas, operational templates. THE ONE RULE holds — the prompts emit `proposed` artefacts only.

## Verification

`python transitrix/skills/reg-intel/tests/test_reg_intel_prompts.py` → **PASS**. `node scripts/check-notations.mjs` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
