### PR TITLE
feat(reg-intel-cli): contract validator — validate (#153, increment 8)

### DIFF
--- a/packages/reg-intel-cli/README.md
+++ b/packages/reg-intel-cli/README.md
@@ -4,7 +4,7 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 
 **The one rule:** this CLI *proposes*. It reads the codex registry, runs the change-signal gate, snapshots / segments / classifies regulatory text, and stages a review digest. It **never writes `canon/`** and **never silently flips** an existing `active` canon element. A human admits.
 
-> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), the snapshot step (`fetch-snapshot`), the SEGMENT + CLASSIFY shapers (`segment`, `classify`), and the review digest (`digest`). The rest of the [SKILL.md](../../transitrix/skills/reg-intel/SKILL.md) pipeline (`validate`, `amendment`) lands in later increments.
+> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), the snapshot step (`fetch-snapshot`), the SEGMENT + CLASSIFY shapers (`segment`, `classify`), the contract validator (`validate`), and the review digest (`digest`). The remaining `amendment` step lands in a later increment.
 
 ## Commands
 
@@ -17,8 +17,9 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 | `fetch-snapshot <CODEX-ID\|file> --from <fetched-file> [--ext <ext>] [--today YYYY-MM-DD]` | ✅ | Snapshot the caller-fetched bytes to `_intake/snapshots/<id>-<date>.<ext>`, fingerprint (`source_hash: sha256:…`), and detect `captured` / `changed` / `bytes_identical` (cross-checkout via the committed cache). Network-free — the caller fetches. |
 | `segment <snapshot> --from <result.json> [--source <CODEX-ID>] [--today YYYY-MM-DD]` | ✅ | Shape the segment agent's `{segments:[…]}` result into proposed `SEGMENT-*` field artefacts under `_intake/processing/segments/` (canonical ids, `text_hash`, `source`/`source_hash` from the snapshot, the field-zone proposed admission record). Network-free; locator-less / text-less segments flagged + skipped. |
 | `classify [segments-dir] --from <result.json> [--today YYYY-MM-DD]` | ✅ | Shape the classify agent's `{candidates:[…]}` into proposed `REQUIREMENT-*` / `CONSTRAINT-*` candidates under `_intake/processing/candidates/` (ids per source slug, `derived_from` → SEGMENT, `obligation_level` + `category`, `ambiguous_alt` on low confidence, `gate_checks` pending). Network-free; bad-kind / no-`derived_from` flagged + skipped. |
+| `validate [org-root] [--json]` | ✅ | Validate staged SEGMENTs + candidates against the contract (`23-segment.md` `SEGMENT-001..008`, ID grammar, candidate field rules; `SEGMENT-002` resolves `source` against `codex/`). Flags with codes + severity, never drops; exit 1 when review is needed. *(Coverage-profile check deferred — see SKILL Step 6.)* |
 | `digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]` | ✅ | Assemble the human review digest (`review-digest.yaml`) — staged SEGMENT / candidate / AMENDMENT artefacts grouped by codex source (candidates via `derived_from` → SEGMENT), with each source's scan block + a tally. `gate.admits_to_canon: false`. Schema: [`schemas/review-digest.schema.json`](../../transitrix/skills/reg-intel/schemas/review-digest.schema.json). |
-| `validate` / `amendment` | ⏳ | Later increments. |
+| `amendment` | ⏳ | Later increment. |
 
 `next_scan_due` math: `daily` +1d, `weekly` +7d, `monthly` +1 month, `quarterly` +3 months; month additions clamp to the target month's last day (Jan 31 + monthly → Feb 28/29). All UTC, so results are host-timezone independent. Dates compare as ISO-8601 strings.
 
@@ -36,6 +37,7 @@ packages/reg-intel-cli/
     snapshot.mjs       # snapshot caller-fetched bytes + source_hash + diff (Step 3)
     segment.mjs        # shape the segment agent result into SEGMENT artefacts (Step 4)
     classify.mjs       # shape the classify agent result into REQUIREMENT/CONSTRAINT candidates (Step 5)
+    validate.mjs       # contract checks over staged SEGMENTs + candidates (Step 6)
     signal-cache.mjs   # read/write the committed operations/state cache (signals + snapshots)
     digest.mjs         # assemble the review digest from staged run artefacts (Step 9)
 ```

--- a/packages/reg-intel-cli/reg-intel.mjs
+++ b/packages/reg-intel-cli/reg-intel.mjs
@@ -24,6 +24,7 @@ import { checkSignal } from './src/check-signal.mjs';
 import { fetchSnapshot } from './src/snapshot.mjs';
 import { emitSegments } from './src/segment.mjs';
 import { emitCandidates } from './src/classify.mjs';
+import { validateStaged } from './src/validate.mjs';
 import { buildDigest, writeDigest, defaultDigestPath } from './src/digest.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -76,6 +77,8 @@ function usage() {
     '  classify [segments-dir] --from <result.json> [--today YYYY-MM-DD]',
     '                                 Shape the classify agent result into proposed REQUIREMENT-* /',
     '                                 CONSTRAINT-* candidates under _intake/processing/candidates/.',
+    '  validate [org-root] [--json]   Validate staged SEGMENTs + candidates against the contract',
+    '                                 (23-segment.md, ID grammar); flags, never drops.',
     '  digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]',
     '                                 Assemble the human review digest from staged run artefacts',
     '                                 (review-digest.yaml). Nothing is admitted — a human gates it.',
@@ -280,6 +283,25 @@ async function cmdClassify(args) {
   }
 }
 
+async function cmdValidate(args) {
+  const { _, flags } = parseArgs(args);
+  const orgRoot = await resolveOrgRoot(_[0], 'validate');
+  if (!orgRoot) return 2;
+
+  const res = await validateStaged(orgRoot);
+  if (flags.json) { console.log(JSON.stringify(res, null, 2)); return res.reviewed ? 1 : 0; }
+
+  if (res.total === 0) { console.log('validate: no staged SEGMENTs or candidates under _intake/processing/.'); return 0; }
+  for (const it of res.items) {
+    if (!it.flags.length) { console.log(`ok     ${it.id}`); continue; }
+    console.log(`FLAG   ${it.id}`);
+    for (const fl of it.flags) console.log(`         - [${fl.code}/${fl.severity}] ${fl.message}`);
+  }
+  console.log(`\n${res.total} artefact(s); ${res.reviewed} need review (${res.errors} error(s), ${res.warnings} warning(s)).`);
+  console.log('  flagged artefacts are review-digest items, not rejections — a human gates them.');
+  return res.reviewed ? 1 : 0;
+}
+
 async function cmdDigest(args) {
   const { _, flags } = parseArgs(args);
   const orgRoot = await resolveOrgRoot(_[0], 'digest');
@@ -310,6 +332,7 @@ async function main(argv) {
     case 'fetch-snapshot': return cmdFetchSnapshot(args);
     case 'segment':      return cmdSegment(args);
     case 'classify':     return cmdClassify(args);
+    case 'validate':     return cmdValidate(args);
     case 'digest':       return cmdDigest(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);

--- a/packages/reg-intel-cli/src/validate.mjs
+++ b/packages/reg-intel-cli/src/validate.mjs
@@ -1,0 +1,154 @@
+// `validate` (SKILL Step 6) — run the staged SEGMENT field artefacts and the
+// REQUIREMENT / CONSTRAINT candidates through the canonical contract checks
+// (23-segment.md §6 SEGMENT-001..008; ID grammar; the candidate field rules). A
+// failing artefact is FLAGGED with an actionable, coded reason and routed to the
+// review digest — never silently dropped, never auto-rejected. The same
+// flag-not-drop discipline as the ingest CLI's validate.
+//
+// Coverage-profile awareness (SKILL Step 6) is deferred: it needs the coverage
+// resolver that today lives only in the ingest CLI. Sharing it (a common package)
+// rather than duplicating it is a separate refactor; until then validate covers the
+// contract + grammar checks. THE ONE RULE holds: read-only over _intake/.
+
+import { readFile, readdir, access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, resolve, basename } from 'node:path';
+import { readTopScalar, readScalarList, readBlockScalars } from './yaml.mjs';
+import { findCodexFile } from './codex.mjs';
+
+const ID_RE = /^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$/;
+const HASH_RE = /^sha256:[0-9a-f]{64}$/;
+const CODEX_TYPES = new Set(['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD']);
+const CAND_TYPES = new Set(['REQUIREMENT', 'CONSTRAINT']);
+const LEVELS = new Set(['SHALL', 'SHALL_NOT', 'SHOULD', 'MAY']);
+const CONFIDENCE = new Set(['high', 'medium', 'low']);
+
+function typeOf(id) { return typeof id === 'string' && id.includes('-') ? id.split('-')[0] : null; }
+function sha256(s) { return `sha256:${createHash('sha256').update(Buffer.from(s, 'utf8')).digest('hex')}`; }
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+async function readYamlFiles(dir) {
+  const out = [];
+  let names;
+  try { names = (await readdir(dir)).filter((n) => n.endsWith('.yaml')).sort(); } catch { return out; }
+  for (const name of names) out.push({ ref: join(dir, name), name, text: await readFile(join(dir, name), 'utf8') });
+  return out;
+}
+
+function flag(code, severity, message) { return { code, severity, message }; }
+
+// Validate one SEGMENT. `segIndex` maps SEGMENT id → { source } for parent resolution;
+// `codexResolve(id)` returns true if a codex artefact with that id exists.
+async function validateSegment(text, segIndex, codexResolve) {
+  const flags = [];
+  const id = readTopScalar(text, 'id');
+  const type = readTopScalar(text, 'type');
+  const name = readTopScalar(text, 'name');
+  const source = readTopScalar(text, 'source');
+  const locator = readTopScalar(text, 'locator');
+  const extractedAt = readTopScalar(text, 'extracted_at');
+  const zone = readTopScalar(text, 'zone');
+  const gate = readBlockScalars(text, 'gate_checks');
+  const excerpt = readTopScalar(text, 'text_excerpt');
+  const textHash = readTopScalar(text, 'text_hash');
+  const sourceHash = readTopScalar(text, 'source_hash');
+  const parent = readTopScalar(text, 'parent');
+
+  // SEGMENT-001 — id grammar, required fields, type literal.
+  if (!ID_RE.test(id || '') || typeOf(id) !== 'SEGMENT') flags.push(flag('SEGMENT-001', 'error', `id missing or not SEGMENT-grammar: ${JSON.stringify(id)}`));
+  if (type !== 'SEGMENT') flags.push(flag('SEGMENT-001', 'error', `type must be the literal "SEGMENT" (got ${JSON.stringify(type)})`));
+  for (const [k, v] of [['name', name], ['source', source], ['locator', locator], ['extracted_at', extractedAt], ['zone', zone]]) {
+    if (!v) flags.push(flag('SEGMENT-001', 'error', `required field ${k} is missing`));
+  }
+  if (!gate) flags.push(flag('SEGMENT-001', 'error', 'required field gate_checks is missing'));
+  if (zone && zone !== 'field') flags.push(flag('SEGMENT-001', 'error', `zone must be "field" (got ${JSON.stringify(zone)})`));
+
+  // SEGMENT-002 — source resolves to a codex artefact of an allowed TYPE.
+  if (!source || !ID_RE.test(source)) flags.push(flag('SEGMENT-002', 'error', `source missing or malformed: ${JSON.stringify(source)}`));
+  else if (!CODEX_TYPES.has(typeOf(source))) flags.push(flag('SEGMENT-002', 'error', `source TYPE must be LAW|REGULATION|POLICY|INTERNAL_STANDARD (got ${typeOf(source)})`));
+  else if (codexResolve && !(await codexResolve(source))) flags.push(flag('SEGMENT-002', 'error', `source does not resolve to a codex artefact under codex/: ${source}`));
+
+  // SEGMENT-003 — text_excerpt or text_hash.
+  if (!excerpt && !textHash) flags.push(flag('SEGMENT-003', 'error', 'neither text_excerpt nor text_hash present'));
+
+  // SEGMENT-006/007 — hash formats (warning).
+  if (textHash && !HASH_RE.test(textHash)) flags.push(flag('SEGMENT-006', 'warning', `text_hash not sha256:<64hex>: ${textHash}`));
+  if (sourceHash && !HASH_RE.test(sourceHash)) flags.push(flag('SEGMENT-007', 'warning', `source_hash not sha256:<64hex>: ${sourceHash}`));
+  // SEGMENT-008 — excerpt vs hash mismatch (warning).
+  if (excerpt && textHash && HASH_RE.test(textHash) && sha256(excerpt) !== textHash) {
+    flags.push(flag('SEGMENT-008', 'warning', 'text_hash does not match the SHA-256 of text_excerpt'));
+  }
+
+  // SEGMENT-004/005 — parent resolution (within the staged batch), same source, acyclic.
+  if (parent) {
+    if (!ID_RE.test(parent) || typeOf(parent) !== 'SEGMENT') flags.push(flag('SEGMENT-004', 'error', `parent not a SEGMENT id: ${parent}`));
+    else if (parent === id) flags.push(flag('SEGMENT-005', 'error', 'parent equals the segment id (self-nesting)'));
+    else if (segIndex.has(parent)) {
+      if (segIndex.get(parent).source !== source) flags.push(flag('SEGMENT-004', 'error', `parent ${parent} has a different source — nesting must be within one source`));
+      // cycle: walk parent chain.
+      const seen = new Set([id]); let cur = parent;
+      while (cur && segIndex.has(cur)) { if (seen.has(cur)) { flags.push(flag('SEGMENT-005', 'error', `parent chain forms a cycle at ${cur}`)); break; } seen.add(cur); cur = segIndex.get(cur).parent; }
+    }
+    // (a parent outside the staged batch is left for the cross-catalogue gate, not flagged here)
+  }
+  return { id, flags };
+}
+
+function validateCandidate(text) {
+  const flags = [];
+  const id = readTopScalar(text, 'id');
+  const notation = readTopScalar(text, 'notation');
+  const name = readTopScalar(text, 'name');
+  const description = readTopScalar(text, 'description');
+  const zone = readTopScalar(text, 'zone');
+  const admissionState = readTopScalar(text, 'admission_state');
+  const proposedAt = readTopScalar(text, 'proposed_at');
+  const level = readTopScalar(text, 'obligation_level');
+  const conf = readTopScalar(text, 'extraction_confidence');
+  const derivedFrom = readScalarList(text, 'derived_from');
+  const t = typeOf(id);
+
+  if (!ID_RE.test(id || '') || !CAND_TYPES.has(t)) flags.push(flag('CAND-001', 'error', `id missing or not a REQUIREMENT/CONSTRAINT id: ${JSON.stringify(id)}`));
+  if (notation && t && notation !== t.toLowerCase()) flags.push(flag('CAND-001', 'error', `notation ${JSON.stringify(notation)} does not match id TYPE ${t}`));
+  if (!name) flags.push(flag('CAND-001', 'error', 'name is missing'));
+  if (!description) flags.push(flag('CAND-001', 'error', 'description is missing'));
+  if (zone && zone !== 'canon') flags.push(flag('CAND-001', 'error', `zone must be "canon" (got ${JSON.stringify(zone)})`));
+  if (!derivedFrom.length) flags.push(flag('CAND-002', 'error', 'derived_from must cite at least one SEGMENT'));
+  else for (const d of derivedFrom) if (!ID_RE.test(d)) flags.push(flag('CAND-002', 'error', `derived_from has an invalid ID: ${d}`));
+  if (admissionState === 'proposed' && !proposedAt) flags.push(flag('CAND-003', 'error', 'admission_state proposed requires proposed_at'));
+  if (level && !LEVELS.has(level)) flags.push(flag('CAND-004', 'warning', `obligation_level not RFC-2119 (SHALL|SHALL_NOT|SHOULD|MAY): ${level}`));
+  if (conf && !CONFIDENCE.has(conf)) flags.push(flag('CAND-005', 'warning', `extraction_confidence not high|medium|low: ${conf}`));
+  return { id, flags };
+}
+
+// Validate everything staged under _intake/processing/. Returns
+// { items: [{ ref, kind, id, flags }], errors, warnings, reviewed }.
+export async function validateStaged(orgRoot) {
+  const procDir = join(resolve(orgRoot), '_intake', 'processing');
+  const segFiles = await readYamlFiles(join(procDir, 'segments'));
+  const candFiles = await readYamlFiles(join(procDir, 'candidates'));
+
+  const segIndex = new Map();
+  for (const f of segFiles) {
+    const id = readTopScalar(f.text, 'id');
+    if (id) segIndex.set(id, { source: readTopScalar(f.text, 'source'), parent: readTopScalar(f.text, 'parent') });
+  }
+  const codexResolve = async (sid) => !!(await findCodexFile(orgRoot, sid));
+
+  const items = [];
+  for (const f of segFiles) {
+    const r = await validateSegment(f.text, segIndex, codexResolve);
+    items.push({ ref: f.ref, kind: 'segment', id: r.id ?? basename(f.name, '.yaml'), flags: r.flags });
+  }
+  for (const f of candFiles) {
+    const r = validateCandidate(f.text);
+    items.push({ ref: f.ref, kind: 'candidate', id: r.id ?? basename(f.name, '.yaml'), flags: r.flags });
+  }
+
+  let errors = 0, warnings = 0, reviewed = 0;
+  for (const it of items) {
+    if (it.flags.length) reviewed++;
+    for (const fl of it.flags) (fl.severity === 'error' ? errors++ : warnings++);
+  }
+  return { items, errors, warnings, reviewed, total: items.length };
+}

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **data-collection process** for the regulatory side of a Transitrix repository: it turns watched **codex sources** (laws, regulations, policies, internal standards) into `field`-zone evidence — `SEGMENT-*` chunks of the source text, `AMENDMENT-*` records when a watched source has drifted — and into `proposed` `REQUIREMENT-*` / `CONSTRAINT-*` canon candidates, then routes everything through a human review digest. It is the operational counterpart to the methodology's codex / SEGMENT / AMENDMENT / REQUIREMENT notation work — the part that watches the registry, runs the change-signal gate, slices and classifies the text, and stages the human gate.
 
-> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `segment` (Step 4), `classify` (Step 5), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `validate` (Step 6), `amendment` (Step 7); when the run loop reaches one of them the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
+> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `segment` (Step 4), `classify` (Step 5), `validate` (Step 6), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `amendment` (Step 7); when the run loop reaches it the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the regulatory-intelligence pipeline against it. It is designed to run **agent-neutrally** under Claude and GitHub Copilot — all heavy logic lives in the CLI, and this `SKILL.md` only sequences it.
 
@@ -180,13 +180,15 @@ npx @transitrix/reg-intel-cli classify <_intake/processing/segments/> --from <re
 
 ## Step 6 — Validate (coverage-profile aware)
 
-Every SEGMENT and every canon candidate is run through the canonical validators — ID grammar, TYPE registry, the SEGMENT / REQUIREMENT / CONSTRAINT field rules ([`SEGMENT-001..008`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/23-segment.md), the REQUIREMENT / CONSTRAINT rules in their specs), and the adopter's **coverage profile** ([COVERAGE_PROFILES](https://raw.githubusercontent.com/transitrix/methodology/main/notations/COVERAGE_PROFILES.md)).
+Every staged SEGMENT and every canon candidate is run through the canonical validators — ID grammar, TYPE registry, and the SEGMENT / REQUIREMENT / CONSTRAINT field rules ([`SEGMENT-001..008`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/23-segment.md), the REQUIREMENT / CONSTRAINT rules in their specs). `SEGMENT-002` resolves each SEGMENT's `source` against the repo's `codex/` (TYPE must be `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`); `SEGMENT-004/005` check `parent` nesting within the staged batch.
 
 ```
-npx @transitrix/reg-intel-cli validate <_intake/processing/>
+npx @transitrix/reg-intel-cli validate [org-root] [--json]
 ```
 
-Out-of-profile or invalid candidates are **flagged with an actionable reason** — not silently emitted, and not silently dropped. A flagged candidate is a review-digest item, not a rejection. The validator is the same `check-notations`-shaped pass the rest of the methodology uses; nothing reg-intel-specific lives in it.
+Out-of-profile or invalid candidates are **flagged with an actionable, coded reason** (e.g. `[SEGMENT-002/error]`) — not silently emitted, and not silently dropped. A flagged artefact is a review-digest item, not a rejection; the command exits `1` when anything needs review, `0` when the batch is clean.
+
+> **Coverage-profile awareness is deferred.** SKILL intent is to also check each candidate's TYPE against the adopter's [coverage profile](https://raw.githubusercontent.com/transitrix/methodology/main/notations/COVERAGE_PROFILES.md). The coverage resolver currently lives only in the ingest CLI; sharing it (a common package) rather than duplicating it is a separate refactor. Until then `validate` covers the contract + grammar checks; coverage is confirmed at the human gate.
 
 ---
 

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
@@ -2,7 +2,7 @@
 """From-scratch integrity test for the Transitrix Reg-Intel skill + @transitrix/reg-intel-cli.
 
 Deterministic, no-API-key, no-network guard for the CLI increments landed so far
-(the rest of the SKILL.md pipeline lands in later increments). Eight parts:
+(the rest of the SKILL.md pipeline lands in later increments). Nine parts:
 
   A. Bundle integrity — SKILL.md + README.md present and frontmatter parses; the CLI
      package.json parses and declares its bin; the entry point exists; `--version`
@@ -37,11 +37,16 @@ Deterministic, no-API-key, no-network guard for the CLI increments landed so far
      + category carried, low-confidence keeps ambiguous_alt (both classifications),
      bad-kind / no-derived_from skipped, proposed record with gate_checks pending; the
      digest counts them; --from required.
+  I. validate (Step 6) — runs staged SEGMENTs + candidates through the contract checks
+     (23-segment.md SEGMENT-001..008, ID grammar, candidate field rules): a conformant
+     batch passes; a non-codex source flags SEGMENT-002, a bad hash SEGMENT-006, a
+     candidate with no derived_from CAND-002; flags-not-drops, exit 1 when review needed.
 
 Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
 """
 
+import hashlib
 import json
 import os
 import re
@@ -560,6 +565,63 @@ def part_h_classify():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part I — validate (Step 6, contract checks) ──────────────────
+
+def part_i_validate():
+    if not shutil.which("node"):
+        print("SKIP Part I: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="regintel-validate-")
+    try:
+        org = _codex_org(work)  # carries REGULATION-A-1 (a codex artefact)
+        seg = os.path.join(org, "_intake", "processing", "segments")
+        cand = os.path.join(org, "_intake", "processing", "candidates")
+        os.makedirs(seg, exist_ok=True)
+        os.makedirs(cand, exist_ok=True)
+
+        txt = "Each controller shall maintain a record."
+        thash = "sha256:" + hashlib.sha256(txt.encode("utf-8")).hexdigest()
+        # valid SEGMENT — source resolves to the codex REGULATION-A-1, hash matches.
+        open(os.path.join(seg, "SEGMENT-a-1.yaml"), "w", encoding="utf-8").write(
+            f'id: "SEGMENT-a-1"\ntype: "SEGMENT"\nname: "x"\nsource: "REGULATION-A-1"\nlocator: "Art.1"\n'
+            f'text_excerpt: "{txt}"\ntext_hash: "{thash}"\nextracted_at: "2026-06-08"\nzone: "field"\n'
+            'gate_checks:\n  provenance: pending_review\n')
+        # broken SEGMENT — source TYPE not codex (SEGMENT-002), bad text_hash (SEGMENT-006).
+        open(os.path.join(seg, "SEGMENT-bad-1.yaml"), "w", encoding="utf-8").write(
+            'id: "SEGMENT-bad-1"\ntype: "SEGMENT"\nname: "y"\nsource: "GOAL-X-1"\nlocator: "§1"\n'
+            'text_hash: "nothex"\nextracted_at: "2026-06-08"\nzone: "field"\n'
+            'gate_checks:\n  provenance: pending_review\n')
+        # valid candidate.
+        open(os.path.join(cand, "REQUIREMENT-a-1.yaml"), "w", encoding="utf-8").write(
+            'notation: "requirement"\nid: "REQUIREMENT-a-1"\nname: "x"\ndescription: "x"\n'
+            'derived_from:\n  - SEGMENT-a-1\nobligation_level: SHALL\nextraction_confidence: high\n'
+            'zone: "canon"\nadmission_state: proposed\nproposed_at: "2026-06-08"\n')
+        # broken candidate — no derived_from (CAND-002), bad obligation_level (CAND-004).
+        open(os.path.join(cand, "CONSTRAINT-bad-1.yaml"), "w", encoding="utf-8").write(
+            'notation: "constraint"\nid: "CONSTRAINT-bad-1"\nname: "x"\ndescription: "x"\n'
+            'obligation_level: MUSTNT\nzone: "canon"\nadmission_state: proposed\nproposed_at: "2026-06-08"\n')
+
+        r = run_cli("validate", org, "--json")
+        check(r.returncode == 1, f"I: validate must exit 1 when artefacts need review (got {r.returncode})")
+        res = json.loads(r.stdout)
+        by = {it["id"]: it for it in res["items"]}
+        check(not by["SEGMENT-a-1"]["flags"], "I: a conformant SEGMENT must pass clean")
+        check(not by["REQUIREMENT-a-1"]["flags"], "I: a conformant candidate must pass clean")
+        codes = lambda i: {f["code"] for f in by[i]["flags"]}
+        check("SEGMENT-002" in codes("SEGMENT-bad-1"), "I: a non-codex source TYPE must flag SEGMENT-002")
+        check("SEGMENT-006" in codes("SEGMENT-bad-1"), "I: a malformed text_hash must flag SEGMENT-006")
+        check("CAND-002" in codes("CONSTRAINT-bad-1"), "I: a candidate with no derived_from must flag CAND-002")
+        check(res["errors"] >= 2 and res["warnings"] >= 2, f"I: tally must count errors + warnings; got {res['errors']}/{res['warnings']}")
+
+        # A clean-only batch exits 0.
+        os.remove(os.path.join(seg, "SEGMENT-bad-1.yaml"))
+        os.remove(os.path.join(cand, "CONSTRAINT-bad-1.yaml"))
+        r = run_cli("validate", org)
+        check(r.returncode == 0, f"I: a clean batch must exit 0; got {r.returncode}: {(r.stdout + r.stderr)}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_list_due()
 part_c_update_scan()
@@ -568,6 +630,7 @@ part_e_check_signal()
 part_f_fetch_snapshot()
 part_g_segment()
 part_h_classify()
+part_i_validate()
 
 if _failures:
     print("FAIL - Transitrix Reg-Intel skill + CLI test:")


### PR DESCRIPTION
Eighth increment of the reg-intel build (HUB-153) — **SKILL Step 6**: run the staged SEGMENT artefacts and the REQUIREMENT / CONSTRAINT candidates through the canonical contract checks. A failing artefact is **flagged with an actionable, coded reason** and routed to the review digest — never silently dropped, never auto-rejected (the same flag-not-drop discipline as the ingest CLI's `validate`).

## What ships

- **`validate [org-root] [--json]`** checks `_intake/processing/segments/` + `candidates/`:
  - **SEGMENT** (`23-segment.md` §6): `SEGMENT-001` (id grammar + required fields + `type` literal), `SEGMENT-002` (`source` resolves against `codex/` and is a `LAW`/`REGULATION`/`POLICY`/`INTERNAL_STANDARD`), `SEGMENT-003` (`text_excerpt` or `text_hash`), `006/007` (hash format — warning), `008` (excerpt vs hash mismatch — warning), `004/005` (`parent` within the staged batch, same source, acyclic);
  - **candidate**: id grammar + TYPE ∈ {REQUIREMENT, CONSTRAINT}, `notation` matches, `name`/`description` present, `derived_from` cites ≥1 valid id, `proposed → proposed_at`, `obligation_level` RFC-2119 (warning), `extraction_confidence` enum (warning), `zone: canon`.
  - Exit `1` when anything needs review, `0` when clean; `--json` emits the coded flags. Read-only over `_intake/`. New module `validate.mjs`.

## Deferred (noted)

**Coverage-profile awareness** (SKILL Step 6): the coverage resolver lives only in the ingest CLI; sharing it via a **common package** rather than duplicating it is a separate refactor. Until then `validate` covers the contract + grammar checks; coverage is confirmed at the human gate. Noted in Step 6 + the issue.

## Tests

Integrity **Part I**: a conformant batch passes; a non-codex `source` flags `SEGMENT-002`, a bad hash `SEGMENT-006`, a candidate with no `derived_from` `CAND-002`; exit 1 on review, 0 when clean. Full suite (A–I) + prompts test pass; doc-lint clean.

## Scope / #153

`SKILL.md` Step 6 + status banner updated — `validate` is live; **only `amendment` (Step 7) remains** of the run-loop commands. **#153 stays open.** Remaining: `amendment`; operational templates; coverage in `validate`; the cosmetic-diff refinement. THE ONE RULE holds — `validate` is read-only and admits nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
