### PR TITLE
docs: accept tiered-approval and codex-registry ADRs

### DIFF
--- a/docs/decisions/2026-06-10-codex-registry-monitoring-source-of-truth.md
+++ b/docs/decisions/2026-06-10-codex-registry-monitoring-source-of-truth.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-06-10
 scope: repo
 supersedes: none
@@ -162,6 +162,10 @@ that flags disagreement.
   premise. Recorded only to make the cost of inaction explicit: every row /
   artefact pair can drift, and "what do we monitor?" stays a question with
   two answers.
+
+## Decision record
+
+- **Option A chosen — Valerii, 2026-06-10.** Split by lifecycle stage: REGISTRY owns curated source list and harvesting prioritisation; codex artefact owns monitoring of the already-ingested source (its `scan` block, its `source_url` as the authoritative watch target). A REGISTRY row adds a `codex_id` link once the source is admitted; scan state defers to the codex `scan` block from that point. A validator gate flags rows where the row's `source_url` disagrees with the linked codex artefact's `source_url`.
 
 ## Consequences
 

--- a/docs/decisions/2026-06-10-tiered-approval-reviewer-authority.md
+++ b/docs/decisions/2026-06-10-tiered-approval-reviewer-authority.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-06-10
 scope: repo
 supersedes: none
@@ -215,6 +215,11 @@ a tool, paired with a validation rule that flags any catalogue scan over
   premise. F19 is precisely this gap: the long tail of
   high-`extraction_confidence` drafts cannot pass the gate at expert pace, so
   the gate either bottlenecks the pipeline or silently lowers its bar.
+
+## Decision record
+
+- **Option A chosen — Valerii, 2026-06-10.** New field `reviewer_authority: ai_reviewed | expert_confirmed` on the admission record, orthogonal to `admission_state` and to the existing two trust signals (`source_quality`, `extraction_confidence`). Both tiers are `admission_state: active` (both are canon). Absent field ⇒ `expert_confirmed` (back-compat; no migration needed).
+- **Cross-cutting dependency rule — Valerii, 2026-06-10.** An `expert_confirmed` artefact MAY depend on an `ai_reviewed` artefact. The lower tier is canon; the dependency is allowed. Views surface the **weakest-link** authority level of the full dependency chain (the chain's displayed reviewer authority = minimum of all nodes in the chain). No `ADMIT-005`-extension to forbid cross-tier dependencies.
 
 ## Consequences
 


### PR DESCRIPTION
Updates `status: proposed → accepted` and adds `## Decision record` sections to both ADRs decided 2026-06-10:

- `2026-06-10-tiered-approval-reviewer-authority.md` — Option A chosen: new `reviewer_authority: ai_reviewed | expert_confirmed` field; cross-tier dependencies allowed; weakest-link display rule.
- `2026-06-10-codex-registry-monitoring-source-of-truth.md` — Option A chosen: lifecycle split; REGISTRY owns pre-admission prioritisation; codex `scan` block owns post-admission state; `codex_id` link + REG-001 validator gate.

Implementation tasks: HUB-179 (tiered-approval) and HUB-180 (codex-registry).