### PR TITLE
feat(acme_corp): add EU compliance corpus (GDPR + NIS2)

### DIFF
--- a/organizations/acme_corp/canon/assertions/ASSERTION-ECOMM-GDPR-CONSENT-1.yaml
+++ b/organizations/acme_corp/canon/assertions/ASSERTION-ECOMM-GDPR-CONSENT-1.yaml
@@ -1,0 +1,40 @@
+# Assertion — GDPR consent × E-Commerce Platform.
+# Schema: notations/elements/16-assertion.md §2.
+# Demo note: partial — demonstrates partial card and upcoming deadline.
+
+notation: assertion
+id: ASSERTION-ECOMM-GDPR-CONSENT-1
+about: REQUIREMENT-GDPR-CONSENT-1
+subject: PRODUCT-ECOMM-1
+
+realised_via:
+  - STAGE-1    # Receive order — consent captured at checkout
+
+status: partial
+
+evidence:
+  - kind: note
+    text: >
+      Consent capture at checkout is fully compliant — checkboxes are
+      unchecked by default and consent text is specific and layered.
+      PARTIAL GAP: one-click withdrawal is not yet available in account
+      settings UI; users must submit a support request to withdraw
+      marketing consent. Remediation tracked in UI sprint Q3 2026.
+      Deadline: 2026-09-30.
+
+assessed_at: "2026-05-20"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-08-01"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-20"
+valid_to: null

--- a/organizations/acme_corp/canon/assertions/ASSERTION-ECOMM-GDPR-ERASURE-1.yaml
+++ b/organizations/acme_corp/canon/assertions/ASSERTION-ECOMM-GDPR-ERASURE-1.yaml
@@ -1,0 +1,41 @@
+# Assertion — GDPR erasure × E-Commerce Platform.
+# Schema: notations/elements/16-assertion.md §2.
+# Demo note: non_compliant — demonstrates gap card in compliance matrix.
+
+notation: assertion
+id: ASSERTION-ECOMM-GDPR-ERASURE-1
+about: REQUIREMENT-GDPR-DATA-ERASURE-1
+subject: PRODUCT-ECOMM-1
+
+realised_via:
+  - STAGE-1    # Receive order — personal data captured
+  - STAGE-3    # Pick & pack — personal data read from CRM
+  - STAGE-4    # Ship — personal data transmitted to carrier
+
+status: non_compliant
+
+evidence:
+  - kind: note
+    text: >
+      Erasure requests are processed in the active-order database and CRM
+      within the 30-day window. KNOWN GAP: the order-history archive
+      (cold storage, 7-year fiscal retention) is not covered by the erasure
+      pipeline. Remediation target Q3 2026 — overdue since Q1 2026.
+      Supervisor pre-audit commitment flag active.
+
+assessed_at: "2026-05-15"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-07-15"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-15"
+valid_to: null

--- a/organizations/acme_corp/canon/assertions/ASSERTION-ECOMM-GDPR-PORTABILITY-1.yaml
+++ b/organizations/acme_corp/canon/assertions/ASSERTION-ECOMM-GDPR-PORTABILITY-1.yaml
@@ -1,0 +1,38 @@
+# Assertion — GDPR portability × E-Commerce Platform.
+# Schema: notations/elements/16-assertion.md §2.
+# Demo note: compliant — demonstrates a green cell in the matrix.
+
+notation: assertion
+id: ASSERTION-ECOMM-GDPR-PORTABILITY-1
+about: REQUIREMENT-GDPR-PORTABILITY-1
+subject: PRODUCT-ECOMM-1
+
+realised_via:
+  - STAGE-5    # Confirm delivery & close — export available post-order
+
+status: compliant
+
+evidence:
+  - kind: note
+    text: >
+      Self-service data export is available in account settings. Export
+      covers order history, personal profile, and consent records in JSON
+      and CSV formats. Delivered within 72 h of request; 30-day deadline
+      met consistently. Verified in Q1 2026 internal audit — no exceptions.
+
+assessed_at: "2026-05-20"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-11-01"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-20"
+valid_to: null

--- a/organizations/acme_corp/canon/assertions/ASSERTION-ECOMM-NIS2-INCIDENT-1.yaml
+++ b/organizations/acme_corp/canon/assertions/ASSERTION-ECOMM-NIS2-INCIDENT-1.yaml
@@ -1,0 +1,40 @@
+# Assertion — NIS2 incident notification × E-Commerce Platform.
+# Schema: notations/elements/16-assertion.md §2.
+# Demo note: under_review — demonstrates the fourth status state.
+
+notation: assertion
+id: ASSERTION-ECOMM-NIS2-INCIDENT-1
+about: REQUIREMENT-NIS2-INCIDENT-1
+subject: PRODUCT-ECOMM-1
+
+realised_via:
+  - STAGE-1    # Receive order — customer data ingestion point
+  - STAGE-4    # Ship — carrier handover; data-in-transit exposure window
+
+status: under_review
+
+evidence:
+  - kind: note
+    text: >
+      Incident response runbook drafted and approved by security team.
+      UNDER REVIEW: the 24-hour notification procedure has not yet been
+      tested in a tabletop exercise; competent authority contact list
+      verification in progress. Re-assessment scheduled after Q3 drill.
+      NIS2 transposition deadline: 2026-09-01.
+
+assessed_at: "2026-06-01"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-09-15"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-06-01"
+valid_to: null

--- a/organizations/acme_corp/canon/assertions/ASSERTION-SUPPORT-GDPR-ERASURE-1.yaml
+++ b/organizations/acme_corp/canon/assertions/ASSERTION-SUPPORT-GDPR-ERASURE-1.yaml
@@ -1,0 +1,37 @@
+# Assertion — GDPR erasure × Customer Support Service.
+# Schema: notations/elements/16-assertion.md §2.
+# Demo note: compliant — shows the same requirement across two products.
+
+notation: assertion
+id: ASSERTION-SUPPORT-GDPR-ERASURE-1
+about: REQUIREMENT-GDPR-DATA-ERASURE-1
+subject: PRODUCT-SUPPORT-1
+
+realised_via: []
+
+status: compliant
+
+evidence:
+  - kind: note
+    text: >
+      Customer Support Service holds only ticketing data linked to the CRM.
+      Erasure requests trigger a CRM cascade that clears all associated
+      support tickets, chat logs, and email threads within the 30-day window.
+      Verified in Q1 2026 internal audit — no exceptions found.
+
+assessed_at: "2026-04-10"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-10-01"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-04-10"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-GDPR-CONSENT-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-GDPR-CONSENT-1.yaml
@@ -1,0 +1,26 @@
+# Requirement — GDPR consent. Schema: notations/ELEMENT_PRIMITIVES.md §7.2.
+
+notation: requirement
+id: REQUIREMENT-GDPR-CONSENT-1
+name: "Freely given, specific consent — one-click withdrawal (GDPR Art. 7)"
+description: >
+  Consent must be freely given, specific, informed, and unambiguous. Withdrawal
+  must be as easy as giving consent — a single click or equivalent mechanism,
+  available at any time without detriment.
+severity: high
+derived_from:
+  - LAW-GDPR-1
+deadline: "2026-09-30"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2018-05-25"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-GDPR-DATA-ERASURE-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-GDPR-DATA-ERASURE-1.yaml
@@ -1,0 +1,26 @@
+# Requirement — GDPR right to erasure. Schema: notations/ELEMENT_PRIMITIVES.md §7.2.
+
+notation: requirement
+id: REQUIREMENT-GDPR-DATA-ERASURE-1
+name: "Right to erasure — respond within 30 days (GDPR Art. 17)"
+description: >
+  On a verified request from a data subject, the controller must erase all
+  personal data relating to that subject within 30 calendar days. Applies to
+  every system holding personal data of EU residents.
+severity: high
+derived_from:
+  - LAW-GDPR-1
+deadline: "2025-12-31"   # past due — supervisory authority pre-audit commitment
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2018-05-25"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-GDPR-PORTABILITY-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-GDPR-PORTABILITY-1.yaml
@@ -1,0 +1,25 @@
+# Requirement — GDPR data portability. Schema: notations/ELEMENT_PRIMITIVES.md §7.2.
+
+notation: requirement
+id: REQUIREMENT-GDPR-PORTABILITY-1
+name: "Data portability — machine-readable export on request (GDPR Art. 20)"
+description: >
+  The data subject has the right to receive their personal data in a structured,
+  commonly used, machine-readable format and to transmit it to another
+  controller without hindrance.
+severity: medium
+derived_from:
+  - LAW-GDPR-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2018-05-25"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-NIS2-INCIDENT-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-NIS2-INCIDENT-1.yaml
@@ -1,0 +1,26 @@
+# Requirement — NIS2 incident notification. Schema: notations/ELEMENT_PRIMITIVES.md §7.2.
+
+notation: requirement
+id: REQUIREMENT-NIS2-INCIDENT-1
+name: "Significant incident notification within 24 h (NIS2 Art. 23)"
+description: >
+  Entities in scope must notify the competent authority of any significant
+  cybersecurity incident within 24 hours of becoming aware of it, with a
+  follow-up report within 72 hours.
+severity: high
+derived_from:
+  - LAW-NIS2-1
+deadline: "2026-09-01"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2023-01-16"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-NIS2-SUPPLY-CHAIN-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/requirements/REQUIREMENT-NIS2-SUPPLY-CHAIN-1.yaml
@@ -1,0 +1,25 @@
+# Requirement — NIS2 supply chain. Schema: notations/ELEMENT_PRIMITIVES.md §7.2.
+
+notation: requirement
+id: REQUIREMENT-NIS2-SUPPLY-CHAIN-1
+name: "Supply-chain cybersecurity risk management (NIS2 Art. 21)"
+description: >
+  Essential and important entities must address risks in supply chains by
+  assessing cybersecurity practices of direct suppliers and service providers,
+  and including contractual security requirements.
+severity: medium
+derived_from:
+  - LAW-NIS2-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2023-01-16"
+valid_to: null

--- a/organizations/acme_corp/canon/views/eu-compliance.compliance-impact.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/eu-compliance.compliance-impact.transitrix.yaml
@@ -1,0 +1,28 @@
+# Compliance-impact view — acme_corp EU (GDPR + NIS2).
+# Opens in Transitrix Studio; notation spec: notations/views/21-compliance-impact.md.
+
+notation: compliance-impact
+spec_version: "0.1"
+
+view:
+  id: COMPLIANCE_IMPACT-ACME-EU-1
+  name: "acme_corp — EU Compliance Impact (GDPR + NIS2)"
+  description: >
+    Obligation × product matrix scoped to the EU jurisdiction (GDPR and NIS2).
+    Shows which regulatory requirements bind each product and the current
+    compliance status. Gaps (no assertion) appear as empty cells.
+    Deadline decorations indicate overdue or imminent remediation targets.
+  snapshot_at: "2026-06-10"
+
+  subjects:
+    products:
+      - PRODUCT-ECOMM-1
+      - PRODUCT-SUPPORT-1
+
+  obligations:
+    filter:
+      derived_from_codex:
+        - LAW-GDPR-1
+        - LAW-NIS2-1
+
+  order_rows_by: id

--- a/organizations/acme_corp/canon/views/eu-coverage.coverage-metric.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/eu-coverage.coverage-metric.transitrix.yaml
@@ -1,0 +1,33 @@
+# Coverage-metric view — acme_corp EU (GDPR + NIS2).
+# Opens in Transitrix Studio; notation spec: notations/views/22-coverage-metric.md.
+
+notation: coverage-metric
+spec_version: "0.1"
+
+coverage_metric:
+  id: COVERAGE_METRIC-ACME-EU-1
+  name: "acme_corp — EU Coverage Metric (GDPR + NIS2)"
+  description: >
+    Measures assertion coverage per law for acme_corp EU compliance.
+    Groups requirements by their source codex and shows the proportion
+    that are compliant, partial, under review, non-compliant, or gap
+    (no assertion filed).
+  date: "2026-06-10"
+  version: "0.1"
+  author: "v.korobeinikov"
+
+  scope:
+    jurisdictions:
+      - eu
+    codex:
+      - LAW-GDPR-1
+      - LAW-NIS2-1
+    subjects:
+      products:
+        - PRODUCT-ECOMM-1
+        - PRODUCT-SUPPORT-1
+
+  thresholds:
+    green: 0.80
+    amber: 0.50
+    red: 0.00

--- a/organizations/acme_corp/codex/external/eu/LAW-GDPR-1.yaml
+++ b/organizations/acme_corp/codex/external/eu/LAW-GDPR-1.yaml
@@ -1,0 +1,29 @@
+# Codex entry — EU law. Schema: notations/CONTRACT.md §6 + notations/elements/14-codex.md.
+
+notation: codex
+id: LAW-GDPR-1
+name: "General Data Protection Regulation (EU) 2016/679"
+type: REGULATION
+description: >
+  EU regulation on data protection and privacy for individuals within the EU
+  and the European Economic Area. Sets out requirements for obtaining consent,
+  handling personal data, responding to data-subject rights requests, and
+  notifying supervisory authorities of breaches.
+jurisdiction: eu
+effective_date: "2018-05-25"
+source_url: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679"
+monitoring_needed: true
+scan_frequency: quarterly
+
+# Admission record (CONTRACT.md §6)
+zone: codex
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2018-05-25"
+valid_to: null

--- a/organizations/acme_corp/codex/external/eu/LAW-NIS2-1.yaml
+++ b/organizations/acme_corp/codex/external/eu/LAW-NIS2-1.yaml
@@ -1,0 +1,30 @@
+# Codex entry — EU directive. Schema: notations/CONTRACT.md §6 + notations/elements/14-codex.md.
+
+notation: codex
+id: LAW-NIS2-1
+name: "NIS2 Directive (EU) 2022/2555"
+type: DIRECTIVE
+description: >
+  EU directive on measures for a high common level of cybersecurity across the
+  Union. Requires essential and important entities to adopt risk-management
+  measures, report significant incidents within 24 hours, and address
+  supply-chain cybersecurity risks.
+jurisdiction: eu
+effective_date: "2023-01-16"
+transposition_deadline: "2024-10-17"
+source_url: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32022L2555"
+monitoring_needed: true
+scan_frequency: quarterly
+
+# Admission record (CONTRACT.md §6)
+zone: codex
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2023-01-16"
+valid_to: null


### PR DESCRIPTION
## What

Adds a coherent, end-to-end EU compliance demo scenario to the `acme_corp` example organisation.  All IDs align with existing acme_corp elements (`PRODUCT-ECOMM-1`, `PRODUCT-SUPPORT-1`, `ROLE-DPO-1`).

### Files added

**Codex** (`codex/external/eu/`)
- `LAW-GDPR-1.yaml` — GDPR (Regulation 2016/679)
- `LAW-NIS2-1.yaml` — NIS2 Directive (2022/2555)

**Requirements** (`canon/elements/01_motivation/requirements/`)
- `REQUIREMENT-GDPR-DATA-ERASURE-1.yaml` — severity high, past-due deadline
- `REQUIREMENT-GDPR-CONSENT-1.yaml` — severity high, upcoming deadline
- `REQUIREMENT-GDPR-PORTABILITY-1.yaml` — severity medium
- `REQUIREMENT-NIS2-INCIDENT-1.yaml` — severity high, upcoming deadline
- `REQUIREMENT-NIS2-SUPPLY-CHAIN-1.yaml` — severity medium

**Assertions** (`canon/assertions/`)
- `ASSERTION-ECOMM-GDPR-ERASURE-1.yaml` — `non_compliant`, `realised_via` STAGE-1/3/4
- `ASSERTION-ECOMM-GDPR-CONSENT-1.yaml` — `partial`, `realised_via` STAGE-1
- `ASSERTION-ECOMM-GDPR-PORTABILITY-1.yaml` — `compliant`, `realised_via` STAGE-5
- `ASSERTION-ECOMM-NIS2-INCIDENT-1.yaml` — `under_review`, `realised_via` STAGE-1/4
- `ASSERTION-SUPPORT-GDPR-ERASURE-1.yaml` — `compliant` (demonstrates same requirement × two products)

**Views** (`canon/views/`) — new directory
- `eu-compliance.compliance-impact.transitrix.yaml` — obligation × product matrix
- `eu-coverage.coverage-metric.transitrix.yaml` — coverage % per law with amber/green thresholds

### Demo coverage

| Feature | Demonstrated by |
|---|---|
| Compliance matrix | compliance-impact view — 2 products × 5 requirements |
| Single-law view | filter `derived_from_codex: [LAW-GDPR-1]` |
| Single-product view | filter `subjects.products: [PRODUCT-ECOMM-1]` |
| Gap dashboard | NIS2 supply-chain has no assertion → shows as gap |
| Compliance-impact view | `eu-compliance.compliance-impact.transitrix.yaml` |
| Coverage-metric view | `eu-coverage.coverage-metric.transitrix.yaml` |
| Process blueprint lane | `realised_via` on assertions; `lane_config.compliance: true` in Studio PR |

### Status mix for the demo

All four assertion statuses represented: `non_compliant` (erasure gap on ECOMM), `partial` (consent), `under_review` (NIS2 incident), `compliant` (portability + support erasure). Supply-chain requirement has no assertion → gap cell.

Closes HUB-178 (compliance demo scenario on acme_corp).