### PR TITLE
fix(ingest-cli): duplicate-source detection by source_hash (F1)

### DIFF
--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -63,6 +63,7 @@ function usage() {
     '                        [--captured-by X] [--source-quality Q] [--slug SL] [--admitted-at A]',
     '                 codex: --type LAW|REGULATION|POLICY|INTERNAL_STANDARD --effective-date YYYY-MM-DD',
     '                        [--jurisdiction J] [--source-authority A] [--issuing-authority A] [--slug SL] [--monitoring]',
+    '                 [--force]  admit even if an identical source (same source_hash) is already admitted',
     '  field-artefact / codex-artefact        Deprecated aliases of admit-source --zone field|codex',
     '  emit-candidates <field-artefact> --from <result.json> [--candidates-dir <dir>]',
     '                                 Shape the agent extraction result into candidates',
@@ -135,6 +136,7 @@ async function cmdFieldArtefact(args) {
       slug: flags.slug,
       admittedAt: flags['admitted-at'] || today(),
       name: flags.name,
+      force: flags.force === true || flags.force === 'true',
     });
     console.log(`field artefact  ${res.id}  ->  ${res.outPath}`);
     console.log(`  proposed source_quality: ${res.proposedSQ} (confirm at admission)`);
@@ -142,6 +144,10 @@ async function cmdFieldArtefact(args) {
     if (res.sourceHash) console.log(`  source_hash:         ${res.sourceHash}`);
     return 0;
   } catch (err) {
+    if (err.duplicate) {
+      console.log(`field artefact  skipped — ${err.message}`);
+      return 0;
+    }
     console.error(`field-artefact: ${err.message}`);
     return 2;
   }
@@ -173,6 +179,7 @@ async function cmdCodexArtefact(args) {
       monitoring: flags.monitoring === true || flags.monitoring === 'true',
       slug: flags.slug,
       name: flags.name,
+      force: flags.force === true || flags.force === 'true',
     });
     console.log(`codex artefact  ${res.id}  ->  ${res.outPath}`);
     console.log(`  zone: codex (${res.scope}) — authoritative by construction; derive obligations as REQUIREMENT + ASSERTION candidates`);
@@ -180,6 +187,10 @@ async function cmdCodexArtefact(args) {
     if (res.sourceHash) console.log(`  source_hash:       ${res.sourceHash}`);
     return 0;
   } catch (err) {
+    if (err.duplicate) {
+      console.log(`codex artefact  skipped — ${err.message}`);
+      return 0;
+    }
     console.error(`codex-artefact: ${err.message}`);
     return 2;
   }

--- a/packages/ingest-cli/src/codex-artefact.mjs
+++ b/packages/ingest-cli/src/codex-artefact.mjs
@@ -13,11 +13,11 @@
 // flow's admission to field/. This command NEVER writes canon/.
 
 import { readFile, writeFile, mkdir, readdir, rename, access } from 'node:fs/promises';
-import { createHash } from 'node:crypto';
 import { join, resolve, basename, extname } from 'node:path';
 import { isValidId, makeId, slugSegment, parseId } from './ids.mjs';
 import { dump } from './yaml.mjs';
 import { stageDir } from './intake.mjs';
+import { hashFile, findDuplicateSource, DuplicateSourceError } from './source-hash.mjs';
 
 // CODEX TYPE -> sub-zone (14-codex.md §2).
 const TYPE_INFO = {
@@ -57,7 +57,7 @@ async function findRaw(orgRoot, mdPath) {
 export async function emitCodexArtefact(opts) {
   const {
     orgRoot, mdPath, type, jurisdiction, effectiveDate, sourceAuthority,
-    issuingAuthority, admittedAt, admittedBy, monitoring, slug, name,
+    issuingAuthority, admittedAt, admittedBy, monitoring, slug, name, force = false,
   } = opts;
 
   const info = TYPE_INFO[type];
@@ -75,6 +75,18 @@ export async function emitCodexArtefact(opts) {
     codexDir = join(resolve(orgRoot), 'codex', 'internal');
   }
 
+  // Fingerprint the raw bytes up front and refuse a duplicate re-ingest (same content
+  // already admitted to codex/) unless --force — before minting an id or snapshotting.
+  const raw = await findRaw(orgRoot, mdPath);
+  let sourceHash = null;
+  if (raw) {
+    sourceHash = await hashFile(raw);
+    if (!force) {
+      const dup = await findDuplicateSource(orgRoot, 'codex', sourceHash);
+      if (dup) throw new DuplicateSourceError(dup.id, sourceHash);
+    }
+  }
+
   const seg = slug ? slugSegment(slug) : slugSegment(name);
   if (!seg) throw new Error('could not derive an ID segment from --slug/--name; pass --slug');
   const middle = [seg];
@@ -82,14 +94,11 @@ export async function emitCodexArtefact(opts) {
   const id = makeId(type, middle, ordinal);
   if (!isValidId(id)) throw new Error(`generated an invalid ID: ${id}`);
 
-  // Snapshot the raw bytes into the codex sources/ subfolder (audit trail) + fingerprint.
-  const raw = await findRaw(orgRoot, mdPath);
+  // Snapshot the raw bytes into the codex sources/ subfolder (audit trail). The snapshot
+  // name is keyed by the unique id, so it never collides across distinct sources.
   let snapshotFile = null;
   let snapshotDate = null;
-  let sourceHash = null;
   if (raw) {
-    const bytes = await readFile(raw);
-    sourceHash = `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
     snapshotDate = admittedAt;
     const sourcesDir = join(codexDir, 'sources');
     await mkdir(sourcesDir, { recursive: true });

--- a/packages/ingest-cli/src/field-artefact.mjs
+++ b/packages/ingest-cli/src/field-artefact.mjs
@@ -7,11 +7,11 @@
 // never touches canon/.
 
 import { readFile, writeFile, mkdir, readdir, rename, access } from 'node:fs/promises';
-import { createHash } from 'node:crypto';
 import { join, resolve, basename, extname } from 'node:path';
 import { isValidId, makeId, slugSegment, parseId } from './ids.mjs';
 import { dump } from './yaml.mjs';
 import { INTAKE, stageDir } from './intake.mjs';
+import { hashFile, shortHash, findDuplicateSource, DuplicateSourceError } from './source-hash.mjs';
 
 // Field TYPE → field/ subfolder and body-block key.
 const TYPE_INFO = {
@@ -60,7 +60,7 @@ async function findRaw(orgRoot, mdPath) {
 export async function emitFieldArtefact(opts) {
   const {
     orgRoot, mdPath, type, role, date,
-    setting, capturedBy, sourceQuality, slug, admittedAt, name,
+    setting, capturedBy, sourceQuality, slug, admittedAt, name, force = false,
   } = opts;
 
   const info = TYPE_INFO[type];
@@ -68,6 +68,18 @@ export async function emitFieldArtefact(opts) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date || '')) throw new Error('--date must be YYYY-MM-DD');
   if (sourceQuality && !SOURCE_QUALITY.has(sourceQuality)) {
     throw new Error(`--source-quality must be one of ${[...SOURCE_QUALITY].join(', ')}`);
+  }
+
+  // Fingerprint the raw bytes up front and refuse a duplicate re-ingest (same content
+  // already admitted to field/) unless --force — before minting an id or moving anything.
+  const raw = await findRaw(orgRoot, mdPath);
+  let sourceHash = null;
+  if (raw) {
+    sourceHash = await hashFile(raw);
+    if (!force) {
+      const dup = await findDuplicateSource(orgRoot, 'field', sourceHash);
+      if (dup) throw new DuplicateSourceError(dup.id, sourceHash);
+    }
   }
 
   const seg = slug ? slugSegment(slug) : slugSegment(role);
@@ -83,19 +95,20 @@ export async function emitFieldArtefact(opts) {
   const body = await readFile(mdPath, 'utf8');
   const proposedSQ = sourceQuality || DEFAULT_SQ[type];
 
-  // Move the raw source into processed/ and record a traceable pointer + SHA-256.
-  // The hash gives the artefact tamper-evidence (a re-saved "same" file is detected
-  // by mismatch) and a stable provenance fingerprint independent of the path.
-  const raw = await findRaw(orgRoot, mdPath);
+  // Move the raw source into processed/ and record a traceable pointer. If a file of the
+  // same basename is already there (a different source that happens to share a name —
+  // a re-ingest of identical content is caught above), disambiguate with the content
+  // hash instead of overwriting, so no prior source is silently clobbered.
   let rawSource = null;
-  let sourceHash = null;
   if (raw) {
-    const bytes = await readFile(raw);
-    sourceHash = `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
-    const dest = join(stageDir(orgRoot, 'processed'), basename(raw));
-    await mkdir(stageDir(orgRoot, 'processed'), { recursive: true });
+    const processedDir = stageDir(orgRoot, 'processed');
+    await mkdir(processedDir, { recursive: true });
+    let dest = join(processedDir, basename(raw));
+    if (await exists(dest)) {
+      dest = join(processedDir, `${basename(raw, extname(raw))}__${shortHash(sourceHash)}${extname(raw)}`);
+    }
     await rename(raw, dest);
-    rawSource = join(INTAKE, 'processed', basename(raw)).replace(/\\/g, '/');
+    rawSource = join(INTAKE, 'processed', basename(dest)).replace(/\\/g, '/');
   }
 
   const artefact = {

--- a/packages/ingest-cli/src/review-queue.mjs
+++ b/packages/ingest-cli/src/review-queue.mjs
@@ -67,12 +67,27 @@ export async function buildReviewQueue({ orgRoot, candidatesDir, profile, sugges
   const field_artefacts = [];
   for (const id of [...fieldIds].sort()) field_artefacts.push(await readFieldArtefact(orgRoot, id));
 
+  // Surface duplicate-by-hash: two source artefacts sharing a source_hash are the same
+  // content admitted twice (e.g. via `admit-source --force`). Flag the clusters so the
+  // human can collapse the duplicates before admitting candidates derived from both.
+  const byHash = new Map();
+  for (const fa of field_artefacts) {
+    if (!fa.source_hash || !fa.id) continue;
+    if (!byHash.has(fa.source_hash)) byHash.set(fa.source_hash, []);
+    byHash.get(fa.source_hash).push(fa.id);
+  }
+  const duplicate_sources = [];
+  for (const [source_hash, ids] of byHash) {
+    if (ids.length > 1) duplicate_sources.push({ source_hash, ids: ids.sort() });
+  }
+
   return {
     generated_by: '@transitrix/ingest-cli',
     org_root: resolve(orgRoot),
     coverage_profile: (profile && profile.display) || 'full',
     ...(profile && profile.warning ? { coverage_warning: profile.warning } : {}),
     field_artefacts,
+    ...(duplicate_sources.length ? { duplicate_sources } : {}),
     candidates,
     excluded_admitted,
     relation_suggestions: suggestions,

--- a/packages/ingest-cli/src/source-hash.mjs
+++ b/packages/ingest-cli/src/source-hash.mjs
@@ -1,0 +1,68 @@
+// Source-content hashing + duplicate detection. A source artefact (field or codex)
+// fingerprints its raw bytes as `source_hash: sha256:<hex>` — the same fingerprint that
+// gives tamper-evidence (CONTRACT §6) doubles as a duplicate key: an identical re-ingest
+// produces the same hash, so we can recognise it instead of silently minting a second
+// artefact. This module is the one place that hash is computed and compared. Read-only
+// over the zones — like the rest of the CLI, it never writes canon.
+
+import { readdir, readFile, access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, resolve } from 'node:path';
+import { readTopScalar } from './yaml.mjs';
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+export function hashBytes(bytes) {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+export async function hashFile(path) {
+  return hashBytes(await readFile(path));
+}
+
+// The 8-hex-char short form of a source_hash, for disambiguating filenames.
+export function shortHash(hash) {
+  return String(hash).replace(/^sha256:/, '').slice(0, 8);
+}
+
+// Recursively collect every *.yaml path under dir.
+async function walkYaml(dir) {
+  const out = [];
+  let entries;
+  try { entries = await readdir(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...await walkYaml(p));
+    else if (e.isFile() && e.name.endsWith('.yaml')) out.push(p);
+  }
+  return out;
+}
+
+// Scan a zone ('field' | 'codex') for an already-admitted artefact whose source_hash
+// equals `hash`. Returns { id, file } for the first match, or null. An absent zone (the
+// common case on the first ingest) yields null — no match, nothing skipped.
+export async function findDuplicateSource(orgRoot, zone, hash) {
+  if (!hash) return null;
+  const dir = join(resolve(orgRoot), zone);
+  if (!(await exists(dir))) return null;
+  for (const file of await walkYaml(dir)) {
+    let text;
+    try { text = await readFile(file, 'utf8'); } catch { continue; }
+    if (readTopScalar(text, 'source_hash') === hash) {
+      return { id: readTopScalar(text, 'id'), file };
+    }
+  }
+  return null;
+}
+
+// Thrown by the emit paths when an identical source is already admitted and --force was
+// not given. The CLI recognises `duplicate` to warn-and-skip instead of erroring.
+export class DuplicateSourceError extends Error {
+  constructor(existingId, hash) {
+    super(`source already admitted as ${existingId} (same source_hash ${hash}) — pass --force to admit a duplicate`);
+    this.name = 'DuplicateSourceError';
+    this.existingId = existingId;
+    this.sourceHash = hash;
+    this.duplicate = true;
+  }
+}

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -80,6 +80,8 @@ npx @transitrix/ingest-cli admit-source --zone field <processing/file.md> \
 
 The CLI fills the admission record (`zone: field`, `gate_checks.provenance`) and **proposes** a `source_quality` from the document type. It also fingerprints the raw bytes as `source_hash: sha256:<hex>` alongside `raw_source` — tamper-evidence for adopters with audit needs (GDPR / SOX / ISO 27001) and source-replacement detection: a re-saved "same" file is caught by hash mismatch, not by silent drift. The schema is [`schemas/field-artefact.schema.json`](schemas/field-artefact.schema.json); the canonical contract is [CONTRACT §6](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md) (admission record) and [§11.2](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md) (the source-trust scale).
 
+The same `source_hash` deduplicates: if the identical content was already admitted to the zone, `admit-source` **skips** it (naming the existing artefact) rather than minting a second one — pass `--force` to admit a deliberate duplicate. (When two artefacts share a hash, `review-queue` surfaces the cluster under `duplicate_sources`.) This applies to both the `field` and `codex` routes.
+
 **Proposed `source_quality` by document character** — closed set, the human confirms at admission:
 
 | Document character | Proposed `source_quality` | Weight |

--- a/transitrix/skills/ingest/schemas/review-queue.schema.json
+++ b/transitrix/skills/ingest/schemas/review-queue.schema.json
@@ -49,6 +49,19 @@
         "additionalProperties": true
       }
     },
+    "duplicate_sources": {
+      "type": "array",
+      "description": "Optional. Clusters of source artefacts that share a source_hash — the same content admitted more than once (e.g. via admit-source --force). Present only when at least one cluster exists; the human collapses duplicates before admitting candidates derived from both.",
+      "items": {
+        "type": "object",
+        "required": ["source_hash", "ids"],
+        "properties": {
+          "source_hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "ids": { "type": "array", "items": { "type": "string" }, "minItems": 2 }
+        },
+        "additionalProperties": false
+      }
+    },
     "candidates": {
       "type": "array",
       "description": "Canon candidates awaiting the human admission gate. Each conforms to candidate.schema.json; the queue references them and surfaces their flags.",

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -702,6 +702,83 @@ def part_i_placement():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part J — F1 duplicate-source detection ───────────────────────
+
+def part_j_duplicate_source():
+    """admit-source dedups by source_hash (skip w/o --force, admit w/ --force);
+    processed/ basename collisions don't clobber; review-queue surfaces duplicate-by-hash."""
+    if not shutil.which("node"):
+        print("SKIP Part J: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-f1-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+
+        inbox = os.path.join(org, "_intake", "inbox")
+        processed = os.path.join(org, "_intake", "processed")
+        fdir = os.path.join(org, "field", "interviews")
+
+        def yamls():
+            return sorted(f for f in os.listdir(fdir) if f.endswith(".yaml")) if os.path.isdir(fdir) else []
+
+        def drop_and_admit(content, *extra):
+            # (re)drop the raw under a fixed basename, convert (passthrough), admit
+            with open(os.path.join(inbox, "src.md"), "w", encoding="utf-8") as fh:
+                fh.write(content)
+            run_cli("convert", os.path.join(inbox, "src.md"))
+            md = os.path.join(org, "_intake", "processing", "src.md")
+            return run_cli("admit-source", md, "--zone", "field", "--type", "INTERVIEW",
+                           "--role", "ops", "--date", "2026-01-01", "--slug", "ops",
+                           "--admitted-at", "2026-01-02", *extra)
+
+        # 1. First admit → exactly one artefact.
+        r = drop_and_admit("AAA\n")
+        check(r.returncode == 0, "F1: first admit failed: %s" % (r.stderr or r.stdout))
+        check(len(yamls()) == 1, "F1: first admit should mint exactly one field artefact, got %r" % yamls())
+
+        # 2. Re-admit identical content WITHOUT --force → skipped, no second artefact.
+        r = drop_and_admit("AAA\n")
+        out = r.stdout + r.stderr
+        check(r.returncode == 0, "F1: a duplicate re-ingest must not error (exit %d): %s" % (r.returncode, out))
+        check("skip" in out.lower() and "force" in out.lower(),
+              "F1: duplicate was not reported as skipped: %r" % out)
+        check(len(yamls()) == 1, "F1: a duplicate must not mint a second artefact, got %r" % yamls())
+
+        # 3. Re-admit identical content WITH --force → a second artefact (distinct id).
+        r = drop_and_admit("AAA\n", "--force")
+        check(r.returncode == 0, "F1: --force admit failed: %s" % (r.stderr or r.stdout))
+        ids = [os.path.splitext(x)[0] for x in yamls()]
+        check(len(ids) == 2, "F1: --force should mint a second artefact, got %r" % ids)
+
+        # processed/ basename collision: the original raw is retained unchanged, the
+        # second lands under a disambiguated name (not clobbered).
+        psrc = os.path.join(processed, "src.md")
+        check(os.path.isfile(psrc) and open(psrc, encoding="utf-8").read() == "AAA\n",
+              "F1: original processed/src.md must survive the collision unchanged")
+        check(len([f for f in os.listdir(processed) if f.startswith("src")]) >= 2,
+              "F1: the second raw must be retained under a disambiguated name")
+
+        # 4. review-queue surfaces the two same-hash artefacts as a duplicate cluster.
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        os.makedirs(cdir, exist_ok=True)
+        with open(os.path.join(cdir, "GOAL-DUP-1.json"), "w", encoding="utf-8") as fh:
+            json.dump({"kind": "element", "id": "GOAL-DUP-1", "name": "x", "element_type": "GOAL",
+                       "derived_from": ids, "admitted_to": "pending",
+                       "extraction_confidence": "high"}, fh)
+        r = run_cli("review-queue", cdir)
+        check(r.returncode == 0, "F1: review-queue failed: %s" % (r.stderr or r.stdout))
+        q = yaml.safe_load(open(os.path.join(org, "_intake", "processing", "review-queue.yaml"), encoding="utf-8"))
+        dups = q.get("duplicate_sources") or []
+        check(any(sorted(c.get("ids", [])) == sorted(ids) for c in dups),
+              "F1: review-queue did not surface the duplicate-by-hash cluster: %r" % dups)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
@@ -711,6 +788,7 @@ part_f_ig3()
 part_g_coverage()
 part_h_idempotent()
 part_i_placement()
+part_j_duplicate_source()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## What

`source_hash` was computed but never compared, so an identical re-ingest minted a second artefact + duplicate candidates and overwrote `processed/` by basename. This adds the three facets of duplicate-source handling:

1. **Dedup on `admit-source`** (field + codex). The raw bytes are fingerprinted up front; if the same content is already admitted to the zone, the emit throws a `DuplicateSourceError` naming the existing artefact. The CLI **warns and skips (exit 0)**; **`--force`** admits a deliberate duplicate.
2. **No `processed/` clobber.** The field move now disambiguates with the content hash when a file of the same basename is already there (a *distinct* source — identical content is caught by #1). Codex snapshots are keyed by the unique id, so they never collide.
3. **Review-queue surfacing.** Source artefacts sharing a `source_hash` are reported under a new `duplicate_sources` cluster, so the human can collapse them before admitting candidates derived from both.

## Structure

- New `src/source-hash.mjs` centralises the hashing (previously duplicated in `field-artefact.mjs` / `codex-artefact.mjs`), the read-only zone scan, and the `DuplicateSourceError` type.
- `review-queue.schema.json` documents `duplicate_sources`.
- `SKILL.md` Step 3 documents the dedup + `--force` behaviour; `admit-source` help gains `--force`.

## Verification

- New F1 integrity-test part: re-admit identical content → skipped, no second artefact; `--force` → second artefact; `processed/` collision retains the original unchanged; `review-queue` surfaces the duplicate cluster.
- Full `test_ingest_integrity.py` → all checks pass.
- `node scripts/check-notations.mjs` → clean.

Note: touches `review-queue.mjs` + `review-queue.schema.json`, which #163 (F13) also touches — independent changes (this adds `duplicate_sources`; F13 adds codex resolution). Both branch from `main`; expect a small merge alignment if both land. Open PR; do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)