### PR TITLE
feat(reg-intel-cli): CLASSIFY shaper — classify (#153, increment 7)

### DIFF
--- a/packages/reg-intel-cli/README.md
+++ b/packages/reg-intel-cli/README.md
@@ -4,7 +4,7 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 
 **The one rule:** this CLI *proposes*. It reads the codex registry, runs the change-signal gate, snapshots / segments / classifies regulatory text, and stages a review digest. It **never writes `canon/`** and **never silently flips** an existing `active` canon element. A human admits.
 
-> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), the snapshot step (`fetch-snapshot`), the SEGMENT shaper (`segment`), and the review digest (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`classify`, `validate`, `amendment`) lands in later increments.
+> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), the snapshot step (`fetch-snapshot`), the SEGMENT + CLASSIFY shapers (`segment`, `classify`), and the review digest (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`validate`, `amendment`) lands in later increments.
 
 ## Commands
 
@@ -16,8 +16,9 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 | `check-signal <CODEX-ID\|file> --observed <value> [--method etag\|last_modified\|api_version\|amended_date\|fragment_hash] [--accept-no-signal] [--today YYYY-MM-DD]` | ✅ | The cheap change-signal gate (network-free — caller supplies the observed value). Compares to the last-seen value in `operations/state/reg-intel/signal-cache.json`: `unchanged` → bump scan; `moved` / `no_signal` → proceed. |
 | `fetch-snapshot <CODEX-ID\|file> --from <fetched-file> [--ext <ext>] [--today YYYY-MM-DD]` | ✅ | Snapshot the caller-fetched bytes to `_intake/snapshots/<id>-<date>.<ext>`, fingerprint (`source_hash: sha256:…`), and detect `captured` / `changed` / `bytes_identical` (cross-checkout via the committed cache). Network-free — the caller fetches. |
 | `segment <snapshot> --from <result.json> [--source <CODEX-ID>] [--today YYYY-MM-DD]` | ✅ | Shape the segment agent's `{segments:[…]}` result into proposed `SEGMENT-*` field artefacts under `_intake/processing/segments/` (canonical ids, `text_hash`, `source`/`source_hash` from the snapshot, the field-zone proposed admission record). Network-free; locator-less / text-less segments flagged + skipped. |
+| `classify [segments-dir] --from <result.json> [--today YYYY-MM-DD]` | ✅ | Shape the classify agent's `{candidates:[…]}` into proposed `REQUIREMENT-*` / `CONSTRAINT-*` candidates under `_intake/processing/candidates/` (ids per source slug, `derived_from` → SEGMENT, `obligation_level` + `category`, `ambiguous_alt` on low confidence, `gate_checks` pending). Network-free; bad-kind / no-`derived_from` flagged + skipped. |
 | `digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]` | ✅ | Assemble the human review digest (`review-digest.yaml`) — staged SEGMENT / candidate / AMENDMENT artefacts grouped by codex source (candidates via `derived_from` → SEGMENT), with each source's scan block + a tally. `gate.admits_to_canon: false`. Schema: [`schemas/review-digest.schema.json`](../../transitrix/skills/reg-intel/schemas/review-digest.schema.json). |
-| `classify` / `validate` / `amendment` | ⏳ | Later increments. |
+| `validate` / `amendment` | ⏳ | Later increments. |
 
 `next_scan_due` math: `daily` +1d, `weekly` +7d, `monthly` +1 month, `quarterly` +3 months; month additions clamp to the target month's last day (Jan 31 + monthly → Feb 28/29). All UTC, so results are host-timezone independent. Dates compare as ISO-8601 strings.
 
@@ -34,6 +35,7 @@ packages/reg-intel-cli/
     check-signal.mjs   # the change-signal gate: compare observed vs cached (Step 2)
     snapshot.mjs       # snapshot caller-fetched bytes + source_hash + diff (Step 3)
     segment.mjs        # shape the segment agent result into SEGMENT artefacts (Step 4)
+    classify.mjs       # shape the classify agent result into REQUIREMENT/CONSTRAINT candidates (Step 5)
     signal-cache.mjs   # read/write the committed operations/state cache (signals + snapshots)
     digest.mjs         # assemble the review digest from staged run artefacts (Step 9)
 ```

--- a/packages/reg-intel-cli/reg-intel.mjs
+++ b/packages/reg-intel-cli/reg-intel.mjs
@@ -23,6 +23,7 @@ import { updateScan } from './src/update-scan.mjs';
 import { checkSignal } from './src/check-signal.mjs';
 import { fetchSnapshot } from './src/snapshot.mjs';
 import { emitSegments } from './src/segment.mjs';
+import { emitCandidates } from './src/classify.mjs';
 import { buildDigest, writeDigest, defaultDigestPath } from './src/digest.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -72,6 +73,9 @@ function usage() {
     '  segment <snapshot> --from <result.json> [--source <CODEX-ID>] [--today YYYY-MM-DD]',
     '                                 Shape the segment agent result into proposed SEGMENT-* field',
     '                                 artefacts under _intake/processing/segments/.',
+    '  classify [segments-dir] --from <result.json> [--today YYYY-MM-DD]',
+    '                                 Shape the classify agent result into proposed REQUIREMENT-* /',
+    '                                 CONSTRAINT-* candidates under _intake/processing/candidates/.',
     '  digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]',
     '                                 Assemble the human review digest from staged run artefacts',
     '                                 (review-digest.yaml). Nothing is admitted — a human gates it.',
@@ -248,6 +252,34 @@ async function cmdSegment(args) {
   }
 }
 
+async function cmdClassify(args) {
+  const { _, flags } = parseArgs(args);
+  if (typeof flags.from !== 'string') { console.error('classify: --from <result.json> is required (the classify agent output)'); return 1; }
+  const fromPath = resolve(flags.from);
+  if (!(await exists(fromPath))) { console.error(`classify: --from file not found: ${flags.from}`); return 2; }
+
+  const segmentsDir = _[0] ? resolve(_[0]) : undefined;
+  const anchor = segmentsDir || process.cwd();
+  const orgRoot = await findOrgRoot(anchor);
+  if (!orgRoot) { console.error('classify: not inside a Transitrix workspace (no transitrix.yaml); pass the <segments-dir> inside one.'); return 2; }
+
+  try {
+    const res = await emitCandidates({
+      orgRoot,
+      resultPath: fromPath,
+      segmentsDir,
+      today: flags.today ? String(flags.today) : today(),
+    });
+    console.log(`classify  ${res.candidates.length} candidate(s) (REQUIREMENT ${res.requirements} / CONSTRAINT ${res.constraints}) -> ${res.dir}`);
+    for (const f of res.flags) console.log(`  flag: ${f}`);
+    console.log('  candidates are proposed — nothing admitted to canon.');
+    return 0;
+  } catch (err) {
+    console.error(`classify: ${err.message}`);
+    return 2;
+  }
+}
+
 async function cmdDigest(args) {
   const { _, flags } = parseArgs(args);
   const orgRoot = await resolveOrgRoot(_[0], 'digest');
@@ -277,6 +309,7 @@ async function main(argv) {
     case 'check-signal': return cmdCheckSignal(args);
     case 'fetch-snapshot': return cmdFetchSnapshot(args);
     case 'segment':      return cmdSegment(args);
+    case 'classify':     return cmdClassify(args);
     case 'digest':       return cmdDigest(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);

--- a/packages/reg-intel-cli/src/classify.mjs
+++ b/packages/reg-intel-cli/src/classify.mjs
@@ -1,0 +1,119 @@
+// `classify` (SKILL Step 5) — shape the classification agent's JSON result into
+// proposed REQUIREMENT / CONSTRAINT canon CANDIDATES, staged in
+// `_intake/processing/candidates/`. The deterministic counterpart to the classify
+// prompt: the agent applies the decision tree (positive obligation -> REQUIREMENT by
+// default) and emits `{ candidates: [...] }`; this assigns canonical ids + the
+// pre-admission record and writes the files. It never admits — a human gates them
+// (proposed -> active | rejected).
+//
+// A candidate is a pre-admission DRAFT shaped by the extraction contract (SKILL
+// Step 5): it carries `derived_from: [SEGMENT-…]` (the human resolves it to the codex
+// source at admission per 15-requirement.md), and `obligation_level` as extraction
+// metadata (REQUIREMENT v1 defers obligation_level, 15-requirement.md §5 — the human
+// maps/drops it at admission). CONSTRAINT has no dedicated spec yet; it mirrors the
+// REQUIREMENT draft shape. THE ONE RULE holds: writes only to _intake/.
+
+import { readFile, writeFile, readdir, mkdir, access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { dump } from './yaml.mjs';
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}$/;
+const CONFIDENCE = new Set(['high', 'medium', 'low']);
+const LEVELS = new Set(['SHALL', 'SHALL_NOT', 'SHOULD', 'MAY']);
+const KIND_TO_TYPE = { requirement: 'REQUIREMENT', constraint: 'CONSTRAINT' };
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+// The middle slug of a candidate is taken from the SEGMENT it derives from
+// (SEGMENT-<slug>-<n> -> <slug>), so candidates group under their source the same way.
+function slugFromSegment(segId) {
+  const m = String(segId || '').match(/^SEGMENT-(.+)-\d+$/);
+  return m ? m[1] : 'src';
+}
+
+function oneLine(text, max = 80) {
+  const s = String(text || '').replace(/\s+/g, ' ').trim();
+  return s.length > max ? `${s.slice(0, max - 1).trimEnd()}…` : s;
+}
+
+async function nextOrdinal(dir, type, slug) {
+  if (!(await exists(dir))) return 1;
+  let max = 0;
+  const re = new RegExp(`^${type}-${slug}-(\\d+)\\.yaml$`);
+  for (const name of await readdir(dir)) {
+    const m = name.match(re);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return max + 1;
+}
+
+export async function emitCandidates({ orgRoot, resultPath, segmentsDir, today }) {
+  if (!ISO_RE.test(today || '')) throw new Error('--today must be YYYY-MM-DD');
+  if (!resultPath) throw new Error('--from <result.json> is required (the classify agent output)');
+
+  let result;
+  try { result = JSON.parse(await readFile(resolve(resultPath), 'utf8')); }
+  catch (err) { throw new Error(`--from does not parse as JSON: ${err.message}`); }
+  const candidates = Array.isArray(result.candidates) ? result.candidates : [];
+
+  // Optional: the set of staged SEGMENT ids, to flag a dangling derived_from.
+  let known = null;
+  if (segmentsDir && (await exists(segmentsDir))) {
+    known = new Set((await readdir(segmentsDir)).filter((n) => n.endsWith('.yaml')).map((n) => n.replace(/\.yaml$/, '')));
+  }
+
+  const dir = join(resolve(orgRoot), '_intake', 'processing', 'candidates');
+  await mkdir(dir, { recursive: true });
+
+  const written = [];
+  const flags = [];
+  const ordinals = {};
+  for (const c of candidates) {
+    const type = KIND_TO_TYPE[c.kind];
+    if (!type) { flags.push(`candidate has unknown kind ${JSON.stringify(c.kind)} (expected requirement|constraint) — skipped`); continue; }
+    const derivedFrom = Array.isArray(c.derived_from) ? c.derived_from.filter((x) => typeof x === 'string') : [];
+    if (derivedFrom.length === 0) { flags.push(`${type} candidate has no derived_from SEGMENT — skipped`); continue; }
+    const text = typeof c.source_text === 'string' ? c.source_text : null;
+    if (!text) { flags.push(`${type} candidate (from ${derivedFrom[0]}) has no source_text — skipped`); continue; }
+    if (known) for (const d of derivedFrom) if (!known.has(d)) flags.push(`${type} candidate cites a SEGMENT not staged in this run: ${d}`);
+
+    const level = c.obligation_level;
+    if (level && !LEVELS.has(level)) flags.push(`${type} candidate has a non-RFC2119 obligation_level ${JSON.stringify(level)}`);
+    const conf = CONFIDENCE.has(c.extraction_confidence) ? c.extraction_confidence : 'low';
+
+    const slug = slugFromSegment(derivedFrom[0]);
+    const key = `${type}|${slug}`;
+    if (ordinals[key] === undefined) ordinals[key] = await nextOrdinal(dir, type, slug);
+    const id = `${type}-${slug}-${ordinals[key]++}`;
+
+    const artefact = {
+      notation: c.kind,
+      id,
+      name: oneLine(text),
+      description: text,
+      derived_from: derivedFrom,
+      ...(level ? { obligation_level: level } : {}),
+      ...(c.category ? { category: String(c.category) } : {}),
+      extraction_confidence: conf,
+      ...(c.extraction_notes ? { extraction_notes: String(c.extraction_notes) } : {}),
+      ...(conf === 'low' && c.ambiguous_alt && typeof c.ambiguous_alt === 'object'
+        ? { ambiguous_alt: { kind: c.ambiguous_alt.kind ?? null, category: c.ambiguous_alt.category ?? null } }
+        : {}),
+      zone: 'canon',
+      admission_state: 'proposed',
+      proposed_at: today,
+      proposed_by: 'reg-intel-scanner',
+      gate_checks: { uniqueness: 'pending', consistency: 'pending', completeness: 'pending' },
+    };
+    await writeFile(join(dir, `${id}.yaml`), dump(artefact), 'utf8');
+    written.push(id);
+  }
+
+  return {
+    dir,
+    candidates: written,
+    requirements: written.filter((id) => id.startsWith('REQUIREMENT-')).length,
+    constraints: written.filter((id) => id.startsWith('CONSTRAINT-')).length,
+    flags,
+  };
+}

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **data-collection process** for the regulatory side of a Transitrix repository: it turns watched **codex sources** (laws, regulations, policies, internal standards) into `field`-zone evidence — `SEGMENT-*` chunks of the source text, `AMENDMENT-*` records when a watched source has drifted — and into `proposed` `REQUIREMENT-*` / `CONSTRAINT-*` canon candidates, then routes everything through a human review digest. It is the operational counterpart to the methodology's codex / SEGMENT / AMENDMENT / REQUIREMENT notation work — the part that watches the registry, runs the change-signal gate, slices and classifies the text, and stages the human gate.
 
-> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `segment` (Step 4), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `classify`, `validate`, `amendment`; when the run loop reaches one of them the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
+> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `segment` (Step 4), `classify` (Step 5), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `validate` (Step 6), `amendment` (Step 7); when the run loop reaches one of them the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the regulatory-intelligence pipeline against it. It is designed to run **agent-neutrally** under Claude and GitHub Copilot — all heavy logic lives in the CLI, and this `SKILL.md` only sequences it.
 
@@ -168,10 +168,12 @@ Each candidate carries:
 - an `extraction_confidence` flag (`high | medium | low`) — separate from `source_quality` (see [§ Two axes of trust](#two-axes-of-trust-never-merged) below);
 - the canon admission record with `admission_state: proposed`, `proposed_by: reg-intel-scanner`, and `gate_checks` left for the human to complete.
 
-**Ambiguity is not silently resolved.** A segment that the classifier cannot confidently place is emitted with `extraction_confidence: low` and surfaced on the digest with both the CONSTRAINT and REQUIREMENT shapes flagged — the human picks. Forcing a deterministic answer on an ambiguous obligation is the path to a quietly wrong canon.
+**Ambiguity is not silently resolved.** A segment that the classifier cannot confidently place is emitted with `extraction_confidence: low` and `ambiguous_alt` carrying the other shape — surfaced on the digest with both the CONSTRAINT and REQUIREMENT classifications — the human picks. Forcing a deterministic answer on an ambiguous obligation is the path to a quietly wrong canon.
+
+Network-free: the agent runs the [`classify` prompt](prompts/classify.md) over the staged SEGMENTs and emits `{ candidates: [...] }`; the CLI shapes that into proposed `REQUIREMENT-*` / `CONSTRAINT-*` candidates (canonical ids per the source slug, `derived_from` citing the SEGMENT, `obligation_level` + `category`, `gate_checks` left `pending` for the human). A candidate is a **pre-admission draft**: `derived_from` cites the SEGMENT (a human resolves it to the codex source at admission, per [`15-requirement.md`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/15-requirement.md)), and `obligation_level` is carried as extraction metadata (REQUIREMENT v1 defers it, `15-requirement.md` §5). A candidate with an unknown kind or no `derived_from` is flagged and skipped.
 
 ```
-npx @transitrix/reg-intel-cli classify <_intake/processing/segments/>
+npx @transitrix/reg-intel-cli classify <_intake/processing/segments/> --from <result.json>
 ```
 
 ---

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
@@ -2,7 +2,7 @@
 """From-scratch integrity test for the Transitrix Reg-Intel skill + @transitrix/reg-intel-cli.
 
 Deterministic, no-API-key, no-network guard for the CLI increments landed so far
-(the rest of the SKILL.md pipeline lands in later increments). Seven parts:
+(the rest of the SKILL.md pipeline lands in later increments). Eight parts:
 
   A. Bundle integrity — SKILL.md + README.md present and frontmatter parses; the CLI
      package.json parses and declares its bin; the entry point exists; `--version`
@@ -32,6 +32,11 @@ Deterministic, no-API-key, no-network guard for the CLI increments landed so far
      artefacts: source + source_hash from the snapshot, text_hash from the excerpt,
      ids per source slug, a locator-less segment skipped, the proposed admission record;
      the digest counts them; --from required; ordinals continue across runs.
+  H. classify (Step 5) — shapes the classify agent result into proposed REQUIREMENT-* /
+     CONSTRAINT-* candidates: kind→TYPE, derived_from cites the SEGMENT, obligation_level
+     + category carried, low-confidence keeps ambiguous_alt (both classifications),
+     bad-kind / no-derived_from skipped, proposed record with gate_checks pending; the
+     digest counts them; --from required.
 
 Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
@@ -491,6 +496,70 @@ def part_g_segment():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part H — classify (Step 5, REQUIREMENT/CONSTRAINT candidates) ─
+
+def part_h_classify():
+    if not shutil.which("node"):
+        print("SKIP Part H: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="regintel-classify-")
+    try:
+        org = _codex_org(work)
+        sdir = os.path.join(org, "_intake", "processing", "segments")
+        os.makedirs(sdir, exist_ok=True)
+        # A staged SEGMENT the candidates derive from.
+        open(os.path.join(sdir, "SEGMENT-gdpr_2016-1.yaml"), "w", encoding="utf-8").write(
+            'id: "SEGMENT-gdpr_2016-1"\ntype: "SEGMENT"\nsource: "REGULATION-GDPR-2016-1"\nlocator: "Art.30(1)"\nzone: "field"\n')
+        res = os.path.join(work, "cls.json")
+        json.dump({"candidates": [
+            {"kind": "requirement", "category": "DOCUMENTATION", "obligation_level": "SHALL",
+             "derived_from": ["SEGMENT-gdpr_2016-1"], "source_text": "Each controller shall maintain a record.",
+             "extraction_confidence": "high"},
+            {"kind": "constraint", "category": "PRODUCT", "obligation_level": "SHALL_NOT",
+             "derived_from": ["SEGMENT-gdpr_2016-1"], "source_text": "A device may not be distributed without approval.",
+             "extraction_confidence": "medium"},
+            {"kind": "requirement", "derived_from": ["SEGMENT-gdpr_2016-1"], "source_text": "ambiguous",
+             "extraction_confidence": "low", "ambiguous_alt": {"kind": "constraint", "category": "DEFINITIONAL"}},
+            {"kind": "bogus", "derived_from": ["SEGMENT-gdpr_2016-1"], "source_text": "x"},
+            {"kind": "requirement", "derived_from": [], "source_text": "no derived_from"},
+        ]}, open(res, "w", encoding="utf-8"))
+
+        r = run_cli("classify", sdir, "--from", res, "--today", "2026-06-08")
+        check(r.returncode == 0, f"H: classify failed: {r.stderr.strip()}")
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        files = sorted(os.listdir(cdir)) if os.path.isdir(cdir) else []
+        check(files == ["CONSTRAINT-gdpr_2016-1.yaml", "REQUIREMENT-gdpr_2016-1.yaml", "REQUIREMENT-gdpr_2016-2.yaml"],
+              f"H: classify must emit 2 REQUIREMENT + 1 CONSTRAINT (bogus + no-derived_from skipped); got {files}")
+
+        req = yaml.safe_load(open(os.path.join(cdir, "REQUIREMENT-gdpr_2016-1.yaml"), encoding="utf-8"))
+        check(req.get("notation") == "requirement" and req.get("zone") == "canon", "H: candidate notation/zone")
+        check(req.get("admission_state") == "proposed" and req.get("proposed_by") == "reg-intel-scanner",
+              "H: candidate must be proposed, by the scanner")
+        check(req.get("derived_from") == ["SEGMENT-gdpr_2016-1"], "H: derived_from cites the SEGMENT")
+        check(req.get("obligation_level") == "SHALL" and req.get("category") == "DOCUMENTATION", "H: obligation_level + category carried")
+        check(req.get("gate_checks", {}).get("uniqueness") == "pending", "H: gate_checks left pending for the human")
+
+        # The low-confidence candidate keeps both classifications via ambiguous_alt.
+        low = yaml.safe_load(open(os.path.join(cdir, "REQUIREMENT-gdpr_2016-2.yaml"), encoding="utf-8"))
+        check(low.get("extraction_confidence") == "low" and low.get("ambiguous_alt", {}).get("kind") == "constraint",
+              "H: a low-confidence candidate must surface ambiguous_alt (both classifications)")
+        # A high-confidence candidate carries no ambiguous_alt.
+        check("ambiguous_alt" not in req, "H: a confident candidate must not carry ambiguous_alt")
+
+        # End-to-end: the digest counts the candidates under their source (via SEGMENT).
+        r = run_cli("digest", org, "--as-of", "2026-06-08")
+        dg = yaml.safe_load(open(os.path.join(org, "_intake", "processing", "review-digest.yaml"), encoding="utf-8"))
+        prop = dg.get("tally", {}).get("proposed", {})
+        check(prop.get("REQUIREMENT") == 2 and prop.get("CONSTRAINT") == 1,
+              f"H: the digest must count the candidates; got {prop}")
+
+        # --from is required.
+        r = run_cli("classify", sdir, "--today", "2026-06-08")
+        check(r.returncode != 0 and "--from" in (r.stdout + r.stderr), "H: classify must require --from")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_list_due()
 part_c_update_scan()
@@ -498,6 +567,7 @@ part_d_digest()
 part_e_check_signal()
 part_f_fetch_snapshot()
 part_g_segment()
+part_h_classify()
 
 if _failures:
     print("FAIL - Transitrix Reg-Intel skill + CLI test:")


### PR DESCRIPTION
Seventh increment of the reg-intel build (HUB-153) — **SKILL Step 5**, completing the extraction pair `segment → classify → digest`. The deterministic counterpart to the classify prompt (#149): the agent applies the decision tree (**positive obligation → REQUIREMENT** by default) and emits `{ candidates: [...] }`; this shapes it into proposed `REQUIREMENT-*` / `CONSTRAINT-*` canon candidates.

## What ships

- **`classify [segments-dir] --from <result.json> [--today]`**:
  - `kind → TYPE` (requirement → REQUIREMENT, constraint → CONSTRAINT); ids `<TYPE>-<source-slug>-<N>` — the slug taken from the cited SEGMENT so candidates **group under their source** (ordinals per TYPE+slug);
  - writes `_intake/processing/candidates/` with the pre-admission record (`notation`, `name` [one-line], `description` [verbatim], `derived_from: [SEGMENT-…]`, `obligation_level`, `category`, `extraction_confidence`, `zone: canon`, `admission_state: proposed`, `proposed_by: reg-intel-scanner`, `gate_checks` left **pending** for the human);
  - a **low-confidence** candidate keeps `ambiguous_alt` (the other classification) so the digest shows both shapes; a confident one omits it;
  - **flags + skips** an unknown kind, a candidate with no `derived_from`, or no `source_text`; flags a dangling SEGMENT ref and a non-RFC2119 `obligation_level`.
  - Network-free. New module `classify.mjs`.

A candidate is a **pre-admission draft** shaped by the extraction contract: `derived_from` cites the SEGMENT (a human resolves it to the codex source at admission per `15-requirement.md`), and `obligation_level` is extraction metadata (**REQUIREMENT v1 defers `obligation_level`**, `15-requirement.md` §5). **CONSTRAINT has no dedicated spec yet** — it mirrors the REQUIREMENT draft shape. The already-built **digest counts the candidates** under their source (via SEGMENT).

`SKILL.md` Step 5 + status banner updated — `classify` is now live (only `validate` + `amendment` remain).

## Tests

Integrity **Part H**: 2 REQUIREMENT + 1 CONSTRAINT shaped, bad-kind / no-`derived_from` skipped, `ambiguous_alt` only on low confidence, `gate_checks` pending, the digest counts them, `--from` required. Full suite (A–H) + prompts test pass; doc-lint clean.

## Scope / #153

**#153 stays open.** Remaining: `validate` (Step 6), `amendment` (Step 7); operational templates; the cosmetic-diff refinement. THE ONE RULE holds — candidates are `proposed` `_intake` drafts, never admitted to canon by this skill.

> The SKILL-vs-notation reconciliations a candidate carries by design (SEGMENT-targeted `derived_from`, carried `obligation_level`, CONSTRAINT mirroring REQUIREMENT) are exactly what the human admission gate — and the upcoming `validate` step — resolve to canon shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
