### PR TITLE
fix(ingest-cli): ID-grammar emit-time surfacing + clarify IDS §1 (F14)

### DIFF
--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -13,8 +13,8 @@ Recorded 2026-05-20 as the canonical decision for the methodology.
 ```
 
 - **TYPE** — uppercase entity-type prefix from the registry in §3. The prefix names *what kind of thing* the ID refers to. The TYPE segment is composed of uppercase letters `A`–`Z`, digits `0`–`9`, and the underscore `_`; it MUST start with a letter. The underscore allows multi-word TYPE names — `PROCESS_BLUEPRINT` (the first registered TYPE to use one, decided 2026-05-21) and `INFORMATION_ENTITY` (registered alongside it).
-- **Middle segments** — optional, notation-specific. Add for disambiguation (a domain code, a period, a programme name). The grammar fixes only the start and the end of an ID; a notation MAY define one or more middle segments where needed.
-- **INTEGER** — terminal positive integer, ≥ 1, **no leading zeros**. Sorting and comparison MUST parse it numerically, never lexically. There is no fixed width and no upper bound.
+- **Middle segments** — optional, notation-specific. Add for disambiguation (a domain code, a period, a programme name). The grammar fixes only the start and the end of an ID; a notation MAY define one or more middle segments where needed. A middle segment may be alphanumeric or purely numeric, and a numeric middle segment **MAY carry leading zeros** where it is a zero-padded date or period component — e.g. the month and day of an ISO date, `INTERVIEW-cfo-onboarding-2026-04-15-1` (`04`, `15`). The no-leading-zeros rule below constrains the **terminal** integer only; middle segments are labels, not the sort key.
+- **INTEGER** — terminal positive integer, ≥ 1, **no leading zeros** — this constraint applies to the **terminal** integer only (it is the numeric sort key; numeric middle segments are exempt, see above). Sorting and comparison MUST parse it numerically, never lexically. There is no fixed width and no upper bound.
 
 **Examples:**
 
@@ -23,7 +23,8 @@ Recorded 2026-05-20 as the canonical decision for the methodology.
 | `FACTOR-1` | FACTOR | — | 1 | minimal form |
 | `GOAL-RETENTION-12` | GOAL | RETENTION | 12 | one middle segment |
 | `ACTIVITY-Q3-2026-7` | ACTIVITY | Q3, 2026 | 7 | two middle segments |
-| `FACTOR-CHURN-001` | — | — | — | **invalid** — leading zero. Use `FACTOR-CHURN-1`. |
+| `INTERVIEW-cfo-onboarding-2026-04-15-1` | INTERVIEW | cfo, onboarding, 2026, 04, 15 | 1 | zero-padded ISO-date middle segments (`04`, `15`) are valid — the ban is terminal-only |
+| `FACTOR-CHURN-001` | — | — | — | **invalid** — leading zero on the *terminal* integer. Use `FACTOR-CHURN-1`. |
 | `factor-1` | — | — | — | **invalid** — TYPE must be uppercase. |
 | `FACTOR-` | — | — | — | **invalid** — missing terminal integer. |
 | `PROCESS_BLUEPRINT-FULFIL-1` | PROCESS_BLUEPRINT | FULFIL | 1 | underscore in TYPE — permitted |

--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -288,6 +288,7 @@ async function cmdEmitCandidates(args) {
     console.log(`emit-candidates  derived_from ${res.derivedFrom}`);
     console.log(`  ${res.candidates.length} candidate(s) -> ${res.dir}`);
     console.log(`  ${res.suggestions.length} relation suggestion(s) held back (relation-conservative) -> ${res.suggPath}`);
+    for (const w of res.warnings || []) console.error(`  WARNING: ${w}`);
     console.log('  candidates are pending — nothing admitted to canon.');
     return 0;
   } catch (err) {

--- a/packages/ingest-cli/src/emit-candidates.mjs
+++ b/packages/ingest-cli/src/emit-candidates.mjs
@@ -20,6 +20,7 @@
 import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { readTopScalar } from './yaml.mjs';
+import { isValidId } from './ids.mjs';
 
 const REL_THRESHOLD = 'high';
 const CONFIDENCE_RANK = { low: 0, medium: 1, high: 2 };
@@ -94,6 +95,25 @@ export function shapeCandidates(derivedFrom, result) {
   return { candidates, suggestions };
 }
 
+// Surface ID-grammar violations at emit time (F14): an element/assertion id or a
+// relation endpoint that breaks the canonical grammar (IDS_AND_REFERENCES §1) is caught
+// here, one step earlier than `validate`, so the agent sees it as soon as candidates are
+// shaped. Pure — returns a list of human-readable warnings; nothing is dropped (the
+// candidate is still written and the human gate / `validate` still flags it).
+export function collectIdWarnings(candidates) {
+  const warnings = [];
+  for (const c of candidates) {
+    if ((c.kind === 'element' || c.kind === 'assertion') && !isValidId(c.id)) {
+      warnings.push(`${c.kind} id violates the ID grammar (IDS §1): ${c.id}`);
+    }
+    if (c.kind === 'relation') {
+      if (!isValidId(c.from)) warnings.push(`relation "from" violates the ID grammar (IDS §1): ${c.from}`);
+      if (!isValidId(c.to)) warnings.push(`relation "to" violates the ID grammar (IDS §1): ${c.to}`);
+    }
+  }
+  return warnings;
+}
+
 function candidateFilename(c, index) {
   if ((c.kind === 'element' || c.kind === 'assertion') && c.id) return `${safeName(c.id)}.json`;
   if (c.kind === 'relation') return `REL_${safeName(c.rel_kind)}__${safeName(c.from)}__${safeName(c.to)}.json`;
@@ -136,6 +156,7 @@ export async function emitCandidates({ orgRoot, fieldArtefactPath, resultPath, c
   catch (err) { throw new Error(`could not read extraction result ${resultPath}: ${err.message}`); }
 
   const { candidates, suggestions } = shapeCandidates(derivedFrom, result);
+  const warnings = collectIdWarnings(candidates);
 
   const dir = candidatesDir || join(resolve(orgRoot), '_intake', 'processing', 'candidates');
   await mkdir(dir, { recursive: true });
@@ -156,7 +177,7 @@ export async function emitCandidates({ orgRoot, fieldArtefactPath, resultPath, c
   const suggPath = join(resolve(orgRoot), '_intake', 'processing', 'relation-suggestions.json');
   await writeFile(suggPath, JSON.stringify(suggestions, null, 2) + '\n', 'utf8');
 
-  return { derivedFrom, dir, candidates, suggestions, suggPath };
+  return { derivedFrom, dir, candidates, suggestions, suggPath, warnings };
 }
 
 export { REL_THRESHOLD };

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -902,6 +902,56 @@ def part_l_repo_check():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part M — F14 ID-grammar: emit-time surfacing + date-stamp middles ─
+
+def part_m_id_grammar():
+    """F14: emit-candidates surfaces an ID-grammar violation at emit time; a zero-padded
+    ISO-date MIDDLE segment is valid (the no-leading-zero ban is terminal-only)."""
+    if not shutil.which("node"):
+        print("SKIP Part M: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-f14-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+        fdir = os.path.join(org, "field", "interviews")
+        os.makedirs(fdir, exist_ok=True)
+        # The field id itself carries zero-padded ISO-date middles (04, 15) — must be valid.
+        fid = "INTERVIEW-ops-2026-04-15-1"
+        with open(os.path.join(fdir, fid + ".yaml"), "w", encoding="utf-8") as fh:
+            fh.write('id: "%s"\nname: "x"\ntype: "INTERVIEW"\nzone: "field"\nnotes: "x"\n' % fid)
+
+        res = os.path.join(work, "res.json")
+        with open(res, "w", encoding="utf-8") as fh:
+            json.dump({"elements": [
+                {"id": "GOAL-CHURN-001", "name": "bad", "element_type": "GOAL", "extraction_confidence": "high"},
+                {"id": "CHANGE-rollout-2026-04-15-1", "name": "ok", "element_type": "CHANGE", "extraction_confidence": "high"},
+            ], "relations": [], "assertions": []}, fh)
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        r = run_cli("emit-candidates", os.path.join(fdir, fid + ".yaml"), "--from", res, "--candidates-dir", cdir)
+        out = r.stdout + r.stderr
+        # F14(a): the terminal-leading-zero id is surfaced as a warning at emit time.
+        # (Assert without the section sign — Windows subprocess decoding mangles non-ASCII.)
+        check("WARNING" in out and "GOAL-CHURN-001" in out and "ID grammar" in out,
+              "F14(a): emit-candidates did not warn on the invalid id at emit time: %r" % out)
+        # F14(b): a zero-padded ISO-date MIDDLE segment is valid — never warned.
+        check("CHANGE-rollout-2026-04-15-1" not in out,
+              "F14(b): a zero-padded ISO-date MIDDLE segment must be valid, not warned: %r" % out)
+
+        # validate agrees: terminal-leading-zero flagged, date-stamped id is not a grammar violation.
+        r = run_cli("validate", cdir)
+        vout = r.stdout + r.stderr
+        check("violates the ID grammar: GOAL-CHURN-001" in vout,
+              "F14(a): validate did not flag the terminal-leading-zero id")
+        check("violates the ID grammar: CHANGE-rollout-2026-04-15-1" not in vout,
+              "F14(b): the date-stamped id must not be flagged for ID grammar")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
@@ -914,6 +964,7 @@ part_i_placement()
 part_j_duplicate_source()
 part_k_suggest_profile()
 part_l_repo_check()
+part_m_id_grammar()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
Resolves **F14** (ID-grammar enforcement on elements) in two parts.

## (b) Spec clarification — the leading-zero ban is terminal-only

Investigating F14(b) surfaced that forbidding leading zeros in **middle** segments would break the **date-stamped id convention**: ids like `INTERVIEW-cfo-onboarding-2026-04-15-1` carry zero-padded ISO-date components (`04`, `15`) and are used as canonical worked examples in `CONTRACT.md §6`, `ELEMENT_PRIMITIVES.md §3`, `acme_corp/field/`, and the onboard prompts. The `no-leading-zeros` rule is, correctly, about the **terminal** integer (the numeric sort key) — middle segments are labels.

`IDS_AND_REFERENCES.md §1` now states this explicitly (the *Middle segments* + *INTEGER* bullets, plus a valid date-stamp example row) so it isn't re-raised as a "bug". **No grammar/regex change** — the current `ID_RE` (terminal `-[1-9][0-9]*`) is already correct.

## (a) emit-time surfacing

`emit-candidates` previously shaped candidates without checking the grammar — a malformed id was only caught later at `validate`. It now checks element/assertion ids and relation endpoints and **WARNs** at emit time (one step earlier), **without dropping anything**: the candidate is still written, and `validate` / the human gate still flag it. New exported `collectIdWarnings()`; the CLI prints the warnings on stderr.

## Verification

- Integrity-test **Part M**: emit-candidates warns on a terminal-leading-zero id (`GOAL-CHURN-001`); a zero-padded ISO-date middle (`CHANGE-rollout-2026-04-15-1`) is accepted by both emit and validate.
- Full `test_ingest_integrity.py` → all checks pass.
- `node scripts/check-notations.mjs` → clean.

Open PR; do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)