### PR TITLE
feat(ingest-cli): repo-check data-free doctor + transitrix:repo-check skill (F2)

### DIFF
--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -26,6 +26,7 @@ import { buildProfileSuggestion } from './src/suggest-profile.mjs';
 import { emitCandidates } from './src/emit-candidates.mjs';
 import { emitCodexArtefact } from './src/codex-artefact.mjs';
 import { resolvePlacement, checkCanonPlacement } from './src/placement.mjs';
+import { repoCheck } from './src/repo-check.mjs';
 import { dump } from './src/yaml.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -73,6 +74,7 @@ function usage() {
     '  review-queue <candidates-dir>  Assemble the human review queue (writes review-queue.yaml)',
     '                 [--out <path>]',
     '  suggest-profile <candidates-dir>  Propose a coverage-profile delta for out-of-profile TYPEs (read-only; prints to stdout)',
+    '  repo-check [org-root]          Data-free health report (version, profile, zone/TYPE counts, integrity flags); read-only',
     '  check-placement [org-root]     Flag admitted elements sitting outside their ELEMENT_PRIMITIVES §4 folder',
     '  resolve-placement <TYPE>       Print a TYPE\'s §4 materialisation mode + layer + folder',
     '  --version, -v                  Print the CLI version',
@@ -311,6 +313,15 @@ async function cmdSuggestProfile(args) {
   return 0;
 }
 
+// Read-only "doctor": emit a short, data-free health report for an adopter repo.
+async function cmdRepoCheck(args) {
+  const { _ } = parseArgs(args);
+  const orgRoot = _[0] ? resolve(_[0]) : (await findOrgRoot(process.cwd()) || process.cwd());
+  const report = await repoCheck(orgRoot);
+  process.stdout.write(dump(report));
+  return 0;
+}
+
 // Print the canonical §4 placement (mode + layer + folder) for a TYPE.
 async function cmdResolvePlacement(args) {
   const { _ } = parseArgs(args);
@@ -356,6 +367,7 @@ async function main(argv) {
     case 'validate':        return cmdValidate(args);
     case 'review-queue':    return cmdReviewQueue(args);
     case 'suggest-profile': return cmdSuggestProfile(args);
+    case 'repo-check':      return cmdRepoCheck(args);
     case 'check-placement': return cmdCheckPlacement(args);
     case 'resolve-placement': return cmdResolvePlacement(args);
     default:

--- a/packages/ingest-cli/src/repo-check.mjs
+++ b/packages/ingest-cli/src/repo-check.mjs
@@ -1,0 +1,111 @@
+// `repo-check` — read-only "doctor" for a Transitrix adopter repo. Emits a SHORT,
+// DATA-FREE health report: methodology version, resolved coverage profile, per-zone +
+// per-TYPE counts, an adoption-level indicator, integrity red flags, and a tooling
+// check. It reports AGGREGATES and STATUSES only — never object ids, names, or
+// contents — so the report is safe to share outside the organisation. Idempotent and
+// non-mutating; like the rest of the CLI it never writes a zone.
+//
+// Data-free guarantee: the per-TYPE breakdown counts only the TYPE prefix of a
+// grammar-valid id (methodology vocabulary — GOAL, PROCESS, …); a malformed id
+// contributes to `invalid_ids` and its prefix is never emitted, so no org-specific
+// string can leak into the report.
+
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { readManifestText } from './intake.mjs';
+import { readTopScalar } from './yaml.mjs';
+import { readCoverageProfile } from './coverage.mjs';
+import { checkCanonPlacement } from './placement.mjs';
+import { isValidId } from './ids.mjs';
+import { PRESETS_VERSION } from './coverage-presets.mjs';
+
+const ZONES = ['canon', 'field', 'codex'];
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+async function walkYaml(dir) {
+  const out = [];
+  let entries;
+  try { entries = await readdir(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...await walkYaml(p));
+    else if (e.isFile() && e.name.endsWith('.yaml')) out.push(p);
+  }
+  return out;
+}
+
+// Tally one zone: { files, with_id, invalid_ids, types: { <TYPE>: n } }. Only the prefix
+// of a grammar-valid id is recorded as a TYPE; malformed ids count toward invalid_ids.
+async function tallyZone(orgRoot, zone) {
+  const dir = join(resolve(orgRoot), zone);
+  const tally = { files: 0, with_id: 0, invalid_ids: 0, types: {} };
+  if (!(await exists(dir))) return { present: false, ...tally };
+  for (const file of await walkYaml(dir)) {
+    tally.files++;
+    let text;
+    try { text = await readFile(file, 'utf8'); } catch { continue; }
+    const id = readTopScalar(text, 'id');
+    if (!id) continue;
+    tally.with_id++;
+    if (!isValidId(id)) { tally.invalid_ids++; continue; }
+    const type = id.split('-')[0];
+    tally.types[type] = (tally.types[type] || 0) + 1;
+  }
+  // Sort the type map for stable output.
+  const sortedTypes = {};
+  for (const k of Object.keys(tally.types).sort()) sortedTypes[k] = tally.types[k];
+  tally.types = sortedTypes;
+  return { present: true, ...tally };
+}
+
+// Heuristic adoption level from how populated canon is (counts only, never contents).
+function adoptionLevel(canonFiles) {
+  if (canonFiles === 0) return 'empty (scaffold only — no canon elements yet)';
+  if (canonFiles < 10) return 'seeded';
+  if (canonFiles < 50) return 'in use';
+  return 'established';
+}
+
+// Build the data-free health report for an org root. Read-only.
+export async function repoCheck(orgRoot) {
+  const root = resolve(orgRoot);
+  const manifestText = await readManifestText(root);
+  const profile = await readCoverageProfile(root);
+
+  const zones = {};
+  let totalInvalid = 0;
+  for (const z of ZONES) {
+    zones[z] = await tallyZone(root, z);
+    totalInvalid += zones[z].invalid_ids || 0;
+  }
+
+  const placement = await checkCanonPlacement(root);
+
+  const red_flags = [];
+  if (totalInvalid > 0) red_flags.push(`${totalInvalid} artefact(s) with an id that violates the canonical grammar (IDS_AND_REFERENCES §1)`);
+  if (placement.findings.length > 0) red_flags.push(`${placement.findings.length} canon element(s) outside their ELEMENT_PRIMITIVES §4 folder`);
+  if (profile.unresolved) red_flags.push('coverage_profile is present but could not be resolved — coverage flags are not authoritative');
+  if (!manifestText) red_flags.push('no transitrix.yaml manifest at the repo root — not a recognised adopter repo');
+
+  return {
+    generated_by: '@transitrix/ingest-cli',
+    manifest_present: Boolean(manifestText),
+    methodology_version: manifestText ? (readTopScalar(manifestText, 'methodology_version') || null) : null,
+    coverage_profile: profile.display,
+    ...(profile.warning ? { coverage_warning: profile.warning } : {}),
+    zones,
+    adoption_level: adoptionLevel(zones.canon.present ? zones.canon.files : 0),
+    integrity: {
+      invalid_ids: totalInvalid,
+      misplaced_canon_elements: placement.findings.length,
+      canon_elements_scanned: placement.scanned,
+      red_flags,
+    },
+    tooling: {
+      cli_presets_version: PRESETS_VERSION,
+      ok: true,
+    },
+    note: 'Data-free — aggregate counts and statuses only; no object ids, names, or contents. Safe to share externally. Read-only: repo-check never writes a zone.',
+  };
+}

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -856,6 +856,52 @@ def part_k_suggest_profile():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part L — F2 repo-check (data-free doctor) ────────────────────
+
+def part_l_repo_check():
+    """repo-check emits a data-free health report: per-zone/TYPE counts, adoption level,
+    integrity flags (invalid ids, misplaced canon elements); never names an object."""
+    if not shutil.which("node"):
+        print("SKIP Part L: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-f2-")
+    try:
+        org = os.path.join(work, "org")
+        goals = os.path.join(org, "canon", "elements", "01_motivation", "goals")
+        os.makedirs(goals)
+        os.makedirs(os.path.join(org, "field", "interviews"))
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: core\n')
+        for gid in ("GOAL-A-1", "GOAL-B-1"):
+            with open(os.path.join(goals, gid + ".yaml"), "w", encoding="utf-8") as fh:
+                fh.write('id: "%s"\nname: "x"\nzone: "canon"\n' % gid)
+        # A PRODUCT sitting in goals/ → misplaced; a leading-zero field id → invalid.
+        with open(os.path.join(goals, "PRODUCT-MIS-1.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('id: "PRODUCT-MIS-1"\nname: "z"\nzone: "canon"\n')
+        with open(os.path.join(org, "field", "interviews", "bad.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('id: "INTERVIEW-007"\nname: "b"\nzone: "field"\n')
+
+        r = run_cli("repo-check", org)
+        check(r.returncode == 0, "F2: repo-check failed: %s" % (r.stderr or r.stdout))
+        rep = yaml.safe_load(r.stdout)
+
+        check(rep.get("manifest_present") is True, "F2: manifest_present should be True")
+        check(rep.get("methodology_version") == "0.5.0", "F2: methodology_version not read: %r" % rep.get("methodology_version"))
+        check(rep.get("coverage_profile") == "core", "F2: coverage_profile not resolved: %r" % rep.get("coverage_profile"))
+        ct = rep.get("zones", {}).get("canon", {}).get("types", {})
+        check(ct.get("GOAL") == 2 and ct.get("PRODUCT") == 1, "F2: canon TYPE counts wrong: %r" % ct)
+        integ = rep.get("integrity", {})
+        check(integ.get("invalid_ids") == 1, "F2: invalid_ids should be 1 (the leading-zero field id): %r" % integ.get("invalid_ids"))
+        check(integ.get("misplaced_canon_elements") == 1, "F2: misplaced_canon_elements should be 1: %r" % integ.get("misplaced_canon_elements"))
+        check(bool(rep.get("adoption_level")), "F2: adoption_level missing")
+        # Data-free guarantee: the report must not carry any object id/name.
+        blob = json.dumps(rep)
+        for leak in ("GOAL-A-1", "GOAL-B-1", "PRODUCT-MIS-1", "INTERVIEW-007"):
+            check(leak not in blob, "F2: report leaked an object id (%s) — must be data-free" % leak)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
@@ -867,6 +913,7 @@ part_h_idempotent()
 part_i_placement()
 part_j_duplicate_source()
 part_k_suggest_profile()
+part_l_repo_check()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")

--- a/transitrix/skills/repo-check/README.md
+++ b/transitrix/skills/repo-check/README.md
@@ -1,0 +1,24 @@
+# Transitrix Repo-Check Skill
+
+A **read-only "doctor"** for a Transitrix adopter repository. It emits a short, **data-free** health report — methodology version, resolved coverage profile, per-zone and per-TYPE counts, an adoption-level indicator, integrity red flags (invalid IDs, misplaced canon elements, unresolved profile), and a tooling check. Aggregates and statuses only — never object ids, names, or contents — so the report is safe to share outside the organisation.
+
+This directory is the **`repo-check` skill** within the `transitrix` plugin (the plugin root is [`transitrix/`](../../), which carries the shared [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) manifest, with one `skills/<name>/` directory per skill). Invoked as `/transitrix:repo-check`.
+
+> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`) implements the `repo-check` subcommand; the agent-facing protocol ([`SKILL.md`](SKILL.md)) only sequences it. The Step 0 pre-check stops cleanly if the CLI is not installed in a given environment.
+
+## Why it exists
+
+Operating a Transitrix repo, you periodically want a quick, shareable answer to "what state is this repo in, and is anything obviously wrong?" — without exposing the model's contents. `repo-check` is that answer: it reuses the same validators and placement/coverage resolvers the ingest pipeline uses, and reports only counts and statuses.
+
+## What it is not
+
+- It is **not** a writer — it never touches a zone, and re-running is always safe (idempotent).
+- It is **not** a detail view — by design it never names an object. To locate a flagged id, use `check-placement` (names ids — keep local) or the validators directly.
+
+## Usage
+
+```
+npx @transitrix/ingest-cli repo-check [org-root]    # defaults to the current repo; prints YAML to stdout
+```
+
+See [`SKILL.md`](SKILL.md) for the agent-facing protocol and the report's field reference.

--- a/transitrix/skills/repo-check/SKILL.md
+++ b/transitrix/skills/repo-check/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: Transitrix Repo-Check
+description: "Read-only health check (\"doctor\") for a Transitrix adopter repository. Emits a short, DATA-FREE report — methodology version, resolved coverage profile, per-zone and per-TYPE counts, an adoption-level indicator, integrity red flags (invalid IDs, misplaced canon elements, unresolved profile), and a tooling check. Reports aggregates and statuses only — never object ids, names, or contents — so the report is safe to share outside the organisation. Idempotent and non-mutating: it reads the zones and never writes one."
+when_to_use: 'User says "check my Transitrix repo", "is my model healthy", "run the repo doctor", "give me a status of the canon", "what state is this adopter repo in", or wants a shareable, data-free summary of a repository''s shape and integrity without exposing any model contents.'
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# Transitrix Repo-Check Skill
+
+A **read-only doctor** for a Transitrix adopter repository. It answers "what state is this repo in, and is anything obviously wrong?" with a **short, data-free report** — counts and statuses only, never the model's contents — so it is safe to paste into a ticket, a status update, or a support thread.
+
+This directory is the **`repo-check` skill** within the `transitrix` plugin (the plugin root is [`transitrix/`](../../), which carries the shared [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) manifest, one `skills/<name>/` directory per skill). Invoked as `/transitrix:repo-check`.
+
+> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`) implements `repo-check`; this `SKILL.md` only sequences it. Run the Step 0 pre-check first.
+
+---
+
+## The one rule
+
+**Read-only, and data-free.** `repo-check` never writes a zone and never emits object ids, names, or file contents — only aggregate counts, the methodology version, the resolved coverage-profile name, TYPE-vocabulary counts, and status flags. That is what makes the report safe to share externally. If you need the underlying detail, use the zone files directly; this skill deliberately does not surface them.
+
+---
+
+## Step 0 — CLI-presence pre-check
+
+The work is done by the CLI, never reimplemented in the agent:
+
+```
+npx @transitrix/ingest-cli --version
+```
+
+- **Present** → proceed.
+- **Absent** → tell the user to install `@transitrix/ingest-cli`; do not hand-roll the scan.
+
+---
+
+## Step 1 — Run the doctor
+
+```
+npx @transitrix/ingest-cli repo-check [org-root]    # defaults to the current repo
+```
+
+It prints a YAML report to stdout:
+
+- `methodology_version` + `manifest_present` — read from `transitrix.yaml`.
+- `coverage_profile` — the resolved profile display (`full` / a preset / `extends:<preset>`), plus a `coverage_warning` if it could not be resolved.
+- `zones` — for each of `canon` / `field` / `codex`: whether present, file count, and a per-**TYPE** count (TYPE vocabulary only — the prefix of a grammar-valid id; a malformed id is counted under `invalid_ids`, never by name).
+- `adoption_level` — a coarse indicator derived from how populated `canon` is (`empty` → `seeded` → `in use` → `established`).
+- `integrity` — `invalid_ids`, `misplaced_canon_elements` (elements outside their `ELEMENT_PRIMITIVES` §4 folder), `canon_elements_scanned`, and a `red_flags` list of short status strings.
+- `tooling` — the CLI's pinned presets version.
+
+---
+
+## Step 2 — Read the report back
+
+Summarise the `adoption_level` and any `red_flags` for the user in plain language, and point at the relevant repair command:
+
+- invalid IDs → fix the offending ids by hand (the report does not name them — by design; locate them with the validators or `git grep` locally).
+- misplaced canon elements → `npx @transitrix/ingest-cli check-placement [org-root]` lists them locally (that command **does** name ids — keep its output local, it is not the data-free report).
+- unresolved `coverage_profile` → fix `transitrix.yaml` per `COVERAGE_PROFILES.md` (CP-001).
+
+Nothing here mutates the repo; re-running is always safe and gives the same answer for the same tree.


### PR DESCRIPTION
## What

A read-only **doctor** for an adopter repo, in two parts:

1. **CLI** — new `repo-check [org-root]` subcommand (`@transitrix/ingest-cli`). Emits a **data-free** YAML health report:
   - `methodology_version` + `manifest_present`, resolved `coverage_profile`;
   - `zones` — per-zone file counts and a per-**TYPE** breakdown (TYPE vocabulary only);
   - `adoption_level` — coarse indicator from how populated `canon` is;
   - `integrity` — `invalid_ids`, `misplaced_canon_elements`, `canon_elements_scanned`, and a `red_flags` list;
   - `tooling` — the CLI's pinned presets version.
2. **Skill** — thin `transitrix:repo-check` (`SKILL.md` + `README.md`) that sequences the command. Skills are auto-discovered under `transitrix/skills/`, so no plugin-manifest change.

## Why (finding F2)

A quick, shareable "what state is this repo in, and is anything wrong?" — without exposing model contents.

## Data-free guarantee

Reports aggregates and statuses only. The per-TYPE breakdown counts only the prefix of a **grammar-valid** id (methodology vocabulary like `GOAL`/`PROCESS`); a malformed id counts toward `invalid_ids` and its prefix is **never emitted**, so no org-specific string can leak. Reuses the existing coverage / placement / id validators. Read-only and idempotent — never writes a zone.

The F11 version-currency check is a natural future addition here (coordinates with #78).

## Verification

- Integrity-test **Part L**: asserts the per-TYPE counts, the integrity flags (1 invalid id, 1 misplaced element), the adoption level, and the **data-free guarantee** (no object id appears anywhere in the report).
- Full `test_ingest_integrity.py` → all checks pass.
- `node scripts/check-notations.mjs` → clean.

Self-contained; branches from `main` (independent of #166/F3). Open PR; do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)