### PR TITLE
docs(onboarding): make the onboard skill the single front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See **[`notations/README.md`](notations/README.md)** for the canonical index of 
 
 ## Validation in one paragraph
 
-Every change runs through five rule categories: syntax (valid YAML, schema-conformant), atomicity (no relations inside element files), referential integrity (every relation endpoint exists), ArchiMate semantics (layer-respecting connections), and policy (Active status requires an owner; deprecated elements reference successors). Adopters validate with **Transitrix Studio** (inline, on save) or the CLI — `npx @transitrix/cli validate <file>` — and gate pull requests on it in CI. *(This methodology repository lints its own example corpus with an internal script, `.validators/lint.py`; adopter repositories use the CLI above.)*
+Transitrix separates validation by responsibility — **view notations**, **element primitives**, **relations**, and **repo structure**. As you author, a single view file validates inline in **Transitrix Studio** (on save) or with `npx @transitrix/cli validate <file>`. Across the whole repository, the model-integrity linter `.validators/lint.py` runs the element/relation/structure checks — atomicity (no relations inside element files), referential integrity (every relation endpoint exists), ArchiMate semantics (layer-respecting connections), and policy (Active status requires an owner; deprecated elements reference successors) — over `canon/` and gates pull requests in CI. See [`integration/ci-example.yaml`](integration/ci-example.yaml) for the pipeline.
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -8,19 +8,34 @@ It builds on **ArchiMate 3.2**, **BPMN 2.0**, and the **Capability Maturity Mode
 
 **License:** MIT.
 
+## Quick start
+
+The fastest way in is the **onboarding Skill** — it scaffolds a clean zoned repo and walks you through your first model file. In a Claude Code session:
+
+```
+/plugin marketplace add transitrix/methodology
+/plugin install transitrix@transitrix-methodology
+/transitrix:onboard
+```
+
+The skill asks what you want to model first, scaffolds the `canon/` + `field/` + `codex/` layout, and authors a starter file with validation. Your **first artefact is a Goals tree** — the simplest notation to start from.
+
+Prefer to do it by hand, or not working in Claude Code? Follow the manual walkthrough in **[`organizations/acme_corp/GETTING_STARTED.md`](organizations/acme_corp/GETTING_STARTED.md)** — same first artefact, against the worked `acme_corp` example. To validate as you go, install **Transitrix Studio** (VS Code) for live preview, or run `npx @transitrix/cli validate <file>`.
+
+New to the ideas behind it? Read **[`method/methodology.md`](method/methodology.md)** for the *why* — but you don't need it to start.
+
 ## Documentation
 
-Start here:
-
-- **[`method/methodology.md`](method/methodology.md)** — the methodology overview. Read this first for the model and principles.
+- **[`method/methodology.md`](method/methodology.md)** — the methodology overview: model, principles, zones, change lifecycle.
 - **[`notations/README.md`](notations/README.md)** — the canonical notation index; [`notations/CONTRACT.md`](notations/CONTRACT.md) and the per-notation specs are the authoritative source for the model in detail.
 - **[`glossary.md`](glossary.md)** — standardised terminology.
-- **[`PROJECT_INDEX.md`](PROJECT_INDEX.md)** — navigation guide.
+- **[`PROJECT_INDEX.md`](PROJECT_INDEX.md)** — full navigation guide.
 
 Tooling:
 
 - **[`integration/studio.md`](integration/studio.md)** — how to use Transitrix Studio (the reference VS Code extension and CLI for editing all Transitrix custom formats).
 - **[`integration/tooling.md`](integration/tooling.md)** — broader tooling and ecosystem notes.
+- **[`integration/ci-example.yaml`](integration/ci-example.yaml)** — CI template that gates pull requests on validation.
 
 Per-organisation:
 
@@ -28,10 +43,6 @@ Per-organisation:
 - `organizations/<org>/GETTING_STARTED.md` — onboarding.
 - `organizations/<org>/CONVENTIONS.md` — local naming overrides.
 - `organizations/<org>/.templates/EXAMPLES.md` — worked examples.
-
-CI:
-
-- **[`integration/ci-example.yaml`](integration/ci-example.yaml)** — CI template for the validators.
 
 ## Repository structure
 
@@ -42,28 +53,6 @@ The repository has three buckets:
 - **Tooling** — what you install or run: [`transitrix/skills/`](transitrix/skills/) (Agent Skills — onboard, ingest), [`packages/`](packages/) (CLIs — e.g. `@transitrix/ingest-cli`), [`integration/`](integration/) (Studio / CI), [`scripts/`](scripts/) (doc-lint).
 
 For the full file map, see [`PROJECT_INDEX.md`](PROJECT_INDEX.md) — the single canonical navigation guide.
-
-## Quick start — for a new organisation
-
-```bash
-# 1. Bootstrap from the worked example
-cp -r organizations/acme_corp organizations/your_company
-
-# 2. Adapt local naming conventions
-$EDITOR organizations/your_company/CONVENTIONS.md
-
-# 3. Create your first element from a template
-cp organizations/your_company/.templates/elements/03_application_template.yaml \
-   organizations/your_company/canon/elements/03_application/MY_SERVICE.yaml
-$EDITOR organizations/your_company/canon/elements/03_application/MY_SERVICE.yaml
-
-# 4. Validate
-python3 organizations/your_company/.validators/lint.py
-
-# 5. Commit and open a pull request
-git add organizations/your_company/
-git commit -m "docs(arch): add MY_SERVICE for your_company"
-```
 
 ## How it works in five lines
 
@@ -81,7 +70,7 @@ See **[`notations/README.md`](notations/README.md)** for the canonical index of 
 
 ## Validation in one paragraph
 
-Every change runs through five rule categories: syntax (valid YAML, schema-conformant), atomicity (no relations inside element files), referential integrity (every relation endpoint exists), ArchiMate semantics (layer-respecting connections), and policy (Active status requires an owner; deprecated elements reference successors). The linter is a single Python script — `python3 .validators/lint.py`. CI gates pull requests on it.
+Every change runs through five rule categories: syntax (valid YAML, schema-conformant), atomicity (no relations inside element files), referential integrity (every relation endpoint exists), ArchiMate semantics (layer-respecting connections), and policy (Active status requires an owner; deprecated elements reference successors). Adopters validate with **Transitrix Studio** (inline, on save) or the CLI — `npx @transitrix/cli validate <file>` — and gate pull requests on it in CI. *(This methodology repository lints its own example corpus with an internal script, `.validators/lint.py`; adopter repositories use the CLI above.)*
 
 ## Use cases
 
@@ -103,4 +92,4 @@ Transitrix — including the FGCA / FGA notations that form part of it — is au
 ---
 
 **Methodology status:** pre-1.0 — see [`CHANGELOG.md`](CHANGELOG.md) for the current release and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10 for the compatibility policy.
-**Last updated:** 2026-06-05
+**Last updated:** 2026-06-11

--- a/docs/decisions/2026-06-11-onboarding-entry-front-door.md
+++ b/docs/decisions/2026-06-11-onboarding-entry-front-door.md
@@ -1,0 +1,96 @@
+---
+status: accepted
+date: 2026-06-11
+scope: repo
+supersedes: none
+superseded_by: none
+tags: [onboarding, documentation, entry-path, validator, cli, developer-experience, readme]
+---
+
+# Single canonical front door for new adopters
+
+## Context
+
+A newcomer to the methodology meets three separate entry points, and they
+disagree with each other:
+
+1. **`README.md` → "Quick start"** — leads with
+   `cp -r organizations/acme_corp organizations/your_company`, edits an
+   **application** element, and validates with
+   `python3 organizations/your_company/.validators/lint.py`.
+2. **`organizations/acme_corp/GETTING_STARTED.md`** — a manual seven-step path
+   whose first artefact is a **Goals tree**, validated with
+   `npx @transitrix/cli validate`.
+3. **The onboarding Skill (`/transitrix:onboard`)** — scaffolds a fresh zoned
+   `canon/` + `field/` + `codex/` tree from templates, lets the user pick the
+   first notation, and validates with `npx @transitrix/cli`.
+
+Three concrete frictions follow from this:
+
+- **Validator drift.** The most-read file (`README.md`) tells a newcomer to run
+  `.validators/lint.py` inside *their* organisation folder. The onboarding Skill
+  does not scaffold any `.validators/lint.py` (it drops `AGENTS.md`,
+  `transitrix.yaml`, and the Copilot pointer), so a freshly onboarded repo
+  cannot run that command. Every other adopter-facing surface
+  (`GETTING_STARTED.md`, `AGENTS.md`, `SKILL.md`) uses `npx @transitrix/cli`,
+  which is the published, canonical validator.
+- **The `cp -r acme_corp` "copy-then-gut" trap.** Bootstrapping by copying the
+  whole worked example inherits `acme_corp`'s content, which the newcomer then
+  has to delete — the opposite of a clean start. The Skill's fresh-scaffold
+  approach is better, but the README still leads with `cp -r`.
+- **Two "simplest first artefact" opinions** — an application element (README)
+  versus a Goals tree (`GETTING_STARTED.md`). There is no single hello-world.
+
+These are documentation/developer-experience problems within the Transitrix
+family — repo ergonomics, not a positioning or category change — so the
+decision is recorded as a local repo ADR rather than surfaced to the hub.
+
+## Decision
+
+Adopt **one canonical front door** and make every entry surface agree with it.
+
+1. **Primary path is the onboarding Skill (`/transitrix:onboard`).** `README.md`
+   leads with the three-line install + invoke. The Skill is presented as the
+   default way to start.
+2. **Manual fallback is `organizations/acme_corp/GETTING_STARTED.md`.** The
+   README links to it for adopters who want to author by hand or are not on
+   Claude Code, instead of duplicating step-by-step instructions in the README.
+   The `cp -r acme_corp` bootstrap is dropped from the README quick start.
+3. **The canonical hello-world artefact is a Goals tree** — the simplest
+   notation. README and `GETTING_STARTED.md` both name it.
+4. **The canonical adopter validator is `npx @transitrix/cli validate`.**
+   Studio provides the same checks inline on save. `.validators/lint.py` is
+   reframed as an **internal linter for this methodology repository's own
+   example corpus** — not an adopter command. The README's "Validation in one
+   paragraph" says so explicitly.
+5. **Reading order is relaxed.** `method/methodology.md` is reframed from
+   "read this first" to "read for the *why* — not required to start."
+
+## Alternatives considered
+
+- **Keep the `cp -r` bootstrap as the primary path.** Rejected: it ships the
+  worked example's content into the adopter repo and contradicts the Skill,
+  which is the supported scaffolder.
+- **Keep `.validators/lint.py` as an adopter-facing command.** Rejected: the
+  Skill does not scaffold it, so the instruction is broken for skill-onboarded
+  repos; `@transitrix/cli` is the published, maintained validator.
+- **Leave the three doors co-equal and just cross-link them.** Rejected: a
+  newcomer still has to reconcile contradictory first-artefact and validator
+  instructions before doing anything.
+
+## Consequences
+
+- `README.md`, `GETTING_STARTED.md`, and the onboarding Skill now tell one
+  consistent story: Skill-first, Goals-tree hello-world, `@transitrix/cli`
+  validation.
+- `GETTING_STARTED.md` already embodies the target (Goals tree +
+  `@transitrix/cli` + Skill-as-fastest-path); it is left unchanged.
+- The `.validators/lint.py` reference survives in the README, now scoped
+  accurately to this repository's own corpus, so the statement stays true.
+- **Follow-up (separate PR):** `integration/ci-example.yaml` is stale — it
+  references the pre-zone layout (`elements/**`, `relations/**`, `views/**` at
+  the repo root rather than under `canon/`) and runs `lint.py`. It should be
+  modernised to the zoned paths and the `@transitrix/cli` validation flow.
+  Deferred from this change because the correct batch/CI invocation of the CLI
+  needs to be confirmed against `@transitrix/cli` (which lives in
+  `transitrix-studio`) before publishing it in an adopter-facing template.

--- a/docs/decisions/2026-06-11-onboarding-entry-front-door.md
+++ b/docs/decisions/2026-06-11-onboarding-entry-front-door.md
@@ -31,9 +31,8 @@ Three concrete frictions follow from this:
   `.validators/lint.py` inside *their* organisation folder. The onboarding Skill
   does not scaffold any `.validators/lint.py` (it drops `AGENTS.md`,
   `transitrix.yaml`, and the Copilot pointer), so a freshly onboarded repo
-  cannot run that command. Every other adopter-facing surface
-  (`GETTING_STARTED.md`, `AGENTS.md`, `SKILL.md`) uses `npx @transitrix/cli`,
-  which is the published, canonical validator.
+  cannot run that command. Per-file authoring elsewhere
+  (`GETTING_STARTED.md`, `AGENTS.md`, `SKILL.md`) uses `npx @transitrix/cli`.
 - **The `cp -r acme_corp` "copy-then-gut" trap.** Bootstrapping by copying the
   whole worked example inherits `acme_corp`'s content, which the newcomer then
   has to delete — the opposite of a clean start. The Skill's fresh-scaffold
@@ -58,11 +57,15 @@ Adopt **one canonical front door** and make every entry surface agree with it.
    The `cp -r acme_corp` bootstrap is dropped from the README quick start.
 3. **The canonical hello-world artefact is a Goals tree** — the simplest
    notation. README and `GETTING_STARTED.md` both name it.
-4. **The canonical adopter validator is `npx @transitrix/cli validate`.**
-   Studio provides the same checks inline on save. `.validators/lint.py` is
-   reframed as an **internal linter for this methodology repository's own
-   example corpus** — not an adopter command. The README's "Validation in one
-   paragraph" says so explicitly.
+4. **Validation is separated by responsibility — view / element / relation /
+   repo-structure — and the docs name both tools accurately.** A single *view
+   notation* file validates inline in **Transitrix Studio** (on save) or with
+   `npx @transitrix/cli validate <file>`. The *element*, *relation*, and
+   *repo-structure* checks (atomicity, referential integrity, ArchiMate
+   semantics, policy) are run across the whole repository by the model-integrity
+   linter `.validators/lint.py` — which is **adopter-facing** (it ships in the
+   worked example and scans `canon/`), not internal to this repository. The two
+   are complementary, not a primary/legacy pair.
 5. **Reading order is relaxed.** `method/methodology.md` is reframed from
    "read this first" to "read for the *why* — not required to start."
 
@@ -71,9 +74,12 @@ Adopt **one canonical front door** and make every entry surface agree with it.
 - **Keep the `cp -r` bootstrap as the primary path.** Rejected: it ships the
   worked example's content into the adopter repo and contradicts the Skill,
   which is the supported scaffolder.
-- **Keep `.validators/lint.py` as an adopter-facing command.** Rejected: the
-  Skill does not scaffold it, so the instruction is broken for skill-onboarded
-  repos; `@transitrix/cli` is the published, maintained validator.
+- **Keep `python3 .validators/lint.py` as the README's headline first-run
+  command.** Rejected as the *quick-start* command: the Skill does not scaffold
+  `.validators/lint.py`, so it is broken for skill-onboarded repos, and a
+  whole-repo lint is the wrong first step when you have authored one file. The
+  linter keeps its place as the whole-repo CI gate (see Decision 4); per-file
+  authoring uses Studio / `@transitrix/cli`.
 - **Leave the three doors co-equal and just cross-link them.** Rejected: a
   newcomer still has to reconcile contradictory first-artefact and validator
   instructions before doing anything.
@@ -85,12 +91,22 @@ Adopt **one canonical front door** and make every entry surface agree with it.
   validation.
 - `GETTING_STARTED.md` already embodies the target (Goals tree +
   `@transitrix/cli` + Skill-as-fastest-path); it is left unchanged.
-- The `.validators/lint.py` reference survives in the README, now scoped
-  accurately to this repository's own corpus, so the statement stays true.
+- The README's "Validation in one paragraph" now names both tools by
+  responsibility: `@transitrix/cli` / Studio for view files, `.validators/lint.py`
+  for whole-repo element/relation/structure integrity.
+- **Open gap (skill).** The onboarding Skill does not scaffold a validator
+  bundle: a freshly onboarded repo has no `.validators/lint.py`, no
+  `requirements.txt`, no `.github/workflows`, and no pinned `@transitrix/cli`.
+  With the `cp -r acme_corp` bootstrap dropped, skill-onboarded repos therefore
+  have no whole-repo validator and no CI until the Skill is taught to scaffold
+  them. Tracked as a follow-up — the Skill (the agent) should own dependency +
+  CI setup at scaffold time.
+- **Possible finer split.** `.validators/lint.py` currently bundles the element,
+  relation, and repo-structure responsibilities into one engine. Splitting it
+  into dedicated per-responsibility validators is a separate methodology
+  decision, not gated here.
 - **Follow-up (separate PR):** `integration/ci-example.yaml` is stale — it
   references the pre-zone layout (`elements/**`, `relations/**`, `views/**` at
-  the repo root rather than under `canon/`) and runs `lint.py`. It should be
-  modernised to the zoned paths and the `@transitrix/cli` validation flow.
-  Deferred from this change because the correct batch/CI invocation of the CLI
-  needs to be confirmed against `@transitrix/cli` (which lives in
-  `transitrix-studio`) before publishing it in an adopter-facing template.
+  the repo root rather than under `canon/`) and runs `lint.py` on those paths.
+  It should be modernised to the zoned `canon/` layout and to validation steps
+  separated by responsibility (structure / model-integrity / view notations).

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -11,6 +11,7 @@ implementation PRs follow) · **Superseded** (replaced by a later ADR).
 
 | Date | Decision | Status | Scope |
 |---|---|---|---|
+| 2026-06-11 | [Single canonical front door for new adopters](2026-06-11-onboarding-entry-front-door.md) | Accepted | repo |
 | 2026-06-11 | [Architecture Decision Log (ADL) — multi-repo aggregation component](2026-06-11-architecture-decision-log.md) | Proposed | repo |
 | 2026-06-10 | [Tiered approval — reviewer-authority axis (AI-reviewed → expert-confirmed)](2026-06-10-tiered-approval-reviewer-authority.md) | Proposed | repo |
 | 2026-06-10 | [Source-of-truth for monitored sources — codex `scan` vs REGISTRY](2026-06-10-codex-registry-monitoring-source-of-truth.md) | Proposed | repo |


### PR DESCRIPTION
> **Updated 2026-06-11 — simplified direction.** This PR is the low-risk, high-value half of the onboarding-entry set and is meant to **land standalone, first**. The validation companions (#197/#198/#199) are being scaled back (single `scope` axis, two-job CI, single-runtime target) and should not block this one.

## Why

A newcomer meets three entry points that contradict each other:

| Surface | First move | First artefact | Validator |
|---|---|---|---|
| `README.md` quick start | `cp -r acme_corp …` | application element | `python3 .validators/lint.py` |
| `acme_corp/GETTING_STARTED.md` | manual 7 steps | **Goals tree** | `npx @transitrix/cli` |
| onboard Skill `/transitrix:onboard` | fresh scaffold | user-picked | `npx @transitrix/cli` |

Concrete frictions:

1. **Validator drift (broken).** README tells a newcomer to run `.validators/lint.py` in *their* org folder, but the onboard Skill never scaffolds that file — so a skill-onboarded repo can't run the README's headline command. Every other adopter surface uses the published `@transitrix/cli`.
2. **`cp -r acme_corp` is a copy-then-gut trap** — it ships the worked example's content into the adopter repo.
3. **Two "simplest first artefact" opinions** — application (README) vs Goals tree (GETTING_STARTED).

## What changes

- README leads with the **onboarding Skill** as the primary path; `cp -r` bootstrap dropped in favour of linking the manual `GETTING_STARTED.md` walkthrough.
- **Goals tree** is the canonical hello-world.
- Adopter validation unified on **`npx @transitrix/cli validate`**; `.validators/lint.py` reframed (accurately) as this repo's own corpus linter.
- **Validation is described by `scope` only** — *file* (per-notation checks) vs *repo* (whole-model checks). The README does **not** introduce a four-way view/element/relation/structure split; that distinction, if it surfaces at all, is reporting-only and lives in #198, not in the front-door prose.
- `methodology.md` reframed from "read first" to "read for the *why*".
- Decision recorded as local repo ADR (`docs/decisions/2026-06-11-onboarding-entry-front-door.md`) + INDEX row.

## Scope / not in scope

- `GETTING_STARTED.md` already embodies the target (Goals tree + `@transitrix/cli` + Skill-as-fastest-path) → **left unchanged**.
- **Deferred to a separate PR (per the ADR):** `integration/ci-example.yaml` is stale — it references the pre-zone layout (`elements/**`, `relations/**`, `views/**` at repo root, not `canon/`) and runs `lint.py`. Modernising it is #197.

Files: `README.md`, `docs/decisions/2026-06-11-onboarding-entry-front-door.md` (new), `docs/decisions/INDEX.md`.

Open for review — not merging; Valerii gates.