### PR TITLE
chore(acme_corp): remove leftover MOVED stubs after view subdir relocation

### DIFF
--- a/organizations/acme_corp/canon/views/eu-compliance.compliance-impact.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/eu-compliance.compliance-impact.transitrix.yaml
@@ -1,2 +1,0 @@
-# MOVED — this file has been relocated.
-# New path: canon/views/compliance-impact/eu-compliance.compliance-impact.transitrix.yaml

--- a/organizations/acme_corp/canon/views/eu-coverage.coverage-metric.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/eu-coverage.coverage-metric.transitrix.yaml
@@ -1,2 +1,0 @@
-# MOVED — this file has been relocated.
-# New path: canon/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml


### PR DESCRIPTION
## What

PR #181 (`d83132c`) relocated the two acme_corp EU-compliance views into subdirectories:

- `canon/views/compliance-impact/eu-compliance.compliance-impact.transitrix.yaml`
- `canon/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml`

…but it did **not** delete the old root-level files — it replaced them with two-line `# MOVED — relocated` redirect stubs. For YAML view-config files that a renderer scans, those stubs are clutter and surface as **duplicate matrices after `git pull`**.

## Change

`git rm` the two leftover stub files so the relocation is a clean move. The real files in the subdirectories are untouched; no references in the repo point at the old root paths (verified by grep).

## Scope

Two file deletions, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)