### PR TITLE
fix(ingest-cli): review-queue resolves codex source artefacts (F13)

### DIFF
--- a/packages/ingest-cli/src/review-queue.mjs
+++ b/packages/ingest-cli/src/review-queue.mjs
@@ -4,21 +4,64 @@
 // + validation flags, and any below-threshold relation suggestions. Emitted as YAML
 // (write-only via the dumper). NOTHING here is admitted to canon.
 
-import { readFile, writeFile, access } from 'node:fs/promises';
+import { readFile, writeFile, access, readdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { dump, readTopScalar } from './yaml.mjs';
 import { validateCandidate, loadCandidates } from './validate.mjs';
 import { buildCanonIndex, admittedMatch } from './canon.mjs';
 import { resolvePlacement } from './placement.mjs';
 import { parseId } from './ids.mjs';
-import { TYPE_INFO } from './field-artefact.mjs';
+import { TYPE_INFO as FIELD_TYPE_INFO } from './field-artefact.mjs';
+import { TYPE_INFO as CODEX_TYPE_INFO } from './codex-artefact.mjs';
 
 async function exists(p) { try { await access(p); return true; } catch { return false; } }
 
-// Resolve a field artefact file from its ID and read its proposed source_quality.
-async function readFieldArtefact(orgRoot, id) {
+// Locate a codex artefact file by id. Internal codex (POLICY / INTERNAL_STANDARD) is
+// flat under codex/internal/; external codex (LAW / REGULATION) lives under
+// codex/external/<jurisdiction>/ and the jurisdiction is not derivable from the id, so
+// scan the jurisdiction subfolders.
+async function findCodexFile(orgRoot, id, scope) {
+  const root = resolve(orgRoot);
+  if (scope === 'internal') {
+    const f = join(root, 'codex', 'internal', `${id}.yaml`);
+    return (await exists(f)) ? f : null;
+  }
+  const extDir = join(root, 'codex', 'external');
+  let entries;
+  try { entries = await readdir(extDir, { withFileTypes: true }); } catch { return null; }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const f = join(extDir, e.name, `${id}.yaml`);
+    if (await exists(f)) return f;
+  }
+  return null;
+}
+
+// Resolve a derived_from id to its source artefact and read what the human gate needs.
+// A FIELD artefact (interview/survey/…) carries a PROPOSED source_quality to confirm.
+// A CODEX artefact (law/regulation/policy/standard) is authoritative by construction —
+// it carries no source_quality, so it is surfaced as such rather than as a missing field
+// artefact (F13).
+async function readSourceArtefact(orgRoot, id) {
   const p = parseId(id);
-  const info = p && TYPE_INFO[p.type];
+  const type = p && p.type;
+
+  const codex = type && CODEX_TYPE_INFO[type];
+  if (codex) {
+    const file = await findCodexFile(orgRoot, id, codex.scope);
+    if (!file) return { id, zone: 'codex', found: false };
+    const text = await readFile(file, 'utf8');
+    return {
+      id,
+      zone: 'codex',
+      found: true,
+      authoritative: true,   // codex is authoritative by construction — no source_quality to confirm
+      effective_date: readTopScalar(text, 'effective_date') || undefined,
+      source_hash: readTopScalar(text, 'source_hash') || undefined,
+    };
+  }
+
+  const info = type && FIELD_TYPE_INFO[type];
   if (!info) return { id, proposed_source_quality: null, found: false };
   const file = join(resolve(orgRoot), 'field', info.sub, `${id}.yaml`);
   if (!(await exists(file))) return { id, proposed_source_quality: null, found: false };
@@ -65,7 +108,7 @@ export async function buildReviewQueue({ orgRoot, candidatesDir, profile, sugges
   }
 
   const field_artefacts = [];
-  for (const id of [...fieldIds].sort()) field_artefacts.push(await readFieldArtefact(orgRoot, id));
+  for (const id of [...fieldIds].sort()) field_artefacts.push(await readSourceArtefact(orgRoot, id));
 
   return {
     generated_by: '@transitrix/ingest-cli',

--- a/transitrix/skills/ingest/schemas/review-queue.schema.json
+++ b/transitrix/skills/ingest/schemas/review-queue.schema.json
@@ -26,18 +26,36 @@
     },
     "field_artefacts": {
       "type": "array",
-      "description": "Field artefacts emitted in this batch, each with its PROPOSED source_quality for the human to confirm.",
+      "description": "Source artefacts the candidates in this batch derive from. A FIELD artefact (interview/survey/observation/draft) carries a PROPOSED source_quality for the human to confirm; a CODEX artefact (law/regulation/policy/standard) is authoritative by construction and carries no source_quality (zone: codex, authoritative: true).",
       "items": {
         "type": "object",
-        "required": ["id", "proposed_source_quality"],
+        "required": ["id"],
         "properties": {
           "id": {
             "type": "string",
             "pattern": "^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$"
           },
-          "proposed_source_quality": {
+          "zone": {
             "type": "string",
-            "enum": ["authoritative", "corroborated", "single_source", "unverified"]
+            "enum": ["field", "codex"],
+            "description": "Which zone the artefact was resolved from. Omitted on a field artefact for backward compatibility."
+          },
+          "found": {
+            "type": "boolean",
+            "description": "Whether the cited artefact resolved to a file on disk."
+          },
+          "proposed_source_quality": {
+            "type": ["string", "null"],
+            "enum": ["authoritative", "corroborated", "single_source", "unverified", null],
+            "description": "Field-zone only — the proposed trust level for the human to confirm. Absent on a codex artefact (authoritative by construction)."
+          },
+          "authoritative": {
+            "type": "boolean",
+            "description": "Codex-zone only — true; a codex source needs no source_quality confirmation."
+          },
+          "effective_date": {
+            "type": "string",
+            "description": "Codex-zone only — the source's effective date."
           },
           "raw_source": { "type": "string" },
           "source_hash": {

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -392,6 +392,22 @@ def part_e_ig2():
               "IG-2: ASSERTION candidate does not cite the codex LAW: %r" % ass.get("derived_from"))
         r = run_cli("validate", cdir)
         check(r.returncode == 0, "IG-2: codex-derived candidates did not validate clean: %s" % (r.stdout + r.stderr))
+
+        # F13 — the review queue resolves the codex source (not only field/): the LAW the
+        # candidates cite is surfaced as a found, authoritative codex artefact.
+        r = run_cli("review-queue", cdir)
+        check(r.returncode == 0, "F13: review-queue failed on codex-derived candidates: %s" % (r.stderr or r.stdout))
+        rq = os.path.join(org, "_intake", "processing", "review-queue.yaml")
+        if check(os.path.isfile(rq), "F13: review-queue.yaml was not created"):
+            q = yaml.safe_load(open(rq, encoding="utf-8"))
+            fas = q.get("field_artefacts") or []
+            law = next((fa for fa in fas if fa.get("id") == "LAW-conveyor_safety-1"), None)
+            if check(law is not None, "F13: review queue did not list the cited codex LAW source"):
+                check(law.get("zone") == "codex", "F13: codex source not marked zone:codex (got %r)" % law.get("zone"))
+                check(law.get("found") is True, "F13: codex source did not resolve (found != True)")
+                check(law.get("authoritative") is True, "F13: codex source not marked authoritative")
+                check("proposed_source_quality" not in law,
+                      "F13: codex source must carry no proposed_source_quality (authoritative by construction)")
     finally:
         shutil.rmtree(work, ignore_errors=True)
 


### PR DESCRIPTION
## What

The review queue's source-artefact section resolved `derived_from` ids only against `field/`. A **codex-derived** candidate (a `REQUIREMENT`/`ASSERTION` citing a `LAW`/`REGULATION`/`POLICY`/`INTERNAL_STANDARD`) therefore showed `found: false` / `source_quality: null`, as if its source were missing.

`review-queue` now resolves codex artefacts too:
- internal codex from `codex/internal/`,
- external codex by scanning `codex/external/<jurisdiction>/` (the jurisdiction isn't derivable from the id).

A codex source is surfaced as `zone: codex`, `found: true`, `authoritative: true`, with its `effective_date` and `source_hash` — and **no** `proposed_source_quality` (a codex source is authoritative by construction; nothing to confirm). Field-artefact resolution is byte-for-byte unchanged.

## Why (finding F13)

Cosmetic gap surfaced dogfooding the pipeline: codex sources looked unresolved in the human review queue.

## Schema

`review-queue.schema.json` — the source-artefact section now documents both field and codex entries; `required` relaxed to `["id"]`, with `zone` / `authoritative` / `effective_date` added and `proposed_source_quality` marked field-only (and nullable). Backward-compatible (existing valid queues stay valid).

## Verification

- Added an F13 assertion to the integrity test's codex part: the review queue lists the cited `LAW` as a found, authoritative codex source with no `proposed_source_quality`.
- Full `test_ingest_integrity.py` → all checks pass.
- `node scripts/check-notations.mjs` → clean.

Independent of #162 (F6); both branch from `main`. Open PR; do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)