### PR TITLE
feat(notations): tiered approval — reviewer_authority axis (F19, ADR Option A)

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -132,6 +132,7 @@ derived_from:
 | Field | Required | Type | Semantics |
 |---|---|---|---|
 | `admission_state` | no | string | `proposed` \| `active` \| `rejected`. **Absent ⇒ `active`** — human-authored canon is admitted by construction, so existing files need no change (back-compat). |
+| `reviewer_authority` | no | string | `ai_reviewed` \| `expert_confirmed` — the authority **tier** of the reviewer who admitted the artefact (tiered approval, §6.2). **Absent ⇒ `expert_confirmed`** (back-compat: every artefact admitted before this axis existed is treated as expert-confirmed; no migration). Only meaningful with `admission_state: active`; both tiers are admitted canon. A **tool** writes `ai_reviewed`, a **human** writes `expert_confirmed` (`ADMIT-007`). Orthogonal to `admission_state` and to the two trust signals (`source_quality`, `extraction_confidence`); never folded into the §11.4 confidence formula (§11.4). |
 | `proposed_at` | when `proposed` / `rejected` | string | Date the automated harvest emitted the draft — quoted ISO 8601 (§4). |
 | `proposed_by` | when `proposed` / `rejected` | string | The tool / harvest identifier that emitted the draft. A human never writes `proposed`. |
 | `rejected_at` | when `rejected` | string | Date a human refused the draft. |
@@ -168,8 +169,39 @@ For `admission_state: proposed`, the §6 requirement on `admitted_at` / `admitte
 | `ADMIT-003` | error | `admission_state` is `active` or absent, but `admitted_at` / `admitted_by` are missing or any `gate_checks` entry is not `pass`. |
 | `ADMIT-004` | error | `admission_state: rejected` but `rejected_at` / `rejected_by` are missing. |
 | `ADMIT-005` | warning | An `active` artefact cross-references a `proposed` or `rejected` artefact — admitted canon must not depend on un-admitted drafts. Cross-cutting (requires the full catalogue). |
+| `ADMIT-006` | error | `reviewer_authority` is present and not one of `ai_reviewed` / `expert_confirmed` (§6.2). |
+| `ADMIT-007` | error | The admitter does not match the tier: `reviewer_authority: ai_reviewed` but `admitted_by` identifies a human, or `reviewer_authority: expert_confirmed` but `admitted_by` identifies a tool. A tool writes `ai_reviewed`; a human writes `expert_confirmed` (§6.2). |
 
 This lifecycle is what an automated regulatory-intelligence collector (a separate task) depends on: the collector emits `proposed` drafts plus a review digest, and the human gate admits or rejects. The per-TYPE specs note it where relevant ([15-requirement.md](elements/15-requirement.md), [16-assertion.md](elements/16-assertion.md)).
+
+### 6.2 Reviewer authority — tiered approval
+
+Admission carries a second, orthogonal axis: *who confirmed it*. The single human gate (§6.1) records only *who* admitted; it cannot distinguish a draft an AI reviewer ticked from one a domain expert confirmed, so the only safe default is to hold everything behind the expert gate — which does not scale to a source that yields hundreds of `REQUIREMENT` / `ASSERTION` candidates. `reviewer_authority` grades the **authority tier** of the reviewer, independent of `admission_state` (gate progress) and of the two trust signals (`source_quality`, `extraction_confidence` — §11). (ADR [`docs/decisions/2026-06-10-tiered-approval-reviewer-authority.md`](../docs/decisions/2026-06-10-tiered-approval-reviewer-authority.md).)
+
+The tiers are ordinal — `ai_reviewed` < `expert_confirmed` — and **both are admitted canon** (`admission_state: active`); the axis adds **no** new exclusion from derived views. Write authority is strict:
+
+- **`ai_reviewed`** — written **only** by a tool acting as reviewer (the ingest skill, an automated cross-check). The tool fills `admitted_by` with its tool id. A tool MAY admit a high-`extraction_confidence` draft straight to this tier; it may **never** write `expert_confirmed`.
+- **`expert_confirmed`** — written **only** by a human reviewer. Absent `reviewer_authority` ⇒ `expert_confirmed`.
+
+This keeps **"propose, never write the expert tier"**: the human gate retains exclusive authority over the top tier, so the core invariant (a tool never mints expert-confirmed canon unreviewed) holds. An `ai_reviewed` active record:
+
+```yaml
+zone: canon
+admission_state: active
+reviewer_authority: ai_reviewed
+admitted_at: "2026-06-10"
+admitted_by: "ingest-reviewer-claude"   # a tool id — ADMIT-007
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+derived_from:
+  - REGULATION-GDPR-2016-1
+```
+
+**Cross-tier dependencies — weakest link.** An `expert_confirmed` artefact MAY depend on an `ai_reviewed` one: the lower tier is canon, so the dependency is allowed and `ADMIT-005` is **not** extended to forbid it. Views surface the **weakest-link** authority of the dependency chain — the displayed reviewer authority of a chain is the *minimum* tier over all of its nodes, so a single `ai_reviewed` node anywhere in the chain makes the whole chain read `ai_reviewed`. Rendering the weakest-link chain in Studio / DSM is a separate follow-up; this section defines the rule.
+
+The routing that decides which drafts a tool may auto-admit to `ai_reviewed` (high `extraction_confidence`) versus send to the expert queue (medium / low) is a **skill-level** rule, not a CONTRACT one — it lives in the ingest skill ([transitrix/skills/ingest/SKILL.md](../transitrix/skills/ingest/SKILL.md)). The CONTRACT defines the tiers; the skill defines the routing.
 
 ---
 
@@ -462,6 +494,8 @@ confidence(element)   = source_trust(element) · freshness(element)
 ```
 
 Source trust takes the **best** available source (`max`): an element corroborated by an authoritative source is not dragged down by an additional weaker one — extra weak sources add nothing, they do not subtract. Multiplying by freshness then ages that trust: an `authoritative`-but-long-unreaffirmed element scores `1.0 · floor`, while a `single_source`-but-fresh element scores `0.5 · 1.0`.
+
+**`reviewer_authority` is not folded into this formula.** The reviewer-authority tier (§6.2 — `ai_reviewed` vs `expert_confirmed`) is a property of the *review*, not of the *statement*; source trust and freshness are properties of the statement. It is surfaced as a qualitative label **alongside** the numeric confidence band, never multiplied into it — the same separation §11.1 keeps between the two existing signals. An adopter reads "confidence 0.5, ai_reviewed", not a single blended number.
 
 ### 11.5 Unsourced elements
 

--- a/notations/views/21-compliance-impact.md
+++ b/notations/views/21-compliance-impact.md
@@ -105,6 +105,7 @@ view:
   status_display:
     show: ["compliant", "partial", "non_compliant", "under_review", "n_a"]
     treat_proposed_as: "hidden"  # hidden | shown-distinct (default: hidden, per ASSERTION §2.2)
+    treat_ai_reviewed_as: "shown-distinct"  # shown-distinct | shown-same | hidden (default: shown-distinct, per CONTRACT §6.2)
 
   # Empty-cell labels — see §5 for the canonical strings.
   empty_cells:
@@ -136,6 +137,7 @@ Every field carries an explicit default, so a view with only the required envelo
 | `view.grouping.columns` | no | string | `product-stage-task` | Column dimension: `product-stage-task` (the finest grain), `product-stage`, `product`. |
 | `view.status_display.show` | no | list | all five (`compliant`, `partial`, `non_compliant`, `under_review`, `n_a`) | Which `ASSERTION.status` values to render. |
 | `view.status_display.treat_proposed_as` | no | string | `hidden` | How to handle `ASSERTION`s in `proposed` admission state ([16-assertion.md](../elements/16-assertion.md) §2.2): `hidden` (the proposed assertion contributes nothing to the cell) or `shown-distinct` (rendered with a distinct marker so a reviewer can see the harvester's draft alongside admitted canon). The default matches the §2.2 rule that proposed assertions are excluded from every derived view until a human admits them. |
+| `view.status_display.treat_ai_reviewed_as` | no | string | `shown-distinct` | How to handle admitted `ASSERTION`s carrying `reviewer_authority: ai_reviewed` ([CONTRACT.md](../CONTRACT.md) §6.2): `shown-distinct` (rendered with a distinct marker so the AI-reviewed tier is visible alongside expert-confirmed canon), `shown-same` (treated identically to `expert_confirmed`), or `hidden` (the AI-reviewed assertion contributes nothing to the cell). Both tiers are admitted canon, so the default surfaces the AI-reviewed tier distinctly rather than hiding it. A cell whose impact rests on an `ai_reviewed` assertion (or a dependency chain containing one) renders at the **weakest-link** authority (§6.2). |
 | `view.empty_cells.no_obligation_label` | no | string | `"No mapped obligation (current model)"` (§5) | Label for cells where no admitted ASSERTION binds the (obligation, subject-cell) pair. |
 | `view.order_rows_by` | no | string | `id` | Row ordering key: `id`, `name`, `regime`, `jurisdiction`. |
 | `view.order_columns_by` | no | string | `process-order` | Column ordering key: `process-order` (each process's stages and tasks in flow order, then the next process), `id`, `name`. |
@@ -242,6 +244,7 @@ Pairs with **Transitrix Studio compliance views / export** (consumer side, track
 | `COMPIMP-003` | error | A reference in `view.subjects.products` / `view.subjects.processes` / `view.obligations.include` / `view.obligations.filter.derived_from_codex` does not resolve to an admitted canonical element of the expected TYPE. |
 | `COMPIMP-004` | error | `view.grouping.rows` or `view.grouping.columns` is set to a value outside the enumerated set in §4. |
 | `COMPIMP-005` | error | `view.status_display.treat_proposed_as` is set to a value outside `{hidden, shown-distinct}`. |
+| `COMPIMP-006` | error | `view.status_display.treat_ai_reviewed_as` is set to a value outside `{shown-distinct, shown-same, hidden}` (CONTRACT §6.2). |
 | `COMPIMP-006` | warning | `view.empty_cells.no_obligation_label` overrides the default but is one of the legacy strings the §5.3 distinction was introduced to retire (e.g. "No direct obligation", "Not applicable" used for the empty case). |
 | `COMPIMP-007` | warning | Both `view.obligations.include` and `view.obligations.filter` are present (the include wins; the filter is silently ignored). |
 | `COMPIMP-008` | warning | The view selects zero obligations after applying `include` / `filter` — the rendered matrix will have no rows. Usually indicates a typo in a codex reference. |

--- a/notations/views/22-coverage-metric.md
+++ b/notations/views/22-coverage-metric.md
@@ -109,6 +109,7 @@ view:
   coverage_rule:
     counts_as_covered: "any-active-assertion"   # any-active-assertion (default) | any-non-na-assertion
     treat_proposed_as: "hidden"                 # hidden | shown-distinct (default: hidden, per ASSERTION §2.2)
+    treat_ai_reviewed_as: "shown-distinct"      # shown-distinct | shown-same | hidden (default: shown-distinct — counts toward coverage, per CONTRACT §6.2)
 
   # Empty-cell labels — see §5.3 for the canonical strings.
   empty_cells:
@@ -146,6 +147,7 @@ Every field carries an explicit default, so a view with only the required envelo
 | `view.grouping.columns` | no | string | `regime` | Column dimension: `regime` (one column per codex artefact), `jurisdiction` (one column per jurisdiction; collapses all regimes from the same jurisdiction). |
 | `view.coverage_rule.counts_as_covered` | no | string | `any-active-assertion` | Defines which admitted `ASSERTION`s count a (subject, regime) pair as **covered**: `any-active-assertion` (an admitted assertion with any `status` value, including `n_a`; means *the model has considered the regime against the subject*) or `any-non-na-assertion` (only admitted assertions with `status` in `{compliant, partial, non_compliant, under_review}`; means *the model carries a substantive obligation, not just an n/a exclusion*). |
 | `view.coverage_rule.treat_proposed_as` | no | string | `hidden` | How to handle `ASSERTION`s in `proposed` admission state ([16-assertion.md](../elements/16-assertion.md) §2.2): `hidden` (the proposed assertion contributes nothing to coverage) or `shown-distinct` (rendered as a distinct partial-coverage marker so a reviewer sees the harvester's draft alongside admitted canon). The default matches the §2.2 rule that proposed assertions are excluded from every derived view until a human admits them. |
+| `view.coverage_rule.treat_ai_reviewed_as` | no | string | `shown-distinct` | How to count admitted `ASSERTION`s carrying `reviewer_authority: ai_reviewed` ([CONTRACT.md](../CONTRACT.md) §6.2): `shown-distinct` (**counts toward coverage**, rendered as a distinct AI-reviewed marker), `shown-same` (counts identically to `expert_confirmed`), or `hidden` (does not count toward coverage). Both tiers are admitted canon, so by **default `ai_reviewed` counts toward coverage**, shown distinct — an adopter who wants an expert-only coverage figure sets `hidden`. Coverage resting on a dependency chain containing an `ai_reviewed` node is reported at the **weakest-link** authority (§6.2). |
 | `view.empty_cells.not_yet_modelled_label` | no | string | `"Not yet modelled"` (§5.3) | Label for cells where coverage is zero **and** no admitted `ASSERTION` with `status: n_a` exists from the regime against the subject. |
 | `view.empty_cells.no_obligation_asserted_label` | no | string | `"No obligation asserted (modelled fact)"` (§5.3) | Label for cells where coverage is zero **and** every admitted `ASSERTION` from the regime against the subject has `status: n_a` (a modelled exclusion). |
 | `view.order_rows_by` | no | string | `id` | Row ordering key: `id`, `name`, `gap-count-desc` (largest modelling gap first — drives harvesting prioritisation), `gap-count-asc`. |
@@ -256,7 +258,7 @@ Pairs with **Transitrix Studio compliance views / export** (consumer side, track
 | `COVMET-002` | error | `view.subjects` is empty (neither `products` nor `processes` present). |
 | `COVMET-003` | error | A reference in `view.subjects.products` / `view.subjects.processes` / `view.regimes.include` does not resolve to an admitted canonical element of the expected TYPE. A value in `view.regimes.include` whose TYPE is not one of `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD` is the same error. |
 | `COVMET-004` | error | `view.grouping.rows`, `view.grouping.subject_grain`, or `view.grouping.columns` is set to a value outside the enumerated set in §4. |
-| `COVMET-005` | error | `view.coverage_rule.counts_as_covered` or `view.coverage_rule.treat_proposed_as` is set to a value outside its enumeration. |
+| `COVMET-005` | error | `view.coverage_rule.counts_as_covered`, `view.coverage_rule.treat_proposed_as`, or `view.coverage_rule.treat_ai_reviewed_as` is set to a value outside its enumeration (the last per CONTRACT §6.2: `shown-distinct` \| `shown-same` \| `hidden`). |
 | `COVMET-006` | warning | `view.regimes.filter.jurisdiction` contains a value that is not ISO 3166-1 alpha-2, `eu`, or `intl` (the only values codex external artefacts permit, [14-codex.md](../elements/14-codex.md) §3). |
 | `COVMET-007` | warning | Both `view.regimes.include` and `view.regimes.filter` are present (the include wins; the filter is silently ignored). |
 | `COVMET-008` | warning | The view selects zero regimes after applying `include` / `filter` — the rendered matrix will have no columns. Usually indicates a typo or that no codex artefacts of the requested kind have been admitted. |

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -123,6 +123,17 @@ Schema: [`schemas/candidate.schema.json`](schemas/candidate.schema.json).
 
 These are different questions with different fixes (get a better source vs. re-read the document). The schemas keep them in separate fields; collapsing them is a defect.
 
+### Tiered approval — routing by `extraction_confidence`
+
+`extraction_confidence` also drives **reviewer-authority routing** (tiered approval — [CONTRACT §6.2](https://raw.githubusercontent.com/transitrix/methodology/main/notations/CONTRACT.md)). Admitted canon carries a `reviewer_authority` tier, `ai_reviewed` < `expert_confirmed`, and the tier a draft is eligible for is decided by its extraction confidence:
+
+- **High `extraction_confidence`** → the draft is eligible for tool admission to **`ai_reviewed`** — the lower canon tier, marked as reviewed by a tool (`admitted_by` = the tool id), surfaced distinctly in views and coverage. The threshold is **adopter-configured** in the manifest (`transitrix.yaml`); below it, nothing auto-admits.
+- **Medium / low `extraction_confidence`** → routed to the **expert review queue** unchanged. Tool admission is forbidden; a human admits to **`expert_confirmed`**.
+
+The hard rule is unchanged in spirit (see [the one rule](#the-one-rule-that-governs-everything)): **a tool never writes `expert_confirmed`.** It may only mark the lower tier and route the draft; the human gate keeps exclusive authority over the top tier. `ai_reviewed` is still admitted canon — it is *provisional confirmation*, not a bypass — so it must clear the same structural validators (Step 5) before admission.
+
+> **Not yet wired into the CLI.** This routing is the **defined policy**; the current `@transitrix/ingest-cli` still only *proposes* (it never auto-admits), and the manifest `extraction_confidence` threshold schema is a downstream follow-up (per the ADR's out-of-scope). Until both land, every candidate continues through the human gate (Step 6); the tier is recorded by whoever admits.
+
 ---
 
 ## Step 5 — Validate (coverage-profile aware)


### PR DESCRIPTION
## What

Adds the **reviewer-authority** axis (`ai_reviewed | expert_confirmed`) to the admission record, per ADR `docs/decisions/2026-06-10-tiered-approval-reviewer-authority.md` (**Option A**). This lets the long tail of high-`extraction_confidence` drafts be tool-admitted to a provisional tier without collapsing the single expert gate (finding F19).

## Changes

- **`CONTRACT.md` §6.1** — new `reviewer_authority` field. Closed enum `ai_reviewed | expert_confirmed`; **absent ⇒ `expert_confirmed`** (back-compat, no migration). Both tiers are `admission_state: active` (both canon). New rules **`ADMIT-006`** (closed enum) and **`ADMIT-007`** (tool writes `ai_reviewed`, human writes `expert_confirmed`).
- **`CONTRACT.md` §6.2** (new subsection) — tiered-approval semantics: ordinal tiers, strict write authority (*a tool never writes `expert_confirmed`* → "propose, never write the **expert** tier"), a worked `ai_reviewed` record, and the **weakest-link** cross-tier dependency rule (`expert_confirmed` MAY depend on `ai_reviewed`; a chain renders at the minimum tier of its nodes; `ADMIT-005` not extended).
- **`CONTRACT.md` §11.4** — `reviewer_authority` is **not** folded into the element-confidence formula; surfaced as a qualitative label beside the numeric band.
- **`views/21-compliance-impact.md` + `views/22-coverage-metric.md`** — new `treat_ai_reviewed_as: shown-distinct | shown-same | hidden` switch (default `shown-distinct`), mirroring `treat_proposed_as`. Coverage counts `ai_reviewed` by default (shown-distinct). New gate `COMPIMP-006`; `COVMET-005` extended.
- **`transitrix/skills/ingest/SKILL.md`** — documents the routing rule: high `extraction_confidence` → tool MAY auto-admit to `ai_reviewed`; medium/low → expert queue; threshold adopter-configured in the manifest.

## Scope / honesty notes

- **Additive, no migration** — existing canon (no `reviewer_authority`) reads as `expert_confirmed`.
- The skill routing is documented as **policy**; CLI auto-admit and the manifest threshold schema are **downstream follow-ups** (per the ADR's out-of-scope) — flagged explicitly so the shipping skill's "propose, never write canon" stays accurate today.
- Out of scope (ADR follow-ups): Studio/DSM weakest-link rendering; manifest `extraction_confidence` threshold schema.

## Checks

- `node scripts/check-notations.mjs` — clean.

Closes methodology task #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)