### PR TITLE
feat(acme_corp): worked view examples for every notation with a compliance spine

### DIFF
--- a/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-DSR-HANDLE-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/processes/PROCESS-DSR-HANDLE-1.yaml
@@ -1,0 +1,35 @@
+# Worked example — PROCESS element primitive (compliance / management process).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.5 + envelope §3.
+# Data-subject-request handling: the GDPR Art. 15-22 rights workflow.
+# Detailed flow lives in canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml.
+
+notation: process
+id: PROCESS-DSR-HANDLE-1
+name: "Data Subject Request Handling"
+owner_role: ROLE-DPO-1
+maturity: 2
+bpmn_file: "canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml"
+description: >
+  Receive, verify, and fulfil data-subject rights requests (access, erasure,
+  portability) within the GDPR statutory window. Coordinates erasure across the
+  active-order database, CRM, and the cold-storage order archive.
+
+# Participants — the lanes (ROLE-… / ACTOR-…), in rendered top-to-bottom order.
+# Lane captions derive from each referenced element's `name`. All resolve in canon.
+participants:
+  - ROLE-CS-1
+  - ROLE-DPO-1
+  - ROLE-OPS-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/roles/ROLE-DPO-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/roles/ROLE-DPO-1.yaml
@@ -1,0 +1,26 @@
+# Worked example — ROLE element primitive (Data Protection Officer).
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+# Accountable party for GDPR/NIS2 compliance; referenced as assessed_by on
+# ASSERTION-… records and as owner_role / actor across the compliance views.
+
+notation: role
+id: ROLE-DPO-1
+name: "Data Protection Officer"
+responsibility_area: "Compliance & Data Protection"
+description: >
+  Accountable for the organisation's GDPR and NIS2 obligations: maintains the
+  data-subject-request register, owns compliance assertions and their evidence,
+  and is the point of contact for the supervisory authority.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/views/README.md
+++ b/organizations/acme_corp/canon/views/README.md
@@ -20,6 +20,9 @@ See [`method/methodology.md` §6](../../../method/methodology.md) for the full n
 | [`applications/`](applications/) | Applications view | `*.applications.transitrix.yaml` | Filtered views over Application elements |
 | [`scenarios/`](scenarios/) | Scenarios | `*.scenarios.transitrix.yaml` | Alternative strategic development paths |
 | [`process-blueprint/`](process-blueprint/) | Process Blueprint | `*.process-blueprint.transitrix.yaml` | Wide value-chain blueprint with stage aspects |
+| [`activity-card/`](activity-card/) | Activity card | `*.activity-card.transitrix.yaml` | Single-project narrative card with milestones |
+| [`compliance-impact/`](compliance-impact/) | Compliance impact | `*.compliance-impact.transitrix.yaml` | Obligation × subject matrix with status |
+| [`coverage-metric/`](coverage-metric/) | Coverage metric | `*.coverage-metric.transitrix.yaml` | Assertion-coverage breakdown per regime |
 | [`issues/`](issues/) | Issues register | `*.issues.transitrix.yaml` | Issue register with parent/child nesting |
 
 ## Naming

--- a/organizations/acme_corp/canon/views/activities/gdpr-remediation.activities.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/activities/gdpr-remediation.activities.transitrix.yaml
@@ -1,0 +1,71 @@
+# Activity-on-Node network (PSND) — the GDPR remediation programme schedule.
+# Notation spec: notations/views/07-activities.md. Inline activities carry
+# CONTRACT.md §7 lifecycle, distinct from the schedule fields (start_date / duration_days).
+
+notation: activities
+spec_version: "0.1"
+
+title: "GDPR Remediation Programme 2026"
+description: |
+  Critical path for closing the EU data-protection gaps surfaced by the 2026
+  gap assessment — including the cold-storage archive erasure gap that holds
+  ASSERTION-ECOMM-GDPR-ERASURE-1 in a non_compliant state.
+version: "0.1"
+date: "2026-06-10"
+author: "Acme Compliance Office"
+
+activities:
+  - id: ACTIVITY-GDPR-GAP-1
+    name: "GDPR & NIS2 gap assessment"
+    duration_days: 15
+    start_date: "2026-03-01"
+    predecessors: []
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTIVITY-GDPR-ERASURE-PIPELINE-1
+    name: "Extend erasure pipeline to cold-storage archive"
+    duration_days: 30
+    start_date: "2026-06-15"
+    predecessors: [ACTIVITY-GDPR-GAP-1]
+    goals: [GOAL-EU-1]
+    delivers_changes: [CHANGE-EU-CRM-1]
+    owner: ROLE-TECH-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTIVITY-GDPR-DSR-WORKFLOW-1
+    name: "Stand up data-subject-request workflow"
+    duration_days: 20
+    start_date: "2026-06-15"
+    predecessors: [ACTIVITY-GDPR-GAP-1]
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTIVITY-GDPR-CONSENT-1
+    name: "Rework onboarding consent capture"
+    duration_days: 18
+    start_date: "2026-06-20"
+    predecessors: [ACTIVITY-GDPR-GAP-1]
+    goals: [GOAL-EU-1]
+    delivers_changes: [CHANGE-ONBOARD-1]
+    owner: ROLE-SALES-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTIVITY-GDPR-AUDIT-1
+    name: "Supervisory-authority pre-audit"
+    duration_days: 5
+    start_date: "2026-08-15"
+    predecessors:
+      - ACTIVITY-GDPR-ERASURE-PIPELINE-1
+      - ACTIVITY-GDPR-DSR-WORKFLOW-1
+      - ACTIVITY-GDPR-CONSENT-1
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-05-26"
+    valid_to: null

--- a/organizations/acme_corp/canon/views/activity-card/README.md
+++ b/organizations/acme_corp/canon/views/activity-card/README.md
@@ -1,0 +1,19 @@
+# `canon/views/activity-card/`
+
+Single-project narrative cards. Each card binds to one project Activity (`project: ACTIVITY-…`) and adds narrative milestones; the motivation chain and child activities are pulled by reference from the FGCA and Activities documents rather than duplicated.
+
+## File convention
+
+`*.activity-card.transitrix.yaml`
+
+See [`notations/views/18-activity-card.md`](../../../../../notations/views/18-activity-card.md) for the full spec.
+
+## Lifecycle
+
+The card is a view, not an element — it carries no lifecycle. The project Activity it binds to and any `delivers_changes: [CHANGE-…]` it names bear their lifecycle on their own canonical files.
+
+## See also
+
+- [`notations/views/18-activity-card.md`](../../../../../notations/views/18-activity-card.md) — the notation spec
+- [`notations/examples/activity-card/`](../../../../../notations/examples/activity-card/) — worked example
+- [`../activities/`](../activities/) — the activity network the card's project lives in

--- a/organizations/acme_corp/canon/views/activity-card/eu-gdpr-remediation.activity-card.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/activity-card/eu-gdpr-remediation.activity-card.transitrix.yaml
@@ -1,0 +1,37 @@
+# Single-project narrative card for the GDPR remediation programme.
+# Notation spec: notations/views/18-activity-card.md. Binds to a project Activity
+# and adds narrative milestones; the motivation chain and child activities are
+# pulled by reference from the FGCA and Activities documents, not duplicated here.
+
+notation: activity-card
+spec_version: "0.1"
+
+activity_card:
+  id: ACTIVITY_CARD-GDPR-REMEDIATION-1
+  project: ACTIVITY-CRM-EU-1
+
+  description: >
+    Programme of work closing the EU data-protection gaps surfaced by the 2026
+    gap assessment: extending the erasure pipeline to the cold-storage archive,
+    standing up data-subject-request handling, and reworking onboarding consent.
+    Spans 2026-Q2 through 2026-Q4 and clears the supervisory-authority pre-audit.
+
+  milestones:
+    - id: MILESTONE-GDPR-ERASURE-CLOSED-1
+      name: "Cold-storage archive erasure gap closed"
+      date: "2026-09-15"
+      description: >
+        Erasure pipeline extended to the 7-year order-history archive, moving
+        ASSERTION-ECOMM-GDPR-ERASURE-1 out of non_compliant. Hard gate for the
+        pre-audit.
+      delivers_changes:
+        - CHANGE-EU-CRM-1
+
+    - id: MILESTONE-GDPR-PREAUDIT-1
+      name: "Supervisory-authority pre-audit cleared"
+      date: "2026-10-31"
+      description: >
+        Data Protection Officer presents closed gaps and the DSR workflow to the
+        supervisory authority; EU go-live proceeds under the new regime.
+      delivers_changes:
+        - CHANGE-EU-CRM-1

--- a/organizations/acme_corp/canon/views/applications/eu-portfolio.applications.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/applications/eu-portfolio.applications.transitrix.yaml
@@ -1,0 +1,47 @@
+# Applications catalogue — systems supporting the EU portfolio, with the OMS → CRM
+# integration that propagates erasure events. Notation spec: notations/views/10-applications.md.
+# Each inline entry carries CONTRACT.md §7 lifecycle; nested integrations share the parent's.
+
+notation: applications
+spec_version: "0.1"
+
+applications_catalogue:
+  id: APPLICATIONS_CAT-EU-1
+  name: "Acme Corp — EU Applications Portfolio"
+  description: "Applications and integrations in operation for the EU portfolio."
+  version: "1.0"
+  updated_at: "2026-06-10"
+
+  applications:
+    - app_id: APPLICATION-OMS-1
+      name: "Order Management System"
+      type: "application"
+      domain: "Operations"
+      owner_role: ROLE-TECH-1
+      vendor: "Internal"
+      status: "Active"
+      maturity: 3
+      description: "Core system for order lifecycle management; holds active-order personal data."
+      capabilities: ["CAPABILITY-V1"]
+      products: ["PRODUCT-ECOMM-1"]
+      integrations:
+        - target: "APPLICATION-CRM-1"
+          direction: "outbound"
+          protocol: "REST"
+          description: "Propagates order and erasure events to CRM"
+      valid_from: "2026-05-26"
+      valid_to: null
+
+    - app_id: APPLICATION-CRM-1
+      name: "CRM System"
+      type: "application"
+      domain: "Sales"
+      owner_role: ROLE-SALES-1
+      vendor: "Salesforce"
+      status: "Active"
+      maturity: 2
+      description: "Customer relationship and consent management; holds contact and consent personal data."
+      capabilities: ["CAPABILITY-V2"]
+      products: ["PRODUCT-ECOMM-1"]
+      valid_from: "2026-05-26"
+      valid_to: null

--- a/organizations/acme_corp/canon/views/blocks/personal-data-landscape.blocks.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/blocks/personal-data-landscape.blocks.transitrix.yaml
@@ -1,0 +1,46 @@
+# Nested block diagram — where personal data lives across Acme systems. This is
+# the data-residency / erasure-scope map behind the GDPR coverage metric: the
+# cold-storage archive (bottom-right) is the known erasure gap.
+# Notation spec: notations/views/08-blocks.md. Document-local labels bear no
+# lifecycle; canonical-id blocks (APPLICATION-…) bear it on their element file.
+
+notation: blocks
+spec_version: "0.1"
+
+nested_blocks:
+  id: BLOCKS-PERSONAL-DATA-1
+  name: "Personal-data landscape"
+  description: "Systems and stores holding EU-resident personal data, grouped by erasure reachability."
+  version: "0.1"
+  date: "2026-06-10"
+  author: "Acme Compliance Office"
+
+  blocks:
+    - id: ACTIVE_SYSTEMS
+      name: "Active systems (erasure-reachable, in 30-day window)"
+      children:
+        - id: APPLICATION-OMS-1
+          name: "Order Management System"
+          children:
+            - id: OMS_ORDERS
+              name: "Active orders"
+            - id: OMS_PAYMENTS
+              name: "Payment tokens"
+        - id: APPLICATION-CRM-1
+          name: "CRM System"
+          children:
+            - id: CRM_CONTACTS
+              name: "Customer contacts"
+            - id: CRM_CONSENT
+              name: "Consent records"
+
+    - id: ARCHIVE
+      name: "Cold storage (7-year fiscal retention — KNOWN ERASURE GAP)"
+      children:
+        - id: ORDER_ARCHIVE
+          name: "Order history archive"
+          children:
+            - id: ARCHIVE_PII
+              name: "Personal data (not erasure-reachable)"
+            - id: ARCHIVE_INVOICES
+              name: "Invoices"

--- a/organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
@@ -1,0 +1,96 @@
+# Detailed BPMN flow for PROCESS-DSR-HANDLE-1 — GDPR right-to-erasure (Art. 17).
+# Compiled to BPMN 2.0 XML by Transitrix Studio. Node ids are file-local labels
+# (POOL-/LANE-/SE-/TASK-/GW-/EE-) per IDS_AND_REFERENCES.md §3.3 — not canonical
+# elements, so this file bears no primitive lifecycle.
+
+notation: bpmn
+spec_version: "0.1"
+
+process:
+  id: PROCESS-DSR-HANDLE-1
+  name: "Data Subject Erasure Request (GDPR Art. 17)"
+  pools:
+    - id: POOL-DSR
+      name: "Data Subject Request Handling"
+      lanes:
+        - id: LANE-SUPPORT
+          name: "Customer Support"
+          elements:
+            - id: SE-REQUEST
+              type: startEvent
+              name: "Erasure request received"
+            - id: TASK-VERIFY-IDENTITY
+              type: userTask
+              name: "Verify data-subject identity"
+            - id: GW-VERIFIED
+              type: exclusiveGateway
+              name: "Identity verified?"
+            - id: TASK-REJECT
+              type: userTask
+              name: "Reject request & notify subject"
+            - id: EE-REJECTED
+              type: endEvent
+              name: "Request rejected"
+            - id: TASK-CONFIRM
+              type: userTask
+              name: "Confirm erasure & notify subject"
+        - id: LANE-DPO
+          name: "Data Protection Officer"
+          elements:
+            - id: TASK-LOG-REQUEST
+              type: task
+              name: "Log request in DSR register"
+            - id: GW-ARCHIVE
+              type: exclusiveGateway
+              name: "Personal data in cold-storage archive?"
+            - id: TASK-FLAG-GAP
+              type: task
+              name: "Flag archive exception for manual review"
+            - id: TASK-RECORD-CLOSURE
+              type: task
+              name: "Record completion within 30-day window"
+            - id: EE-CLOSED
+              type: endEvent
+              name: "Request closed & evidenced"
+        - id: LANE-OPS
+          name: "Operations & Engineering"
+          elements:
+            - id: TASK-LOCATE
+              type: task
+              name: "Locate personal data across systems"
+            - id: TASK-ERASE-ACTIVE
+              type: task
+              name: "Erase from active OMS & CRM"
+  flows:
+    - from: SE-REQUEST
+      to: TASK-VERIFY-IDENTITY
+    - from: TASK-VERIFY-IDENTITY
+      to: GW-VERIFIED
+    - from: GW-VERIFIED
+      to: TASK-REJECT
+      condition: "identity not verified"
+      default: true
+    - from: TASK-REJECT
+      to: EE-REJECTED
+    - from: GW-VERIFIED
+      to: TASK-LOG-REQUEST
+      condition: "identity verified"
+    - from: TASK-LOG-REQUEST
+      to: TASK-LOCATE
+    - from: TASK-LOCATE
+      to: TASK-ERASE-ACTIVE
+    - from: TASK-ERASE-ACTIVE
+      to: GW-ARCHIVE
+    - from: GW-ARCHIVE
+      to: TASK-FLAG-GAP
+      condition: "data present in 7-year archive (known gap)"
+    - from: GW-ARCHIVE
+      to: TASK-CONFIRM
+      condition: "active systems only"
+      default: true
+    - from: TASK-FLAG-GAP
+      to: TASK-CONFIRM
+    - from: TASK-CONFIRM
+      to: TASK-RECORD-CLOSURE
+    - from: TASK-RECORD-CLOSURE
+      to: EE-CLOSED

--- a/organizations/acme_corp/canon/views/capabilities/compliance-domain.capability-map.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/capabilities/compliance-domain.capability-map.transitrix.yaml
@@ -1,0 +1,74 @@
+# Capability map — core domains plus the cross-cutting Compliance & Data
+# Protection capability, with CMMI maturity overlay. Notation spec:
+# notations/views/05-capability-map.md. Every inline capability (recursively)
+# carries `type` and CONTRACT.md §7 lifecycle.
+
+notation: capability-map
+spec_version: "0.1"
+title: "Acme Corp — Capability Map with Compliance Overlay"
+description: "Core business capabilities and the cross-cutting compliance capability, with current and target CMMI maturity."
+version: "1.0"
+date: "2026-06-10"
+
+capability_map:
+  id: CAPABILITY_MAP-COMPLIANCE-1
+  name: "Compliance-Domain Capability Map"
+  description: "Business capabilities with current and target maturity, highlighting the data-protection gap."
+  assessment_date: "2026-06-10"
+
+  capabilities:
+    - id: CAPABILITY-V1
+      name: "Order Management"
+      type: domain
+      current_maturity: 2
+      target_maturity: 3
+      target_date: "2026-12-31"
+      owner_role: ROLE-OPS-1
+      business_process: PROCESS-ORD-FULFILL-1
+      applications:
+        - APPLICATION-OMS-1
+        - APPLICATION-CRM-1
+      valid_from: "2026-05-26"
+      valid_to: null
+      children:
+        - id: CAPABILITY-V1.1
+          name: "Order Intake"
+          type: domain
+          current_maturity: 3
+          target_maturity: 3
+          valid_from: "2026-05-26"
+          valid_to: null
+        - id: CAPABILITY-V1.2
+          name: "Order Fulfilment"
+          type: domain
+          current_maturity: 2
+          target_maturity: 3
+          target_date: "2026-09-30"
+          valid_from: "2026-05-26"
+          valid_to: null
+
+    - id: CAPABILITY-V2
+      name: "Customer Relationship Management"
+      type: domain
+      current_maturity: 2
+      target_maturity: 3
+      owner_role: ROLE-SALES-1
+      applications:
+        - APPLICATION-CRM-1
+      valid_from: "2026-05-26"
+      valid_to: null
+
+    - id: CAPABILITY-H1
+      name: "Compliance & Data Protection"
+      type: supporting
+      description: >
+        Cross-cutting capability covering GDPR/NIS2 obligations: data-subject
+        rights, breach reporting, and data residency. Lowest current maturity —
+        the focus of the 2026 remediation programme.
+      current_maturity: 1
+      target_maturity: 3
+      target_date: "2026-12-31"
+      owner_role: ROLE-DPO-1
+      business_process: PROCESS-DSR-HANDLE-1
+      valid_from: "2026-05-26"
+      valid_to: null

--- a/organizations/acme_corp/canon/views/fga/eu-compliance.fga.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/fga/eu-compliance.fga.transitrix.yaml
@@ -1,0 +1,56 @@
+# FGA chain — direct factor → goal → activity for the compliance workstream,
+# where the transformation step is implicit. Notation spec: notations/views/03-fga.md.
+
+notation: fga
+spec_version: "0.1"
+
+id: FGA-COMPLIANCE-1
+name: "EU Compliance 2026"
+description: >
+  Factor → Goal → Activity chain for the GDPR/NIS2 compliance workstream.
+  Changes layer omitted — activities map directly to the compliance goal.
+period: "2026"
+date: "2026-06-10"
+author: "Acme Compliance Office"
+
+factors:
+  - id: FACTOR-EU-REG-1
+    name: "EU regulatory window for market entry"
+    type: external
+    category: legal
+    references_constraint: [CONSTRAINT-GDPR-RESIDENCY-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+goals:
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets under full GDPR/NIS2 compliance"
+    factors: [FACTOR-EU-REG-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+activities:
+  - id: ACTIVITY-DISCOVERY-1
+    name: "GDPR & NIS2 gap assessment"
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    status: "Done"
+    due_date: "2026-03-31"
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: ACTIVITY-CRM-EU-1
+    name: "Implement EU-localised CRM rollout"
+    goals: [GOAL-EU-1]
+    owner: ROLE-SALES-1
+    status: "In Progress"
+    due_date: "2026-09-30"
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: ACTIVITY-SUPPORT-1
+    name: "Stand up data-subject-request handling"
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    status: "In Progress"
+    due_date: "2026-08-31"
+    valid_from: "2026-05-26"
+    valid_to: null

--- a/organizations/acme_corp/canon/views/fgca/eu-expansion.fgca.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/fgca/eu-expansion.fgca.transitrix.yaml
@@ -1,0 +1,67 @@
+# FGCA chain — EU market entry under GDPR/NIS2.
+# Notation spec: notations/views/02-fgca.md. Inline elements carry CONTRACT.md §7
+# lifecycle; the view itself does not.
+
+notation: fgca
+spec_version: "0.1"
+
+id: FGCA-EU-1
+name: "EU Expansion 2026 — compliance-driven"
+description: >
+  Factor → Goal → Change → Activity chain for EU market entry. The closing EU
+  regulatory window drives a market-presence goal; the required transformation is
+  an EU-localised, GDPR-conformant platform; activities deliver it.
+period: "2026"
+date: "2026-06-10"
+author: "Acme Strategy Office"
+
+factors:
+  - id: FACTOR-EU-REG-1
+    name: "EU regulatory window for market entry"
+    type: external
+    category: legal
+    references_constraint: [CONSTRAINT-GDPR-RESIDENCY-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: FACTOR-COMP-1
+    name: "Competitive pressure"
+    type: external
+    category: economic
+    valid_from: "2026-05-26"
+    valid_to: null
+
+goals:
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    factors: [FACTOR-EU-REG-1, FACTOR-COMP-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+changes:
+  - id: CHANGE-EU-CRM-1
+    name: "Stand up EU-localised CRM and payment processing"
+    goals: [GOAL-EU-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: CHANGE-ONBOARD-1
+    name: "Rework customer onboarding for GDPR consent capture"
+    goals: [GOAL-EU-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+activities:
+  - id: ACTIVITY-CRM-EU-1
+    name: "Implement EU-localised CRM rollout"
+    changes: [CHANGE-EU-CRM-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: ACTIVITY-BUILD-1
+    name: "Build & test EU compliance controls"
+    changes: [CHANGE-EU-CRM-1, CHANGE-ONBOARD-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: ACTIVITY-LAUNCH-1
+    name: "Launch in EU markets"
+    changes: [CHANGE-EU-CRM-1]
+    valid_from: "2026-05-26"
+    valid_to: null

--- a/organizations/acme_corp/canon/views/goals/eu-strategy.goals.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/goals/eu-strategy.goals.transitrix.yaml
@@ -1,0 +1,49 @@
+# Goals tree — 2026 EU-expansion plan with the compliance goal as a first-class
+# strategic goal. Notation spec: notations/views/04-goals.md. Inline goals carry
+# CONTRACT.md §7 lifecycle.
+
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-STRATEGY-2026
+name: "Acme Corp — Strategy 2026 Goals Tree"
+description: "Goal hierarchy for the 2026 EU-expansion plan, including the regulatory-compliance branch."
+period: "2026"
+date: "2026-06-10"
+author: "Acme Strategy Office"
+
+goal_types:
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
+
+goals:
+  - id: GOAL-REVENUE-1
+    name: "Triple revenue by 2028"
+    type: "Strategy"
+    level: 0
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: GOAL-CUST-1
+    name: "Raise customer satisfaction"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: GOAL-OPS-1
+    name: "Operational excellence"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null

--- a/organizations/acme_corp/canon/views/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
@@ -1,0 +1,78 @@
+# Value-chain blueprint for order fulfilment — defines the STAGE-1..STAGE-5 that
+# ASSERTION-ECOMM-GDPR-ERASURE-1 references via `realised_via`. Notation spec:
+# notations/views/13-process-blueprint.md. stages/systems/actors are document-local;
+# business_objects[] carry CONTRACT.md §7 lifecycle.
+
+notation: process-blueprint
+spec_version: "0.1"
+
+process_blueprint:
+  id: PROCESS_BLUEPRINT-FULFIL-1
+  name: "Order fulfilment — operational blueprint"
+  description: |
+    End-to-end order fulfilment value chain. Personal data is captured at
+    STAGE-1, read at STAGE-3, and transmitted to the carrier at STAGE-4 — the
+    three stages a GDPR erasure request must reach (see
+    ASSERTION-ECOMM-GDPR-ERASURE-1).
+  period: "2026"
+  version: "0.1"
+  date: "2026-06-10"
+  author: "Acme Compliance Office"
+  process: PROCESS-ORD-FULFILL-1
+
+  stages:
+    - id: STAGE-1
+      name: "Receive order"
+      goal: "Capture a validated customer order with consent recorded."
+      result: "Validated order in OMS with personal data captured and consent logged."
+    - id: STAGE-2
+      name: "Allocate inventory"
+      goal: "Reserve stock to satisfy the order."
+      result: "Reservation lines linked to the order."
+    - id: STAGE-3
+      name: "Pick & pack"
+      goal: "Assemble the physical order; personal data read from CRM for labelling."
+      result: "Packed shipment scanned out and ready for carrier handover."
+    - id: STAGE-4
+      name: "Ship"
+      goal: "Hand the shipment to the carrier; personal data transmitted on the label."
+      result: "In-transit shipment with tracking number sent to the customer."
+    - id: STAGE-5
+      name: "Confirm delivery & close"
+      goal: "Confirm delivery, settle payment, and archive the order."
+      result: "Closed order; record written to the 7-year cold-storage archive."
+
+  systems:
+    - id: APPLICATION-OMS-1
+      name: "Order Management System"
+      stages: [STAGE-1, STAGE-2, STAGE-3, STAGE-4, STAGE-5]
+    - id: APPLICATION-CRM-1
+      name: "CRM System"
+      stages: [STAGE-1, STAGE-3]
+
+  actors:
+    - id: ROLE-CS-1
+      name: "Customer Support Lead"
+      stages: [STAGE-1, STAGE-5]
+    - id: ROLE-OPS-1
+      name: "Operations Lead"
+      stages: [STAGE-2, STAGE-3, STAGE-4]
+    - id: ROLE-DPO-1
+      name: "Data Protection Officer"
+      stages: [STAGE-1, STAGE-5]
+
+  business_objects:
+    - id: BUSINESS_OBJECT-CUST-ORDER-1
+      name: "Customer order"
+      stages: [STAGE-1, STAGE-2, STAGE-3, STAGE-4, STAGE-5]
+      valid_from: "2026-05-26"
+      valid_to: null
+    - name: "Personal data record"
+      description: "EU-resident personal data; subject to GDPR erasure across STAGE-1, STAGE-3, STAGE-4."
+      stages: [STAGE-1, STAGE-3, STAGE-4]
+      valid_from: "2026-05-26"
+      valid_to: null
+    - name: "Consent record"
+      stages: [STAGE-1]
+      valid_from: "2026-05-26"
+      valid_to: null

--- a/organizations/acme_corp/canon/views/processmap/enterprise.process-map.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/processmap/enterprise.process-map.transitrix.yaml
@@ -1,0 +1,71 @@
+# Process landscape — operating / supporting / management groups, including the
+# compliance (data-subject-request) process. Notation spec: notations/views/06-process-map.md.
+# Each inline process carries CONTRACT.md §7 lifecycle, distinct from operational `status`.
+
+notation: process-map
+spec_version: "0.1"
+
+process_map:
+  id: PM-ACME-1
+  name: "Acme Corp — Process Landscape"
+  description: "Top-level catalogue of operating, supporting, and management processes."
+  version: "1.0"
+  updated_at: "2026-06-10"
+
+  groups:
+    - id: GRP-OPERATING
+      name: "Operating Processes"
+      type: operating
+      description: "Core processes that deliver value to customers."
+      processes:
+        - process_id: PROCESS-ORD-FULFILL-1
+          name: "Order Fulfilment"
+          owner_role: ROLE-OPS-1
+          capability: CAPABILITY-V1
+          maturity: 2
+          status: "Active"
+          valid_from: "2026-05-26"
+          valid_to: null
+        - process_id: PROCESS-CUST-ONBOARD-1
+          name: "Customer Onboarding"
+          owner_role: ROLE-SALES-1
+          capability: CAPABILITY-V2
+          maturity: 1
+          status: "Active"
+          valid_from: "2026-05-26"
+          valid_to: null
+
+    - id: GRP-SUPPORTING
+      name: "Supporting Processes"
+      type: supporting
+      description: "Internal enablers for operating processes."
+      processes:
+        - process_id: PROCESS-CS-RESOLVE-1
+          name: "Customer Support Resolution"
+          owner_role: ROLE-CS-1
+          status: "Active"
+          maturity: 2
+          valid_from: "2026-05-26"
+          valid_to: null
+
+    - id: GRP-MANAGEMENT
+      name: "Management Processes"
+      type: management
+      description: "Governance, planning, and regulatory oversight."
+      processes:
+        - process_id: PROCESS-STRAT-PLAN-1
+          name: "Annual Strategy Planning"
+          owner_role: ROLE-EXEC-1
+          status: "Active"
+          maturity: 2
+          valid_from: "2026-05-26"
+          valid_to: null
+        - process_id: PROCESS-DSR-HANDLE-1
+          name: "Data Subject Request Handling"
+          owner_role: ROLE-DPO-1
+          capability: CAPABILITY-H1
+          maturity: 2
+          status: "Active"
+          bpmn_file: "canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml"
+          valid_from: "2026-05-26"
+          valid_to: null

--- a/organizations/acme_corp/canon/views/products/eu-portfolio.products.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/products/eu-portfolio.products.transitrix.yaml
@@ -1,0 +1,41 @@
+# Products catalogue — the EU-facing portfolio that the compliance views bind to.
+# Notation spec: notations/views/09-products.md. Each inline product carries
+# CONTRACT.md §7 lifecycle, distinct from operational `status`.
+
+notation: products
+spec_version: "0.1"
+
+products_catalogue:
+  id: PRODUCTS_CAT-EU-1
+  name: "Acme Corp — EU Products Portfolio"
+  description: "Products and services in scope for EU GDPR/NIS2 compliance."
+  version: "1.0"
+  updated_at: "2026-06-10"
+
+  products:
+    - product_id: PRODUCT-ECOMM-1
+      name: "E-Commerce Platform"
+      type: "digital_product"
+      domain: "Digital"
+      owner_role: ROLE-PROD-1
+      status: "Active"
+      maturity: 3
+      description: "Online storefront and order management for end customers; primary GDPR data controller surface."
+      capabilities: ["CAPABILITY-V1", "CAPABILITY-V2", "CAPABILITY-H1"]
+      processes: ["PROCESS-ORD-FULFILL-1", "PROCESS-DSR-HANDLE-1"]
+      supporting_apps: ["APPLICATION-OMS-1", "APPLICATION-CRM-1"]
+      valid_from: "2026-05-26"
+      valid_to: null
+
+    - product_id: PRODUCT-SUPPORT-1
+      name: "Customer Support Service"
+      type: "service"
+      domain: "Operations"
+      owner_role: ROLE-CS-1
+      status: "Active"
+      maturity: 2
+      description: "Tier-1 and Tier-2 support; first point of contact for data-subject requests."
+      capabilities: ["CAPABILITY-H1"]
+      processes: ["PROCESS-CS-RESOLVE-1", "PROCESS-DSR-HANDLE-1"]
+      valid_from: "2026-05-26"
+      valid_to: null

--- a/organizations/acme_corp/canon/views/scenarios/eu-go-live.scenarios.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/scenarios/eu-go-live.scenarios.transitrix.yaml
@@ -1,0 +1,51 @@
+# Scenario — EU go-live under full GDPR/NIS2 compliance. Notation spec:
+# notations/views/11-scenarios.md. The inline scenario entry carries CONTRACT.md §7
+# lifecycle; the referenced goals/capabilities/activities/products/processes/apps
+# carry theirs on their own element files.
+
+notation: scenarios
+spec_version: "0.1"
+title: "EU Go-Live 2026"
+description: "Target scenario: live in three EU markets with all compliance gaps closed."
+version: "1.0"
+date: "2026-06-10"
+
+scenario:
+  id: SCENARIO-EU-GOLIVE-1
+  name: "EU Go-Live 2026"
+  description: "Three EU markets live with GDPR/NIS2 obligations fully satisfied and the erasure-archive gap closed."
+  status: Active
+  created_at: "2026-06-10"
+  valid_from: "2026-05-26"
+  valid_to: null
+
+  vision: |
+    By Q4 2026 Acme Corp operates in three EU markets. Every data-subject request
+    is fulfilled within the statutory window across both active systems and the
+    cold-storage archive, and the supervisory-authority pre-audit is cleared.
+
+  goals:
+    - goal_id: GOAL-EU-1
+    - goal_id: GOAL-REVENUE-1
+
+  capabilities:
+    - capability_id: CAPABILITY-V1
+    - capability_id: CAPABILITY-V2
+    - capability_id: CAPABILITY-H1
+
+  activities:
+    - activity_id: ACTIVITY-CRM-EU-1
+    - activity_id: ACTIVITY-GDPR-ERASURE-PIPELINE-1
+    - activity_id: ACTIVITY-GDPR-DSR-WORKFLOW-1
+
+  products:
+    - product_id: PRODUCT-ECOMM-1
+    - product_id: PRODUCT-SUPPORT-1
+
+  processes:
+    - process_id: PROCESS-ORD-FULFILL-1
+    - process_id: PROCESS-DSR-HANDLE-1
+
+  applications:
+    - app_id: APPLICATION-OMS-1
+    - app_id: APPLICATION-CRM-1


### PR DESCRIPTION
## What

Gives `acme_corp` a worked **view instance for every supported notation**, so the demo org can render the full diagram kit — with the EU **GDPR/NIS2 compliance** story as the connecting spine.

Before this PR only the two compliance report-views (`compliance-impact`, `coverage-metric`) had instances; every other view folder held just a README.

### Views added (13)
| Notation | File | Compliance angle |
|---|---|---|
| `bpmn` | `bpmn/data-subject-erasure.*` | GDPR Art. 17 erasure-request flow (Support / DPO / Ops lanes) |
| `fgca` | `fgca/eu-expansion.*` | Factor→Goal→Change→Activity for EU entry |
| `fga` | `fga/eu-compliance.*` | 3-layer compliance workstream |
| `goals` | `goals/eu-strategy.*` | 2026 goals tree |
| `capability-map` | `capabilities/compliance-domain.*` | Compliance & Data Protection capability (maturity 1→3) |
| `process-map` | `processmap/enterprise.*` | landscape incl. DSR handling |
| `activities` | `activities/gdpr-remediation.*` | PSND of the remediation programme |
| `blocks` | `blocks/personal-data-landscape.*` | where personal data lives; the archive erasure gap |
| `products` | `products/eu-portfolio.*` | EU-facing portfolio |
| `applications` | `applications/eu-portfolio.*` | OMS/CRM + erasure-event integration |
| `scenarios` | `scenarios/eu-go-live.*` | target go-live scenario |
| `process-blueprint` | `process-blueprint/order-fulfilment.*` | defines `STAGE-1..5` |
| `activity-card` | `activity-card/eu-gdpr-remediation.*` | single-project card + milestones |

### Elements added (2)
`ROLE-DPO-1` (Data Protection Officer) and `PROCESS-DSR-HANDLE-1`. Both **fill dangling references the catalogue already carried**: the existing `ASSERTION-ECOMM-GDPR-ERASURE-1` already names `assessed_by: ROLE-DPO-1` and `realised_via: STAGE-1/3/4`, now backed by a real role and a real order-fulfilment blueprint.

### Index
Registered `activity-card`, `compliance-impact`, and `coverage-metric` in the views README subfolder map (previously missing).

## Verification
- `node scripts/check-notations.mjs` → clean (15 view notations; examples, links, version pins consistent)
- `organizations/acme_corp/.validators/lint.py` → **0 errors / 0 warnings** (53 elements, 6 relations)
- All 17 files YAML-parse; every referenced canonical ID resolves to an element file.

Scope: additive worked examples for one demo org; no spec or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
