### PR TITLE
feat(acme_corp): add GOAL-EU-COMPLIANCE-1 enabling goal under GOAL-EU-1

### DIFF
--- a/organizations/acme_corp/canon/views/goals/eu-strategy.goals.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/goals/eu-strategy.goals.transitrix.yaml
@@ -15,6 +15,7 @@ author: "Acme Strategy Office"
 goal_types:
   - { name: "Strategy",       level: 0 }
   - { name: "Strategic Goal", level: 1 }
+  - { name: "Enabling Goal",  level: 2 }
 
 goals:
   - id: GOAL-REVENUE-1
@@ -29,6 +30,18 @@ goals:
     type: "Strategic Goal"
     level: 1
     parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: GOAL-EU-COMPLIANCE-1
+    name: "Achieve full GDPR & NIS2 compliance"
+    type: "Enabling Goal"
+    level: 2
+    parent: GOAL-EU-1
+    description: >
+      Satisfy all GDPR and NIS2 obligations applicable to EU-resident customers
+      before go-live: data-subject rights, breach reporting, and data residency.
+      Gate condition for the EU launch.
     valid_from: "2026-05-26"
     valid_to: null
 


### PR DESCRIPTION
## What

Adds `GOAL-EU-COMPLIANCE-1` "Achieve full GDPR & NIS2 compliance" as an **Enabling Goal** (level 2) child of `GOAL-EU-1` "Launch in 3 EU markets".

Introduces `Enabling Goal` type in `goal_types` to support level-2 goals.

## Why

Demo step 1 shows the Goals tree. The EU launch goal needs a visible derived sub-goal making compliance a first-class gate condition — not just implied by the FGCA factors.