### PR TITLE
docs(ingest-cli): local-install (transitrix-ingest) as primary invocation; Step-0 tolerates both names (F5)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,16 +46,17 @@ When an adopter repo moves from one methodology version to another, **three arte
    ```
 3. **Re-validate canon** to confirm the migrated artefacts are still valid:
    ```
-   npx @transitrix/ingest-cli validate <candidates-dir>
+   transitrix-ingest validate <candidates-dir>
    ```
-4. **Reinstall `@transitrix/ingest-cli`** — the installed binary does not auto-update; it remains pinned to the version it was installed from. Re-run your install command and confirm `--version` reflects the new release:
+4. **Reinstall `@transitrix/ingest-cli`** — the installed binary does not auto-update; it remains pinned to the version it was installed from. Re-run your install command and confirm `--version` reflects the new release. Pre-1.0 the package is not yet on npm, so the install is local from a fresh checkout of this repo:
    ```
-   npm install -g @transitrix/ingest-cli   # or npx/local install per your project setup
-   npx @transitrix/ingest-cli --version
+   npm install -g ./packages/ingest-cli   # or `npm link` from inside the package
+   transitrix-ingest --version
    ```
+   Once the CLI is published from its own tooling repo at the ~1.0 extraction, `npm install -g @transitrix/ingest-cli` (or `npx @transitrix/ingest-cli --version`) becomes the equivalent shorthand.
 5. **Run `repo-check`** to confirm version currency:
    ```
-   npx @transitrix/ingest-cli repo-check [org-root]
+   transitrix-ingest repo-check [org-root]
    ```
    A clean run shows `tooling.ok: true` and no version-mismatch red flag. If `tooling.ok: false` still appears, the installed binary is still the old version — repeat step 4.
 6. **Re-resolve the coverage profile** (if the new release changed the preset vocabulary — see `COVERAGE_PROFILES.md` §7 for what changes between versions). Fix `transitrix.yaml` if needed, then re-run `repo-check` to clear any `coverage_warning`.

--- a/packages/ingest-cli/README.md
+++ b/packages/ingest-cli/README.md
@@ -2,7 +2,19 @@
 
 The deterministic CLI behind the **ingest skill** (`transitrix/skills/ingest/`, `/transitrix:ingest`). The skill's `SKILL.md` shells out to this CLI; it never reimplements the logic, so behaviour is identical under Claude and GitHub Copilot.
 
-It lives here — a standalone package at the repo root, **outside** the skill bundle and the plugin payload — because it is consumed as a **published package** (`npx @transitrix/ingest-cli`), not vendored into the skill directory and not referenced by a repo-relative sibling path (which would dangle when only the skill directory ships into a Copilot `.github/skills/` install).
+It lives here — a standalone package at the repo root, **outside** the skill bundle and the plugin payload — because it is consumed as a **standalone package**, not vendored into the skill directory and not referenced by a repo-relative sibling path (which would dangle when only the skill directory ships into a Copilot `.github/skills/` install).
+
+## Install (pre-1.0)
+
+The package is not yet published to npm; the planned npm publish rides the ~1.0 extraction to its own tooling repo (`IG-7`). Today the install is local from this checkout:
+
+```
+npm install -g ./packages/ingest-cli   # provides the `transitrix-ingest` bin globally
+# or, from inside packages/ingest-cli/:
+npm link
+```
+
+The local install resolves the `transitrix-ingest` invocations used throughout the ingest and repo-check skills. Once the package ships to npm the equivalent shorthand becomes `npm install -g @transitrix/ingest-cli` (or `npx @transitrix/ingest-cli <command>`) — the two forms invoke the same binary, with identical subcommands and flags.
 
 ## The one rule
 

--- a/transitrix/skills/ingest/README.md
+++ b/transitrix/skills/ingest/README.md
@@ -38,9 +38,9 @@ All heavy logic — Markitdown conversion, coverage-profile read, validator pass
 
 Python in this repo is used **only in the onboarding skill's tests**, not in shipped deterministic logic. Markitdown stays a shell-out from one subcommand; the rest of the pipeline is pure Node and behaves identically under either agent.
 
-### CLI resolution — a published package
+### CLI resolution — a standalone package
 
-The CLI is resolved as a **published package** (installed / invoked via `npx`), not vendored per skill and not referenced by a repo-relative sibling path. A sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/ingest/` install; a published package is the single versioned source for both skills and both agents.
+The CLI is resolved as a **standalone package** — not vendored per skill and not referenced by a repo-relative sibling path. A sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/ingest/` install; a standalone package is the single versioned source for both skills and both agents. Pre-1.0 the install is local (`npm install -g ./packages/ingest-cli` → `transitrix-ingest`); once the package ships from its own tooling repo at the ~1.0 extraction, `npm install -g @transitrix/ingest-cli` (or `npx @transitrix/ingest-cli <command>`) becomes the equivalent shorthand. Both forms invoke the same binary.
 
 ---
 

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -26,11 +26,13 @@ The methodology is canon at `github.com/transitrix/methodology`; this skill is t
 The deterministic work (document conversion, coverage-profile read, validator pass, artefact + candidate emission, `_intake/` moves) is done by the CLI, never reimplemented in the agent. Confirm it is available:
 
 ```
-npx @transitrix/ingest-cli --version
+transitrix-ingest --version             # primary — local install
+# or, once the package is published to npm:
+npx @transitrix/ingest-cli --version    # equivalent — same binary
 ```
 
-- **Present** → proceed.
-- **Absent** → the CLI is not installed (or not published) in this environment. Stop and tell the user; do not hand-roll the pipeline, because hand-rolled extraction has no deterministic validator gate and risks the one rule above.
+- **Present** under either name → proceed. Use whichever form resolved; both invoke the same CLI, and the rest of this protocol shows the primary form. If only the `npx` form is reachable, substitute it for `transitrix-ingest` in the commands below — the subcommands and flags are identical.
+- **Absent** under both → the CLI is not installed in this environment. Stop and tell the user; do not hand-roll the pipeline, because hand-rolled extraction has no deterministic validator gate and risks the one rule above. Pre-1.0 the package is **not yet on npm**, so the expected install path is local: clone the methodology repo and `npm install -g ./packages/ingest-cli` (which provides the `transitrix-ingest` bin); the `npx @transitrix/ingest-cli` form starts to resolve once the CLI is published from its own tooling repo at the ~1.0 extraction.
 
 Also confirm you are operating inside a Transitrix adopter repository (a `transitrix.yaml` manifest at the repo root; see [MANIFEST](https://raw.githubusercontent.com/transitrix/methodology/main/notations/MANIFEST.md)). If there is no repo yet, the user wants `/transitrix:onboard` first.
 
@@ -52,7 +54,7 @@ Also confirm you are operating inside a Transitrix adopter repository (a `transi
 ```
 
 ```
-npx @transitrix/ingest-cli scaffold-intake <org-root>
+transitrix-ingest scaffold-intake <org-root>
 ```
 
 Idempotent — it never overwrites existing intake content. A source file flows `inbox/ → processing/ → processed/`. In v0 the `_intake/` convention is **skill-local**: it is documented here and in [`templates/_intake.README.md`](templates/_intake.README.md), not yet reserved in the methodology MANIFEST/CONTRACT. (Promotion to a reserved org-structure convention is a separate proposal once the skill stabilises.)
@@ -64,7 +66,7 @@ Idempotent — it never overwrites existing intake content. A source file flows 
 Office documents are converted to Markdown with **MS Markitdown** before extraction (per project convention), unless illustrations must be preserved. The CLI shells out to Markitdown; `.md` / `.txt` inputs pass through unchanged.
 
 ```
-npx @transitrix/ingest-cli convert <_intake/inbox/file>   # → _intake/processing/<file>.md
+transitrix-ingest convert <_intake/inbox/file>   # → _intake/processing/<file>.md
 ```
 
 Markitdown is a Python tool (`pip install "markitdown[all]"`); install it into the environment you run the CLI from, and if you use a virtualenv, activate it first. The CLI looks for the `markitdown` console-script and **falls back to `python -m markitdown` / `python3 -m markitdown`** — so it still works inside a venv where only the interpreter is on PATH. On Windows, if `markitdown`/`npx` are blocked by the PowerShell execution policy, run `python -m markitdown` directly or `Set-ExecutionPolicy -Scope Process RemoteSigned`. If Markitdown cannot be reached at all the CLI exits with an actionable message naming the install step. Conversion is the only point of contact with Markitdown — the rest of the pipeline is pure Node and runs identically under either agent.
@@ -76,7 +78,7 @@ Markitdown is a Python tool (`pip install "markitdown[all]"`); install it into t
 Each converted document becomes one `field` artefact carrying a complete **admission record** — provenance (who / when / in what setting) and a **proposed** `source_quality`. The field artefact is what lives in `field/`; the original raw bytes stay in `_intake/processed/` so the artefact is traceable to its source.
 
 ```
-npx @transitrix/ingest-cli admit-source --zone field <processing/file.md> \
+transitrix-ingest admit-source --zone field <processing/file.md> \
     --type INTERVIEW|SURVEY|OBSERVATION|DRAFT --role "<role>" --date YYYY-MM-DD
 ```
 
@@ -95,7 +97,7 @@ The same `source_hash` deduplicates: if the identical content was already admitt
 
 The skill **proposes**; a human **confirms**. Never silently bake a higher trust than the source warrants.
 
-**Codex sources — laws, regulations, policies, standards — take the parallel `codex` route:** `npx @transitrix/ingest-cli admit-source --zone codex <processing/file.md> --type LAW|REGULATION|POLICY|INTERNAL_STANDARD --effective-date YYYY-MM-DD [--jurisdiction <code>] [--source-authority <who>]`. A codex artefact is *authoritative by construction* — it carries **no** `source_quality`, records a snapshot of the source + a `source_hash`, and lands in `codex/external/<jurisdiction>/` (LAW/REGULATION) or `codex/internal/` (POLICY/INTERNAL_STANDARD) per [14-codex.md](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/14-codex.md). Its obligations are derived in Step 4 as `REQUIREMENT` + `ASSERTION` candidates that cite it via `derived_from`.
+**Codex sources — laws, regulations, policies, standards — take the parallel `codex` route:** `transitrix-ingest admit-source --zone codex <processing/file.md> --type LAW|REGULATION|POLICY|INTERNAL_STANDARD --effective-date YYYY-MM-DD [--jurisdiction <code>] [--source-authority <who>]`. A codex artefact is *authoritative by construction* — it carries **no** `source_quality`, records a snapshot of the source + a `source_hash`, and lands in `codex/external/<jurisdiction>/` (LAW/REGULATION) or `codex/internal/` (POLICY/INTERNAL_STANDARD) per [14-codex.md](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/14-codex.md). Its obligations are derived in Step 4 as `REQUIREMENT` + `ASSERTION` candidates that cite it via `derived_from`.
 
 ---
 
@@ -109,7 +111,7 @@ The agent runs the per-layer extraction prompts in [`prompts/`](prompts/) over t
 - carries an **`extraction_confidence`** flag (`high | medium | low`) — see the two-axes rule below.
 
 ```
-npx @transitrix/ingest-cli emit-candidates <field/artefact.yaml>   # → _intake/processing/candidates/
+transitrix-ingest emit-candidates <field/artefact.yaml>   # → _intake/processing/candidates/
 ```
 
 Schema: [`schemas/candidate.schema.json`](schemas/candidate.schema.json).
@@ -130,7 +132,7 @@ These are different questions with different fixes (get a better source vs. re-r
 Every candidate is run through the canonical validators — ID grammar, TYPE registry, closed REL kinds, lifecycle fields — and the adopter's **coverage profile**.
 
 ```
-npx @transitrix/ingest-cli validate <processing/candidates/>
+transitrix-ingest validate <processing/candidates/>
 ```
 
 The CLI reads the repo's `coverage_profile` ([COVERAGE_PROFILES](https://raw.githubusercontent.com/transitrix/methodology/main/notations/COVERAGE_PROFILES.md)) and **resolves membership** before classifying each candidate: it ships the preset definitions (§3 / §3.1) and resolves all three declared forms — a **short-form preset** (`coverage_profile: core`), a **custom map** (`extends:` a preset + per-layer `add`/`remove`/`disabled` deltas, §4), and the **absent** default (`full`). A TYPE / REL kind in the resolved profile is `in_profile`; one outside it is flagged `out_of_profile` per `CP-003`. `ASSERTION` and codex artefacts are never bounded by the profile (§2.1). Out-of-profile or invalid candidates are **flagged with an actionable reason** — not silently emitted into canon, and not silently dropped. A flagged candidate is a review-queue item, not a rejection.
@@ -140,7 +142,7 @@ If a profile is **present but cannot be resolved** (unknown preset, missing `ext
 When a corpus keeps surfacing the same out-of-profile TYPE, **`suggest-profile`** turns that signal into a concrete proposal instead of a manual profile edit:
 
 ```
-npx @transitrix/ingest-cli suggest-profile <processing/candidates/>   # read-only; prints to stdout
+transitrix-ingest suggest-profile <processing/candidates/>   # read-only; prints to stdout
 ```
 
 It scans the candidates, collects the out-of-profile element TYPEs and relation kinds, and prints a paste-ready `coverage_profile` delta (`extends:` the active base + the TYPEs grouped under their layer). It **never widens the profile itself** — the profile is the guardrail; the human reviews the proposal and edits `transitrix.yaml` deliberately. TYPEs whose layer the CLI cannot derive are listed under `unplaceable` to site by hand.
@@ -150,7 +152,7 @@ It scans the candidates, collects the out-of-profile element TYPEs and relation 
 ## Step 6 — Produce the review queue
 
 ```
-npx @transitrix/ingest-cli review-queue <processing/candidates/>   # → review-queue.yaml
+transitrix-ingest review-queue <processing/candidates/>   # → review-queue.yaml
 ```
 
 The queue is the human gate. It lists every field artefact (with its proposed `source_quality`), every candidate element and relation (with `derived_from`, `extraction_confidence`, and any validation/coverage flags), and the relation *suggestions* that fell below threshold. Schema: [`schemas/review-queue.schema.json`](schemas/review-queue.schema.json).
@@ -164,9 +166,9 @@ The queue is the human gate. It lists every field artefact (with its proposed `s
 Where an admitted element lands is **not** a judgement call. Every element TYPE has a canonical **materialisation mode + layer + folder** in [`ELEMENT_PRIMITIVES.md` §4](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md); the CLI resolves it so equals are treated equally — `ACTOR`, `ROLE`, `PROCESS`, `PRODUCT`, `APPLICATION` are all `standalone` and each gets its own per-TYPE folder, never inline-by-accident.
 
 - The review queue annotates each element candidate with its resolved `placement` (`mode`, `layer`, `folder`). Admit a `standalone` element to exactly that folder, one file per element.
-- Check any TYPE on demand: `npx @transitrix/ingest-cli resolve-placement <TYPE>`.
+- Check any TYPE on demand: `transitrix-ingest resolve-placement <TYPE>`.
 - **Honour the §1 promotion rule explicitly.** A `view-defined` / `contained` TYPE (`INTEGRATION`, `STEP`, `EQUIPMENT`, `INFORMATION_ENTITY`, registry rows) stays **inline** in its host/view document and is promoted to its own catalogue file **only when a second document references it** — the id never changes on promotion. Do not pre-create a standalone file for a still-single-reference element.
-- After admitting, verify placement: `npx @transitrix/ingest-cli check-placement [org-root]` flags any admitted element sitting outside its §4 folder (and any `view-defined` TYPE wrongly given its own catalogue file). Read-only over `canon/`.
+- After admitting, verify placement: `transitrix-ingest check-placement [org-root]` flags any admitted element sitting outside its §4 folder (and any `view-defined` TYPE wrongly given its own catalogue file). Read-only over `canon/`.
 
 ---
 
@@ -174,7 +176,7 @@ Where an admitted element lands is **not** a judgement call. Every element TYPE 
 
 All deterministic behaviour lives in **`@transitrix/ingest-cli`** — document conversion, coverage-profile read, validator pass, field-artefact + candidate emission, and the `_intake/` moves. This keeps the deterministic guarantees independent of which agent drives the skill (the same principle as the methodology's CI validators): neither Claude nor Copilot reimplements the logic, and both get identical results.
 
-The CLI is resolved as a **published package** (installed/invoked via `npx`), not vendored per skill and not referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`, `suggest-profile`, `check-placement`, `resolve-placement`.
+The CLI is resolved as a **standalone package** — installed locally (it provides the `transitrix-ingest` bin) and, once published from its own tooling repo at the ~1.0 extraction, equivalently via `npx @transitrix/ingest-cli`. It is **not** vendored per skill and **not** referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`, `suggest-profile`, `check-placement`, `resolve-placement`.
 
 ---
 

--- a/transitrix/skills/repo-check/README.md
+++ b/transitrix/skills/repo-check/README.md
@@ -18,7 +18,9 @@ Operating a Transitrix repo, you periodically want a quick, shareable answer to 
 ## Usage
 
 ```
-npx @transitrix/ingest-cli repo-check [org-root]    # defaults to the current repo; prints YAML to stdout
+transitrix-ingest repo-check [org-root]    # defaults to the current repo; prints YAML to stdout
 ```
+
+The CLI is also reachable as `npx @transitrix/ingest-cli repo-check ...` once the package is published to npm; pre-1.0 the local-install form is primary.
 
 See [`SKILL.md`](SKILL.md) for the agent-facing protocol and the report's field reference.

--- a/transitrix/skills/repo-check/SKILL.md
+++ b/transitrix/skills/repo-check/SKILL.md
@@ -26,18 +26,20 @@ This directory is the **`repo-check` skill** within the `transitrix` plugin (the
 The work is done by the CLI, never reimplemented in the agent:
 
 ```
-npx @transitrix/ingest-cli --version
+transitrix-ingest --version             # primary — local install
+# or, once the package is published to npm:
+npx @transitrix/ingest-cli --version    # equivalent — same binary
 ```
 
-- **Present** → proceed.
-- **Absent** → tell the user to install `@transitrix/ingest-cli`; do not hand-roll the scan.
+- **Present** under either name → proceed. Use whichever form resolved (the subcommands and flags below are identical between the two).
+- **Absent** under both → tell the user to install the CLI; do not hand-roll the scan. Pre-1.0 the package is **not yet on npm**, so the expected install path is local: clone the methodology repo and `npm install -g ./packages/ingest-cli` (which provides the `transitrix-ingest` bin); the `npx @transitrix/ingest-cli` form starts to resolve once the CLI is published from its own tooling repo at the ~1.0 extraction.
 
 ---
 
 ## Step 1 — Run the doctor
 
 ```
-npx @transitrix/ingest-cli repo-check [org-root]    # defaults to the current repo
+transitrix-ingest repo-check [org-root]    # defaults to the current repo
 ```
 
 It prints a YAML report to stdout:
@@ -56,7 +58,7 @@ It prints a YAML report to stdout:
 Summarise the `adoption_level` and any `red_flags` for the user in plain language, and point at the relevant repair command:
 
 - invalid IDs → fix the offending ids by hand (the report does not name them — by design; locate them with the validators or `git grep` locally).
-- misplaced canon elements → `npx @transitrix/ingest-cli check-placement [org-root]` lists them locally (that command **does** name ids — keep its output local, it is not the data-free report).
+- misplaced canon elements → `transitrix-ingest check-placement [org-root]` lists them locally (that command **does** name ids — keep its output local, it is not the data-free report).
 - unresolved `coverage_profile` → fix `transitrix.yaml` per `COVERAGE_PROFILES.md` (CP-001).
 - `tooling.ok: false` / version mismatch → the installed CLI binary targets a different methodology version than `transitrix.yaml` declares. Reinstall the CLI (see the adopter upgrade procedure in `RELEASING.md`) and re-run `repo-check` to confirm the flag clears.
 


### PR DESCRIPTION
## What

Resolves **F5** from the ingest dogfooding findings (#172 IH-8) per the
**2026-06-09 decision**: no npm publish until the ~1.0 IG-7 extraction
to a dedicated tooling repo. Today every command example in the ingest
and repo-check skills used `npx @transitrix/ingest-cli ...` as primary,
but that form does not resolve until the package ships — adopters
trying to run the pipeline today see `npx` fail. Documentation pivot
only; no code change.

## Changes

- **`transitrix/skills/ingest/SKILL.md`** — Step 0 pre-check now lists
  both invocation forms and accepts either; primary form is
  `transitrix-ingest`. All command examples (`scaffold-intake`,
  `convert`, `admit-source` for field + codex, `emit-candidates`,
  `validate`, `suggest-profile`, `review-queue`,
  `resolve-placement`, `check-placement`) pivoted to
  `transitrix-ingest`. "CLI resolution" note updated from "published
  package" to "standalone package", with the pre-1.0 install path
  spelled out.
- **`transitrix/skills/ingest/README.md`** — "CLI resolution" section
  updated to match: pre-1.0 local install (`transitrix-ingest`),
  post-publish `@transitrix/ingest-cli` shorthand, same binary.
- **`transitrix/skills/repo-check/SKILL.md`** — Step 0 + `repo-check` /
  `check-placement` examples pivoted in the same way.
- **`transitrix/skills/repo-check/README.md`** — Usage example pivoted;
  noted the `npx` form becomes available post-publish.
- **`packages/ingest-cli/README.md`** — New short "Install (pre-1.0)"
  section names the local-install command (`npm install -g
  ./packages/ingest-cli` or `npm link`) and notes the eventual `npx`
  equivalence; "published package" → "standalone package" in the
  resolution note.
- **`RELEASING.md`** — Adopter upgrade procedure: validate / repo-check
  examples pivoted to `transitrix-ingest`, reinstall step explains the
  pre-1.0 local form vs the post-publish shorthand.

## Scope / out-of-scope

- **In scope (F5 only):** the four `@transitrix/ingest-cli` reference
  surfaces named above. One concern, one PR.
- **Untouched:** `@transitrix/cli` examples in the onboarding skill and
  `@transitrix/reg-intel-cli` examples in the reg-intel skill —
  different binaries with their own distribution decisions; not part
  of F5.
- **No code change.** The CLI bin already exposes `transitrix-ingest`
  via the package's `bin` entry (unchanged); the help text already
  prints `transitrix-ingest <command> [args]`. This PR aligns the
  surrounding documentation with what the bin has always advertised.

## Checks

- `node scripts/check-notations.mjs` — clean.
- `python transitrix/skills/ingest/tests/test_ingest_integrity.py` —
  pass.
- Verified the rewritten Step 0 in both skills is symmetric and that
  the install path (clone + `npm install -g ./packages/ingest-cli`)
  resolves the `transitrix-ingest` bin used in every example below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)