### PR TITLE
docs(ingest-cli): add upgrade-reinstall caveat to SKILL.md Step 0 and CLI README

### DIFF
--- a/packages/ingest-cli/README.md
+++ b/packages/ingest-cli/README.md
@@ -32,6 +32,10 @@ transitrix-ingest <command> [args]
 | `resolve-placement <TYPE>` | ✅ | Print a TYPE's `ELEMENT_PRIMITIVES.md` §4 materialisation mode + layer + folder. |
 | `check-placement [org-root]` | ✅ | Flag admitted elements sitting outside their §4 folder (read-only over `canon/`). |
 
+## Upgrading
+
+After pulling a new methodology version, reinstall the CLI before running the pipeline. A cached or globally-installed binary from a prior release does not auto-update and may run stale validators, a stale profile resolver, or stale review-queue logic. Re-run your install command and verify `transitrix-ingest --version` reflects the new release.
+
 ## Layout
 
 ```

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -34,6 +34,8 @@ npx @transitrix/ingest-cli --version
 
 Also confirm you are operating inside a Transitrix adopter repository (a `transitrix.yaml` manifest at the repo root; see [MANIFEST](https://raw.githubusercontent.com/transitrix/methodology/main/notations/MANIFEST.md)). If there is no repo yet, the user wants `/transitrix:onboard` first.
 
+> **After a methodology upgrade** — reinstall the CLI before running the pipeline. A cached or globally-installed binary from a prior release does not auto-update; it may run against stale validators, a stale profile resolver, or stale `review-queue` logic. Re-run your install command and confirm the version above reflects the new release.
+
 ---
 
 ## Step 1 — Scaffold the intake folder


### PR DESCRIPTION
﻿After a methodology upgrade the installed CLI binary is stale until reinstalled. A cached or globally-installed binary from a prior release runs stale validators, a stale profile resolver, and stale review-queue logic (see PRs #144, #145 for concrete examples of silent-fallback fixes that required a reinstall to pick up).

## Changes

- **transitrix/skills/ingest/SKILL.md Step 0** -- adds a callout block after the presence-check bullets about reinstalling after an upgrade. This is where an operator looks first.

- **packages/ingest-cli/README.md** -- adds an Upgrading section stating the same caveat: reinstall and verify the version before re-running the pipeline.

No logic change; no schema change; doc-lint clean.

Open PR; do not merge -- Valerii gates.
