### PR TITLE
fix(ingest-cli): version-currency check in repo-check + adopter upgrade procedure (F11.2/F11.3)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,6 +33,37 @@ For every release, in order:
 
 ---
 
+## Adopter upgrade procedure
+
+When an adopter repo moves from one methodology version to another, **three artefacts must move together** — specs, skill bundle, and CLI — in this order:
+
+1. **Bump `methodology_version`** in the adopter's `transitrix.yaml` to the new version string.
+2. **Run the migration recipe** (MAJOR bump only) from `migrations/<prev>-to-<this>/` in this repo:
+   ```
+   node migrations/<prev>-to-<this>/codemod.mjs <adopter-root> --dry-run   # preview
+   node migrations/<prev>-to-<this>/codemod.mjs <adopter-root>              # apply
+   node migrations/<prev>-to-<this>/validate.mjs <adopter-root>             # post-check
+   ```
+3. **Re-validate canon** to confirm the migrated artefacts are still valid:
+   ```
+   npx @transitrix/ingest-cli validate <candidates-dir>
+   ```
+4. **Reinstall `@transitrix/ingest-cli`** — the installed binary does not auto-update; it remains pinned to the version it was installed from. Re-run your install command and confirm `--version` reflects the new release:
+   ```
+   npm install -g @transitrix/ingest-cli   # or npx/local install per your project setup
+   npx @transitrix/ingest-cli --version
+   ```
+5. **Run `repo-check`** to confirm version currency:
+   ```
+   npx @transitrix/ingest-cli repo-check [org-root]
+   ```
+   A clean run shows `tooling.ok: true` and no version-mismatch red flag. If `tooling.ok: false` still appears, the installed binary is still the old version — repeat step 4.
+6. **Re-resolve the coverage profile** (if the new release changed the preset vocabulary — see `COVERAGE_PROFILES.md` §7 for what changes between versions). Fix `transitrix.yaml` if needed, then re-run `repo-check` to clear any `coverage_warning`.
+
+Steps 1–3 handle the **spec and canon**; step 4 handles the **CLI**; steps 5–6 confirm the three artefacts are in sync. Skipping step 4 leaves the CLI binary stale — it will run against new artefacts with old validators and a mismatched coverage-preset vocabulary.
+
+---
+
 ## What this file does NOT cover
 
 - **Compatibility semantics** — what each bump promises adopters. See [`notations/CONTRACT.md`](notations/CONTRACT.md) §10.

--- a/docs/decisions/2026-06-10-tiered-approval-reviewer-authority.md
+++ b/docs/decisions/2026-06-10-tiered-approval-reviewer-authority.md
@@ -1,0 +1,291 @@
+---
+status: proposed
+date: 2026-06-10
+scope: repo
+supersedes: none
+superseded_by: none
+tags: [admission, tiered-approval, reviewer-authority, confidence, source-quality, extraction-confidence, ingest, ai-review]
+---
+
+# Tiered approval — reviewer-authority axis (AI-reviewed → expert-confirmed)
+
+## Context
+
+Today canon has **one human gate**. A harvest emits a draft as
+`admission_state: proposed`; a human reviewer admits it by setting
+`admission_state: active` and filling `admitted_by` with their handle
+(`notations/CONTRACT.md` §6.1). The model treats every reviewer as
+indistinguishable — the gate is on / off, and the only thing in the audit trail
+is *who* admitted. This works for tens of assertions; it does not scale to a
+real source.
+
+Surfaced 2026-06-09 dogfooding the ingest skill, **finding F19** in that pass.
+Data-free, within the Transitrix family. A single GDPR-sized source can yield
+hundreds of `REQUIREMENT` / `ASSERTION` candidates; expecting a domain expert
+to manually confirm each before any value can be drawn from the harvest stalls
+the pipeline at the gate. The ingest skill already separates two trust signals
+to avoid this very collapse:
+
+- **`source_quality`** — trust in the *source* (signed policy →
+  `authoritative`; meeting note → `single_source`). A closed ordinal label on
+  the field artefact's admission record (`CONTRACT.md` §§6, 11.2), authored at
+  entry, fixed once recorded.
+- **`extraction_confidence`** — "did the model read the document correctly".
+  A separate review flag on each candidate. Surfaces in the review queue and
+  is **never** folded into `source_quality`, **never** persisted into canon
+  (`CONTRACT.md` §11.8; `transitrix/skills/ingest/README.md`).
+
+The two axes are deliberately orthogonal: *who said it* vs *did the harvest
+read it right*. Neither captures a third dimension that the single human gate
+silently collapses today — *who confirmed it*. A draft confirmed by a domain
+expert and a draft confirmed by an AI reviewer end up indistinguishable as
+plain `admission_state: active`, with only the `admitted_by` handle to tell
+them apart by inspection. That collapse is the F19 finding: there is no
+machine-readable way to say "this is good enough for an AI to have ticked, not
+yet expert-confirmed", and so the only safe default is to keep everything
+behind the expert gate.
+
+The pre-admission machine already has the shape needed to receive a third axis
+without breaking the core invariant *"propose, never write canon"* — the
+`admission_state` enum is closed (CONTRACT §6.1, rule `ADMIT-001`), the
+admitted set already excludes proposed/rejected drafts from derived views
+(§6.1, "Exclusion from derived views"), and views already carry a
+`treat_proposed_as` switch (`hidden | shown-distinct`) used by the
+compliance-impact and coverage-metric notations (`notations/views/21-…`,
+`22-…`). A third axis that *grades reviewer authority* can be layered on this
+machine without redefining the existing two trust signals.
+
+Carried from the now-closed round-2 epic on ingest hardening; tightly coupled
+to the existing data-quality model in CONTRACT §11. The direction here gates
+whether the ingest skill can route the long tail of high-`extraction_confidence`
+drafts past the manual gate without violating the model.
+
+## Decision needed
+
+Define **the reviewer-authority axis** — its name, its states, where it lives
+on the admission record, how it composes with (and does not merge into)
+`source_quality` and `extraction_confidence`, and what it means for canon
+membership and view rendering. The framing question is whether to model the
+axis as a **new field** that grades the *authority* of the admitting reviewer,
+or as an **extension of the existing admission_state enum** that distinguishes
+provisional admission from expert admission. Three candidate shapes are on the
+table.
+
+### Option A — new field `reviewer_authority`, orthogonal to `admission_state`
+
+Add a third axis as a **first-class field** on the admission record,
+independent of `admission_state` and independent of the existing two trust
+signals.
+
+```yaml
+zone: canon
+admission_state: active                # proposed | active | rejected (unchanged)
+reviewer_authority: ai_reviewed        # ai_reviewed | expert_confirmed
+admitted_at: "2026-06-10"
+admitted_by: "ingest-reviewer-claude"  # the reviewer — tool ID for ai_reviewed,
+                                       # human handle for expert_confirmed
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+derived_from:
+  - REGULATION-GDPR-2016-1
+```
+
+- **States.** Closed set, ordinal: `ai_reviewed` < `expert_confirmed`. Absent ⇒
+  `expert_confirmed` (back-compat for existing human-authored canon — every
+  artefact admitted before this ADR is treated as expert-confirmed by
+  construction, no migration).
+- **What writes which.** `ai_reviewed` is written **only** by a tool acting as
+  reviewer (the ingest skill, an automated cross-check). `expert_confirmed` is
+  written **only** by a human reviewer. A human admitting a draft directly
+  sets `expert_confirmed`; a tool admitting a high-`extraction_confidence`
+  draft sets `ai_reviewed` and may **never** write `expert_confirmed`.
+- **Routing by `extraction_confidence`.** High `extraction_confidence` →
+  the ingest skill MAY auto-admit to `ai_reviewed` (provisional). Medium / low
+  `extraction_confidence` → routed to the expert review queue; tool admission
+  is forbidden. The threshold is configured per adopter (manifest).
+- **Composition with the other axes.** `reviewer_authority` is independent of
+  `source_quality` (an `authoritative` source can be `ai_reviewed`; an
+  `unverified` field artefact can be `expert_confirmed`) and independent of
+  `extraction_confidence` (which gates *eligibility* for `ai_reviewed`, not
+  the value itself). Never folded into the §11.4 element-confidence formula;
+  surfaced as a separate label.
+- **Canon membership.** Both `ai_reviewed` and `expert_confirmed` artefacts
+  are admitted canon (`admission_state: active`). The reviewer-authority axis
+  does **not** add a new exclusion from derived views.
+- **View rendering.** Views render `ai_reviewed` *distinct* from
+  `expert_confirmed` by convention. A new view switch
+  `treat_ai_reviewed_as: shown-distinct | shown-same | hidden` (default
+  `shown-distinct`) extends the existing `treat_proposed_as` switch on the
+  21-compliance-impact and 22-coverage-metric notations. Coverage metrics MAY
+  exclude `ai_reviewed` by configuration; by default they include both with
+  the reviewer-authority label surfaced.
+- **Weight in confidence scoring.** `reviewer_authority` does not enter the
+  §11.4 formula. The provisional-vs-confirmed distinction is rendered as a
+  qualitative label alongside the numeric confidence band, not multiplied
+  into it — keeping the existing two-signal model intact.
+
+### Option B — extend `admission_state` with a provisional state
+
+Add a fourth value to the existing enum:
+`proposed → admitted_provisional → active | rejected`, with
+`admitted_provisional` distinguishing AI-reviewed-but-not-expert-confirmed.
+
+```yaml
+admission_state: admitted_provisional   # proposed | admitted_provisional | active | rejected
+admitted_provisional_at: "2026-06-10"
+admitted_provisional_by: "ingest-reviewer-claude"   # tool ID — never a human
+# admitted_at / admitted_by remain absent until an expert confirms
+```
+
+- **States.** The pre-admission machine grows from three terminal states to
+  four: `proposed` (harvest), `admitted_provisional` (tool-confirmed),
+  `active` (expert-confirmed), `rejected`. `active` becomes "expert-confirmed
+  canon"; `admitted_provisional` is canon-shaped but tagged.
+- **Authority.** Encoded in the state itself — the field is the same field as
+  today; no new axis.
+- **Routing by `extraction_confidence`.** As in Option A — high confidence
+  may transition to `admitted_provisional` via tool; otherwise the draft sits
+  at `proposed` until an expert promotes it directly to `active`.
+- **Composition with the other axes.** No new field; the existing axes are
+  unchanged. The state collapses *gate progress* and *reviewer authority*
+  into one enum, which is the same simplification CONTRACT §6.1 explicitly
+  chose to **un-collapse** for `zone` vs `admission_state` (orthogonal axes).
+- **Canon membership.** `admitted_provisional` artefacts MAY be excluded from
+  derived views by configuration. The existing `treat_proposed_as` switch on
+  views generalises to `treat_provisional_as` (or grows to a small enum).
+- **Validation rules.** `ADMIT-001` is extended; new `ADMIT-006`-class rules
+  govern transitions out of `admitted_provisional`. The rule that
+  `admission_state: active` requires complete `gate_checks` + `admitted_by`
+  is unchanged; `admitted_provisional` requires the provisional-pair fields
+  and bans the active-pair fields, mirroring §6.1's `ADMIT-002` shape.
+
+### Option C — keep the single gate; surface authority via `admitted_by` prefix
+
+No new axis, no new state. Distinguish AI from expert review by an enforced
+**naming convention on `admitted_by`** — a prefix that marks the admitter as
+a tool, paired with a validation rule that flags any catalogue scan over
+`admitted_by` values not matching either an `agent:` or `human:` prefix.
+
+- **Authority.** Read from the `admitted_by` string itself
+  (`agent:ingest-reviewer-claude` vs `human:v.korobeinikov`).
+- **Composition with the other axes.** Nothing changes on the model.
+- **Canon membership.** Every admitted artefact is canon, indistinguishable
+  for view rendering. Downstream analysis MAY filter by prefix, but the model
+  carries no first-class signal.
+- **Routing.** Cannot be enforced by the model — the ingest skill decides
+  whether to admit at `agent:` authority without canon flagging it.
+- **Cost.** Smallest spec churn (a string-format rule), but the *purpose* of
+  the F19 finding — a machine-readable reviewer-authority signal that can
+  drive view rendering, coverage metrics, and downstream tooling — is
+  satisfied only by string-parsing, which the rest of the model has
+  deliberately avoided (`CONTRACT.md` §§2, 3).
+
+## Alternatives considered
+
+- **A — new `reviewer_authority` field.** Above. Keeps the existing trust
+  signals (`source_quality`, `extraction_confidence`) and the existing
+  admission machine untouched; adds one orthogonal axis. Mirrors the §6.1
+  pattern that resisted collapsing orthogonal axes into one enum (zone vs
+  admission_state). Costs one new field on the admission record and one new
+  view-rendering switch.
+- **B — extend `admission_state` with `admitted_provisional`.** Above. No
+  new field, but collapses *reviewer authority* into *gate progress* — the
+  same collapse §6.1 explicitly avoided for zone vs state. Heavier change to
+  the validation rules (`ADMIT-001`, `ADMIT-003`) and the state machine
+  diagram.
+- **C — convention on `admitted_by`.** Above. Smallest spec change; carries
+  no first-class signal; requires every downstream consumer to string-parse
+  the field. Recorded to mark the floor of the design space.
+- **D — fold reviewer authority into `source_quality`.** Rejected in framing.
+  `source_quality` is trust in the **source**, not in the reviewer. Folding
+  reviewer authority in would corrupt the §11.2 semantics — an
+  `expert_confirmed` `single_source` is not the same as a `corroborated`
+  source, and the §11.4 element-confidence formula uses
+  `max(source_quality.weight)` precisely on the *source* axis.
+- **E — multiply reviewer authority into the §11.4 element confidence.**
+  Rejected. The two existing signals (source trust, freshness) are
+  *properties of the statement*; reviewer authority is a *property of the
+  review*. The CONTRACT §11.1 frame — *"two independent signals, deliberately
+  separate"* — applies recursively: collapsing them into one decaying number
+  erases each. Reviewer authority is surfaced as a label alongside the band,
+  not multiplied into it.
+- **F — keep the status quo (one human gate).** Rejected as the framing
+  premise. F19 is precisely this gap: the long tail of
+  high-`extraction_confidence` drafts cannot pass the gate at expert pace, so
+  the gate either bottlenecks the pipeline or silently lowers its bar.
+
+## Consequences
+
+The consequences below are common to all live options; items marked
+*(direction-specific)* resolve only once Valerii picks A, B, or C.
+
+- **Core invariant preserved.** *(both)* "Propose, never write canon"
+  (CONTRACT §6.1) is unchanged — a tool never writes `expert_confirmed`
+  (Option A) or `active` (Option B); it can only mark the lower tier and
+  route the draft. The human gate retains exclusive authority to promote to
+  the top tier.
+- **No change to `source_quality` or `extraction_confidence`.** *(both)* The
+  two axes stay orthogonal to each other and to the new signal. The
+  data-quality model in CONTRACT §11 is unchanged; nothing folds into §11.4.
+- **Routing rule lands in the ingest skill.** *(both)* The mapping
+  high-`extraction_confidence` → tool-admit-to-lower-tier, medium/low →
+  expert queue, is a skill-level rule and belongs in
+  `transitrix/skills/ingest/SKILL.md` (or its README), not in the CONTRACT.
+  The CONTRACT defines the states; the skill defines the routing.
+- **Admission record growth.** *(direction-specific)*
+  - **A** adds one field (`reviewer_authority`) plus a back-compat default
+    (`absent ⇒ expert_confirmed`). Schema additive; existing canon untouched.
+  - **B** extends the enum, adds two new fields (`admitted_provisional_at`,
+    `admitted_provisional_by`), and updates the state-machine diagram.
+    Existing canon (no provisional state) is unaffected; the change is
+    additive.
+  - **C** adds a string-format rule on `admitted_by`. Existing canon may
+    need a one-time backfill to add the `human:` prefix.
+- **View rendering.** *(direction-specific)*
+  - **A** adds a new view switch
+    (`treat_ai_reviewed_as: shown-distinct | shown-same | hidden`) on the
+    21-compliance-impact and 22-coverage-metric notations, mirroring the
+    existing `treat_proposed_as` switch (CONTRACT §6.1, ASSERTION §2.2).
+    Default `shown-distinct`.
+  - **B** generalises `treat_proposed_as` to cover the new
+    `admitted_provisional` state — either by widening the enum on that
+    switch or by adding a parallel `treat_provisional_as` switch.
+  - **C** carries no view signal — string-parsing in the renderer.
+- **Validation rules.** *(direction-specific)*
+  - **A** adds rules along the shape of §6.1: `ADMIT-006` (closed enum on
+    `reviewer_authority`), `ADMIT-007` (`reviewer_authority: ai_reviewed`
+    requires `admitted_by` to identify a tool, not a human; vice versa for
+    `expert_confirmed`). The existing `ADMIT-001..005` are unchanged.
+  - **B** extends `ADMIT-001` (closed enum grows), adds `ADMIT-006`
+    (provisional-pair fields required when state is provisional), and
+    `ADMIT-007` (no expert-only fields in provisional state). The
+    cross-cutting `ADMIT-005` (no active dependency on un-admitted)
+    generalises to "no `expert_confirmed`/`active` dependency on lower-tier"
+    if the family wants to forbid expert-confirmed canon depending on
+    AI-reviewed canon.
+  - **C** adds one format rule on `admitted_by`.
+- **Cross-cutting dependency rule.** *(direction-specific, common to A and B)*
+  The §6.1 rule `ADMIT-005` — *"an `active` artefact MUST NOT depend on a
+  `proposed` one"* — has a parallel question for the new tier: MAY an
+  expert-confirmed artefact depend on an AI-reviewed one? The ADR's chosen
+  direction must state this — either permitting it (the lower tier is canon,
+  so dependencies are allowed) or forbidding it by `ADMIT-005`-extension
+  (expert-confirmed canon must depend only on expert-confirmed canon). This
+  is a real cross-cutting cost worth stating up front.
+- **Coverage metrics.** *(both)* The 22-coverage-metric notation's
+  `view.coverage_rule.treat_proposed_as` switch already lets adopters choose
+  whether unadmitted drafts contribute to coverage. The new signal extends
+  that choice — adopters should be able to count `ai_reviewed` as covered,
+  shown-distinct, or excluded. Default behaviour and the per-adopter
+  override are part of the direction.
+- **Migration.** *(both)* Additive — existing canon stays valid. Existing
+  human-admitted artefacts are treated as the top tier by default (either
+  `reviewer_authority` absent ⇒ `expert_confirmed` under A, or
+  `admission_state: active` unchanged under B). No file rewrite required.
+- This is a notation/schema decision, so **once the direction is set this ADR
+  becomes the decision record** and implementation lands as PRs (one concern
+  each): CONTRACT §6.1 update → CONTRACT §11 wording (clarify non-fold) →
+  view-rendering switch on 21 / 22 → ingest skill routing rule. Until then,
+  no canon/spec edits.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -11,5 +11,6 @@ implementation PRs follow) · **Superseded** (replaced by a later ADR).
 
 | Date | Decision | Status | Scope |
 |---|---|---|---|
+| 2026-06-10 | [Tiered approval — reviewer-authority axis (AI-reviewed → expert-confirmed)](2026-06-10-tiered-approval-reviewer-authority.md) | Proposed | repo |
 | 2026-06-09 | [Canonical home for element aliases / alternative names](2026-06-09-element-aliases.md) | Proposed | repo |
 | 2026-06-08 | [EQUIPMENT and BUSINESS_OBJECT become first-class catalogued elements](2026-06-08-equipment-catalogued-element.md) | Accepted | repo |

--- a/packages/ingest-cli/src/repo-check.mjs
+++ b/packages/ingest-cli/src/repo-check.mjs
@@ -82,16 +82,23 @@ export async function repoCheck(orgRoot) {
 
   const placement = await checkCanonPlacement(root);
 
+  const declaredVersion = manifestText ? (readTopScalar(manifestText, 'methodology_version') || null) : null;
+  // Version-currency check (F11.2): flag when the CLI's built-in presets were built for a
+  // different methodology version than the one declared in transitrix.yaml. A mismatch means
+  // the CLI binary is stale and needs to be reinstalled after a methodology upgrade.
+  const versionMatch = !declaredVersion || declaredVersion === PRESETS_VERSION;
+
   const red_flags = [];
   if (totalInvalid > 0) red_flags.push(`${totalInvalid} artefact(s) with an id that violates the canonical grammar (IDS_AND_REFERENCES §1)`);
   if (placement.findings.length > 0) red_flags.push(`${placement.findings.length} canon element(s) outside their ELEMENT_PRIMITIVES §4 folder`);
   if (profile.unresolved) red_flags.push('coverage_profile is present but could not be resolved — coverage flags are not authoritative');
   if (!manifestText) red_flags.push('no transitrix.yaml manifest at the repo root — not a recognised adopter repo');
+  if (!versionMatch) red_flags.push(`methodology_version in transitrix.yaml (${declaredVersion}) does not match the CLI built-in presets version (${PRESETS_VERSION}) — reinstall @transitrix/ingest-cli after a methodology upgrade`);
 
   return {
     generated_by: '@transitrix/ingest-cli',
     manifest_present: Boolean(manifestText),
-    methodology_version: manifestText ? (readTopScalar(manifestText, 'methodology_version') || null) : null,
+    methodology_version: declaredVersion,
     coverage_profile: profile.display,
     ...(profile.warning ? { coverage_warning: profile.warning } : {}),
     zones,
@@ -104,7 +111,8 @@ export async function repoCheck(orgRoot) {
     },
     tooling: {
       cli_presets_version: PRESETS_VERSION,
-      ok: true,
+      methodology_version_match: versionMatch,
+      ok: versionMatch,
     },
     note: 'Data-free — aggregate counts and statuses only; no object ids, names, or contents. Safe to share externally. Read-only: repo-check never writes a zone.',
   };

--- a/transitrix/skills/repo-check/SKILL.md
+++ b/transitrix/skills/repo-check/SKILL.md
@@ -47,7 +47,7 @@ It prints a YAML report to stdout:
 - `zones` — for each of `canon` / `field` / `codex`: whether present, file count, and a per-**TYPE** count (TYPE vocabulary only — the prefix of a grammar-valid id; a malformed id is counted under `invalid_ids`, never by name).
 - `adoption_level` — a coarse indicator derived from how populated `canon` is (`empty` → `seeded` → `in use` → `established`).
 - `integrity` — `invalid_ids`, `misplaced_canon_elements` (elements outside their `ELEMENT_PRIMITIVES` §4 folder), `canon_elements_scanned`, and a `red_flags` list of short status strings.
-- `tooling` — the CLI's pinned presets version.
+- `tooling` — `cli_presets_version` (the methodology version the CLI's built-in presets target), `methodology_version_match` (whether that matches the version declared in `transitrix.yaml`), and `ok` (`false` when there is a version mismatch).
 
 ---
 
@@ -58,5 +58,6 @@ Summarise the `adoption_level` and any `red_flags` for the user in plain languag
 - invalid IDs → fix the offending ids by hand (the report does not name them — by design; locate them with the validators or `git grep` locally).
 - misplaced canon elements → `npx @transitrix/ingest-cli check-placement [org-root]` lists them locally (that command **does** name ids — keep its output local, it is not the data-free report).
 - unresolved `coverage_profile` → fix `transitrix.yaml` per `COVERAGE_PROFILES.md` (CP-001).
+- `tooling.ok: false` / version mismatch → the installed CLI binary targets a different methodology version than `transitrix.yaml` declares. Reinstall the CLI (see the adopter upgrade procedure in `RELEASING.md`) and re-run `repo-check` to confirm the flag clears.
 
 Nothing here mutates the repo; re-running is always safe and gives the same answer for the same tree.


### PR DESCRIPTION
﻿## What

Addresses F11.2 and F11.3 from the ingest dogfooding (scope addition to epic #78 — see epic comments):

### F11.2 — Version-currency check in `repo-check`

`packages/ingest-cli/src/repo-check.mjs`: compares the `methodology_version` declared in `transitrix.yaml` against the CLI's built-in `PRESETS_VERSION`. When they differ:
- a human-readable entry is appended to `integrity.red_flags`
- `tooling.methodology_version_match: false` is set
- `tooling.ok: false` is set

No false positive on a fresh repo with no `transitrix.yaml` (`declaredVersion` null → match = true).

### F11.3 — Adopter upgrade procedure in `RELEASING.md`

New *Adopter upgrade procedure* section documenting the **3-artifact version-lock** (specs + skill bundle + CLI). Six ordered steps: bump `methodology_version`, run migration recipe (MAJOR only), re-validate canon, reinstall CLI, run `repo-check` to confirm `tooling.ok`, re-resolve coverage profile.

### `SKILL.md` (repo-check)

Updated `tooling` field description + added a version-mismatch repair instruction to Step 2.

## Scope

3 files: `RELEASING.md`, `packages/ingest-cli/src/repo-check.mjs`, `transitrix/skills/repo-check/SKILL.md`. No canon/spec edits.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean
- [x] File tails re-read; both changed files end correctly
- [ ] Manual: run `repo-check` on a repo with mismatched `methodology_version` — `tooling.ok` should be `false` and the red flag should appear