### PR TITLE
feat(reg-intel-cli): SEGMENT shaper — segment (#153, increment 6)

### DIFF
--- a/packages/reg-intel-cli/README.md
+++ b/packages/reg-intel-cli/README.md
@@ -4,7 +4,7 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 
 **The one rule:** this CLI *proposes*. It reads the codex registry, runs the change-signal gate, snapshots / segments / classifies regulatory text, and stages a review digest. It **never writes `canon/`** and **never silently flips** an existing `active` canon element. A human admits.
 
-> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), the snapshot step (`fetch-snapshot`), and the review digest (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`segment`, `classify`, `validate`, `amendment`) lands in later increments.
+> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), the snapshot step (`fetch-snapshot`), the SEGMENT shaper (`segment`), and the review digest (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`classify`, `validate`, `amendment`) lands in later increments.
 
 ## Commands
 
@@ -15,8 +15,9 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 | `update-scan <CODEX-ID\|file> [--today YYYY-MM-DD] [--frequency daily\|weekly\|monthly\|quarterly] [--change "<summary>"] [--review]` | ✅ | Write the codex `scan` block (`last_scanned_at`, `next_scan_due` from the cadence, `change_detected`, `change_description`, `review_needed`) — operating state only; never touches any other field. |
 | `check-signal <CODEX-ID\|file> --observed <value> [--method etag\|last_modified\|api_version\|amended_date\|fragment_hash] [--accept-no-signal] [--today YYYY-MM-DD]` | ✅ | The cheap change-signal gate (network-free — caller supplies the observed value). Compares to the last-seen value in `operations/state/reg-intel/signal-cache.json`: `unchanged` → bump scan; `moved` / `no_signal` → proceed. |
 | `fetch-snapshot <CODEX-ID\|file> --from <fetched-file> [--ext <ext>] [--today YYYY-MM-DD]` | ✅ | Snapshot the caller-fetched bytes to `_intake/snapshots/<id>-<date>.<ext>`, fingerprint (`source_hash: sha256:…`), and detect `captured` / `changed` / `bytes_identical` (cross-checkout via the committed cache). Network-free — the caller fetches. |
+| `segment <snapshot> --from <result.json> [--source <CODEX-ID>] [--today YYYY-MM-DD]` | ✅ | Shape the segment agent's `{segments:[…]}` result into proposed `SEGMENT-*` field artefacts under `_intake/processing/segments/` (canonical ids, `text_hash`, `source`/`source_hash` from the snapshot, the field-zone proposed admission record). Network-free; locator-less / text-less segments flagged + skipped. |
 | `digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]` | ✅ | Assemble the human review digest (`review-digest.yaml`) — staged SEGMENT / candidate / AMENDMENT artefacts grouped by codex source (candidates via `derived_from` → SEGMENT), with each source's scan block + a tally. `gate.admits_to_canon: false`. Schema: [`schemas/review-digest.schema.json`](../../transitrix/skills/reg-intel/schemas/review-digest.schema.json). |
-| `segment` / `classify` / `validate` / `amendment` | ⏳ | Later increments. |
+| `classify` / `validate` / `amendment` | ⏳ | Later increments. |
 
 `next_scan_due` math: `daily` +1d, `weekly` +7d, `monthly` +1 month, `quarterly` +3 months; month additions clamp to the target month's last day (Jan 31 + monthly → Feb 28/29). All UTC, so results are host-timezone independent. Dates compare as ISO-8601 strings.
 
@@ -32,6 +33,7 @@ packages/reg-intel-cli/
     update-scan.mjs    # write/replace the codex scan block in place (Step 8)
     check-signal.mjs   # the change-signal gate: compare observed vs cached (Step 2)
     snapshot.mjs       # snapshot caller-fetched bytes + source_hash + diff (Step 3)
+    segment.mjs        # shape the segment agent result into SEGMENT artefacts (Step 4)
     signal-cache.mjs   # read/write the committed operations/state cache (signals + snapshots)
     digest.mjs         # assemble the review digest from staged run artefacts (Step 9)
 ```

--- a/packages/reg-intel-cli/reg-intel.mjs
+++ b/packages/reg-intel-cli/reg-intel.mjs
@@ -22,6 +22,7 @@ import { findOrgRoot, listDue, findCodexFile } from './src/codex.mjs';
 import { updateScan } from './src/update-scan.mjs';
 import { checkSignal } from './src/check-signal.mjs';
 import { fetchSnapshot } from './src/snapshot.mjs';
+import { emitSegments } from './src/segment.mjs';
 import { buildDigest, writeDigest, defaultDigestPath } from './src/digest.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -68,6 +69,9 @@ function usage() {
     '  fetch-snapshot <CODEX-ID|file> --from <fetched-file> [--ext <ext>] [--today YYYY-MM-DD] [--json]',
     '                                 Snapshot the fetched bytes to _intake/snapshots/, fingerprint',
     '                                 (source_hash), and detect captured | changed | bytes_identical.',
+    '  segment <snapshot> --from <result.json> [--source <CODEX-ID>] [--today YYYY-MM-DD]',
+    '                                 Shape the segment agent result into proposed SEGMENT-* field',
+    '                                 artefacts under _intake/processing/segments/.',
     '  digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]',
     '                                 Assemble the human review digest from staged run artefacts',
     '                                 (review-digest.yaml). Nothing is admitted — a human gates it.',
@@ -215,6 +219,35 @@ async function cmdFetchSnapshot(args) {
   }
 }
 
+async function cmdSegment(args) {
+  const { _, flags } = parseArgs(args);
+  const snapshot = _[0];
+  if (typeof flags.from !== 'string') { console.error('segment: --from <result.json> is required (the segment agent output)'); return 1; }
+  const fromPath = resolve(flags.from);
+  if (!(await exists(fromPath))) { console.error(`segment: --from file not found: ${flags.from}`); return 2; }
+
+  const anchor = snapshot ? resolve(snapshot) : process.cwd();
+  const orgRoot = await findOrgRoot(anchor);
+  if (!orgRoot) { console.error('segment: not inside a Transitrix workspace (no transitrix.yaml); pass a <snapshot> inside one.'); return 2; }
+
+  try {
+    const res = await emitSegments({
+      orgRoot,
+      snapshotPath: snapshot ? resolve(snapshot) : undefined,
+      resultPath: fromPath,
+      source: typeof flags.source === 'string' ? flags.source : undefined,
+      today: flags.today ? String(flags.today) : today(),
+    });
+    console.log(`segment  source ${res.source}  ->  ${res.segments.length} SEGMENT(s) -> ${res.dir}`);
+    for (const f of res.flags) console.log(`  flag: ${f}`);
+    console.log('  segments are proposed — nothing admitted to the field zone.');
+    return 0;
+  } catch (err) {
+    console.error(`segment: ${err.message}`);
+    return 2;
+  }
+}
+
 async function cmdDigest(args) {
   const { _, flags } = parseArgs(args);
   const orgRoot = await resolveOrgRoot(_[0], 'digest');
@@ -243,6 +276,7 @@ async function main(argv) {
     case 'update-scan':  return cmdUpdateScan(args);
     case 'check-signal': return cmdCheckSignal(args);
     case 'fetch-snapshot': return cmdFetchSnapshot(args);
+    case 'segment':      return cmdSegment(args);
     case 'digest':       return cmdDigest(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);

--- a/packages/reg-intel-cli/src/segment.mjs
+++ b/packages/reg-intel-cli/src/segment.mjs
@@ -1,0 +1,114 @@
+// `segment` (SKILL Step 4) — shape the segmentation agent's JSON result into
+// `SEGMENT-*` field-zone artefacts (23-segment.md), staged in
+// `_intake/processing/segments/` in the `proposed` state. The deterministic
+// counterpart to the segment prompt: the agent reads the snapshot and emits
+// `{ segments: [...] }`; this assigns canonical ids + the admission record and writes
+// the files. It never admits — a human gates them (proposed -> active | rejected).
+//
+// THE ONE RULE holds: writes only to _intake/, never canon/ or field/.
+
+import { readFile, writeFile, readdir, mkdir, access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, resolve, basename, extname } from 'node:path';
+import { dump } from './yaml.mjs';
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}$/;
+const CONFIDENCE = new Set(['high', 'medium', 'low']);
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+function sha256(buf) { return createHash('sha256').update(buf).digest('hex'); }
+
+// Lower-case a label into a safe ID middle segment (letters/digits/underscore).
+function slugSegment(text) {
+  const s = String(text || '').normalize('NFKD').replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '').toLowerCase();
+  return s || null;
+}
+
+// Derive the source CODEX-ID from a snapshot filename `<CODEX-ID>-<YYYY-MM-DD>.<ext>`.
+export function sourceFromSnapshot(snapshotPath) {
+  const stem = basename(snapshotPath, extname(snapshotPath));
+  return stem.replace(/-\d{4}-\d{2}-\d{2}$/, '') || stem;
+}
+
+// A middle slug for SEGMENT ids derived from the source id: drop the leading TYPE and
+// the terminal integer, join the rest (REGULATION-GDPR-2016-1 -> gdpr_2016). Falls back
+// to the whole id slugged.
+function sourceSlug(sourceId) {
+  const parts = String(sourceId || '').split('-');
+  const middle = parts.length >= 3 ? parts.slice(1, -1) : parts;
+  return slugSegment(middle.join('_')) || slugSegment(sourceId) || 'src';
+}
+
+// Next free SEGMENT ordinal for a given middle slug in the segments dir.
+async function nextOrdinal(dir, slug) {
+  if (!(await exists(dir))) return 1;
+  let max = 0;
+  const re = new RegExp(`^SEGMENT-${slug}-(\\d+)\\.yaml$`);
+  for (const name of await readdir(dir)) {
+    const m = name.match(re);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return max + 1;
+}
+
+export async function emitSegments({ orgRoot, snapshotPath, resultPath, source, today }) {
+  if (!ISO_RE.test(today || '')) throw new Error('--today must be YYYY-MM-DD');
+  if (!resultPath) throw new Error('--from <result.json> is required (the segment agent output)');
+
+  let sourceHash = null;
+  if (snapshotPath) {
+    const sp = resolve(snapshotPath);
+    if (!(await exists(sp))) throw new Error(`snapshot not found: ${snapshotPath}`);
+    sourceHash = `sha256:${sha256(await readFile(sp))}`;
+    if (!source) source = sourceFromSnapshot(sp);
+  }
+  if (!source) throw new Error('cannot determine source: pass a <snapshot> path or --source <CODEX-ID>');
+
+  let result;
+  try { result = JSON.parse(await readFile(resolve(resultPath), 'utf8')); }
+  catch (err) { throw new Error(`--from does not parse as JSON: ${err.message}`); }
+  const segments = Array.isArray(result.segments) ? result.segments : [];
+
+  const dir = join(resolve(orgRoot), '_intake', 'processing', 'segments');
+  await mkdir(dir, { recursive: true });
+  const slug = sourceSlug(source);
+  let ordinal = await nextOrdinal(dir, slug);
+
+  const written = [];
+  const flags = [];
+  for (const seg of segments) {
+    const locator = seg.locator ? String(seg.locator) : null;
+    const excerpt = typeof seg.text_excerpt === 'string' ? seg.text_excerpt : null;
+    const textHash = excerpt ? `sha256:${sha256(Buffer.from(excerpt, 'utf8'))}`
+      : (typeof seg.text_hash === 'string' ? seg.text_hash : null);
+    if (!locator) { flags.push('a segment is missing locator — skipped'); continue; }
+    if (!excerpt && !textHash) { flags.push(`SEGMENT at ${locator} has neither text_excerpt nor text_hash — skipped (SEGMENT-003)`); continue; }
+    const conf = CONFIDENCE.has(seg.extraction_confidence) ? seg.extraction_confidence : 'low';
+
+    const id = `SEGMENT-${slug}-${ordinal++}`;
+    const artefact = {
+      id,
+      type: 'SEGMENT',
+      name: `${source} ${locator}`,
+      source,
+      locator,
+      ...(excerpt ? { text_excerpt: excerpt } : {}),
+      ...(textHash ? { text_hash: textHash } : {}),
+      extracted_at: today,
+      ...(sourceHash ? { source_hash: sourceHash } : {}),
+      // Review flag — "did I find a real, atomic obligation and cite it correctly"
+      // (CONTRACT §11.8); separate from source_quality, surfaced in the digest.
+      extraction_confidence: conf,
+      ...(seg.extraction_notes ? { extraction_notes: String(seg.extraction_notes) } : {}),
+      zone: 'field',
+      admission_state: 'proposed',
+      proposed_at: today,
+      proposed_by: 'reg-intel-scanner',
+      gate_checks: { provenance: 'pending_review' },
+    };
+    await writeFile(join(dir, `${id}.yaml`), dump(artefact), 'utf8');
+    written.push(id);
+  }
+
+  return { dir, source, source_hash: sourceHash, segments: written, flags };
+}

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **data-collection process** for the regulatory side of a Transitrix repository: it turns watched **codex sources** (laws, regulations, policies, internal standards) into `field`-zone evidence — `SEGMENT-*` chunks of the source text, `AMENDMENT-*` records when a watched source has drifted — and into `proposed` `REQUIREMENT-*` / `CONSTRAINT-*` canon candidates, then routes everything through a human review digest. It is the operational counterpart to the methodology's codex / SEGMENT / AMENDMENT / REQUIREMENT notation work — the part that watches the registry, runs the change-signal gate, slices and classifies the text, and stages the human gate.
 
-> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `segment`, `classify`, `validate`, `amendment`; when the run loop reaches one of them the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
+> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `segment` (Step 4), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `classify`, `validate`, `amendment`; when the run loop reaches one of them the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the regulatory-intelligence pipeline against it. It is designed to run **agent-neutrally** under Claude and GitHub Copilot — all heavy logic lives in the CLI, and this `SKILL.md` only sequences it.
 
@@ -125,8 +125,10 @@ Each emitted SEGMENT carries:
 
 SEGMENTs are emitted to `_intake/processing/segments/` first; the CLI moves them to `field/segments/` only after the validator pass in Step 6. They are never auto-admitted.
 
+The CLI is network-free here too: the agent runs the [`segment` prompt](prompts/segment.md) over the snapshot and emits `{ segments: [...] }`; the CLI shapes that result into SEGMENT artefacts (assigning canonical ids per the source slug, the field-zone `proposed` admission record, `text_hash` from the excerpt, and `source` / `source_hash` derived from the snapshot). A segment missing a locator or any text is flagged and skipped, never silently emitted.
+
 ```
-npx @transitrix/reg-intel-cli segment <_intake/snapshots/<CODEX-ID>-<DATE>.<ext>>
+npx @transitrix/reg-intel-cli segment <_intake/snapshots/<CODEX-ID>-<DATE>.<ext>> --from <result.json> [--source <CODEX-ID>]
 ```
 
 ---

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
@@ -2,7 +2,7 @@
 """From-scratch integrity test for the Transitrix Reg-Intel skill + @transitrix/reg-intel-cli.
 
 Deterministic, no-API-key, no-network guard for the CLI increments landed so far
-(the rest of the SKILL.md pipeline lands in later increments). Six parts:
+(the rest of the SKILL.md pipeline lands in later increments). Seven parts:
 
   A. Bundle integrity — SKILL.md + README.md present and frontmatter parses; the CLI
      package.json parses and declares its bin; the entry point exists; `--version`
@@ -28,6 +28,10 @@ Deterministic, no-API-key, no-network guard for the CLI increments landed so far
      'bytes_identical'; changed bytes are 'changed'; the committed operations cache
      detects identical bytes even after _intake/ is wiped (cross-checkout); --from is
      required; a static artefact is rejected.
+  G. segment (Step 4) — shapes the segment agent result into proposed SEGMENT-* field
+     artefacts: source + source_hash from the snapshot, text_hash from the excerpt,
+     ids per source slug, a locator-less segment skipped, the proposed admission record;
+     the digest counts them; --from required; ordinals continue across runs.
 
 Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
@@ -429,12 +433,71 @@ def part_f_fetch_snapshot():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part G — segment (Step 4, shape the agent result) ────────────
+
+def part_g_segment():
+    if not shutil.which("node"):
+        print("SKIP Part G: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="regintel-segment-")
+    try:
+        org = _codex_org(work)
+        snapdir = os.path.join(org, "_intake", "snapshots")
+        os.makedirs(snapdir, exist_ok=True)
+        snap = os.path.join(snapdir, "REGULATION-GDPR-2016-1-2026-06-08.html")
+        open(snap, "w", encoding="utf-8").write("<html>Art 30</html>")
+        res = os.path.join(work, "segres.json")
+        json.dump({"segments": [
+            {"locator": "Art.30(1)", "text_excerpt": "Each controller shall maintain a record.",
+             "obligation_signal": "shall", "extraction_confidence": "high"},
+            {"locator": "Art.30(1)(b)", "text_excerpt": "the purposes of the processing;",
+             "obligation_signal": "shall", "extraction_confidence": "medium"},
+            {"locator": None, "text_excerpt": "orphan — no locator"},
+        ]}, open(res, "w", encoding="utf-8"))
+
+        r = run_cli("segment", snap, "--from", res, "--today", "2026-06-08")
+        check(r.returncode == 0, f"G: segment failed: {r.stderr.strip()}")
+        sdir = os.path.join(org, "_intake", "processing", "segments")
+        files = sorted(f for f in os.listdir(sdir)) if os.path.isdir(sdir) else []
+        check(files == ["SEGMENT-gdpr_2016-1.yaml", "SEGMENT-gdpr_2016-2.yaml"],
+              f"G: segment must emit 2 SEGMENTs (the locator-less one skipped), ids per source slug; got {files}")
+
+        d = yaml.safe_load(open(os.path.join(sdir, "SEGMENT-gdpr_2016-1.yaml"), encoding="utf-8"))
+        check(d.get("type") == "SEGMENT" and d.get("zone") == "field", "G: SEGMENT type/zone")
+        check(d.get("source") == "REGULATION-GDPR-2016-1", "G: source derived from the snapshot filename")
+        check(d.get("locator") == "Art.30(1)", "G: locator carried")
+        check(d.get("admission_state") == "proposed" and d.get("proposed_by") == "reg-intel-scanner",
+              "G: SEGMENT must be emitted proposed, by the scanner")
+        check(d.get("gate_checks", {}).get("provenance") == "pending_review", "G: gate_checks.provenance pending_review")
+        check(re.match(r"^sha256:[0-9a-f]{64}$", d.get("text_hash", "")), "G: text_hash computed from the excerpt")
+        check(re.match(r"^sha256:[0-9a-f]{64}$", d.get("source_hash", "")), "G: source_hash from the snapshot bytes")
+        check(d.get("extraction_confidence") == "high", "G: extraction_confidence (review flag) carried")
+
+        # The digest already built consumes the staged SEGMENTs end-to-end.
+        r = run_cli("digest", org, "--as-of", "2026-06-08")
+        dg = yaml.safe_load(open(os.path.join(org, "_intake", "processing", "review-digest.yaml"), encoding="utf-8"))
+        check(dg.get("tally", {}).get("proposed", {}).get("SEGMENT") == 2, "G: the digest must count the 2 staged SEGMENTs")
+
+        # --from is required.
+        r = run_cli("segment", snap, "--today", "2026-06-08")
+        check(r.returncode != 0 and "--from" in (r.stdout + r.stderr), "G: segment must require --from")
+
+        # Ordinals continue on a second run (append, not overwrite).
+        r = run_cli("segment", snap, "--from", res, "--today", "2026-06-09")
+        files2 = sorted(os.listdir(sdir))
+        check("SEGMENT-gdpr_2016-3.yaml" in files2 and "SEGMENT-gdpr_2016-4.yaml" in files2,
+              f"G: a second run must continue the ordinal sequence; got {files2}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_list_due()
 part_c_update_scan()
 part_d_digest()
 part_e_check_signal()
 part_f_fetch_snapshot()
+part_g_segment()
 
 if _failures:
     print("FAIL - Transitrix Reg-Intel skill + CLI test:")


### PR DESCRIPTION
Sixth increment of the reg-intel build (HUB-153) — **SKILL Step 4**, the deterministic counterpart to the segment prompt (#149). The agent reads a snapshot and emits `{ segments: [...] }`; this shapes that result into proposed `SEGMENT-*` field artefacts (`23-segment.md`), the same pattern as the ingest CLI's `emit-candidates`.

## What ships

- **`segment <snapshot> --from <result.json> [--source <CODEX-ID>] [--today]`**:
  - derives `source` (CODEX-ID) and `source_hash` from the snapshot filename + bytes (`--source` overrides);
  - assigns canonical ids `SEGMENT-<source-slug>-<N>` (ordinals **continue across runs**, never overwrite);
  - writes each to `_intake/processing/segments/` with the field-zone **proposed** admission record (`zone: field`, `admission_state: proposed`, `proposed_by: reg-intel-scanner`, `gate_checks.provenance: pending_review`), `locator`, verbatim `text_excerpt` + a computed `text_hash`, `extracted_at`, and the `extraction_confidence` review flag (CONTRACT §11.8, separate from `source_quality`);
  - **flags + skips** a segment with no locator or no text (`SEGMENT-003`) — never silently emits.
  - Network-free: the agent does the read; the CLI shapes. New module `segment.mjs`.

The already-built **digest consumes the staged SEGMENTs end-to-end** (the test drives `segment → digest`). `SKILL.md` Step 4 + status banner updated — `segment` is now live.

## Tests

Integrity **Part G**: 2 SEGMENTs shaped (locator-less skipped), `source`/`source_hash` from the snapshot, `text_hash` from the excerpt, the proposed admission record, the digest counts them, `--from` required, ordinals continue across runs. Full suite (A–G) + prompts test pass; doc-lint clean.

## Scope / #153

**#153 stays open.** Remaining: `classify`, `validate`, `amendment`; operational templates; the cosmetic-diff refinement. THE ONE RULE holds — SEGMENTs are `proposed` `_intake` artefacts, never admitted to the field zone or canon by this skill.

> Minor: `extraction_confidence` is carried on the proposed SEGMENT as the CONTRACT §11.8 review flag (SKILL Step 9's digest lists it, and the prompt emits it). `23-segment.md`'s field table doesn't enumerate it — a small SKILL/notation alignment note, not drift; the field is pre-admission review metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
