### PR TITLE
fix(ingest-cli): markitdown fallback to `python -m markitdown` (F6)

### DIFF
--- a/packages/ingest-cli/README.md
+++ b/packages/ingest-cli/README.md
@@ -11,7 +11,7 @@ The CLI **proposes**. It writes field artefacts, candidates, and a review queue 
 ## Design
 
 - Pure Node ESM, **no dependencies**. `npx`-able with zero install footprint.
-- **MS Markitdown** is the only external touchpoint, shelled out from the `convert` command alone (Office → Markdown). The rest of the pipeline is pure Node.
+- **MS Markitdown** is the only external touchpoint, shelled out from the `convert` command alone (Office → Markdown). The rest of the pipeline is pure Node. Install it with `pip install "markitdown[all]"`; `convert` looks for the `markitdown` console-script and falls back to `python -m markitdown` / `python3 -m markitdown`, so it works inside a venv where only the interpreter is on PATH. On Windows, if `markitdown`/`npx` are blocked by the PowerShell execution policy, run `python -m markitdown` directly or `Set-ExecutionPolicy -Scope Process RemoteSigned`.
 - Exit codes: `0` ok · `1` usage / findings that need review · `2` error.
 
 ## Commands

--- a/packages/ingest-cli/src/convert.mjs
+++ b/packages/ingest-cli/src/convert.mjs
@@ -23,6 +23,65 @@ function outName(srcPath) {
   return basename(srcPath, extname(srcPath)) + '.md';
 }
 
+// How we try to reach Markitdown, in order. The bare `markitdown` console-script is
+// the happy path, but it is absent from PATH in two common cases: a venv where only
+// the interpreter (not the entry-point shim) is on PATH, and Windows where the
+// `markitdown.ps1` / `npx.ps1` shims are blocked by the execution policy. In both the
+// module is importable, so `python -m markitdown` (and the `python3` alias) reaches it.
+const MARKITDOWN_LAUNCHERS = [
+  { cmd: 'markitdown', args: (src) => [src] },
+  { cmd: 'python', args: (src) => ['-m', 'markitdown', src] },
+  { cmd: 'python3', args: (src) => ['-m', 'markitdown', src] },
+];
+
+// The launcher binary itself is not on PATH — try the next launcher.
+function isLauncherMissing(err) {
+  return err && err.code === 'ENOENT';
+}
+// The launcher ran but markitdown is not importable under it — try the next launcher.
+function isModuleNotFound(err) {
+  const s = `${(err && err.stderr) || ''}${(err && err.message) || ''}`;
+  return /No module named ['"]?markitdown/i.test(s);
+}
+
+// Run Markitdown over `srcPath`, falling back across MARKITDOWN_LAUNCHERS. Returns the
+// converted Markdown. Distinguishes "Markitdown is not reachable at all" (→ install
+// guidance) from "Markitdown ran but failed on THIS document" (→ conversion error) so
+// a genuine conversion failure is never masked by trying the remaining launchers.
+function runMarkitdown(srcPath, ext) {
+  let convertFailure = null;
+  for (const launcher of MARKITDOWN_LAUNCHERS) {
+    try {
+      return execFileSync(launcher.cmd, launcher.args(srcPath), {
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+      });
+    } catch (err) {
+      // Launcher not on PATH, or present but without the module: keep looking.
+      if (isLauncherMissing(err) || isModuleNotFound(err)) continue;
+      // Launcher reached Markitdown and it failed converting this document — real error.
+      convertFailure = err;
+      break;
+    }
+  }
+
+  if (convertFailure) {
+    throw new ConvertError(
+      `Markitdown failed to convert "${basename(srcPath)}": ` +
+      `${convertFailure.message ? convertFailure.message : convertFailure}`
+    );
+  }
+  throw new ConvertError(
+    `MS Markitdown is required to convert "${basename(srcPath)}" (${ext}) but it could not ` +
+    `be reached — tried \`markitdown\`, \`python -m markitdown\`, and \`python3 -m markitdown\`.\n` +
+    `Install it into the active environment (\`pip install "markitdown[all]"\`) and ensure the ` +
+    `interpreter is on PATH; inside a venv, activate it first.\n` +
+    `On Windows, if \`markitdown\`/\`npx\` are blocked by the PowerShell execution policy, run ` +
+    `\`python -m markitdown\` directly or set \`Set-ExecutionPolicy -Scope Process RemoteSigned\`.\n` +
+    `Or convert the document to Markdown by hand and drop the .md into _intake/inbox/.`
+  );
+}
+
 // Convert one source file into Markdown written to `processingDir`.
 // Returns the output path. Throws ConvertError (exitCode 2) on an unrecoverable
 // problem (e.g. Markitdown not installed) with an actionable message.
@@ -37,26 +96,7 @@ export async function convert(srcPath, processingDir) {
     return { out, mode: 'passthrough' };
   }
 
-  let markdown;
-  try {
-    markdown = execFileSync('markitdown', [srcPath], {
-      encoding: 'utf8',
-      maxBuffer: 64 * 1024 * 1024,
-    });
-  } catch (err) {
-    if (err && err.code === 'ENOENT') {
-      throw new ConvertError(
-        `MS Markitdown is required to convert "${basename(srcPath)}" (${ext}) but the ` +
-        `\`markitdown\` CLI was not found on PATH.\n` +
-        `Install it (e.g. \`pip install markitdown[all]\`) and retry, or convert the ` +
-        `document to Markdown by hand and drop the .md into _intake/inbox/.`
-      );
-    }
-    throw new ConvertError(
-      `Markitdown failed to convert "${basename(srcPath)}": ${err && err.message ? err.message : err}`
-    );
-  }
-
+  const markdown = runMarkitdown(srcPath, ext);
   await writeFile(out, markdown, 'utf8');
   return { out, mode: 'markitdown' };
 }

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -65,7 +65,7 @@ Office documents are converted to Markdown with **MS Markitdown** before extract
 npx @transitrix/ingest-cli convert <_intake/inbox/file>   # → _intake/processing/<file>.md
 ```
 
-If Markitdown is not installed the CLI exits with an actionable message naming the install step. Conversion is the only point of contact with Markitdown — the rest of the pipeline is pure Node and runs identically under either agent.
+Markitdown is a Python tool (`pip install "markitdown[all]"`); install it into the environment you run the CLI from, and if you use a virtualenv, activate it first. The CLI looks for the `markitdown` console-script and **falls back to `python -m markitdown` / `python3 -m markitdown`** — so it still works inside a venv where only the interpreter is on PATH. On Windows, if `markitdown`/`npx` are blocked by the PowerShell execution policy, run `python -m markitdown` directly or `Set-ExecutionPolicy -Scope Process RemoteSigned`. If Markitdown cannot be reached at all the CLI exits with an actionable message naming the install step. Conversion is the only point of contact with Markitdown — the rest of the pipeline is pure Node and runs identically under either agent.
 
 ---
 


### PR DESCRIPTION
## What

`convert` shelled out to the bare `markitdown` console-script only. It now tries, in order:

1. `markitdown <src>`
2. `python -m markitdown <src>`
3. `python3 -m markitdown <src>`

falling through when a launcher is **not on PATH** or present **without the module**, and surfacing the **real conversion error** when a launcher reaches Markitdown but it fails on the document (so a genuine failure is never masked by trying the rest).

## Why (finding F6)

The bare `markitdown` shim is absent from PATH in two common cases the dogfooding run hit:
- a virtualenv where only the interpreter is on PATH (the entry-point shim isn't linked);
- Windows, where `markitdown.ps1` / `npx.ps1` are blocked by the PowerShell execution policy.

In both, the module is importable, so `python -m markitdown` reaches it.

## Also

- The "could not reach Markitdown" error now names the install step (`pip install "markitdown[all]"`), the venv/PATH requirement, and the Windows execution-policy workaround.
- Documents venv/PATH + execution-policy in the ingest `SKILL.md` (Step 2) and the `ingest-cli` README.

## Verification

- Ingest integrity test (`test_ingest_integrity.py`) → all checks pass.
- Manually exercised both branches: markitdown-reachable-but-doc-fails → conversion error; no-launcher-reachable (empty PATH) → install-guidance message.
- `node scripts/check-notations.mjs` → clean.

Open PR; do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)