### PR TITLE
feat(reg-intel-cli): AMENDMENT emitter — amendment (#153, increment 9; run loop complete)

### DIFF
--- a/packages/reg-intel-cli/README.md
+++ b/packages/reg-intel-cli/README.md
@@ -4,7 +4,7 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 
 **The one rule:** this CLI *proposes*. It reads the codex registry, runs the change-signal gate, snapshots / segments / classifies regulatory text, and stages a review digest. It **never writes `canon/`** and **never silently flips** an existing `active` canon element. A human admits.
 
-> **Status — built incrementally.** The package ships in increments mirroring the ingest-cli roll-out. **Landed:** the scheduler core (`list-due`, `update-scan`), the change-signal gate (`check-signal`), the snapshot step (`fetch-snapshot`), the SEGMENT + CLASSIFY shapers (`segment`, `classify`), the contract validator (`validate`), and the review digest (`digest`). The remaining `amendment` step lands in a later increment.
+> **Status — all nine run-loop commands live.** `list-due` · `check-signal` · `fetch-snapshot` · `segment` · `classify` · `validate` · `amendment` · `update-scan` · `digest`. Remaining polish: coverage-profile awareness in `validate`, content-aware cosmetic-diff in `fetch-snapshot`, and the operational templates.
 
 ## Commands
 
@@ -18,8 +18,8 @@ Deterministic CLI for the [Transitrix Reg-Intel skill](../../transitrix/skills/r
 | `segment <snapshot> --from <result.json> [--source <CODEX-ID>] [--today YYYY-MM-DD]` | ✅ | Shape the segment agent's `{segments:[…]}` result into proposed `SEGMENT-*` field artefacts under `_intake/processing/segments/` (canonical ids, `text_hash`, `source`/`source_hash` from the snapshot, the field-zone proposed admission record). Network-free; locator-less / text-less segments flagged + skipped. |
 | `classify [segments-dir] --from <result.json> [--today YYYY-MM-DD]` | ✅ | Shape the classify agent's `{candidates:[…]}` into proposed `REQUIREMENT-*` / `CONSTRAINT-*` candidates under `_intake/processing/candidates/` (ids per source slug, `derived_from` → SEGMENT, `obligation_level` + `category`, `ambiguous_alt` on low confidence, `gate_checks` pending). Network-free; bad-kind / no-`derived_from` flagged + skipped. |
 | `validate [org-root] [--json]` | ✅ | Validate staged SEGMENTs + candidates against the contract (`23-segment.md` `SEGMENT-001..008`, ID grammar, candidate field rules; `SEGMENT-002` resolves `source` against `codex/`). Flags with codes + severity, never drops; exit 1 when review is needed. *(Coverage-profile check deferred — see SKILL Step 6.)* |
+| `amendment <CODEX-ID\|file> --change "<what moved>" [--name N] [--amended-at YYYY-MM-DD] [--likely-impacted ID,ID] [--from <result.json>] [--today]` | ✅ | Emit a proposed `AMENDMENT-*` field artefact (`22-amendment.md`) recording source drift: `source` + `detected_at`, `segment_refs` auto-collected from the run's staged SEGMENTs of this source, `likely_impacted` hints, `motivates: []`. Rejects a static source. |
 | `digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]` | ✅ | Assemble the human review digest (`review-digest.yaml`) — staged SEGMENT / candidate / AMENDMENT artefacts grouped by codex source (candidates via `derived_from` → SEGMENT), with each source's scan block + a tally. `gate.admits_to_canon: false`. Schema: [`schemas/review-digest.schema.json`](../../transitrix/skills/reg-intel/schemas/review-digest.schema.json). |
-| `amendment` | ⏳ | Later increment. |
 
 `next_scan_due` math: `daily` +1d, `weekly` +7d, `monthly` +1 month, `quarterly` +3 months; month additions clamp to the target month's last day (Jan 31 + monthly → Feb 28/29). All UTC, so results are host-timezone independent. Dates compare as ISO-8601 strings.
 
@@ -38,6 +38,7 @@ packages/reg-intel-cli/
     segment.mjs        # shape the segment agent result into SEGMENT artefacts (Step 4)
     classify.mjs       # shape the classify agent result into REQUIREMENT/CONSTRAINT candidates (Step 5)
     validate.mjs       # contract checks over staged SEGMENTs + candidates (Step 6)
+    amendment.mjs      # emit a proposed AMENDMENT on source drift (Step 7)
     signal-cache.mjs   # read/write the committed operations/state cache (signals + snapshots)
     digest.mjs         # assemble the review digest from staged run artefacts (Step 9)
 ```

--- a/packages/reg-intel-cli/reg-intel.mjs
+++ b/packages/reg-intel-cli/reg-intel.mjs
@@ -25,6 +25,7 @@ import { fetchSnapshot } from './src/snapshot.mjs';
 import { emitSegments } from './src/segment.mjs';
 import { emitCandidates } from './src/classify.mjs';
 import { validateStaged } from './src/validate.mjs';
+import { emitAmendment } from './src/amendment.mjs';
 import { buildDigest, writeDigest, defaultDigestPath } from './src/digest.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -79,6 +80,9 @@ function usage() {
     '                                 CONSTRAINT-* candidates under _intake/processing/candidates/.',
     '  validate [org-root] [--json]   Validate staged SEGMENTs + candidates against the contract',
     '                                 (23-segment.md, ID grammar); flags, never drops.',
+    '  amendment <CODEX-ID|file> --change "<what moved>" [--name N] [--amended-at YYYY-MM-DD]',
+    '            [--likely-impacted ID,ID] [--from <result.json>] [--today YYYY-MM-DD]',
+    '                                 Emit a proposed AMENDMENT-* field artefact recording source drift.',
     '  digest [org-root] [--run-id <id>] [--as-of YYYY-MM-DD] [--out <path>]',
     '                                 Assemble the human review digest from staged run artefacts',
     '                                 (review-digest.yaml). Nothing is admitted — a human gates it.',
@@ -302,6 +306,52 @@ async function cmdValidate(args) {
   return res.reviewed ? 1 : 0;
 }
 
+async function cmdAmendment(args) {
+  const { _, flags } = parseArgs(args);
+  const target = _[0];
+  if (!target) { console.error('amendment: missing <CODEX-ID|file>'); return 1; }
+
+  let file = null;
+  let orgRoot = null;
+  if (await exists(resolve(target))) {
+    file = resolve(target);
+    orgRoot = await findOrgRoot(file);
+    if (!orgRoot) { console.error('amendment: file is not inside a Transitrix workspace (no transitrix.yaml).'); return 2; }
+  } else {
+    orgRoot = await resolveOrgRoot(undefined, 'amendment');
+    if (!orgRoot) return 2;
+    file = await findCodexFile(orgRoot, target);
+    if (!file) { console.error(`amendment: no codex artefact with id ${target} under codex/`); return 2; }
+  }
+
+  let fromResult;
+  if (typeof flags.from === 'string') {
+    try { fromResult = JSON.parse(await readFile(resolve(flags.from), 'utf8')); }
+    catch (err) { console.error(`amendment: --from does not parse as JSON: ${err.message}`); return 2; }
+  }
+  const list = (v) => (typeof v === 'string' ? v.split(',').map((s) => s.trim()).filter(Boolean) : []);
+
+  try {
+    const res = await emitAmendment(orgRoot, file, {
+      changeDescription: typeof flags.change === 'string' ? flags.change : undefined,
+      name: typeof flags.name === 'string' ? flags.name : undefined,
+      amendedAt: typeof flags['amended-at'] === 'string' ? flags['amended-at'] : undefined,
+      likelyImpacted: list(flags['likely-impacted']),
+      segmentRefs: list(flags['segment-refs']),
+      fromResult,
+      today: flags.today ? String(flags.today) : today(),
+    });
+    console.log(`amendment  ${res.id}  (source ${res.source})  ->  ${res.file}`);
+    console.log(`  segment_refs: ${res.segment_refs.length}  likely_impacted: ${res.likely_impacted.length}  motivates: 0 (human fills)`);
+    for (const w of res.warnings) console.log(`  warning: ${w}`);
+    console.log('  proposed — a human adjudicates and authors the canon CHANGE response.');
+    return 0;
+  } catch (err) {
+    console.error(`amendment: ${err.message}`);
+    return 2;
+  }
+}
+
 async function cmdDigest(args) {
   const { _, flags } = parseArgs(args);
   const orgRoot = await resolveOrgRoot(_[0], 'digest');
@@ -333,6 +383,7 @@ async function main(argv) {
     case 'segment':      return cmdSegment(args);
     case 'classify':     return cmdClassify(args);
     case 'validate':     return cmdValidate(args);
+    case 'amendment':    return cmdAmendment(args);
     case 'digest':       return cmdDigest(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);

--- a/packages/reg-intel-cli/src/amendment.mjs
+++ b/packages/reg-intel-cli/src/amendment.mjs
@@ -1,0 +1,105 @@
+// `amendment` (SKILL Step 7) — emit an AMENDMENT field artefact (22-amendment.md) when
+// a watched codex source has drifted. The AMENDMENT records the detection EVENT (what
+// moved), not the response: the authoritative impact set is the canon CHANGE / Gap
+// elements a human authors later and links via `motivates[]`. Emitted in the `proposed`
+// state; a human gates it. THE ONE RULE holds: writes only to _intake/.
+
+import { readFile, writeFile, readdir, mkdir, access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { dump, readTopScalar } from './yaml.mjs';
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}$/;
+const CODEX_TYPES = new Set(['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD']);
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+function slugSegment(text) {
+  const s = String(text || '').normalize('NFKD').replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '').toLowerCase();
+  return s || null;
+}
+function sourceSlug(sourceId) {
+  const parts = String(sourceId || '').split('-');
+  const middle = parts.length >= 3 ? parts.slice(1, -1) : parts;
+  return slugSegment(middle.join('_')) || slugSegment(sourceId) || 'src';
+}
+
+async function nextOrdinal(dir, slug) {
+  if (!(await exists(dir))) return 1;
+  let max = 0;
+  const re = new RegExp(`^AMENDMENT-${slug}-(\\d+)\\.yaml$`);
+  for (const name of await readdir(dir)) {
+    const m = name.match(re);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return max + 1;
+}
+
+function oneLine(text, max = 80) {
+  const s = String(text || '').replace(/\s+/g, ' ').trim();
+  return s.length > max ? `${s.slice(0, max - 1).trimEnd()}…` : s;
+}
+
+// Collect the staged SEGMENT ids whose `source` is this amendment's source — the
+// structured replacement for the free-text source_section (22-amendment.md §2).
+async function stagedSegmentRefs(orgRoot, source) {
+  const dir = join(resolve(orgRoot), '_intake', 'processing', 'segments');
+  const refs = [];
+  let names;
+  try { names = (await readdir(dir)).filter((n) => n.endsWith('.yaml')); } catch { return refs; }
+  for (const name of names.sort()) {
+    const text = await readFile(join(dir, name), 'utf8');
+    if (readTopScalar(text, 'source') === source) refs.push(readTopScalar(text, 'id') || name.replace(/\.yaml$/, ''));
+  }
+  return refs;
+}
+
+export async function emitAmendment(orgRoot, file, { changeDescription, name, amendedAt, likelyImpacted, segmentRefs, fromResult, today } = {}) {
+  if (!ISO_RE.test(today || '')) throw new Error('--today must be YYYY-MM-DD');
+  const text = await readFile(file, 'utf8');
+  const source = readTopScalar(text, 'id');
+  const stype = readTopScalar(text, 'type');
+  if (!source) throw new Error(`${file}: codex artefact has no id`);
+  if (!CODEX_TYPES.has(stype)) throw new Error(`${file}: amendment source TYPE must be LAW|REGULATION|POLICY|INTERNAL_STANDARD (got ${JSON.stringify(stype)}) (AMENDMENT-002)`);
+  if (readTopScalar(text, 'monitoring_needed') !== true) {
+    throw new Error(`${file}: amendment applies to a monitoring_needed: true source (14-codex.md §3.4)`);
+  }
+
+  // Merge --from result with explicit flags (flags win).
+  const r = fromResult || {};
+  const desc = changeDescription ?? (typeof r.change_description === 'string' ? r.change_description : null);
+  if (!desc) throw new Error('change_description is required: pass --change "<what moved>" or --from <result.json> (AMENDMENT-001)');
+  const amended = amendedAt ?? (typeof r.amended_at === 'string' ? r.amended_at : null);
+  if (amended && !ISO_RE.test(amended)) throw new Error('--amended-at must be YYYY-MM-DD');
+  const impacted = (likelyImpacted && likelyImpacted.length) ? likelyImpacted
+    : (Array.isArray(r.likely_impacted) ? r.likely_impacted.filter((x) => typeof x === 'string') : []);
+  const refs = (segmentRefs && segmentRefs.length) ? segmentRefs
+    : (Array.isArray(r.segment_refs) ? r.segment_refs.filter((x) => typeof x === 'string') : await stagedSegmentRefs(orgRoot, source));
+
+  const dir = join(resolve(orgRoot), '_intake', 'processing', 'amendments');
+  await mkdir(dir, { recursive: true });
+  const slug = sourceSlug(source);
+  const id = `AMENDMENT-${slug}-${await nextOrdinal(dir, slug)}`;
+
+  const warnings = [];
+  if (amended && amended > today) warnings.push('amended_at is later than detected_at (AMENDMENT-005)');
+
+  const artefact = {
+    id,
+    type: 'AMENDMENT',
+    name: name || oneLine(`${source} — ${desc}`),
+    change_description: desc,
+    source,
+    ...(amended ? { amended_at: amended } : {}),
+    detected_at: today,
+    segment_refs: refs,
+    likely_impacted: impacted,
+    motivates: [],
+    zone: 'field',
+    admission_state: 'proposed',
+    proposed_at: today,
+    proposed_by: 'reg-intel-scanner',
+    gate_checks: { provenance: 'pending_review' },
+  };
+  await writeFile(join(dir, `${id}.yaml`), dump(artefact), 'utf8');
+  return { id, source, file: join(dir, `${id}.yaml`), segment_refs: refs, likely_impacted: impacted, warnings };
+}

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **data-collection process** for the regulatory side of a Transitrix repository: it turns watched **codex sources** (laws, regulations, policies, internal standards) into `field`-zone evidence — `SEGMENT-*` chunks of the source text, `AMENDMENT-*` records when a watched source has drifted — and into `proposed` `REQUIREMENT-*` / `CONSTRAINT-*` canon candidates, then routes everything through a human review digest. It is the operational counterpart to the methodology's codex / SEGMENT / AMENDMENT / REQUIREMENT notation work — the part that watches the registry, runs the change-signal gate, slices and classifies the text, and stages the human gate.
 
-> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **Live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `segment` (Step 4), `classify` (Step 5), `validate` (Step 6), `update-scan` (Step 8), and `digest` (Step 9). **Not yet published:** `amendment` (Step 7); when the run loop reaches it the CLI reports `unknown command` and the skill defers to manual extraction for that step rather than hand-rolling the pipeline.
+> **Status — building.** This `SKILL.md` is the agent-neutral protocol. The deterministic CLI ([`@transitrix/reg-intel-cli`](../../../packages/reg-intel-cli/README.md)) ships in increments. **All nine run-loop commands are live:** `list-due` (Step 1), `check-signal` (Step 2), `fetch-snapshot` (Step 3), `segment` (Step 4), `classify` (Step 5), `validate` (Step 6), `amendment` (Step 7), `update-scan` (Step 8), and `digest` (Step 9). Remaining polish lands later: coverage-profile awareness in `validate`, content-aware cosmetic-diff in `fetch-snapshot`, and the operational templates.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the regulatory-intelligence pipeline against it. It is designed to run **agent-neutrally** under Claude and GitHub Copilot — all heavy logic lives in the CLI, and this `SKILL.md` only sequences it.
 
@@ -208,8 +208,10 @@ Each emitted AMENDMENT carries:
 
 **AMENDMENT is the field-zone TYPE, not `CHANGE-*`.** Canon `CHANGE-*` is reserved for the organisation's **planned delta** (an ArchiMate Gap — what the organisation will do to close the resulting compliance gap), per [`IDS_AND_REFERENCES.md`](https://raw.githubusercontent.com/transitrix/methodology/main/notations/IDS_AND_REFERENCES.md) §3.1. The scanner emits the external fact (AMENDMENT); the human authors the response (canon CHANGE).
 
+The agent supplies the `change_description` (the editorial trail of the diff) and any `likely_impacted` hints; the CLI shapes the AMENDMENT, assigning the canonical id, `detected_at`, the proposed admission record, and — unless overridden — auto-collecting `segment_refs` from the run's staged SEGMENTs **of this source** (the structured replacement for `source_section`). `motivates` is always empty on emission; a human fills it. A static (`monitoring_needed: false`) source is rejected.
+
 ```
-npx @transitrix/reg-intel-cli amendment <CODEX-ID> --since <prior-snapshot>
+npx @transitrix/reg-intel-cli amendment <CODEX-ID> --change "<what moved>" [--likely-impacted ID,ID] [--amended-at YYYY-MM-DD]
 ```
 
 ---

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
@@ -2,7 +2,7 @@
 """From-scratch integrity test for the Transitrix Reg-Intel skill + @transitrix/reg-intel-cli.
 
 Deterministic, no-API-key, no-network guard for the CLI increments landed so far
-(the rest of the SKILL.md pipeline lands in later increments). Nine parts:
+(operational templates + coverage-in-validate land later). Ten parts:
 
   A. Bundle integrity — SKILL.md + README.md present and frontmatter parses; the CLI
      package.json parses and declares its bin; the entry point exists; `--version`
@@ -41,6 +41,10 @@ Deterministic, no-API-key, no-network guard for the CLI increments landed so far
      (23-segment.md SEGMENT-001..008, ID grammar, candidate field rules): a conformant
      batch passes; a non-codex source flags SEGMENT-002, a bad hash SEGMENT-006, a
      candidate with no derived_from CAND-002; flags-not-drops, exit 1 when review needed.
+  J. amendment (Step 7) — emits a proposed AMENDMENT-* recording source drift: source +
+     detected_at, segment_refs auto-collected from this source's staged SEGMENTs only,
+     likely_impacted hints, motivates [] on first emission; the digest counts it;
+     --change required; a static (monitoring_needed: false) source is rejected.
 
 Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
@@ -622,6 +626,53 @@ def part_i_validate():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part J — amendment (Step 7, source drift) ────────────────────
+
+def part_j_amendment():
+    if not shutil.which("node"):
+        print("SKIP Part J: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="regintel-amend-")
+    try:
+        org = _codex_org(work)  # REGULATION-A-1 is a monitoring codex artefact
+        a_file = os.path.join(org, "codex", "external", "eu", "REGULATION-A-1.yaml")
+        seg = os.path.join(org, "_intake", "processing", "segments")
+        os.makedirs(seg, exist_ok=True)
+        # Two SEGMENTs of REGULATION-A-1 (auto segment_refs) + one of another source (excluded).
+        for sid, src in [("SEGMENT-a-1", "REGULATION-A-1"), ("SEGMENT-a-2", "REGULATION-A-1"), ("SEGMENT-z-1", "LAW-OTHER-1")]:
+            open(os.path.join(seg, f"{sid}.yaml"), "w", encoding="utf-8").write(
+                f'id: "{sid}"\ntype: "SEGMENT"\nsource: "{src}"\nlocator: "x"\nzone: "field"\n')
+
+        r = run_cli("amendment", a_file, "--change", "Art.1 wording tightened",
+                    "--likely-impacted", "REQUIREMENT-X-1,PROCESS-Y-1", "--amended-at", "2026-05-21", "--today", "2026-06-08")
+        check(r.returncode == 0, f"J: amendment failed: {r.stderr.strip()}")
+        adir = os.path.join(org, "_intake", "processing", "amendments")
+        files = sorted(os.listdir(adir)) if os.path.isdir(adir) else []
+        check(files == ["AMENDMENT-a-1.yaml"], f"J: one AMENDMENT expected; got {files}")
+        a = yaml.safe_load(open(os.path.join(adir, "AMENDMENT-a-1.yaml"), encoding="utf-8"))
+        check(a.get("type") == "AMENDMENT" and a.get("zone") == "field", "J: AMENDMENT type/zone")
+        check(a.get("source") == "REGULATION-A-1" and a.get("detected_at") == "2026-06-08", "J: source + detected_at")
+        check(sorted(a.get("segment_refs", [])) == ["SEGMENT-a-1", "SEGMENT-a-2"],
+              f"J: segment_refs must auto-collect this source's staged SEGMENTs only; got {a.get('segment_refs')}")
+        check(a.get("likely_impacted") == ["REQUIREMENT-X-1", "PROCESS-Y-1"], "J: likely_impacted hints carried")
+        check(a.get("motivates") == [], "J: motivates must be empty on first emission")
+        check(a.get("admission_state") == "proposed" and a.get("proposed_by") == "reg-intel-scanner", "J: proposed by the scanner")
+
+        # The digest counts the AMENDMENT under its source.
+        r = run_cli("digest", org, "--as-of", "2026-06-08")
+        dg = yaml.safe_load(open(os.path.join(org, "_intake", "processing", "review-digest.yaml"), encoding="utf-8"))
+        check(dg.get("tally", {}).get("proposed", {}).get("AMENDMENT") == 1, "J: the digest must count the AMENDMENT")
+
+        # Guards: --change required; a static (monitoring_needed: false) source rejected.
+        r = run_cli("amendment", a_file, "--today", "2026-06-08")
+        check(r.returncode != 0 and "change_description is required" in (r.stdout + r.stderr), "J: amendment must require --change")
+        s_file = os.path.join(org, "codex", "external", "us", "REGULATION-D-1.yaml")
+        r = run_cli("amendment", s_file, "--change", "x", "--today", "2026-06-08")
+        check(r.returncode != 0 and "monitoring_needed: true" in (r.stdout + r.stderr), "J: amendment must reject a static source")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_list_due()
 part_c_update_scan()
@@ -631,6 +682,7 @@ part_f_fetch_snapshot()
 part_g_segment()
 part_h_classify()
 part_i_validate()
+part_j_amendment()
 
 if _failures:
     print("FAIL - Transitrix Reg-Intel skill + CLI test:")


### PR DESCRIPTION
Ninth increment of the reg-intel build (HUB-153) — **SKILL Step 7**, the last run-loop command. Emit an AMENDMENT field artefact (`22-amendment.md`) when a watched codex source has drifted. The AMENDMENT records the detection **event**, not the response — the authoritative impact set is the canon `CHANGE` / Gap elements a human authors later and links via `motivates[]`.

**With this, all nine run-loop commands are live (Steps 1–9).**

## What ships

- **`amendment <CODEX-ID|file> --change "<what moved>" [--name] [--amended-at] [--likely-impacted ID,ID] [--from <result.json>] [--today]`**:
  - `source` = the resolved codex artefact's id; rejects a non-codex TYPE (`AMENDMENT-002`) and a **static** (`monitoring_needed: false`) source;
  - `change_description` required (`AMENDMENT-001`); `detected_at` = today; `amended_at` optional (warns if later than `detected_at`, `AMENDMENT-005`);
  - **`segment_refs` auto-collected** from the run's staged SEGMENTs whose `source` is this source (the structured replacement for `source_section`), overridable;
  - `likely_impacted` hints (flags, not commitments); **`motivates: []`** on emission;
  - field-zone **proposed** admission record; id `AMENDMENT-<source-slug>-<N>` (ordinals continue across runs).
  - Network-free. New module `amendment.mjs`. The already-built **digest counts it**.

## Tests

Integrity **Part J**: a proposed AMENDMENT with `source` + `detected_at`, `segment_refs` auto-collected from this source's SEGMENTs **only**, `likely_impacted` hints, `motivates []`; the digest counts it; `--change` required; a static source rejected. Full suite (A–J) + prompts test pass; doc-lint clean.

## Scope / #153

`SKILL.md` Step 7 + status banner updated — the banner now states the **full run loop is implemented**. **#153 stays open** for the remaining polish: coverage-profile awareness in `validate`, content-aware cosmetic-diff in `fetch-snapshot`, and the operational templates. THE ONE RULE holds — the AMENDMENT is a `proposed` `_intake` artefact; the human authors the canon `CHANGE` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
