### PR TITLE
feat(reg-intel-cli): review digest + digest schema (#153, increment 3)

### DIFF
--- a/packages/reg-intel-cli/README.md
+++ b/packages/reg-intel-cli/README.md
@@ -4,7 +4,7 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 
 **The one rule:** this CLI *proposes*. It reads the codex registry, runs the change-signal gate, snapshots / segments / classifies regulatory text, and stages a review digest. It **never writes `canon/`** and **never silently flips** an existing `active` canon element. A human admits.
 
-> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed: the scheduler core** (`list-due`, `update-scan`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`check-signal`, `fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`, `digest`) lands in later increments.
+> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed: the scheduler core** (`list-due`, `update-scan`) **and the review digest** (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`check-signal`, `fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`) lands in later increments.
 
 ## Commands
 
@@ -13,7 +13,8 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 | `--version` / `--help` | ✅ | Version (the skill's Step-0 pre-check) and usage. |
 | `list-due [org-root] [--as-of YYYY-MM-DD] [--json]` | ✅ | List codex sources due for a scan: `monitoring_needed: true` artefacts whose `scan.next_scan_due <= as-of` (or never scanned), plus the `monitor_instead[]` counterparts of static sources. One run filters by date — not N schedules. |
 | `update-scan <CODEX-ID\|file> [--today YYYY-MM-DD] [--frequency daily\|weekly\|monthly\|quarterly] [--change "<summary>"] [--review]` | ✅ | Write the codex `scan` block (`last_scanned_at`, `next_scan_due` from the cadence, `change_detected`, `change_description`, `review_needed`) — operating state only; never touches any other field. |
-| `check-signal` / `fetch-snapshot` / `segment` / `classify` / `validate` / `amendment` / `digest` | ⏳ | Later increments. |
+| `digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]` | ✅ | Assemble the human review digest (`review-digest.yaml`) — staged SEGMENT / candidate / AMENDMENT artefacts grouped by codex source (candidates via `derived_from` → SEGMENT), with each source's scan block + a tally. `gate.admits_to_canon: false`. Schema: [`schemas/review-digest.schema.json`](../../transitrix/skills/reg-intel/schemas/review-digest.schema.json). |
+| `check-signal` / `fetch-snapshot` / `segment` / `classify` / `validate` / `amendment` | ⏳ | Later increments. |
 
 `next_scan_due` math: `daily` +1d, `weekly` +7d, `monthly` +1 month, `quarterly` +3 months; month additions clamp to the target month's last day (Jan 31 + monthly → Feb 28/29). All UTC, so results are host-timezone independent. Dates compare as ISO-8601 strings.
 
@@ -23,10 +24,11 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 packages/reg-intel-cli/
   reg-intel.mjs       # dispatcher / entry point (bin: transitrix-reg-intel)
   src/
-    yaml.mjs           # zero-dep codex YAML reader (top scalars, scan block, monitor_instead)
+    yaml.mjs           # zero-dep codex YAML reader (scalars, scan block, lists) + digest emitter
     schedule.mjs       # scan_frequency enum + next_scan_due date math + isDue
     codex.mjs          # discover codex artefacts; the due set (list-due); find by ID
     update-scan.mjs    # write/replace the codex scan block in place (Step 8)
+    digest.mjs         # assemble the review digest from staged run artefacts (Step 9)
 ```
 
 The "source registry" is **the codex artefacts the repo already carries** (`14-codex.md` §3.4–3.5), not a separate database — the schedule rides on each codex YAML's `scan` block, so scan history is auditable via git. Zero runtime dependencies, Node ≥ 18.

--- a/packages/reg-intel-cli/reg-intel.mjs
+++ b/packages/reg-intel-cli/reg-intel.mjs
@@ -20,6 +20,7 @@ import { access } from 'node:fs/promises';
 
 import { findOrgRoot, listDue, findCodexFile } from './src/codex.mjs';
 import { updateScan } from './src/update-scan.mjs';
+import { buildDigest, writeDigest, defaultDigestPath } from './src/digest.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -57,6 +58,9 @@ function usage() {
     '  update-scan <CODEX-ID|file> [--today YYYY-MM-DD] [--frequency daily|weekly|monthly|quarterly]',
     '              [--change "<summary>"] [--review]',
     '                                 Write the codex scan block (last_scanned_at, next_scan_due, …).',
+    '  digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]',
+    '                                 Assemble the human review digest from staged run artefacts',
+    '                                 (review-digest.yaml). Nothing is admitted — a human gates it.',
     '  --version, -v                  Print the CLI version',
     '  --help, -h                     Show this help',
     '',
@@ -127,6 +131,24 @@ async function cmdUpdateScan(args) {
   }
 }
 
+async function cmdDigest(args) {
+  const { _, flags } = parseArgs(args);
+  const orgRoot = await resolveOrgRoot(_[0], 'digest');
+  if (!orgRoot) return 2;
+  const asOf = flags['as-of'] ? String(flags['as-of']) : today();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(asOf)) { console.error('digest: --as-of must be YYYY-MM-DD'); return 1; }
+
+  const digest = await buildDigest({ orgRoot, asOf, runId: typeof flags['run-id'] === 'string' ? flags['run-id'] : undefined });
+  const out = flags.out ? resolve(flags.out) : await defaultDigestPath(orgRoot);
+  await writeDigest(digest, out);
+
+  const t = digest.tally;
+  console.log(`review digest  ->  ${out}`);
+  console.log(`  ${t.sources_touched} source(s) · proposed: SEGMENT ${t.proposed.SEGMENT} / REQUIREMENT ${t.proposed.REQUIREMENT} / CONSTRAINT ${t.proposed.CONSTRAINT} / AMENDMENT ${t.proposed.AMENDMENT} · review_needed ${t.review_needed}`);
+  console.log('  nothing admitted to canon — a human gates this digest.');
+  return 0;
+}
+
 async function main(argv) {
   const [cmd, ...args] = argv;
   if (!cmd || cmd === '--help' || cmd === '-h') { console.log(usage()); return cmd ? 0 : 1; }
@@ -135,6 +157,7 @@ async function main(argv) {
   switch (cmd) {
     case 'list-due':    return cmdListDue(args);
     case 'update-scan': return cmdUpdateScan(args);
+    case 'digest':      return cmdDigest(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);
       return 1;

--- a/packages/reg-intel-cli/src/digest.mjs
+++ b/packages/reg-intel-cli/src/digest.mjs
@@ -1,0 +1,141 @@
+// `digest` (SKILL Step 9) — assemble the review digest, the human gate. Reads the
+// artefacts a run has staged under _intake/processing/ (segments, candidates,
+// amendments) and the codex `scan` blocks, groups them by source, and writes
+// review-digest.yaml. NOTHING here is admitted: the digest is read by a human who then
+// flips `proposed → active | rejected`. This CLI never writes canon and never
+// auto-flips an active element (the two rules, SKILL § The two rules).
+
+import { readdir, readFile, writeFile, access, mkdir } from 'node:fs/promises';
+import { join, resolve, basename } from 'node:path';
+import { dump, readTopScalar, readBlockScalars, readScalarList } from './yaml.mjs';
+import { discoverCodex } from './codex.mjs';
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+async function readDir(dir) {
+  try { return (await readdir(dir)).filter((n) => n.endsWith('.yaml')).sort(); }
+  catch { return []; }
+}
+
+// REQUIREMENT-… / CONSTRAINT-… → requirement | constraint (the candidate kind).
+function kindOf(id) {
+  const t = typeof id === 'string' ? id.split('-')[0] : '';
+  if (t === 'REQUIREMENT') return 'requirement';
+  if (t === 'CONSTRAINT') return 'constraint';
+  return 'unknown';
+}
+
+async function readSegments(procDir) {
+  const dir = join(procDir, 'segments');
+  const out = [];
+  for (const name of await readDir(dir)) {
+    const text = await readFile(join(dir, name), 'utf8');
+    out.push({
+      id: readTopScalar(text, 'id') ?? basename(name, '.yaml'),
+      source: readTopScalar(text, 'source') ?? null,
+      locator: readTopScalar(text, 'locator') ?? null,
+      extraction_confidence: readTopScalar(text, 'extraction_confidence') ?? null,
+    });
+  }
+  return out;
+}
+
+async function readCandidates(procDir) {
+  const dir = join(procDir, 'candidates');
+  const out = [];
+  for (const name of await readDir(dir)) {
+    const text = await readFile(join(dir, name), 'utf8');
+    const id = readTopScalar(text, 'id') ?? basename(name, '.yaml');
+    out.push({
+      id,
+      kind: kindOf(id),
+      derived_from: readScalarList(text, 'derived_from'),
+      extraction_confidence: readTopScalar(text, 'extraction_confidence') ?? null,
+    });
+  }
+  return out;
+}
+
+async function readAmendments(procDir) {
+  const dir = join(procDir, 'amendments');
+  const out = [];
+  for (const name of await readDir(dir)) {
+    const text = await readFile(join(dir, name), 'utf8');
+    out.push({
+      id: readTopScalar(text, 'id') ?? basename(name, '.yaml'),
+      source: readTopScalar(text, 'source') ?? null,
+      change_description: readTopScalar(text, 'change_description') ?? null,
+      segment_refs: readScalarList(text, 'segment_refs'),
+    });
+  }
+  return out;
+}
+
+// Build the digest object for the run. Groups staged artefacts by their codex source;
+// candidates are attached via derived_from → SEGMENT → source. Artefacts whose source
+// cannot be resolved are surfaced under an `unassociated` bucket (never dropped).
+export async function buildDigest({ orgRoot, asOf, runId }) {
+  const procDir = join(resolve(orgRoot), '_intake', 'processing');
+  const [segments, candidates, amendments, codex] = await Promise.all([
+    readSegments(procDir), readCandidates(procDir), readAmendments(procDir), discoverCodex(orgRoot),
+  ]);
+
+  const segSource = new Map(segments.map((s) => [s.id, s.source]));
+  const candSource = (c) => {
+    for (const d of c.derived_from || []) if (segSource.has(d)) return segSource.get(d);
+    return null;
+  };
+
+  // Index by source id.
+  const bucket = new Map();
+  const ensure = (id) => {
+    if (!bucket.has(id)) bucket.set(id, { id, scan: null, segments: [], candidates: [], amendments: [] });
+    return bucket.get(id);
+  };
+  for (const a of codex) if (a.monitoring_needed === true) ensure(a.id).scan = a.scan || null;
+  for (const s of segments) (s.source ? ensure(s.source) : ensure('(unassociated)')).segments.push(s);
+  for (const c of candidates) { const src = candSource(c); (src ? ensure(src) : ensure('(unassociated)')).candidates.push(c); }
+  for (const a of amendments) (a.source ? ensure(a.source) : ensure('(unassociated)')).amendments.push(a);
+
+  const sources = [...bucket.values()].sort((x, y) => x.id.localeCompare(y.id)).map((b) => ({
+    id: b.id,
+    ...(b.scan ? { scan: {
+      last_scanned_at: b.scan.last_scanned_at ?? null,
+      next_scan_due: b.scan.next_scan_due ?? null,
+      change_detected: b.scan.change_detected ?? null,
+      review_needed: b.scan.review_needed ?? null,
+    } } : {}),
+    segments: b.segments.map((s) => ({ id: s.id, locator: s.locator, extraction_confidence: s.extraction_confidence })),
+    candidates: b.candidates.map((c) => ({ id: c.id, kind: c.kind, derived_from: c.derived_from, extraction_confidence: c.extraction_confidence })),
+    amendments: b.amendments.map((a) => ({ id: a.id, change_description: a.change_description, segment_refs: a.segment_refs })),
+  }));
+
+  const requirements = candidates.filter((c) => c.kind === 'requirement').length;
+  const constraints = candidates.filter((c) => c.kind === 'constraint').length;
+
+  return {
+    generated_by: '@transitrix/reg-intel-cli',
+    org_root: resolve(orgRoot),
+    ...(runId ? { run_id: String(runId) } : {}),
+    as_of: asOf,
+    sources,
+    tally: {
+      sources_touched: sources.length,
+      proposed: { SEGMENT: segments.length, REQUIREMENT: requirements, CONSTRAINT: constraints, AMENDMENT: amendments.length },
+      review_needed: codex.filter((a) => a.scan && a.scan.review_needed === true).length,
+    },
+    gate: { admits_to_canon: false },
+  };
+}
+
+export async function writeDigest(digest, outPath) {
+  await mkdir(join(outPath, '..'), { recursive: true }).catch(() => {});
+  await writeFile(outPath, dump(digest), 'utf8');
+  return outPath;
+}
+
+export async function defaultDigestPath(orgRoot) {
+  const dir = join(resolve(orgRoot), '_intake', 'processing');
+  if (!(await exists(dir))) await mkdir(dir, { recursive: true });
+  return join(dir, 'review-digest.yaml');
+}

--- a/packages/reg-intel-cli/src/yaml.mjs
+++ b/packages/reg-intel-cli/src/yaml.mjs
@@ -1,9 +1,9 @@
-// Minimal, purpose-built YAML reader for codex artefacts — just enough to read the
-// top-level scalars (`id`, `type`, `monitoring_needed`, `source_url`), the nested
-// `scan:` block, and the `monitor_instead:` list-of-maps that the scheduler needs.
-// NOT a general YAML library; the reg-intel CLI keeps zero dependencies, the same
-// discipline as the ingest CLI's yaml.mjs. Writing the `scan` block back is done by
-// update-scan.mjs textually, so this file is read-only.
+// Minimal, purpose-built YAML for codex artefacts + the reg-intel review digest —
+// just enough to read the codex top-level scalars (`id`, `type`, `monitoring_needed`,
+// `source_url`), the nested `scan:` block, `monitor_instead:` / scalar lists, and to
+// EMIT the constrained shapes the digest produces. NOT a general YAML library; the
+// reg-intel CLI keeps zero dependencies, the same discipline as the ingest CLI's
+// yaml.mjs. The `scan` block is written back textually by update-scan.mjs.
 
 // Trim, strip a trailing ` # comment`, unquote, and type bare null/true/false.
 function cleanScalar(raw) {
@@ -47,6 +47,30 @@ export function readBlockScalars(text, key) {
   return out;
 }
 
+// Read a top-level scalar list `key:` — inline `[a, b]` or a block of `- ` items.
+// Returns an array of typed scalars, or [] when the key is absent.
+export function readScalarList(text, key) {
+  if (typeof text !== 'string') return [];
+  const lines = text.split(/\r?\n/);
+  const start = lines.findIndex((l) => new RegExp(`^${key}:[ \\t]*(.*)$`).test(l));
+  if (start < 0) return [];
+  const inline = lines[start].replace(new RegExp(`^${key}:[ \\t]*`), '').trim();
+  if (inline.startsWith('[')) {
+    const body = inline.replace(/^\[/, '').replace(/\][ \t]*(#.*)?$/, '').trim();
+    return body === '' ? [] : body.split(',').map((x) => cleanScalar(x)).filter((v) => v !== undefined);
+  }
+  const out = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (l.trim() === '') continue;
+    if (/^\S/.test(l)) break;
+    const m = l.match(/^[ \t]+-[ \t]+(.*)$/);
+    if (m) { const v = cleanScalar(m[1]); if (v !== undefined) out.push(v); }
+    else break;
+  }
+  return out;
+}
+
 // Read a top-level list-of-maps `key:` (e.g. `monitor_instead:`). Returns an array of
 // objects (one per `- ` item), or [] when the key is absent.
 export function readMapList(text, key) {
@@ -66,4 +90,57 @@ export function readMapList(text, key) {
     if (m && cur) cur[m[1]] = cleanScalar(m[2]);
   }
   return items;
+}
+
+// ── Emission ─────────────────────────────────────────────────────
+// Purpose-built dumper for the digest's constrained shapes — strings double-quoted,
+// numbers/booleans/null bare, block-style maps + lists, nested maps inside list items
+// keep their indentation. Mirrors the ingest CLI's emitter (same rules + the list-item
+// nesting fix), so the two CLIs produce consistent YAML.
+
+function scalar(v) {
+  if (v === null || v === undefined) return 'null';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (typeof v === 'number') return Number.isFinite(v) ? String(v) : 'null';
+  return JSON.stringify(String(v));
+}
+
+function isPlainObject(v) { return v !== null && typeof v === 'object' && !Array.isArray(v); }
+
+function dumpMap(obj, indent) {
+  const pad = '  '.repeat(indent);
+  const lines = [];
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) continue;
+    if (typeof v === 'string' && v.includes('\n')) {
+      lines.push(`${pad}${k}: |`);
+      for (const ln of v.replace(/\n$/, '').split('\n')) lines.push(`${pad}  ${ln}`);
+    } else if (Array.isArray(v)) {
+      if (v.length === 0) { lines.push(`${pad}${k}: []`); continue; }
+      lines.push(`${pad}${k}:`);
+      for (const item of v) {
+        if (isPlainObject(item)) {
+          const itemIndent = indent + 2;
+          const sub = dumpMap(item, itemIndent);
+          const childPad = '  '.repeat(itemIndent);
+          lines.push(`${pad}  - ${sub[0].slice(childPad.length)}`);
+          for (let i = 1; i < sub.length; i++) lines.push(sub[i]);
+        } else {
+          lines.push(`${pad}  - ${scalar(item)}`);
+        }
+      }
+    } else if (isPlainObject(v)) {
+      if (Object.keys(v).length === 0) { lines.push(`${pad}${k}: {}`); continue; }
+      lines.push(`${pad}${k}:`);
+      lines.push(...dumpMap(v, indent + 1));
+    } else {
+      lines.push(`${pad}${k}: ${scalar(v)}`);
+    }
+  }
+  return lines;
+}
+
+export function dump(obj) {
+  if (!isPlainObject(obj)) throw new Error('yaml.dump expects a plain object at the top level');
+  return dumpMap(obj, 0).join('\n') + '\n';
 }

--- a/transitrix/skills/reg-intel/schemas/review-digest.schema.json
+++ b/transitrix/skills/reg-intel/schemas/review-digest.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://transitrix.com/schemas/reg-intel/review-digest.schema.json",
+  "title": "Transitrix reg-intel review digest",
+  "description": "The human gate produced by the reg-intel pipeline for one run (SKILL Step 9). Groups the staged run artefacts by codex source — the SEGMENT field artefacts, the proposed REQUIREMENT/CONSTRAINT candidates, and the AMENDMENT field artefacts — alongside each source's scan block. NOTHING in this digest is admitted to canon: a human reads it and flips proposed -> active | rejected. gate.admits_to_canon is always false.",
+  "type": "object",
+  "required": ["generated_by", "org_root", "as_of", "sources", "tally", "gate"],
+  "additionalProperties": true,
+  "properties": {
+    "generated_by": { "type": "string", "description": "Tool identifier that produced the digest (e.g. @transitrix/reg-intel-cli)." },
+    "org_root": { "type": "string", "description": "Path to the adopter organisation root this run scanned." },
+    "run_id": { "type": "string", "description": "Optional caller-supplied identifier for the run." },
+    "as_of": { "type": "string", "description": "Quoted ISO 8601 date the digest was assembled.", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+    "sources": {
+      "type": "array",
+      "description": "One entry per codex source touched in the run (plus an (unassociated) bucket for artefacts whose source could not be resolved — never dropped).",
+      "items": {
+        "type": "object",
+        "required": ["id", "segments", "candidates", "amendments"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string", "description": "The codex source id (CODEX-…), or the literal (unassociated)." },
+          "scan": {
+            "type": "object",
+            "description": "The source's scan block at digest time (14-codex.md §3.5). Present only for monitoring_needed: true sources.",
+            "additionalProperties": true,
+            "properties": {
+              "last_scanned_at": { "type": ["string", "null"] },
+              "next_scan_due": { "type": ["string", "null"] },
+              "change_detected": { "type": ["boolean", "null"] },
+              "review_needed": { "type": ["boolean", "null"] }
+            }
+          },
+          "segments": {
+            "type": "array",
+            "description": "SEGMENT field artefacts derived from this source in the run.",
+            "items": {
+              "type": "object",
+              "required": ["id"],
+              "additionalProperties": true,
+              "properties": {
+                "id": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$" },
+                "locator": { "type": ["string", "null"] },
+                "extraction_confidence": { "type": ["string", "null"], "enum": ["high", "medium", "low", null] }
+              }
+            }
+          },
+          "candidates": {
+            "type": "array",
+            "description": "Proposed REQUIREMENT / CONSTRAINT candidates derived (via a SEGMENT) from this source.",
+            "items": {
+              "type": "object",
+              "required": ["id", "kind"],
+              "additionalProperties": true,
+              "properties": {
+                "id": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$" },
+                "kind": { "type": "string", "enum": ["requirement", "constraint", "unknown"] },
+                "derived_from": { "type": "array", "items": { "type": "string" } },
+                "extraction_confidence": { "type": ["string", "null"], "enum": ["high", "medium", "low", null] }
+              }
+            }
+          },
+          "amendments": {
+            "type": "array",
+            "description": "AMENDMENT field artefacts recording detected drift on this source.",
+            "items": {
+              "type": "object",
+              "required": ["id"],
+              "additionalProperties": true,
+              "properties": {
+                "id": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$" },
+                "change_description": { "type": ["string", "null"] },
+                "segment_refs": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tally": {
+      "type": "object",
+      "description": "Run summary counts.",
+      "required": ["sources_touched", "proposed"],
+      "additionalProperties": true,
+      "properties": {
+        "sources_touched": { "type": "integer", "minimum": 0 },
+        "proposed": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "SEGMENT": { "type": "integer", "minimum": 0 },
+            "REQUIREMENT": { "type": "integer", "minimum": 0 },
+            "CONSTRAINT": { "type": "integer", "minimum": 0 },
+            "AMENDMENT": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "review_needed": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "gate": {
+      "type": "object",
+      "description": "Invariant statement for auditors and tooling: this skill admits nothing.",
+      "properties": { "admits_to_canon": { "const": false } },
+      "additionalProperties": true
+    }
+  }
+}

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """From-scratch integrity test for the Transitrix Reg-Intel skill + @transitrix/reg-intel-cli.
 
-Deterministic, no-API-key, no-network guard for the SCHEDULER CORE — the first
-increment of the CLI (the rest of the SKILL.md pipeline lands in later increments).
-Three parts:
+Deterministic, no-API-key, no-network guard for the CLI increments landed so far
+(the rest of the SKILL.md pipeline lands in later increments). Four parts:
 
   A. Bundle integrity — SKILL.md + README.md present and frontmatter parses; the CLI
      package.json parses and declares its bin; the entry point exists; `--version`
@@ -15,6 +14,10 @@ Three parts:
   C. update-scan (Step 8) — writes the codex scan block with correct cadence math
      (clamping month-ends), sets change/review flags, preserves every other field, and
      refuses a static (monitoring_needed: false) artefact and a missing cadence.
+  D. digest (Step 9, the human gate) — the digest schema parses; the digest groups
+     staged SEGMENT / candidate / AMENDMENT artefacts by codex source (candidates via
+     derived_from -> segment), surfaces orphans under (unassociated), tallies, and is
+     always gated (admits_to_canon: false) — even on an empty run.
 
 Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
@@ -215,14 +218,96 @@ def part_c_update_scan():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part D — digest (Step 9, the human gate) ─────────────────────
+
+def part_d_digest():
+    if not shutil.which("node"):
+        print("SKIP Part D: `node` not found.")
+        return
+
+    # The digest schema ships with the bundle and parses.
+    schema = os.path.join(SKILL_DIR, "schemas", "review-digest.schema.json")
+    if check(os.path.isfile(schema), "review-digest.schema.json missing from bundle"):
+        try:
+            import json as _json
+            _json.load(open(schema, encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            check(False, f"review-digest.schema.json does not parse: {e}")
+
+    work = tempfile.mkdtemp(prefix="regintel-digest-")
+    try:
+        org = _codex_org(work)
+        proc = os.path.join(org, "_intake", "processing")
+        for sub in ("segments", "candidates", "amendments"):
+            os.makedirs(os.path.join(proc, sub), exist_ok=True)
+
+        def w(rel, body):
+            with open(os.path.join(proc, rel), "w", encoding="utf-8") as fh:
+                fh.write(body)
+
+        # Give REGULATION-A-1 a scan block + a full set of run artefacts.
+        run_cli("update-scan", os.path.join(org, "codex", "external", "eu", "REGULATION-A-1.yaml"),
+                "--today", "2026-06-08", "--change", "Art 3 changed", "--review")
+        w("segments/SEGMENT-a-1.yaml",
+          'id: "SEGMENT-a-1"\nsource: "REGULATION-A-1"\nlocator: "Art.3(1)"\nextraction_confidence: high\nzone: "field"\n')
+        w("candidates/REQUIREMENT-a-1.yaml",
+          'id: "REQUIREMENT-a-1"\nderived_from: [SEGMENT-a-1]\nextraction_confidence: medium\nadmission_state: proposed\n')
+        w("candidates/CONSTRAINT-a-1.yaml",
+          'id: "CONSTRAINT-a-1"\nderived_from:\n  - SEGMENT-a-1\nextraction_confidence: high\n')
+        w("amendments/AMENDMENT-a-1.yaml",
+          'id: "AMENDMENT-a-1"\nsource: "REGULATION-A-1"\nchange_description: "Article 3 amended"\nsegment_refs: [SEGMENT-a-1]\n')
+        # An orphan segment with no source must surface, not vanish.
+        w("segments/SEGMENT-orphan-1.yaml", 'id: "SEGMENT-orphan-1"\nlocator: "§1"\nextraction_confidence: low\n')
+
+        r = run_cli("digest", org, "--run-id", "run-1", "--as-of", "2026-06-08")
+        check(r.returncode == 0, f"D: digest failed: {r.stderr.strip()}")
+        dg = yaml.safe_load(open(os.path.join(proc, "review-digest.yaml"), encoding="utf-8"))
+
+        check(dg.get("gate", {}).get("admits_to_canon") is False, "D: digest gate.admits_to_canon must be False")
+        check(dg.get("run_id") == "run-1" and dg.get("as_of") == "2026-06-08", "D: digest run_id / as_of not carried")
+        by = {s["id"]: s for s in dg.get("sources", [])}
+
+        a = by.get("REGULATION-A-1")
+        if check(a is not None, "D: REGULATION-A-1 must appear as a source in the digest"):
+            check(a.get("scan", {}).get("review_needed") is True, "D: source scan block (review_needed) must be carried")
+            check([s["id"] for s in a["segments"]] == ["SEGMENT-a-1"], "D: SEGMENT must group under its source")
+            cands = sorted((c["id"], c["kind"]) for c in a["candidates"])
+            check(cands == [("CONSTRAINT-a-1", "constraint"), ("REQUIREMENT-a-1", "requirement")],
+                  f"D: candidates must group under the source via derived_from->segment, with kinds; got {cands}")
+            check([m["id"] for m in a["amendments"]] == ["AMENDMENT-a-1"], "D: AMENDMENT must group under its source")
+
+        check("(unassociated)" in by and [s["id"] for s in by["(unassociated)"]["segments"]] == ["SEGMENT-orphan-1"],
+              "D: an artefact with no resolvable source must surface under (unassociated), never be dropped")
+
+        t = dg.get("tally", {})
+        check(t.get("proposed", {}) == {"SEGMENT": 2, "REQUIREMENT": 1, "CONSTRAINT": 1, "AMENDMENT": 1},
+              f"D: tally.proposed wrong: {t.get('proposed')}")
+        check(t.get("review_needed") == 1, f"D: tally.review_needed wrong: {t.get('review_needed')}")
+
+        # An empty run (no artefacts) still produces a valid, gated digest.
+        work2 = tempfile.mkdtemp(prefix="regintel-digest-empty-")
+        try:
+            org2 = _codex_org(work2)
+            r = run_cli("digest", org2, "--as-of", "2026-06-08")
+            check(r.returncode == 0, "D: digest on an empty run must succeed")
+            dg2 = yaml.safe_load(open(os.path.join(org2, "_intake", "processing", "review-digest.yaml"), encoding="utf-8"))
+            check(dg2.get("tally", {}).get("proposed", {}).get("SEGMENT") == 0, "D: empty run must tally zero segments")
+            check(dg2.get("gate", {}).get("admits_to_canon") is False, "D: empty digest still gates")
+        finally:
+            shutil.rmtree(work2, ignore_errors=True)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_list_due()
 part_c_update_scan()
+part_d_digest()
 
 if _failures:
-    print("FAIL - Transitrix Reg-Intel skill + CLI scheduler-core test:")
+    print("FAIL - Transitrix Reg-Intel skill + CLI test:")
     for f in _failures:
         print(f"  - {f}")
     sys.exit(1)
-print("PASS - Transitrix Reg-Intel skill + CLI scheduler-core test: all checks passed.")
+print("PASS - Transitrix Reg-Intel skill + CLI test: all checks passed.")
 sys.exit(0)


### PR DESCRIPTION
Third increment of the reg-intel build (HUB-153) — the **human gate**, SKILL Step 9. Builds on the scheduler core (#148); based on `main`, **no stacking**.

## What ships

- **`digest [org-root] [--run-id] [--as-of] [--out]`** — assembles `_intake/processing/review-digest.yaml` from the artefacts a run has staged: SEGMENT field artefacts (`_intake/processing/segments/`), proposed `REQUIREMENT`/`CONSTRAINT` candidates (`candidates/`), and AMENDMENT field artefacts (`amendments/`), **grouped by codex source**. Candidates attach to a source via `derived_from` → SEGMENT → `source`. Each source carries its `scan` block; artefacts with no resolvable source surface under **`(unassociated)` — never dropped**. A tally + `gate.admits_to_canon: false` close it. **Nothing is admitted** — a human reads the digest and flips `proposed → active | rejected`.
- **`schemas/review-digest.schema.json`** — the digest contract (a bundle schema, same role as the ingest skill's `schemas/`; **not** a canon notation change).
- `src/digest.mjs` + a purpose-built YAML **emitter** and a scalar-list reader added to `src/yaml.mjs` (the emitter mirrors the ingest CLI's, incl. the nested-map-in-list-item fix, so both CLIs produce consistent YAML).

## Tests

Integrity **Part D**: the schema parses; the digest groups artefacts by source (candidates via `derived_from`→segment, with kinds), surfaces an orphan under `(unassociated)`, tallies correctly, and is **always gated** — even on an empty run. Full suite (A–D) + the prompts test pass; doc-lint clean.

## Scope / #153

Closes the **"Human gate — review digest"** acceptance bullet. **#153 stays open.** Remaining increments (each depends on its predecessors): `check-signal`, `fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`; operational templates. 

> Note: `check-signal` needs a decision on **where the last-seen signal cache lives** — SKILL Step 2 says "on the codex artefact alongside the `scan` block", but `14-codex.md` §3.5 is a closed field set. Extending it is a canon change I'll raise as a proposal before implementing that increment, rather than extend the notation unilaterally.

THE ONE RULE holds — the digest admits nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
