### PR TITLE
feat(reg-intel-cli): snapshot step — fetch-snapshot (#153, increment 5)

### DIFF
--- a/packages/reg-intel-cli/README.md
+++ b/packages/reg-intel-cli/README.md
@@ -4,7 +4,7 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 
 **The one rule:** this CLI *proposes*. It reads the codex registry, runs the change-signal gate, snapshots / segments / classifies regulatory text, and stages a review digest. It **never writes `canon/`** and **never silently flips** an existing `active` canon element. A human admits.
 
-> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), and the review digest (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`) lands in later increments.
+> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), the snapshot step (`fetch-snapshot`), and the review digest (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`segment`, `classify`, `validate`, `amendment`) lands in later increments.
 
 ## Commands
 
@@ -14,8 +14,9 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 | `list-due [org-root] [--as-of YYYY-MM-DD] [--json]` | ✅ | List codex sources due for a scan: `monitoring_needed: true` artefacts whose `scan.next_scan_due <= as-of` (or never scanned), plus the `monitor_instead[]` counterparts of static sources. One run filters by date — not N schedules. |
 | `update-scan <CODEX-ID\|file> [--today YYYY-MM-DD] [--frequency daily\|weekly\|monthly\|quarterly] [--change "<summary>"] [--review]` | ✅ | Write the codex `scan` block (`last_scanned_at`, `next_scan_due` from the cadence, `change_detected`, `change_description`, `review_needed`) — operating state only; never touches any other field. |
 | `check-signal <CODEX-ID\|file> --observed <value> [--method etag\|last_modified\|api_version\|amended_date\|fragment_hash] [--accept-no-signal] [--today YYYY-MM-DD]` | ✅ | The cheap change-signal gate (network-free — caller supplies the observed value). Compares to the last-seen value in `operations/state/reg-intel/signal-cache.json`: `unchanged` → bump scan; `moved` / `no_signal` → proceed. |
+| `fetch-snapshot <CODEX-ID\|file> --from <fetched-file> [--ext <ext>] [--today YYYY-MM-DD]` | ✅ | Snapshot the caller-fetched bytes to `_intake/snapshots/<id>-<date>.<ext>`, fingerprint (`source_hash: sha256:…`), and detect `captured` / `changed` / `bytes_identical` (cross-checkout via the committed cache). Network-free — the caller fetches. |
 | `digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]` | ✅ | Assemble the human review digest (`review-digest.yaml`) — staged SEGMENT / candidate / AMENDMENT artefacts grouped by codex source (candidates via `derived_from` → SEGMENT), with each source's scan block + a tally. `gate.admits_to_canon: false`. Schema: [`schemas/review-digest.schema.json`](../../transitrix/skills/reg-intel/schemas/review-digest.schema.json). |
-| `fetch-snapshot` / `segment` / `classify` / `validate` / `amendment` | ⏳ | Later increments. |
+| `segment` / `classify` / `validate` / `amendment` | ⏳ | Later increments. |
 
 `next_scan_due` math: `daily` +1d, `weekly` +7d, `monthly` +1 month, `quarterly` +3 months; month additions clamp to the target month's last day (Jan 31 + monthly → Feb 28/29). All UTC, so results are host-timezone independent. Dates compare as ISO-8601 strings.
 
@@ -30,7 +31,8 @@ packages/reg-intel-cli/
     codex.mjs          # discover codex artefacts; the due set (list-due); find by ID
     update-scan.mjs    # write/replace the codex scan block in place (Step 8)
     check-signal.mjs   # the change-signal gate: compare observed vs cached (Step 2)
-    signal-cache.mjs   # read/write the committed operations/state signal cache
+    snapshot.mjs       # snapshot caller-fetched bytes + source_hash + diff (Step 3)
+    signal-cache.mjs   # read/write the committed operations/state cache (signals + snapshots)
     digest.mjs         # assemble the review digest from staged run artefacts (Step 9)
 ```
 

--- a/packages/reg-intel-cli/reg-intel.mjs
+++ b/packages/reg-intel-cli/reg-intel.mjs
@@ -21,6 +21,7 @@ import { access } from 'node:fs/promises';
 import { findOrgRoot, listDue, findCodexFile } from './src/codex.mjs';
 import { updateScan } from './src/update-scan.mjs';
 import { checkSignal } from './src/check-signal.mjs';
+import { fetchSnapshot } from './src/snapshot.mjs';
 import { buildDigest, writeDigest, defaultDigestPath } from './src/digest.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -64,6 +65,9 @@ function usage() {
     '                                 The cheap change-signal gate: compare the observed signal to the',
     '                                 last-seen value (operations/state/reg-intel/signal-cache.json).',
     '                                 unchanged → bump scan; moved/no_signal → proceed.',
+    '  fetch-snapshot <CODEX-ID|file> --from <fetched-file> [--ext <ext>] [--today YYYY-MM-DD] [--json]',
+    '                                 Snapshot the fetched bytes to _intake/snapshots/, fingerprint',
+    '                                 (source_hash), and detect captured | changed | bytes_identical.',
     '  digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]',
     '                                 Assemble the human review digest from staged run artefacts',
     '                                 (review-digest.yaml). Nothing is admitted — a human gates it.',
@@ -174,6 +178,43 @@ async function cmdCheckSignal(args) {
   }
 }
 
+async function cmdFetchSnapshot(args) {
+  const { _, flags } = parseArgs(args);
+  const target = _[0];
+  if (!target) { console.error('fetch-snapshot: missing <CODEX-ID|file>'); return 1; }
+  if (typeof flags.from !== 'string') { console.error('fetch-snapshot: --from <fetched-file> is required (the CLI is network-free; the caller fetches)'); return 1; }
+
+  let file = null;
+  let orgRoot = null;
+  if (await exists(resolve(target))) {
+    file = resolve(target);
+    orgRoot = await findOrgRoot(file);
+    if (!orgRoot) { console.error('fetch-snapshot: file is not inside a Transitrix workspace (no transitrix.yaml).'); return 2; }
+  } else {
+    orgRoot = await resolveOrgRoot(undefined, 'fetch-snapshot');
+    if (!orgRoot) return 2;
+    file = await findCodexFile(orgRoot, target);
+    if (!file) { console.error(`fetch-snapshot: no codex artefact with id ${target} under codex/`); return 2; }
+  }
+
+  try {
+    const res = await fetchSnapshot(orgRoot, file, {
+      fromPath: flags.from,
+      today: flags.today ? String(flags.today) : today(),
+      ext: typeof flags.ext === 'string' ? flags.ext : undefined,
+    });
+    if (flags.json) { console.log(JSON.stringify(res, null, 2)); return 0; }
+    console.log(`fetch-snapshot  ${res.id}  ->  ${res.outcome}  (proceed: ${res.proceed})`);
+    console.log(`  snapshot: ${res.snapshot}`);
+    console.log(`  source_hash: ${res.source_hash}`);
+    if (res.outcome === 'bytes_identical') console.log('  signal moved, bytes identical — no extraction; reported on the digest.');
+    return 0;
+  } catch (err) {
+    console.error(`fetch-snapshot: ${err.message}`);
+    return 2;
+  }
+}
+
 async function cmdDigest(args) {
   const { _, flags } = parseArgs(args);
   const orgRoot = await resolveOrgRoot(_[0], 'digest');
@@ -201,6 +242,7 @@ async function main(argv) {
     case 'list-due':     return cmdListDue(args);
     case 'update-scan':  return cmdUpdateScan(args);
     case 'check-signal': return cmdCheckSignal(args);
+    case 'fetch-snapshot': return cmdFetchSnapshot(args);
     case 'digest':       return cmdDigest(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);

--- a/packages/reg-intel-cli/src/signal-cache.mjs
+++ b/packages/reg-intel-cli/src/signal-cache.mjs
@@ -42,3 +42,17 @@ export function setEntry(cache, sourceId, entry) {
   cache.sources[sourceId] = entry;
   return cache;
 }
+
+// Snapshot state is kept in a separate `snapshots` map (the last captured snapshot
+// hash per source), so the signal gate (`sources`) and the snapshot step
+// (`snapshots`) never overwrite each other's entry. It lets bytes-identical detection
+// survive a fresh clone / CI checkout where the prior _intake/ snapshot is gone.
+export function getSnapshotEntry(cache, sourceId) {
+  return (cache.snapshots && cache.snapshots[sourceId]) || null;
+}
+
+export function setSnapshotEntry(cache, sourceId, entry) {
+  cache.snapshots = cache.snapshots || {};
+  cache.snapshots[sourceId] = entry;
+  return cache;
+}

--- a/packages/reg-intel-cli/src/snapshot.mjs
+++ b/packages/reg-intel-cli/src/snapshot.mjs
@@ -1,0 +1,87 @@
+// `fetch-snapshot` (SKILL Step 3) — capture a point-in-time copy of a moved source
+// and fingerprint it, so the rest of the pipeline (SEGMENT, AMENDMENT) has stable
+// bytes to work against and a later amendment is provable against them.
+//
+// Network-free, like the rest of this CLI: the agent/scheduler does the actual fetch
+// (preferring APIs/feeds over HTML scraping, JS-render where needed) and passes the
+// fetched file in via `--from`; this code snapshots the bytes, computes the
+// `source_hash`, and decides whether the bytes actually changed.
+//
+// Snapshots are operational, in-flight artefacts under `_intake/snapshots/` — NOT the
+// codex `sources/` copy (that is the human-admitted canonical snapshot, 14-codex.md
+// §3.1). THE ONE RULE holds: nothing here writes canon. Bytes-identical detection
+// compares to the latest prior _intake snapshot, falling back to the last snapshot
+// hash in the committed operations cache so detection survives a fresh clone / CI
+// checkout (where _intake/ is gone).
+//
+// Outcomes: captured (first harvest) · changed (bytes differ from prior) ·
+// bytes_identical (signal moved but the publisher re-stamped without changing bytes).
+// Content-aware cosmetic-vs-normative diffing is a later increment.
+
+import { readFile, writeFile, readdir, mkdir, access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, resolve, extname, basename } from 'node:path';
+import { readTopScalar } from './yaml.mjs';
+import { readCache, writeCache, getSnapshotEntry, setSnapshotEntry } from './signal-cache.mjs';
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+function sha256(buf) { return createHash('sha256').update(buf).digest('hex'); }
+
+// Latest prior snapshot file for this source id (by name — the date is embedded, so a
+// lexical sort orders by date), excluding `exclude`. Returns the absolute path or null.
+async function priorSnapshot(snapDir, id, exclude) {
+  if (!(await exists(snapDir))) return null;
+  const prefix = `${id}-`;
+  const names = (await readdir(snapDir))
+    .filter((n) => n.startsWith(prefix) && n !== exclude)
+    .sort();
+  return names.length ? join(snapDir, names[names.length - 1]) : null;
+}
+
+export async function fetchSnapshot(orgRoot, file, { fromPath, today, ext } = {}) {
+  if (!ISO_RE.test(today || '')) throw new Error('--today must be YYYY-MM-DD');
+  if (!fromPath) throw new Error('--from <fetched-file> is required (this CLI is network-free; the caller fetches)');
+  const text = await readFile(file, 'utf8');
+  if (readTopScalar(text, 'monitoring_needed') !== true) {
+    throw new Error(`${file}: fetch-snapshot only applies to a monitoring_needed: true artefact (14-codex.md §3.4)`);
+  }
+  const id = readTopScalar(text, 'id');
+  if (!id) throw new Error(`${file}: codex artefact has no id`);
+
+  const src = resolve(fromPath);
+  if (!(await exists(src))) throw new Error(`--from file not found: ${fromPath}`);
+  const bytes = await readFile(src);
+  const hash = sha256(bytes);
+
+  const cleanExt = (ext || extname(src).replace(/^\./, '') || 'html').replace(/^\./, '');
+  const snapDir = join(resolve(orgRoot), '_intake', 'snapshots');
+  const snapName = `${id}-${today}.${cleanExt}`;
+
+  // Determine the prior hash: the latest other _intake snapshot, else the committed
+  // operations cache (so detection survives a fresh checkout).
+  const cache = await readCache(orgRoot);
+  const cachedSnap = getSnapshotEntry(cache, id);
+  const prior = await priorSnapshot(snapDir, id, snapName);
+  let priorHash = null;
+  if (prior) priorHash = sha256(await readFile(prior));
+  else if (cachedSnap && cachedSnap.hash) priorHash = cachedSnap.hash;
+
+  await mkdir(snapDir, { recursive: true });
+  await writeFile(join(snapDir, snapName), bytes);
+
+  const outcome = priorHash === null ? 'captured' : (priorHash === hash ? 'bytes_identical' : 'changed');
+  const rel = ['_intake', 'snapshots', snapName].join('/');
+  setSnapshotEntry(cache, id, { hash, file: rel, at: today });
+  await writeCache(orgRoot, cache);
+
+  return {
+    id,
+    outcome,
+    proceed: outcome === 'changed' || outcome === 'captured',
+    source_hash: `sha256:${hash}`,
+    snapshot: rel,
+    prior_snapshot: prior ? ['_intake', 'snapshots', basename(prior)].join('/') : (cachedSnap ? cachedSnap.file : null),
+  };
+}

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **data-collection process** for the regulatory side of a Transitrix repository: it turns watched **codex sources** (laws, regulations, policies, internal standards) into `field`-zone evidence — `SEGMENT-*` chunks of the source text, `AMENDMENT-*` records when a watched source has drifted — and into `proposed` `REQUIREMENT-*` / `CONSTRAINT-*` canon candidates, then routes everything through a human review digest. It is the operational counterpart to the methodology's codex / SEGMENT / AMENDMENT / REQUIREMENT notation work — the part that watches the registry, runs the change-signal gate, slices and classifies the text, and stages the human gate.
 
-> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `fetch-snapshot`, `segment`, `classify`, `validate`, `amendment`; when the run loop reaches one of them the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
+> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `segment`, `classify`, `validate`, `amendment`; when the run loop reaches one of them the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the regulatory-intelligence pipeline against it. It is designed to run **agent-neutrally** under Claude and GitHub Copilot — all heavy logic lives in the CLI, and this `SKILL.md` only sequences it.
 
@@ -80,23 +80,23 @@ npx @transitrix/reg-intel-cli check-signal <CODEX-ID> --accept-no-signal
 
 ## Step 3 — Fetch and snapshot (only if the signal moved)
 
-The CLI fetches the source's `source_url` (or each entry in `monitor_instead[]` when the artefact is static and points at live counterparts) and stores a snapshot in `_intake/snapshots/`:
+The agent/scheduler fetches the source's `source_url` (or each entry in `monitor_instead[]` when the artefact is static and points at live counterparts) and passes the fetched file to the **network-free** CLI via `--from`; the CLI stores a snapshot in `_intake/snapshots/`:
 
 ```
 _intake/snapshots/<CODEX-ID>-<YYYY-MM-DD>.<ext>
 ```
 
-Where `<ext>` follows the source format (`.pdf`, `.html`, `.json`, `.xml`). The full bytes are fingerprinted (`source_hash: sha256:<hex>` — the same convention the ingest pipeline uses for field artefacts) and the snapshot is retained for diff and provenance. If the source was previously snapshotted, the new hash is compared to the prior one: a hash match here (despite a moved signal) means the publisher re-stamped the file without changing its bytes, and the pipeline ends with a "signal moved, bytes identical" entry on the digest.
+Where `<ext>` follows the source format (`.pdf`, `.html`, `.json`, `.xml`). The full bytes are fingerprinted (`source_hash: sha256:<hex>` — the same convention the ingest pipeline uses for field artefacts) and the snapshot is retained for diff and provenance. The new hash is compared to the prior one — the latest prior `_intake/snapshots/` capture, falling back to the last snapshot hash in the committed operations cache (`operations/state/reg-intel/signal-cache.json`) so detection survives a fresh clone / CI checkout. Outcomes: **captured** (first harvest), **changed** (bytes differ — advance to Step 4), **bytes_identical** (the publisher re-stamped the file without changing its bytes — the run ends with a "signal moved, bytes identical" entry on the digest).
 
 **Fetch preferences and failure handling.**
 
 - **Prefer APIs / feeds over HTML scraping.** When a source publishes a JSON / XML / RSS feed (eCFR API, EUR-Lex CELLAR, Federal Register API, …), use it. HTML scraping is the fallback, not the default — feeds are versioned, structured, and far less prone to cosmetic-diff noise.
 - **JS-capable fetch.** Some regulator portals render content via JavaScript; the CLI's fetch supports a headless-browser mode (`--render js`) for these. The mode is opt-in per artefact (recorded as `scan.fetch_mode: js` on the codex YAML) — the cost is real, so the default stays plain HTTP.
 - **Source unreachable.** A fetch that fails (DNS, HTTP 5xx, timeout, captcha wall) does **not** bump `next_scan_due` — the source remains in the due set for the next tick. The failure is reported on the digest with the error reason; repeated failures (≥ 3 consecutive ticks) escalate the source on the digest as `fetch_blocked` so an adopter can intervene (proxy, source URL change, robots.txt etc.).
-- **Cosmetic / sub-threshold diff.** A snapshot whose normative-text region (after stripping headers, footers, pagination, and tracker IDs) does not differ from the previous snapshot is logged as `cosmetic_change` on the digest and does **not** advance to Step 4. The signal moved; the substance did not.
+- **Cosmetic / sub-threshold diff.** A snapshot whose normative-text region (after stripping headers, footers, pagination, and tracker IDs) does not differ from the previous snapshot should be logged as `cosmetic_change` and not advance to Step 4. *This content-aware diff is a later increment*; the CLI today distinguishes only byte-level `changed` vs `bytes_identical` — a byte-identical re-stamp is already caught, but a cosmetic-but-byte-different re-publication still advances and is filtered at the human gate for now.
 
 ```
-npx @transitrix/reg-intel-cli fetch-snapshot <CODEX-ID>
+npx @transitrix/reg-intel-cli fetch-snapshot <CODEX-ID> --from <fetched-file> [--ext <ext>]
 ```
 
 ---

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
@@ -2,7 +2,7 @@
 """From-scratch integrity test for the Transitrix Reg-Intel skill + @transitrix/reg-intel-cli.
 
 Deterministic, no-API-key, no-network guard for the CLI increments landed so far
-(the rest of the SKILL.md pipeline lands in later increments). Five parts:
+(the rest of the SKILL.md pipeline lands in later increments). Six parts:
 
   A. Bundle integrity — SKILL.md + README.md present and frontmatter parses; the CLI
      package.json parses and declares its bin; the entry point exists; `--version`
@@ -23,6 +23,11 @@ Deterministic, no-API-key, no-network guard for the CLI increments landed so far
      writes the cache (scan NOT bumped); an unchanged signal bumps the scan cadence; a
      changed signal is 'moved' with the prior value; no signal refuses unless
      --accept-no-signal; a static artefact is rejected.
+  F. fetch-snapshot (Step 3) — snapshots the caller-fetched bytes to _intake/snapshots/
+     and fingerprints them: first harvest is 'captured'; identical bytes are
+     'bytes_identical'; changed bytes are 'changed'; the committed operations cache
+     detects identical bytes even after _intake/ is wiped (cross-checkout); --from is
+     required; a static artefact is rejected.
 
 Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
@@ -370,11 +375,66 @@ def part_e_check_signal():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part F — fetch-snapshot (Step 3) ─────────────────────────────
+
+def part_f_fetch_snapshot():
+    if not shutil.which("node"):
+        print("SKIP Part F: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="regintel-snap-")
+    try:
+        org = _codex_org(work)
+        a_file = os.path.join(org, "codex", "external", "eu", "REGULATION-A-1.yaml")
+        snapdir = os.path.join(org, "_intake", "snapshots")
+        v1 = os.path.join(work, "v1.html"); open(v1, "w", encoding="utf-8").write("<html>Article 3 v1</html>")
+        v2 = os.path.join(work, "v2.html"); open(v2, "w", encoding="utf-8").write("<html>Article 3 v2 CHANGED</html>")
+
+        # First harvest → captured; snapshot written; source_hash present.
+        r = run_cli("fetch-snapshot", a_file, "--from", v1, "--today", "2026-06-08", "--json")
+        check(r.returncode == 0, f"F: fetch-snapshot failed: {r.stderr.strip()}")
+        res = json.loads(r.stdout)
+        check(res.get("outcome") == "captured", "F: first harvest must be 'captured'")
+        check(re.match(r"^sha256:[0-9a-f]{64}$", res.get("source_hash", "")), f"F: source_hash malformed: {res.get('source_hash')!r}")
+        check(os.path.isfile(os.path.join(snapdir, "REGULATION-A-1-2026-06-08.html")), "F: snapshot must be written under _intake/snapshots/")
+
+        # Same bytes, later date → bytes_identical (signal moved, bytes unchanged).
+        r = run_cli("fetch-snapshot", a_file, "--from", v1, "--today", "2026-07-08", "--json")
+        res = json.loads(r.stdout)
+        check(res.get("outcome") == "bytes_identical" and res.get("proceed") is False,
+              "F: re-snapshot of identical bytes must be 'bytes_identical' (no proceed)")
+
+        # Changed bytes → changed.
+        r = run_cli("fetch-snapshot", a_file, "--from", v2, "--today", "2026-08-08", "--json")
+        res = json.loads(r.stdout)
+        check(res.get("outcome") == "changed" and res.get("proceed") is True, "F: changed bytes must be 'changed' (proceed)")
+
+        # Cross-run: wipe _intake/snapshots; the committed operations cache still detects
+        # identical bytes (the reason snapshot state is committed, not in transient _intake/).
+        shutil.rmtree(snapdir, ignore_errors=True)
+        r = run_cli("fetch-snapshot", a_file, "--from", v2, "--today", "2026-09-08", "--json")
+        res = json.loads(r.stdout)
+        check(res.get("outcome") == "bytes_identical",
+              "F: with _intake/ wiped, the committed cache must still detect identical bytes (cross-checkout)")
+
+        # --from required (network-free CLI).
+        r = run_cli("fetch-snapshot", a_file, "--today", "2026-06-08")
+        check(r.returncode != 0 and "--from" in (r.stdout + r.stderr), "F: fetch-snapshot must require --from")
+
+        # Static artefact rejected.
+        s_file = os.path.join(org, "codex", "external", "us", "REGULATION-D-1.yaml")
+        r = run_cli("fetch-snapshot", s_file, "--from", v1, "--today", "2026-06-08")
+        check(r.returncode != 0 and "monitoring_needed: true" in (r.stdout + r.stderr),
+              "F: fetch-snapshot must reject a monitoring_needed: false artefact")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_list_due()
 part_c_update_scan()
 part_d_digest()
 part_e_check_signal()
+part_f_fetch_snapshot()
 
 if _failures:
     print("FAIL - Transitrix Reg-Intel skill + CLI test:")


### PR DESCRIPTION
Fifth increment of the reg-intel build (HUB-153) — **SKILL Step 3, the snapshot step**: capture a point-in-time copy of a moved source and fingerprint it, so SEGMENT/AMENDMENT have stable bytes and a later amendment is provable against them.

## What ships

- **`fetch-snapshot <CODEX-ID|file> --from <fetched-file> [--ext] [--today]`** writes the snapshot to `_intake/snapshots/<id>-<date>.<ext>` (operational, in-flight — **not** the codex `sources/` copy, which is the human-admitted canonical snapshot per `14-codex.md` §3.1), computes `source_hash: sha256:<hex>` (the ingest convention), and detects:
  - **captured** — first harvest;
  - **changed** — bytes differ → proceed to Step 4;
  - **bytes_identical** — publisher re-stamped without changing bytes → stop, report on the digest.
- **Network-free** (like `check-signal`): the agent/scheduler fetches and passes `--from`; the CLI snapshots + hashes + diffs. `--from` required; a `monitoring_needed: false` artefact is rejected.
- **Cross-checkout detection.** Bytes-identical compares to the latest prior `_intake/snapshots/` capture, falling back to the last snapshot hash in the committed operations cache (`operations/state/reg-intel/signal-cache.json`, under a separate `snapshots` map so it never collides with the signal gate's `sources` map) — so detection survives a fresh clone / CI checkout where `_intake/` is gone. New module `snapshot.mjs`; `signal-cache.mjs` gains `get/setSnapshotEntry`.

## Docs

`SKILL.md` Step 3 rewritten to the `--from` network-free interface + the captured/changed/bytes_identical outcomes; status banner adds `fetch-snapshot` to **live**.

> **Deferred:** content-aware cosmetic-vs-normative diffing (the `cosmetic_change` outcome). Today only byte-level `changed` vs `bytes_identical` is decided — a byte-identical re-stamp is caught, but a cosmetic-but-byte-different re-publication still advances and is filtered at the human gate. Noted in Step 3 + the issue as a follow-up.

## Tests

Integrity **Part F**: `captured` → `bytes_identical` → `changed`; cross-checkout detection after `_intake/` is wiped; `--from` required; static rejected. Full suite (A–F) + prompts test pass; doc-lint clean.

## Scope / #153

**#153 stays open.** Remaining: `segment`, `classify`, `validate`, `amendment`; operational templates; the cosmetic-diff refinement. THE ONE RULE holds — snapshots are operational `_intake` artefacts, never canon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
