### PR TITLE
docs(decisions): converge validation on one runtime; scope axis (reporting taxonomy deferred)

### DIFF
--- a/docs/decisions/2026-06-11-validation-two-axis-model.md
+++ b/docs/decisions/2026-06-11-validation-two-axis-model.md
@@ -4,125 +4,110 @@ date: 2026-06-11
 scope: repo
 supersedes: none
 superseded_by: none
-tags: [validation, validator, architecture, cli, lint, referential-integrity, archimate, tooling, developer-experience]
+tags: [validation, validator, cli, lint, referential-integrity, archimate, tooling, developer-experience]
 ---
 
-# Two-axis validation model: scope × responsibility
+# Validation: converge on one runtime; `scope` as the one execution axis
 
 ## Context
 
-The methodology validates adopter repositories with **two** validators today:
+The methodology validates adopter repositories with **two** runtimes today:
 
 - **`.validators/lint.py`** — Python, **whole-repo** graph checks (atomicity,
   referential integrity, ArchiMate semantics, policy). Ships in the worked
   example `organizations/acme_corp/`, scans `canon/`.
 - **`@transitrix/cli validate <file>`** — TypeScript, **per-file**. Built on
-  `@transitrix/diagrams`, the parser/model library shared by Transitrix Studio
-  and DSM.
+  `@transitrix/diagrams`, the parser/model library already shared by Transitrix
+  Studio and DSM.
 
-The canon already names **five rule categories** — syntax, atomicity,
-referential integrity, ArchiMate semantics, policy — organised by *rule kind*
-(`README.md` §Validation; `lint.py`).
+The live pain is **two runtimes**: two dependency stories the onboarding Skill
+must scaffold, and two places where ID-grammar / TYPE-registry rules can drift.
 
-A question surfaced during the onboarding front-door work
-([`2026-06-11-onboarding-entry-front-door.md`](2026-06-11-onboarding-entry-front-door.md)):
-should validation be split by **entity type** — *view / element / relation /
-repo-structure*? Two failure modes if the axis is chosen wrong:
-
-- **Entity-type fragments referential integrity, which is inherently
-  cross-entity.** A relation references elements in other files; an element's
-  inline cross-references (`goal.factors: [FACTOR-…]`, `owner_role: ROLE-…`)
-  resolve against the whole model. A standalone "element validator" and
-  "relation validator" each end up needing the entire graph — so the split is
-  either double-loading or cosmetic (two entry points over one core).
-- **Entity-type competes with the existing five-category (rule-kind)
-  taxonomy** — two classification systems for one concern.
-
-Meanwhile the live pain is **two runtimes** (Python + TS): two dependency
-stories the onboarding Skill must scaffold, and two places where ID-grammar /
-TYPE-registry rules can drift.
+The onboarding front-door work
+([`2026-06-11-onboarding-entry-front-door.md`](2026-06-11-onboarding-entry-front-door.md))
+also raised a modelling question — should validation be split by **entity type**
+(view / element / relation / structure)? That question is answered below, but it
+is **not** the decision that matters: the decision that matters is removing a
+runtime.
 
 ## Decision
 
-Model validation along **two orthogonal axes**, over **one shared model**, and
-**converge on one runtime**. This keeps the four-way responsibility split the
-adopter cares about while putting the *execution* split on the seam that has
-engineering meaning.
-
-1. **Execution axis — `scope`.** Validation runs at one of two scopes:
-   - **`file`** — a single notation/element file: syntax, schema/header,
-     lifecycle, atomicity (no `relations:` block inside an element file). Cheap
-     and incremental; runs in Studio on save and per-changed-file in CI.
-   - **`repo`** — the whole loaded model: referential integrity, ArchiMate
-     layer-semantics on relations, policy, ID uniqueness. The CI gate.
-
-   This seam is the one with engineering meaning (caching, incrementality,
-   editor-feedback latency). It already exists implicitly — CLI is `file`-scope,
-   `lint.py` is `repo`-scope — and is now made explicit.
-
-2. **Contract / reporting axis — every finding is tagged on two dimensions:**
-   - **`target`** ∈ {`view`, `element`, `relation`, `structure`} — *which layer*
-     is wrong (the four-way responsibility split).
-   - **`category`** ∈ {`syntax`, `atomicity`, `referential`, `semantics`,
-     `policy`} — *which rule kind* broke (the existing canonical five).
-
-   A finding reads, e.g., `[repo][relation][referential] REL-…-3 → endpoint
-   GOAL-… not found`. The responsibility split lives **here** — in the contract
-   and the output — not as four engines.
-
-3. **Shared finding vocabulary.** Both validators emit findings shaped
-   `{scope, target, category, id, message}`. CI jobs are named by `scope`;
-   output is filterable by `target` / `category`. Adopting this now makes the
-   two current runtimes interchangeable in *reporting* before they are unified
-   in *code*.
-
-4. **Recommended target direction — converge on one runtime.** Consolidate
-   validation onto the TypeScript stack (`@transitrix/diagrams`, already the
-   shared parser/model for Studio and DSM), exposed through the CLI as
-   `validate --scope=file|repo [--target=…] [--category=…]`. Retire the Python
+1. **Converge on one runtime (the decision that matters).** Consolidate
+   validation onto the TypeScript stack (`@transitrix/diagrams`), exposed through
+   the CLI as `@transitrix/cli validate --scope=file|repo`. Retire the Python
    `.validators/lint.py` once the TS path reaches parity on the `repo`-scope
    checks. One parser, one source of truth for ID grammar / TYPE registry, one
-   dependency for the onboarding Skill to scaffold. This is the **recommended
-   direction**, sequenced as follow-ups below — not a flag-day rewrite.
+   dependency for the onboarding Skill to scaffold. Sequenced as follow-ups
+   below — not a flag-day rewrite.
+
+2. **One execution axis — `scope`.** This is the only axis with engineering
+   meaning (caching, incrementality, editor-feedback latency), and it already
+   exists implicitly (CLI = file-scope, `lint.py` = repo-scope). Make it explicit:
+   - **`file`** — a single notation/element file: syntax, schema/header,
+     lifecycle, atomicity. Cheap and incremental; Studio-on-save, per-changed-file
+     in CI.
+   - **`repo`** — the whole loaded model: referential integrity, ArchiMate
+     layer-semantics, policy, ID uniqueness. The CI gate.
+
+3. **Findings stay `{scope, id, message}` for now.** No richer reporting contract
+   is adopted at this time (see Deferred).
+
+## Deferred — finding-reporting taxonomy (proposed, not adopted)
+
+A taxonomy that tags every finding on two further dimensions —
+`target` ∈ {view, element, relation, structure} and
+`category` ∈ {syntax, atomicity, referential, semantics, policy} — was considered
+as a second "axis". It is **demoted to a proposal** and not adopted now:
+
+- These are **labels on a message, not an execution axis.** Calling them an "axis"
+  over-states a reporting concern.
+- Freezing the contract now would design an output format **ahead of any
+  consumer**: nothing reads `target`/`category` yet (no Studio problems-panel
+  filter, no CI annotation formatter). That is speculative generality.
+
+Revisit when a real consumer needs to filter or group findings by `target` /
+`category`. The four-way responsibility framing in the README and the CI header
+comment is fine as **documentation**; it does not need to be a contract or four
+engines yet.
 
 ## Alternatives considered
 
 - **Split into four validators by entity type (view / element / relation /
   structure).** Rejected as the *implementation* axis: referential integrity is
-  cross-entity, so element/relation cannot truly separate without each loading
-  the whole graph, and it introduces a second taxonomy competing with the five
-  rule-kind categories. **Kept as the reporting dimension (`target`)** — which
-  is the part of the instinct that earns its keep.
-- **Keep two runtimes indefinitely, only align paths.** Rejected as the end
-  state: the dual Python/TS dependency story is the live pain. Aligning the
-  finding vocabulary is step one; runtime convergence is the target.
-- **Use the storage decomposition (elements-vs-relations files) as the
-  validation architecture.** Rejected: atomic decomposition is a storage / diff
-  axis, not a verification axis; conflating them is a category error.
+  cross-entity (a relation references elements in other files; an element's inline
+  cross-references resolve against the whole model), so element/relation cannot
+  truly separate without each loading the whole graph — the split is either
+  double-loading or cosmetic, and it competes with the existing five rule-kind
+  categories.
+- **A formal "two-axis model" (scope × responsibility), adopted now.** This was
+  the original framing of this ADR; it is **superseded by the framing above** —
+  the responsibility dimension is demoted to a deferred reporting proposal so the
+  ADR commits only to what removes complexity.
+- **Keep two runtimes indefinitely.** Rejected as the end state: the dual
+  Python/TS dependency story is the live pain. Convergence is the target.
 
 ## Consequences
 
-- The modernised CI template (PR #197) already matches the `scope` axis —
-  `view` = file-scope, `model-integrity` = repo-scope (elements + relations),
-  `structure` = repo-scope. It adopts the `{scope, target, category}` output
-  vocabulary once the validators emit it.
-- The README responsibility framing (PR #196) stays correct: it names the four
-  `target`s and both tools. This ADR formalises that into the two-axis model and
-  **supersedes the "possible finer split" note** in
+- **CI template.** The example pipeline is structured by `scope` — `model`
+  (repo-scope: structure + `lint.py`) and `views` (file-scope: CLI) — per
+  PR #200, which collapses the earlier four-job version (#197) onto this axis.
+- **README framing (#196).** Stays correct: it describes validation by `scope`
+  and names both tools. This ADR formalises that.
+- **Supersedes** the "possible finer split" note in
   [`2026-06-11-onboarding-entry-front-door.md`](2026-06-11-onboarding-entry-front-door.md).
-- **Cross-repo reach.** Runtime convergence spans `methodology` (`lint.py`) and
-  `transitrix-studio` (`@transitrix/cli`, `@transitrix/diagrams`). This stays
-  within the Transitrix family — recorded here, with a referencing ADR to be
-  dropped in `transitrix-studio/docs/decisions/`. Not a hub matter.
+- **Cross-repo but in-family.** Runtime convergence spans `methodology`
+  (`lint.py`) and `transitrix-studio` (`@transitrix/cli`, `@transitrix/diagrams`).
+  Recorded here, with a referencing ADR to be dropped in
+  `transitrix-studio/docs/decisions/`. Not a hub matter.
 - **Follow-ups (sequenced, separate PRs):**
-  1. Define the shared finding schema `{scope, target, category, id, message}`
-     (JSON) in the methodology spec.
-  2. Teach `@transitrix/cli` to emit it and to run `--scope=repo` (referential /
-     semantics / policy / ID-uniqueness over `canon/`).
-  3. Port `lint.py`'s repo-scope checks to the TS engine; reach parity; retire
+  1. Teach `@transitrix/cli` to run `--scope=repo` (referential / semantics /
+     policy / ID-uniqueness over `canon/`).
+  2. Port `lint.py`'s repo-scope checks to the TS engine; reach parity; retire
      `lint.py`.
-  4. The onboarding Skill scaffolds the single canonical validator + a CI
-     workflow that emits the shared vocabulary.
-- **No adopter breakage in the interim.** Until convergence completes,
-  `lint.py` remains the adopter whole-repo gate and `@transitrix/cli` the
-  per-file validator; existing repos keep working.
+  3. The onboarding Skill scaffolds a single canonical validator instead of two
+     (collapses the interim two-runtime scaffold in #199).
+  4. *(Deferred, only if a consumer needs it)* define and emit the
+     `{scope, target, category, id, message}` finding schema.
+- **No adopter breakage in the interim.** Until convergence completes, `lint.py`
+  remains the adopter whole-repo gate and `@transitrix/cli` the per-file
+  validator; existing repos keep working.

--- a/docs/decisions/2026-06-11-validation-two-axis-model.md
+++ b/docs/decisions/2026-06-11-validation-two-axis-model.md
@@ -1,0 +1,128 @@
+---
+status: accepted
+date: 2026-06-11
+scope: repo
+supersedes: none
+superseded_by: none
+tags: [validation, validator, architecture, cli, lint, referential-integrity, archimate, tooling, developer-experience]
+---
+
+# Two-axis validation model: scope × responsibility
+
+## Context
+
+The methodology validates adopter repositories with **two** validators today:
+
+- **`.validators/lint.py`** — Python, **whole-repo** graph checks (atomicity,
+  referential integrity, ArchiMate semantics, policy). Ships in the worked
+  example `organizations/acme_corp/`, scans `canon/`.
+- **`@transitrix/cli validate <file>`** — TypeScript, **per-file**. Built on
+  `@transitrix/diagrams`, the parser/model library shared by Transitrix Studio
+  and DSM.
+
+The canon already names **five rule categories** — syntax, atomicity,
+referential integrity, ArchiMate semantics, policy — organised by *rule kind*
+(`README.md` §Validation; `lint.py`).
+
+A question surfaced during the onboarding front-door work
+([`2026-06-11-onboarding-entry-front-door.md`](2026-06-11-onboarding-entry-front-door.md)):
+should validation be split by **entity type** — *view / element / relation /
+repo-structure*? Two failure modes if the axis is chosen wrong:
+
+- **Entity-type fragments referential integrity, which is inherently
+  cross-entity.** A relation references elements in other files; an element's
+  inline cross-references (`goal.factors: [FACTOR-…]`, `owner_role: ROLE-…`)
+  resolve against the whole model. A standalone "element validator" and
+  "relation validator" each end up needing the entire graph — so the split is
+  either double-loading or cosmetic (two entry points over one core).
+- **Entity-type competes with the existing five-category (rule-kind)
+  taxonomy** — two classification systems for one concern.
+
+Meanwhile the live pain is **two runtimes** (Python + TS): two dependency
+stories the onboarding Skill must scaffold, and two places where ID-grammar /
+TYPE-registry rules can drift.
+
+## Decision
+
+Model validation along **two orthogonal axes**, over **one shared model**, and
+**converge on one runtime**. This keeps the four-way responsibility split the
+adopter cares about while putting the *execution* split on the seam that has
+engineering meaning.
+
+1. **Execution axis — `scope`.** Validation runs at one of two scopes:
+   - **`file`** — a single notation/element file: syntax, schema/header,
+     lifecycle, atomicity (no `relations:` block inside an element file). Cheap
+     and incremental; runs in Studio on save and per-changed-file in CI.
+   - **`repo`** — the whole loaded model: referential integrity, ArchiMate
+     layer-semantics on relations, policy, ID uniqueness. The CI gate.
+
+   This seam is the one with engineering meaning (caching, incrementality,
+   editor-feedback latency). It already exists implicitly — CLI is `file`-scope,
+   `lint.py` is `repo`-scope — and is now made explicit.
+
+2. **Contract / reporting axis — every finding is tagged on two dimensions:**
+   - **`target`** ∈ {`view`, `element`, `relation`, `structure`} — *which layer*
+     is wrong (the four-way responsibility split).
+   - **`category`** ∈ {`syntax`, `atomicity`, `referential`, `semantics`,
+     `policy`} — *which rule kind* broke (the existing canonical five).
+
+   A finding reads, e.g., `[repo][relation][referential] REL-…-3 → endpoint
+   GOAL-… not found`. The responsibility split lives **here** — in the contract
+   and the output — not as four engines.
+
+3. **Shared finding vocabulary.** Both validators emit findings shaped
+   `{scope, target, category, id, message}`. CI jobs are named by `scope`;
+   output is filterable by `target` / `category`. Adopting this now makes the
+   two current runtimes interchangeable in *reporting* before they are unified
+   in *code*.
+
+4. **Recommended target direction — converge on one runtime.** Consolidate
+   validation onto the TypeScript stack (`@transitrix/diagrams`, already the
+   shared parser/model for Studio and DSM), exposed through the CLI as
+   `validate --scope=file|repo [--target=…] [--category=…]`. Retire the Python
+   `.validators/lint.py` once the TS path reaches parity on the `repo`-scope
+   checks. One parser, one source of truth for ID grammar / TYPE registry, one
+   dependency for the onboarding Skill to scaffold. This is the **recommended
+   direction**, sequenced as follow-ups below — not a flag-day rewrite.
+
+## Alternatives considered
+
+- **Split into four validators by entity type (view / element / relation /
+  structure).** Rejected as the *implementation* axis: referential integrity is
+  cross-entity, so element/relation cannot truly separate without each loading
+  the whole graph, and it introduces a second taxonomy competing with the five
+  rule-kind categories. **Kept as the reporting dimension (`target`)** — which
+  is the part of the instinct that earns its keep.
+- **Keep two runtimes indefinitely, only align paths.** Rejected as the end
+  state: the dual Python/TS dependency story is the live pain. Aligning the
+  finding vocabulary is step one; runtime convergence is the target.
+- **Use the storage decomposition (elements-vs-relations files) as the
+  validation architecture.** Rejected: atomic decomposition is a storage / diff
+  axis, not a verification axis; conflating them is a category error.
+
+## Consequences
+
+- The modernised CI template (PR #197) already matches the `scope` axis —
+  `view` = file-scope, `model-integrity` = repo-scope (elements + relations),
+  `structure` = repo-scope. It adopts the `{scope, target, category}` output
+  vocabulary once the validators emit it.
+- The README responsibility framing (PR #196) stays correct: it names the four
+  `target`s and both tools. This ADR formalises that into the two-axis model and
+  **supersedes the "possible finer split" note** in
+  [`2026-06-11-onboarding-entry-front-door.md`](2026-06-11-onboarding-entry-front-door.md).
+- **Cross-repo reach.** Runtime convergence spans `methodology` (`lint.py`) and
+  `transitrix-studio` (`@transitrix/cli`, `@transitrix/diagrams`). This stays
+  within the Transitrix family — recorded here, with a referencing ADR to be
+  dropped in `transitrix-studio/docs/decisions/`. Not a hub matter.
+- **Follow-ups (sequenced, separate PRs):**
+  1. Define the shared finding schema `{scope, target, category, id, message}`
+     (JSON) in the methodology spec.
+  2. Teach `@transitrix/cli` to emit it and to run `--scope=repo` (referential /
+     semantics / policy / ID-uniqueness over `canon/`).
+  3. Port `lint.py`'s repo-scope checks to the TS engine; reach parity; retire
+     `lint.py`.
+  4. The onboarding Skill scaffolds the single canonical validator + a CI
+     workflow that emits the shared vocabulary.
+- **No adopter breakage in the interim.** Until convergence completes,
+  `lint.py` remains the adopter whole-repo gate and `@transitrix/cli` the
+  per-file validator; existing repos keep working.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -11,6 +11,7 @@ implementation PRs follow) · **Superseded** (replaced by a later ADR).
 
 | Date | Decision | Status | Scope |
 |---|---|---|---|
+| 2026-06-11 | [Single canonical front door for new adopters](2026-06-11-onboarding-entry-front-door.md) | Accepted | repo |
 | 2026-06-11 | [Two-axis validation model — scope × responsibility](2026-06-11-validation-two-axis-model.md) | Accepted | repo |
 | 2026-06-11 | [Architecture Decision Log (ADL) — multi-repo aggregation component](2026-06-11-architecture-decision-log.md) | Proposed | repo |
 | 2026-06-10 | [Tiered approval — reviewer-authority axis (AI-reviewed → expert-confirmed)](2026-06-10-tiered-approval-reviewer-authority.md) | Proposed | repo |

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -12,7 +12,7 @@ implementation PRs follow) · **Superseded** (replaced by a later ADR).
 | Date | Decision | Status | Scope |
 |---|---|---|---|
 | 2026-06-11 | [Single canonical front door for new adopters](2026-06-11-onboarding-entry-front-door.md) | Accepted | repo |
-| 2026-06-11 | [Two-axis validation model — scope × responsibility](2026-06-11-validation-two-axis-model.md) | Accepted | repo |
+| 2026-06-11 | [Validation: converge on one runtime; scope axis](2026-06-11-validation-two-axis-model.md) | Accepted | repo |
 | 2026-06-11 | [Architecture Decision Log (ADL) — multi-repo aggregation component](2026-06-11-architecture-decision-log.md) | Proposed | repo |
 | 2026-06-10 | [Tiered approval — reviewer-authority axis (AI-reviewed → expert-confirmed)](2026-06-10-tiered-approval-reviewer-authority.md) | Proposed | repo |
 | 2026-06-10 | [Source-of-truth for monitored sources — codex `scan` vs REGISTRY](2026-06-10-codex-registry-monitoring-source-of-truth.md) | Proposed | repo |

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -11,6 +11,7 @@ implementation PRs follow) · **Superseded** (replaced by a later ADR).
 
 | Date | Decision | Status | Scope |
 |---|---|---|---|
+| 2026-06-11 | [Two-axis validation model — scope × responsibility](2026-06-11-validation-two-axis-model.md) | Accepted | repo |
 | 2026-06-11 | [Architecture Decision Log (ADL) — multi-repo aggregation component](2026-06-11-architecture-decision-log.md) | Proposed | repo |
 | 2026-06-10 | [Tiered approval — reviewer-authority axis (AI-reviewed → expert-confirmed)](2026-06-10-tiered-approval-reviewer-authority.md) | Proposed | repo |
 | 2026-06-10 | [Source-of-truth for monitored sources — codex `scan` vs REGISTRY](2026-06-10-codex-registry-monitoring-source-of-truth.md) | Proposed | repo |


### PR DESCRIPTION
> **Updated 2026-06-11 — simplified direction.** Re-framed so the ADR's headline is the decision that *removes* complexity (one runtime). The three-dimensional finding taxonomy is **demoted to `proposed` and deferred** until a consumer exists. **The committed ADR file on this branch still presents the original "two-axis, accepted" framing — it will be revised to match this description before merge.**

## What

Records the validation-architecture decision raised by the onboarding front-door work (#196).

## The decision that matters (status: accepted)

**Converge validation onto one runtime.** Today there are two: `.validators/lint.py` (Python, whole-repo) and `@transitrix/cli validate <file>` (TypeScript, per-file, built on `@transitrix/diagrams` — already the shared parser/model for Studio + DSM). Two runtimes = two dependency stories the onboarding Skill must scaffold, and two places where ID-grammar / TYPE-registry rules drift. This is the live pain.

Direction: consolidate onto the TS stack, exposed as `@transitrix/cli validate --scope=file|repo`. Retire `lint.py` once the TS path reaches parity on the repo-scope checks. One parser, one source of truth, one dependency to scaffold. Sequenced as follow-ups, not a flag-day rewrite.

## The one axis worth naming: `scope`

Validation runs at one of two scopes, and this is the seam with engineering meaning (caching, incrementality, editor-feedback latency):

- **`file`** — single notation/element file: syntax, schema/header, lifecycle, atomicity. Cheap, incremental; Studio-on-save, per-changed-file in CI.
- **`repo`** — whole loaded model: referential integrity, ArchiMate layer-semantics, policy, ID uniqueness. The CI gate.

It already exists implicitly (CLI = file, `lint.py` = repo); this just makes it explicit.

## Deferred (status: proposed — not adopted now)

A **finding-reporting taxonomy** — tagging each finding with `target` ∈ {view, element, relation, structure} and `category` ∈ {syntax, atomicity, referential, semantics, policy}. This is **labels on a message, not a second execution axis**, and freezing the contract now would design an output format ahead of any consumer (no Studio problems-panel filter, no CI annotation formatter reads these yet — YAGNI). Revisit when a consumer actually filters by `target`/`category`. Until then findings stay `{scope, id, message}`.

**Explicitly rejected as the *implementation* axis:** splitting into four validators by entity type. Referential integrity is cross-entity (a relation references elements in other files), so element/relation can't separate without each loading the whole graph — the split is double-loading or cosmetic, and competes with the existing five rule-kind categories.

## Notes

- Supersedes the "possible finer split" note in [`2026-06-11-onboarding-entry-front-door.md`](2026-06-11-onboarding-entry-front-door.md).
- **Cross-repo but in-family:** convergence touches `methodology` (`lint.py`) + `transitrix-studio` (`@transitrix/cli`, `@transitrix/diagrams`); recorded locally per the family ADR rule, with a referencing ADR in `transitrix-studio/docs/decisions/`. Not a hub matter.
- **`INDEX.md`:** #196 also adds a row. If #196 merges first, expect a trivial conflict here — keep both new rows.

Open for review — not merging; Valerii gates.