### PR TITLE
feat(ingest-cli): suggest-profile discovery mode (F3)

### DIFF
--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -16,15 +16,17 @@ import { readFile, access } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 
-import { scaffoldIntake, findOrgRoot, stageDir } from './src/intake.mjs';
+import { scaffoldIntake, findOrgRoot, stageDir, readManifestText } from './src/intake.mjs';
 import { convert, ConvertError } from './src/convert.mjs';
 import { emitFieldArtefact } from './src/field-artefact.mjs';
 import { validateCandidate, loadCandidates } from './src/validate.mjs';
-import { readCoverageProfile } from './src/coverage.mjs';
+import { readCoverageProfile, parseProfileDecl } from './src/coverage.mjs';
 import { buildReviewQueue, writeReviewQueue } from './src/review-queue.mjs';
+import { buildProfileSuggestion } from './src/suggest-profile.mjs';
 import { emitCandidates } from './src/emit-candidates.mjs';
 import { emitCodexArtefact } from './src/codex-artefact.mjs';
 import { resolvePlacement, checkCanonPlacement } from './src/placement.mjs';
+import { dump } from './src/yaml.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -70,6 +72,7 @@ function usage() {
     '  validate <candidates-dir>      Validate candidate *.json against the contract + coverage profile',
     '  review-queue <candidates-dir>  Assemble the human review queue (writes review-queue.yaml)',
     '                 [--out <path>]',
+    '  suggest-profile <candidates-dir>  Propose a coverage-profile delta for out-of-profile TYPEs (read-only; prints to stdout)',
     '  check-placement [org-root]     Flag admitted elements sitting outside their ELEMENT_PRIMITIVES §4 folder',
     '  resolve-placement <TYPE>       Print a TYPE\'s §4 materialisation mode + layer + folder',
     '  --version, -v                  Print the CLI version',
@@ -291,6 +294,23 @@ async function cmdEmitCandidates(args) {
   }
 }
 
+// Discovery: scan candidates for out-of-profile TYPEs and PROPOSE a coverage delta.
+// Read-only — prints a paste-ready suggestion to stdout, never widens the profile.
+async function cmdSuggestProfile(args) {
+  const { _ } = parseArgs(args);
+  const r = await resolveDir(_[0], 'suggest-profile');
+  if (r.code) return r.code;
+
+  const loaded = await loadCandidates(r.dir);
+  if (loaded.length === 0) { console.error(`suggest-profile: no candidate *.json files in ${_[0]}`); return 0; }
+
+  const decl = parseProfileDecl((await readManifestText(r.orgRoot)) || '');
+  const baseName = decl.kind === 'short' ? decl.name : decl.kind === 'custom' ? decl.extends : 'full';
+  const report = buildProfileSuggestion(loaded, r.profile, baseName);
+  process.stdout.write(dump(report));
+  return 0;
+}
+
 // Print the canonical §4 placement (mode + layer + folder) for a TYPE.
 async function cmdResolvePlacement(args) {
   const { _ } = parseArgs(args);
@@ -335,6 +355,7 @@ async function main(argv) {
     case 'emit-candidates': return cmdEmitCandidates(args);
     case 'validate':        return cmdValidate(args);
     case 'review-queue':    return cmdReviewQueue(args);
+    case 'suggest-profile': return cmdSuggestProfile(args);
     case 'check-placement': return cmdCheckPlacement(args);
     case 'resolve-placement': return cmdResolvePlacement(args);
     default:

--- a/packages/ingest-cli/src/suggest-profile.mjs
+++ b/packages/ingest-cli/src/suggest-profile.mjs
@@ -1,0 +1,94 @@
+// `suggest-profile` — discovery mode. Scans candidate TYPEs against the adopter's
+// active coverage profile and PROPOSES a profile delta covering the out-of-profile TYPEs
+// it finds. Read-only and non-mutating: it never widens the profile itself — the profile
+// is the guardrail, and widening it is a human decision (COVERAGE_PROFILES.md CP-001 /
+// CP-003). The output is a paste-ready `coverage_profile:` map plus a per-TYPE breakdown.
+
+import { classifyCoverage } from './coverage.mjs';
+import { resolvePlacement } from './placement.mjs';
+import { PRESETS } from './coverage-presets.mjs';
+
+// rel kind -> layer, learned from the shipped presets (best-effort). A kind that appears
+// in no preset has no layer the CLI can derive; it is reported as `unplaceable` for the
+// human to site, never guessed.
+function relLayerIndex() {
+  const idx = {};
+  for (const name of Object.keys(PRESETS)) {
+    const p = PRESETS[name];
+    if (!p || p === 'ALL' || !p.relations) continue;
+    for (const [layer, kinds] of Object.entries(p.relations)) {
+      for (const k of kinds) if (!(k in idx)) idx[k] = layer;
+    }
+  }
+  return idx;
+}
+
+// Build a profile-suggestion report from loaded candidates (the [{candidate}] shape
+// loadCandidates returns), the resolved `profile`, and the base preset name the delta
+// should `extends:`. Pure — no I/O.
+export function buildProfileSuggestion(loaded, profile, baseName) {
+  const relLayer = relLayerIndex();
+  const elements = new Map();   // element TYPE -> { layer, count }
+  const relations = new Map();  // rel kind    -> { layer, count }
+
+  for (const { candidate } of loaded) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    if (candidate.kind === 'element' && candidate.element_type) {
+      if (classifyCoverage(profile, 'element', candidate.element_type).flag === 'out_of_profile') {
+        const cur = elements.get(candidate.element_type)
+          || { layer: (resolvePlacement(candidate.element_type) || {}).layer || null, count: 0 };
+        cur.count++;
+        elements.set(candidate.element_type, cur);
+      }
+    } else if (candidate.kind === 'relation' && candidate.rel_kind) {
+      if (classifyCoverage(profile, 'relation', candidate.rel_kind).flag === 'out_of_profile') {
+        const cur = relations.get(candidate.rel_kind) || { layer: relLayer[candidate.rel_kind] || null, count: 0 };
+        cur.count++;
+        relations.set(candidate.rel_kind, cur);
+      }
+    }
+    // ASSERTION (and codex) are never coverage-bounded (§2.1) — skipped.
+  }
+
+  // Group the placeable TYPEs into a layer-keyed delta; collect the rest as unplaceable.
+  const layers = {};
+  const ensure = (L) => (layers[L] = layers[L] || {});
+  const unplaceable = { elements: [], relations: [] };
+
+  for (const type of [...elements.keys()].sort()) {
+    const layer = elements.get(type).layer;
+    if (layer) { const e = ensure(layer); (e.elements = e.elements || { add: [] }).add.push(type); }
+    else unplaceable.elements.push(type);
+  }
+  for (const kind of [...relations.keys()].sort()) {
+    const layer = relations.get(kind).layer;
+    if (layer) { const e = ensure(layer); (e.relations = e.relations || { add: [] }).add.push(kind); }
+    else unplaceable.relations.push(kind);
+  }
+
+  const oopElements = [...elements.keys()].sort().map((type) => ({ type, layer: elements.get(type).layer, count: elements.get(type).count }));
+  const oopRelations = [...relations.keys()].sort().map((kind) => ({ kind, layer: relations.get(kind).layer, count: relations.get(kind).count }));
+
+  const report = {
+    generated_by: '@transitrix/ingest-cli',
+    active_profile: profile.display,
+    ...(profile.warning ? { coverage_warning: profile.warning } : {}),
+    scanned_candidates: loaded.length,
+    out_of_profile: { elements: oopElements, relations: oopRelations },
+  };
+
+  if (!oopElements.length && !oopRelations.length) {
+    report.note = `No out-of-profile candidates under "${profile.display}" — no profile change needed.`;
+    return report;
+  }
+
+  report.proposed_delta = { extends: baseName, layers };
+  if (unplaceable.elements.length || unplaceable.relations.length) report.unplaceable = unplaceable;
+  report.note =
+    'PROPOSED ONLY — never auto-applied; the coverage profile is the guardrail. Review these out-of-profile ' +
+    'TYPEs and, if they belong in the model, set `coverage_profile:` in transitrix.yaml to `proposed_delta` ' +
+    '(CP-001 / CP-003). If you already use a custom coverage_profile map, merge the `add:` lists into your ' +
+    'existing `layers` and keep your current `extends:`. Anything under `unplaceable` has no layer the CLI ' +
+    'could derive — site it by hand.';
+  return report;
+}

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **front door** to a Transitrix repository: it turns raw material into `field`-zone artefacts and typed `canon` *candidates*, at scale, and routes everything through a human review gate. It is the operational counterpart to the per-layer extraction prompts — the part that converts documents, scores source trust, runs the validators, and stages a review queue.
 
-> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`, see [§ The CLI](#the-cli)) implements every subcommand below — `scaffold-intake`, `convert`, `admit-source` (field + codex routes), `emit-candidates`, `validate`, `review-queue`, `check-placement`, `resolve-placement` — and is exercised end-to-end by the bundle's integrity test. Run the **CLI-presence pre-check** (Step 0) first; if the CLI is not on PATH in this install, install it before proceeding.
+> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`, see [§ The CLI](#the-cli)) implements every subcommand below — `scaffold-intake`, `convert`, `admit-source` (field + codex routes), `emit-candidates`, `validate`, `review-queue`, `suggest-profile`, `check-placement`, `resolve-placement` — and is exercised end-to-end by the bundle's integrity test. Run the **CLI-presence pre-check** (Step 0) first; if the CLI is not on PATH in this install, install it before proceeding.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the field→canon pipeline against it. It runs **agent-neutrally** under Claude and GitHub Copilot — all heavy logic is in the CLI, and this `SKILL.md` only sequences it.
 
@@ -135,6 +135,14 @@ The CLI reads the repo's `coverage_profile` ([COVERAGE_PROFILES](https://raw.git
 
 If a profile is **present but cannot be resolved** (unknown preset, missing `extends:`, malformed), the CLI does **not** silently treat the repo as `full`: it resolves permissively but emits an explicit **WARNING** (in CLI output and as `coverage_warning` in the review queue), so the unreliable coverage signal is visible rather than hidden.
 
+When a corpus keeps surfacing the same out-of-profile TYPE, **`suggest-profile`** turns that signal into a concrete proposal instead of a manual profile edit:
+
+```
+npx @transitrix/ingest-cli suggest-profile <processing/candidates/>   # read-only; prints to stdout
+```
+
+It scans the candidates, collects the out-of-profile element TYPEs and relation kinds, and prints a paste-ready `coverage_profile` delta (`extends:` the active base + the TYPEs grouped under their layer). It **never widens the profile itself** — the profile is the guardrail; the human reviews the proposal and edits `transitrix.yaml` deliberately. TYPEs whose layer the CLI cannot derive are listed under `unplaceable` to site by hand.
+
 ---
 
 ## Step 6 — Produce the review queue
@@ -164,7 +172,7 @@ Where an admitted element lands is **not** a judgement call. Every element TYPE 
 
 All deterministic behaviour lives in **`@transitrix/ingest-cli`** — document conversion, coverage-profile read, validator pass, field-artefact + candidate emission, and the `_intake/` moves. This keeps the deterministic guarantees independent of which agent drives the skill (the same principle as the methodology's CI validators): neither Claude nor Copilot reimplements the logic, and both get identical results.
 
-The CLI is resolved as a **published package** (installed/invoked via `npx`), not vendored per skill and not referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`, `check-placement`, `resolve-placement`.
+The CLI is resolved as a **published package** (installed/invoked via `npx`), not vendored per skill and not referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`, `suggest-profile`, `check-placement`, `resolve-placement`.
 
 ---
 

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -795,6 +795,67 @@ def part_j_duplicate_source():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part K — F3 suggest-profile (discovery) ──────────────────────
+
+def part_k_suggest_profile():
+    """suggest-profile proposes a delta for out-of-profile TYPEs (read-only); an
+    in-profile TYPE is not flagged; under `full` nothing is proposed."""
+    if not shutil.which("node"):
+        print("SKIP Part K: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-f3-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: core\n')
+
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        os.makedirs(cdir, exist_ok=True)
+        fid = "INTERVIEW-x-20260101-1"
+
+        def cand(name, obj):
+            with open(os.path.join(cdir, name), "w", encoding="utf-8") as fh:
+                json.dump({**obj, "derived_from": [fid], "admitted_to": "pending",
+                           "extraction_confidence": "high"}, fh)
+
+        # PRODUCT is out of `core`; GOAL is in `core`.
+        cand("PRODUCT.json", {"kind": "element", "id": "PRODUCT-X-1", "name": "x", "element_type": "PRODUCT"})
+        cand("GOAL.json", {"kind": "element", "id": "GOAL-X-1", "name": "g", "element_type": "GOAL"})
+
+        r = run_cli("suggest-profile", cdir)
+        check(r.returncode == 0, "F3: suggest-profile failed: %s" % (r.stderr or r.stdout))
+        rep = yaml.safe_load(r.stdout)
+        oop = {e["type"] for e in rep.get("out_of_profile", {}).get("elements", [])}
+        check("PRODUCT" in oop, "F3: PRODUCT (out of core) was not surfaced: %r" % sorted(oop))
+        check("GOAL" not in oop, "F3: GOAL (in core) must not be surfaced as out-of-profile")
+        delta = rep.get("proposed_delta") or {}
+        check(delta.get("extends") == "core", "F3: proposed delta should extend the active base: %r" % delta.get("extends"))
+        add = (delta.get("layers", {}).get("02_business", {}).get("elements", {}) or {}).get("add", [])
+        check("PRODUCT" in add, "F3: PRODUCT not placed under 02_business in the proposed delta: %r" % delta)
+
+        # Under `full`, nothing is out of profile → no delta proposed.
+        org2 = os.path.join(work, "org2")
+        os.makedirs(org2)
+        run_cli("scaffold-intake", org2)
+        with open(os.path.join(org2, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+        cdir2 = os.path.join(org2, "_intake", "processing", "candidates")
+        os.makedirs(cdir2, exist_ok=True)
+        with open(os.path.join(cdir2, "PRODUCT.json"), "w", encoding="utf-8") as fh:
+            json.dump({"kind": "element", "id": "PRODUCT-Y-1", "name": "y", "element_type": "PRODUCT",
+                       "derived_from": [fid], "admitted_to": "pending", "extraction_confidence": "high"}, fh)
+        r = run_cli("suggest-profile", cdir2)
+        check(r.returncode == 0, "F3: suggest-profile (full) failed: %s" % (r.stderr or r.stdout))
+        rep2 = yaml.safe_load(r.stdout)
+        check(not rep2.get("out_of_profile", {}).get("elements"),
+              "F3: under `full` no element should be out of profile")
+        check("proposed_delta" not in rep2, "F3: under `full` no delta should be proposed")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
@@ -805,6 +866,7 @@ part_g_coverage()
 part_h_idempotent()
 part_i_placement()
 part_j_duplicate_source()
+part_k_suggest_profile()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## What

New read-only subcommand **`suggest-profile <candidates-dir>`**. It scans the candidates, classifies each against the adopter's active coverage profile, and prints a **proposed** delta to stdout:

- `out_of_profile`: the element TYPEs + relation kinds outside the active profile, each with its layer and an occurrence count;
- `proposed_delta`: a paste-ready `coverage_profile` map — `extends:` the active base, TYPEs grouped under their `ELEMENT_PRIMITIVES` §4 layer (via the placement resolver; rel kinds via the shipped-preset layer index);
- `unplaceable`: any TYPE/kind whose layer the CLI cannot derive — listed for the human to site by hand, never guessed.

## Why (finding F3)

Dogfooding hit the case where a corpus needs an out-of-profile TYPE and the human had to hand-edit the profile with no help locating what was missing. This turns the signal the validator/review-queue already produce into a concrete, reviewable proposal.

## Guardrail

It **never widens the profile itself** — the profile is the guardrail, and widening it stays a deliberate human edit. The proposed delta round-trips through the profile reader (verified), so the human can paste it straight into `transitrix.yaml`. Under `full`, nothing is proposed.

## Verification

- New integrity-test **Part K**: an out-of-profile TYPE (`PRODUCT` under `core`) is proposed under `02_business`; an in-profile TYPE (`GOAL`) is not flagged; under `full` no delta is proposed.
- Full `test_ingest_integrity.py` → all checks pass.
- `node scripts/check-notations.mjs` → clean.

New `src/suggest-profile.mjs` (pure builder) + CLI wiring + help; `SKILL.md` Step 5 documents it. Open PR; do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)