### PR TITLE
feat(reg-intel-cli): change-signal gate — check-signal (#153, increment 4)

### DIFF
--- a/packages/reg-intel-cli/README.md
+++ b/packages/reg-intel-cli/README.md
@@ -4,7 +4,7 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 
 **The one rule:** this CLI *proposes*. It reads the codex registry, runs the change-signal gate, snapshots / segments / classifies regulatory text, and stages a review digest. It **never writes `canon/`** and **never silently flips** an existing `active` canon element. A human admits.
 
-> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed: the scheduler core** (`list-due`, `update-scan`) **and the review digest** (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`check-signal`, `fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`) lands in later increments.
+> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), and the review digest (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`) lands in later increments.
 
 ## Commands
 
@@ -13,8 +13,9 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 | `--version` / `--help` | ✅ | Version (the skill's Step-0 pre-check) and usage. |
 | `list-due [org-root] [--as-of YYYY-MM-DD] [--json]` | ✅ | List codex sources due for a scan: `monitoring_needed: true` artefacts whose `scan.next_scan_due <= as-of` (or never scanned), plus the `monitor_instead[]` counterparts of static sources. One run filters by date — not N schedules. |
 | `update-scan <CODEX-ID\|file> [--today YYYY-MM-DD] [--frequency daily\|weekly\|monthly\|quarterly] [--change "<summary>"] [--review]` | ✅ | Write the codex `scan` block (`last_scanned_at`, `next_scan_due` from the cadence, `change_detected`, `change_description`, `review_needed`) — operating state only; never touches any other field. |
+| `check-signal <CODEX-ID\|file> --observed <value> [--method etag\|last_modified\|api_version\|amended_date\|fragment_hash] [--accept-no-signal] [--today YYYY-MM-DD]` | ✅ | The cheap change-signal gate (network-free — caller supplies the observed value). Compares to the last-seen value in `operations/state/reg-intel/signal-cache.json`: `unchanged` → bump scan; `moved` / `no_signal` → proceed. |
 | `digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]` | ✅ | Assemble the human review digest (`review-digest.yaml`) — staged SEGMENT / candidate / AMENDMENT artefacts grouped by codex source (candidates via `derived_from` → SEGMENT), with each source's scan block + a tally. `gate.admits_to_canon: false`. Schema: [`schemas/review-digest.schema.json`](../../transitrix/skills/reg-intel/schemas/review-digest.schema.json). |
-| `check-signal` / `fetch-snapshot` / `segment` / `classify` / `validate` / `amendment` | ⏳ | Later increments. |
+| `fetch-snapshot` / `segment` / `classify` / `validate` / `amendment` | ⏳ | Later increments. |
 
 `next_scan_due` math: `daily` +1d, `weekly` +7d, `monthly` +1 month, `quarterly` +3 months; month additions clamp to the target month's last day (Jan 31 + monthly → Feb 28/29). All UTC, so results are host-timezone independent. Dates compare as ISO-8601 strings.
 
@@ -28,10 +29,12 @@ packages/reg-intel-cli/
     schedule.mjs       # scan_frequency enum + next_scan_due date math + isDue
     codex.mjs          # discover codex artefacts; the due set (list-due); find by ID
     update-scan.mjs    # write/replace the codex scan block in place (Step 8)
+    check-signal.mjs   # the change-signal gate: compare observed vs cached (Step 2)
+    signal-cache.mjs   # read/write the committed operations/state signal cache
     digest.mjs         # assemble the review digest from staged run artefacts (Step 9)
 ```
 
-The "source registry" is **the codex artefacts the repo already carries** (`14-codex.md` §3.4–3.5), not a separate database — the schedule rides on each codex YAML's `scan` block, so scan history is auditable via git. Zero runtime dependencies, Node ≥ 18.
+The "source registry" is **the codex artefacts the repo already carries** (`14-codex.md` §3.4–3.5), not a separate database — the schedule rides on each codex YAML's `scan` block, so scan history is auditable via git. The change-signal cache is committed operational **state** at `operations/state/reg-intel/signal-cache.json` (`method/team-operations.md` §3.3) — outside the model, disposable, survives clone/CI. Zero runtime dependencies, Node ≥ 18.
 
 ## Tests
 

--- a/packages/reg-intel-cli/reg-intel.mjs
+++ b/packages/reg-intel-cli/reg-intel.mjs
@@ -20,6 +20,7 @@ import { access } from 'node:fs/promises';
 
 import { findOrgRoot, listDue, findCodexFile } from './src/codex.mjs';
 import { updateScan } from './src/update-scan.mjs';
+import { checkSignal } from './src/check-signal.mjs';
 import { buildDigest, writeDigest, defaultDigestPath } from './src/digest.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -58,6 +59,11 @@ function usage() {
     '  update-scan <CODEX-ID|file> [--today YYYY-MM-DD] [--frequency daily|weekly|monthly|quarterly]',
     '              [--change "<summary>"] [--review]',
     '                                 Write the codex scan block (last_scanned_at, next_scan_due, …).',
+    '  check-signal <CODEX-ID|file> --observed <value> [--method etag|last_modified|api_version|amended_date|fragment_hash]',
+    '               [--accept-no-signal] [--today YYYY-MM-DD]',
+    '                                 The cheap change-signal gate: compare the observed signal to the',
+    '                                 last-seen value (operations/state/reg-intel/signal-cache.json).',
+    '                                 unchanged → bump scan; moved/no_signal → proceed.',
     '  digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]',
     '                                 Assemble the human review digest from staged run artefacts',
     '                                 (review-digest.yaml). Nothing is admitted — a human gates it.',
@@ -131,6 +137,43 @@ async function cmdUpdateScan(args) {
   }
 }
 
+async function cmdCheckSignal(args) {
+  const { _, flags } = parseArgs(args);
+  const target = _[0];
+  if (!target) { console.error('check-signal: missing <CODEX-ID|file>'); return 1; }
+
+  let file = null;
+  let orgRoot = null;
+  if (await exists(resolve(target))) {
+    file = resolve(target);
+    orgRoot = await findOrgRoot(file);
+    if (!orgRoot) { console.error('check-signal: file is not inside a Transitrix workspace (no transitrix.yaml).'); return 2; }
+  } else {
+    orgRoot = await resolveOrgRoot(undefined, 'check-signal');
+    if (!orgRoot) return 2;
+    file = await findCodexFile(orgRoot, target);
+    if (!file) { console.error(`check-signal: no codex artefact with id ${target} under codex/`); return 2; }
+  }
+
+  try {
+    const res = await checkSignal(orgRoot, file, {
+      observed: typeof flags.observed === 'string' ? flags.observed : null,
+      method: typeof flags.method === 'string' ? flags.method : null,
+      acceptNoSignal: flags['accept-no-signal'] === true || flags['accept-no-signal'] === 'true',
+      today: flags.today ? String(flags.today) : today(),
+    });
+    if (flags.json) { console.log(JSON.stringify(res, null, 2)); return 0; }
+    console.log(`check-signal  ${res.id}  ->  ${res.outcome}  (proceed: ${res.proceed})`);
+    if (res.outcome === 'moved') console.log(`  signal moved [${res.method}] — fetch + segment/classify next. previous: ${res.previous ?? '(none)'}`);
+    else if (res.outcome === 'unchanged') console.log(`  signal unchanged [${res.method}] — scan bumped to next_scan_due ${res.scan.next_scan_due}; no extraction.`);
+    else console.log('  no cheap signal available — proceeding to fetch (degraded gate).');
+    return 0;
+  } catch (err) {
+    console.error(`check-signal: ${err.message}`);
+    return 2;
+  }
+}
+
 async function cmdDigest(args) {
   const { _, flags } = parseArgs(args);
   const orgRoot = await resolveOrgRoot(_[0], 'digest');
@@ -155,9 +198,10 @@ async function main(argv) {
   if (cmd === '--version' || cmd === '-v') { console.log(await version()); return 0; }
 
   switch (cmd) {
-    case 'list-due':    return cmdListDue(args);
-    case 'update-scan': return cmdUpdateScan(args);
-    case 'digest':      return cmdDigest(args);
+    case 'list-due':     return cmdListDue(args);
+    case 'update-scan':  return cmdUpdateScan(args);
+    case 'check-signal': return cmdCheckSignal(args);
+    case 'digest':       return cmdDigest(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);
       return 1;

--- a/packages/reg-intel-cli/src/check-signal.mjs
+++ b/packages/reg-intel-cli/src/check-signal.mjs
@@ -1,0 +1,77 @@
+// `check-signal` (SKILL Step 2, the "whether") — the cheap change-signal gate that
+// runs before any expensive fetch + SEGMENT + CLASSIFY pass. It compares a freshly
+// observed cheap signal (HTTP ETag / Last-Modified, an API updated/version field, a
+// source "last amended" date, or a cheap-fragment hash) against the last-seen value in
+// the operations signal-cache, and decides whether the source moved.
+//
+// Deterministic + network-free: the caller supplies the observed value (`observed` +
+// `method`) — the same split the ingest CLI uses (the agent/scheduler does the cheap
+// fetch; the CLI does the comparison + state). With no observed value the gate either
+// degrades to "proceed" (`acceptNoSignal`) or refuses.
+//
+// Outcomes:
+//   - unchanged : observed == cached. Terminal for this source — bump the scan block
+//                 (last_scanned_at + next_scan_due), no SEGMENT/CLASSIFY. proceed=false.
+//   - moved     : no cached baseline yet, or observed != cached. proceed=true; the
+//                 baseline advances to the observed value so the NEXT run compares
+//                 against it. The scan block is NOT bumped here — that is the full
+//                 pass's Step 8 (update-scan) once the move is processed.
+//   - no_signal : the source exposes no cheap signal. proceed=true; cache untouched.
+//
+// THE ONE RULE holds: nothing here writes canon. The only writes are the codex scan
+// block (operating state, on `unchanged`) and the operations signal-cache.
+
+import { readFile } from 'node:fs/promises';
+import { readTopScalar, readBlockScalars } from './yaml.mjs';
+import { readCache, writeCache, getEntry, setEntry } from './signal-cache.mjs';
+import { updateScan } from './update-scan.mjs';
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}$/;
+const METHODS = new Set(['etag', 'last_modified', 'api_version', 'amended_date', 'fragment_hash']);
+
+export { METHODS };
+
+// Run the gate for one codex source file. Returns { id, outcome, proceed, method,
+// observed, previous, scan? }.
+export async function checkSignal(orgRoot, file, { observed = null, method = null, acceptNoSignal = false, today } = {}) {
+  if (!ISO_RE.test(today || '')) throw new Error('--today must be YYYY-MM-DD');
+  const text = await readFile(file, 'utf8');
+  if (readTopScalar(text, 'monitoring_needed') !== true) {
+    throw new Error(`${file}: check-signal only applies to a monitoring_needed: true artefact (14-codex.md §3.4)`);
+  }
+  const id = readTopScalar(text, 'id');
+  if (!id) throw new Error(`${file}: codex artefact has no id`);
+
+  if (method && !METHODS.has(method)) {
+    throw new Error(`--method must be one of ${[...METHODS].join('|')} (got ${JSON.stringify(method)})`);
+  }
+
+  // No observed signal: degrade to proceed (only with explicit opt-in) — never guess.
+  if (observed === null || observed === undefined || observed === '') {
+    if (!acceptNoSignal) {
+      throw new Error('no observed signal: pass --observed <value> [--method <m>], or --accept-no-signal for a source with no cheap signal');
+    }
+    return { id, outcome: 'no_signal', proceed: true, method: method || 'none', observed: null, previous: null };
+  }
+
+  const cache = await readCache(orgRoot);
+  const prev = getEntry(cache, id);
+  const previous = prev ? prev.value : null;
+  const moved = previous === null || String(previous) !== String(observed);
+
+  if (!moved) {
+    // Unchanged — refresh the baseline timestamp and bump the scan cadence. This is the
+    // terminal action for an unchanged source (SKILL Step 2).
+    setEntry(cache, id, { method: method || (prev && prev.method) || 'unknown', value: String(observed), observed_at: today });
+    await writeCache(orgRoot, cache);
+    const scanBlock = readBlockScalars(text, 'scan') || {};
+    const res = await updateScan(file, { today, frequency: scanBlock.scan_frequency, changeDescription: null, reviewNeeded: false });
+    return { id, outcome: 'unchanged', proceed: false, method: method || (prev && prev.method) || 'unknown', observed: String(observed), previous, scan: res.scan };
+  }
+
+  // Moved — advance the baseline so the next run detects the next move; the full pass
+  // (and its Step 8 update-scan) handles the scan block + extraction downstream.
+  setEntry(cache, id, { method: method || 'unknown', value: String(observed), observed_at: today });
+  await writeCache(orgRoot, cache);
+  return { id, outcome: 'moved', proceed: true, method: method || 'unknown', observed: String(observed), previous };
+}

--- a/packages/reg-intel-cli/src/signal-cache.mjs
+++ b/packages/reg-intel-cli/src/signal-cache.mjs
@@ -1,0 +1,44 @@
+// Last-seen change-signal cache — committed operational STATE, per the operations
+// config/state convention (method/team-operations.md §3.3, decided in strategy#169).
+// It lives at `operations/state/reg-intel/signal-cache.json` — NOT on the codex
+// artefact (the §3.5 scan block stays closed) and NOT in transient _intake/ (the cache
+// must survive a fresh clone / CI checkout for the gate to pay off).
+//
+// The shape is owned by this tool (the convention fixes only the location + the
+// committed-but-disposable contract): the cache is correctness-non-critical — a miss
+// or a delete simply degrades the gate to "treat as moved / always fetch", never wrong
+// model truth.
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join, resolve, dirname } from 'node:path';
+
+export function cachePath(orgRoot) {
+  return join(resolve(orgRoot), 'operations', 'state', 'reg-intel', 'signal-cache.json');
+}
+
+// Read the cache. A missing or unparseable file yields an empty cache (safe default —
+// the gate then treats every source as moved).
+export async function readCache(orgRoot) {
+  try {
+    const obj = JSON.parse(await readFile(cachePath(orgRoot), 'utf8'));
+    if (obj && typeof obj === 'object' && obj.sources && typeof obj.sources === 'object') return obj;
+  } catch { /* absent / malformed → empty */ }
+  return { version: 1, sources: {} };
+}
+
+export async function writeCache(orgRoot, cache) {
+  const p = cachePath(orgRoot);
+  await mkdir(dirname(p), { recursive: true });
+  await writeFile(p, JSON.stringify(cache, null, 2) + '\n', 'utf8');
+  return p;
+}
+
+export function getEntry(cache, sourceId) {
+  return (cache.sources && cache.sources[sourceId]) || null;
+}
+
+export function setEntry(cache, sourceId, entry) {
+  cache.sources = cache.sources || {};
+  cache.sources[sourceId] = entry;
+  return cache;
+}

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **data-collection process** for the regulatory side of a Transitrix repository: it turns watched **codex sources** (laws, regulations, policies, internal standards) into `field`-zone evidence — `SEGMENT-*` chunks of the source text, `AMENDMENT-*` records when a watched source has drifted — and into `proposed` `REQUIREMENT-*` / `CONSTRAINT-*` canon candidates, then routes everything through a human review digest. It is the operational counterpart to the methodology's codex / SEGMENT / AMENDMENT / REQUIREMENT notation work — the part that watches the registry, runs the change-signal gate, slices and classifies the text, and stages the human gate.
 
-> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments: **the scheduler core is live** — `list-due` (Step 1) and `update-scan` (Step 8). The remaining subcommands (`check-signal`, `fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`, `digest`) are not yet published; when the run loop reaches one of them, the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
+> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`; when the run loop reaches one of them the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the regulatory-intelligence pipeline against it. It is designed to run **agent-neutrally** under Claude and GitHub Copilot — all heavy logic lives in the CLI, and this `SKILL.md` only sequences it.
 
@@ -56,21 +56,24 @@ Emits the set of codex artefacts whose `scan.next_scan_due <= today` (or the sup
 
 Before any fetch of the full source body, the CLI runs a cheap signal check on each due artefact:
 
-| Signal source | What the agent compares |
+| Signal source (`--method`) | What is compared |
 |---|---|
-| HTTP `ETag` / `Last-Modified` response headers | last seen values, stored on the codex artefact alongside the `scan` block |
-| API "updated" / version field (where the source offers a feed or JSON endpoint) | last seen value |
-| Source's own "last amended" date (where the page exposes one) | last seen value |
-| Hash of a known cheap-to-fetch fragment (TOC, masthead) | last seen hash |
+| HTTP `ETag` / `Last-Modified` response headers (`etag` / `last_modified`) | last-seen value in the signal cache |
+| API "updated" / version field (`api_version`) | last-seen value |
+| Source's own "last amended" date (`amended_date`) | last-seen value |
+| Hash of a known cheap-to-fetch fragment — TOC, masthead (`fragment_hash`) | last-seen hash |
 
-If **no signal source is available** (a plain HTML page with no ETag, no API, no published "last amended" date), the gate degrades to "always proceed to fetch" — the absence of a signal source is recorded on the artefact so adopters can prioritise fixing it.
+The last-seen values live in the **operations signal-cache** at `operations/state/reg-intel/signal-cache.json` — committed operational **state** (per [`method/team-operations.md`](https://raw.githubusercontent.com/transitrix/methodology/main/method/team-operations.md) §3.3), **not** on the codex artefact (the `14-codex.md` §3.5 `scan` block stays closed) and **not** in transient `_intake/` (the cache must survive a fresh clone / CI checkout for the gate to pay off). The cache is disposable — if it is lost, the gate degrades to "treat as moved / always fetch", never wrong.
 
-If the signal **has not moved**: bump `scan.last_scanned_at` to today and `scan.next_scan_due` to today + `scan_frequency`. No SEGMENT / CLASSIFY pass. No AMENDMENT. The artefact is reported in the run's "checked, unchanged" tally and dropped from the rest of the pipeline.
+The CLI is **network-free**: the agent/scheduler does the cheap fetch and passes the observed value in via `--observed`; the CLI does the comparison and the state update. With **no signal source available** (a plain HTML page with no ETag, no API, no published "last amended" date), pass `--accept-no-signal` — the gate degrades to "proceed to fetch".
 
-If the signal **has moved**: proceed to Step 3. The signal change alone is not yet an AMENDMENT — a cosmetic re-publication can move `Last-Modified` without changing any normative text. The AMENDMENT is decided in Step 5 against the snapshot diff, not against the signal.
+If the signal **has not moved**: the CLI bumps `scan.last_scanned_at` to today and `scan.next_scan_due` to today + `scan_frequency`. No SEGMENT / CLASSIFY pass, no AMENDMENT — the artefact is reported "checked, unchanged" and dropped from the rest of the pipeline.
+
+If the signal **has moved** (or there is no cached baseline yet): proceed to Step 3, and the cache baseline advances to the observed value so the next run detects the next move. The signal change alone is not yet an AMENDMENT — a cosmetic re-publication can move `Last-Modified` without changing any normative text. The AMENDMENT is decided in Step 5 against the snapshot diff, not against the signal. (The scan block is bumped by Step 8 once the moved source's pass completes, not by the gate.)
 
 ```
-npx @transitrix/reg-intel-cli check-signal <CODEX-ID> [--accept-no-signal]
+npx @transitrix/reg-intel-cli check-signal <CODEX-ID> --observed <value> [--method etag|last_modified|api_version|amended_date|fragment_hash]
+npx @transitrix/reg-intel-cli check-signal <CODEX-ID> --accept-no-signal
 ```
 
 ---

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
@@ -2,7 +2,7 @@
 """From-scratch integrity test for the Transitrix Reg-Intel skill + @transitrix/reg-intel-cli.
 
 Deterministic, no-API-key, no-network guard for the CLI increments landed so far
-(the rest of the SKILL.md pipeline lands in later increments). Four parts:
+(the rest of the SKILL.md pipeline lands in later increments). Five parts:
 
   A. Bundle integrity — SKILL.md + README.md present and frontmatter parses; the CLI
      package.json parses and declares its bin; the entry point exists; `--version`
@@ -18,6 +18,11 @@ Deterministic, no-API-key, no-network guard for the CLI increments landed so far
      staged SEGMENT / candidate / AMENDMENT artefacts by codex source (candidates via
      derived_from -> segment), surfaces orphans under (unassociated), tallies, and is
      always gated (admits_to_canon: false) — even on an empty run.
+  E. check-signal (Step 2, the change-signal gate) — compares an observed signal to the
+     last-seen value in the operations signal-cache: first observation is 'moved' and
+     writes the cache (scan NOT bumped); an unchanged signal bumps the scan cadence; a
+     changed signal is 'moved' with the prior value; no signal refuses unless
+     --accept-no-signal; a static artefact is rejected.
 
 Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
@@ -299,10 +304,77 @@ def part_d_digest():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part E — check-signal (Step 2, the change-signal gate) ───────
+
+def part_e_check_signal():
+    if not shutil.which("node"):
+        print("SKIP Part E: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="regintel-signal-")
+    try:
+        org = _codex_org(work)
+        a_file = os.path.join(org, "codex", "external", "eu", "REGULATION-A-1.yaml")  # monthly, due 2026-05-01
+        cache = os.path.join(org, "operations", "state", "reg-intel", "signal-cache.json")
+
+        def scan_of(f):
+            return yaml.safe_load(open(f, encoding="utf-8")).get("scan", {})
+
+        before_due = scan_of(a_file).get("next_scan_due")
+
+        # First observation, no cache yet → moved; cache is written to the operations
+        # state location; the scan block is NOT bumped (the full pass does Step 8).
+        r = run_cli("check-signal", a_file, "--observed", "etag-v1", "--method", "etag", "--today", "2026-06-08", "--json")
+        check(r.returncode == 0, f"E: check-signal failed: {r.stderr.strip()}")
+        res = json.loads(r.stdout)
+        check(res.get("outcome") == "moved" and res.get("proceed") is True, "E: first observation must be 'moved'")
+        check(os.path.isfile(cache), "E: signal cache must be written under operations/state/reg-intel/")
+        c = json.load(open(cache, encoding="utf-8"))
+        check(c.get("sources", {}).get("REGULATION-A-1", {}).get("value") == "etag-v1",
+              "E: the cache must record the observed signal value")
+        check(scan_of(a_file).get("next_scan_due") == before_due, "E: a moved signal must NOT bump the scan block (that is Step 8)")
+
+        # Same value again → unchanged; the scan block IS bumped (monthly cadence).
+        r = run_cli("check-signal", a_file, "--observed", "etag-v1", "--method", "etag", "--today", "2026-06-08", "--json")
+        res = json.loads(r.stdout)
+        check(res.get("outcome") == "unchanged" and res.get("proceed") is False, "E: an unchanged signal must be 'unchanged' (no proceed)")
+        check(scan_of(a_file).get("next_scan_due") == "2026-07-08", f"E: unchanged must bump next_scan_due by the cadence; got {scan_of(a_file).get('next_scan_due')}")
+        check(scan_of(a_file).get("change_detected") is False, "E: unchanged must leave change_detected false")
+
+        # A new value → moved again, with the prior value reported.
+        r = run_cli("check-signal", a_file, "--observed", "etag-v2", "--method", "etag", "--today", "2026-06-09", "--json")
+        res = json.loads(r.stdout)
+        check(res.get("outcome") == "moved" and res.get("previous") == "etag-v1",
+              f"E: a changed signal must be 'moved' with previous=etag-v1; got {res}")
+
+        # No observed value + no opt-in → refuse (never guess).
+        r = run_cli("check-signal", a_file, "--today", "2026-06-08")
+        check(r.returncode != 0 and "no observed signal" in (r.stdout + r.stderr),
+              "E: check-signal with no signal and no --accept-no-signal must refuse")
+        # --accept-no-signal → degrade to proceed.
+        r = run_cli("check-signal", a_file, "--accept-no-signal", "--today", "2026-06-08", "--json")
+        res = json.loads(r.stdout)
+        check(res.get("outcome") == "no_signal" and res.get("proceed") is True, "E: --accept-no-signal must degrade to no_signal/proceed")
+
+        # A static (monitoring_needed: false) artefact has no signal gate.
+        s_file = os.path.join(org, "codex", "external", "us", "REGULATION-D-1.yaml")
+        r = run_cli("check-signal", s_file, "--observed", "x", "--today", "2026-06-08")
+        check(r.returncode != 0 and "monitoring_needed: true" in (r.stdout + r.stderr),
+              "E: check-signal must reject a monitoring_needed: false artefact")
+
+        # Resolve by CODEX-ID (cwd in org).
+        r = subprocess.run(["node", CLI, "check-signal", "POLICY-C-1", "--observed", "v", "--today", "2026-06-08", "--json"],
+                           capture_output=True, text=True, cwd=org)
+        check(r.returncode == 0 and json.loads(r.stdout).get("id") == "POLICY-C-1",
+              f"E: check-signal by CODEX-ID failed: {(r.stdout + r.stderr).strip()}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_list_due()
 part_c_update_scan()
 part_d_digest()
+part_e_check_signal()
 
 if _failures:
     print("FAIL - Transitrix Reg-Intel skill + CLI test:")


### PR DESCRIPTION
Fourth increment of the reg-intel build (HUB-153) — **SKILL Step 2, the change-signal gate** (*the "whether"*). Un-paused by the operations config/state shape (#151, implementing the HUB-169 decision): the last-seen signal cache now has a committed home.

## What ships

- **`check-signal <CODEX-ID|file> --observed <value> [--method etag|last_modified|api_version|amended_date|fragment_hash] [--accept-no-signal] [--today]`** — compares the observed cheap signal against the last-seen value and decides:
  - **unchanged** → bump the scan block (`last_scanned_at` + `next_scan_due`), no extraction, `proceed=false`;
  - **moved** (or no cached baseline) → `proceed=true`; the cache baseline advances to the observed value; the scan block is bumped later by Step 8, **not** here (so a moved-but-unprocessed source isn't prematurely advanced);
  - **no_signal** (`--accept-no-signal`) → degrade to proceed; cache untouched.
- **Network-free**: the agent/scheduler does the cheap fetch and passes `--observed`; the CLI does the comparison + state (the same split as the ingest CLI). With no signal and no `--accept-no-signal`, it **refuses** rather than guess. A `monitoring_needed: false` artefact is rejected.
- The cache lives at **`operations/state/reg-intel/signal-cache.json`** — committed operational **state** (`method/team-operations.md` §3.3), **not** on the codex artefact (§3.5 `scan` block stays closed) and **not** in transient `_intake/`. **Disposable**: a miss degrades the gate to "treat as moved", never wrong. New modules `check-signal.mjs` + `signal-cache.mjs`.

## Docs

`SKILL.md` Step 2 rewritten to the `operations/state` cache + the `--observed` / `--accept-no-signal` interface. Status banner now lists `list-due` / `check-signal` / `update-scan` / `digest` as **live** (it had also gone stale on `digest` from #150 — fixed here).

## Tests

Integrity **Part E**: first observation is `moved` and writes the cache (scan **not** bumped); an unchanged signal bumps the cadence; a changed signal is `moved` with the prior value; no-signal refuses unless `--accept-no-signal`; static rejected; by-CODEX-ID resolution. Full suite (A–E) + prompts test pass; doc-lint clean.

## Scope / #153

Closes the **"Change-signal gate (the whether)"** acceptance bullet. **#153 stays open.** Remaining: `fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`; operational templates. THE ONE RULE holds — the only writes are the codex scan block (operating state) and the operations signal-cache.

> Note: cache-commit timing is conservative for now (baseline advances on observe; the scan bump for a *moved* source is deferred to Step 8). When `fetch-snapshot` lands, the moved-source cache/commit ordering can be refined so a fetch failure doesn't lose a pending move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
