### PR TITLE
docs(views): pin defaults and name the saved view-config convention (RPT-1)

### DIFF
--- a/notations/README.md
+++ b/notations/README.md
@@ -47,6 +47,8 @@ The cross-cutting **element-primitive file schema** — the common envelope ever
 
 The cross-cutting **Coverage Profile** — the mechanism an adopter uses to declare which slice of the methodology's vocabulary (per-layer element TYPEs + relation TYPEs) is in scope for their repository — is defined in [`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md). Adopters declare a profile in [`transitrix.yaml`](MANIFEST.md); the default when omitted is `full`.
 
+The cross-cutting **Named view-config convention** — where saved view-configs live in an adopter repo, how they're named, listed, and re-run — is defined in [`views/REPORT_VIEW_CONFIG.md`](views/REPORT_VIEW_CONFIG.md). The convention applies uniformly across every view notation, and is the registry the report-config view specs ([`11-scenarios.md`](views/11-scenarios.md), [`21-compliance-impact.md`](views/21-compliance-impact.md), [`22-coverage-metric.md`](views/22-coverage-metric.md)) and the future report skill ([ADR 2026-06-09](../docs/decisions/2026-06-09-report-skill-over-declarative-views.md)) lean on.
+
 ## Status vocabulary
 
 The `status:` field in each spec's front-matter describes the **spec's maturity** — how stable and complete the notation specification is. It does **not** describe whether a tool implements the notation; tool implementation is tracked separately in the `dsm_status:` field on the same spec.

--- a/notations/views/11-scenarios.md
+++ b/notations/views/11-scenarios.md
@@ -1,8 +1,8 @@
 ---
 notation: "Scenarios"
-version: "0.3"
+version: "0.4"
 author: "Valerii Korobeinikov"
-last_updated: "2026-06-03"
+last_updated: "2026-06-12"
 status: "draft"
 file_extension: "*.scenarios.transitrix.yaml"
 dsm_status: "implemented — Scenarios page; selector reclassification (v0.3) planned for next cut"
@@ -10,9 +10,9 @@ dsm_status: "implemented — Scenarios page; selector reclassification (v0.3) pl
 
 # Scenarios — Report-Configuration View — Reference
 
-**Version:** 0.3
-**Date:** 2026-06-03
-**Status:** Draft — the v0.2 "scenario document scopes its own goals/capabilities/activities/…" shape was retired by the SCENARIO reclassification (epic [strategy#122](https://github.com/vkgeorgia/strategy/issues/122)); this revision documents the post-reclassification, report-config shape.
+**Version:** 0.4
+**Date:** 2026-06-12
+**Status:** Draft — the v0.2 "scenario document scopes its own goals/capabilities/activities/…" shape was retired by the SCENARIO reclassification (epic [strategy#122](https://github.com/vkgeorgia/strategy/issues/122)); this revision documents the post-reclassification, report-config shape. **v0.4 pins explicit defaults on every non-required field and adds the §4.1 zero-configuration default** ([ADR 2026-06-09](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md) §7 Step 1) so the report skill has a well-defined "what I assumed" fallback.
 **File extension:** `*.scenarios.transitrix.yaml`
 **Scope:** A **rendering / ordering / filtering configuration** for the Scenarios view over the `SCENARIO` content-element catalogue (`canon/elements/05_implementation/scenarios/`). The document is a presentation surface — it carries no canonical content of its own.
 **Renderer:** Transitrix DSM — Scenarios page; Transitrix Studio (planned).
@@ -100,20 +100,41 @@ The document carries the canonical envelope (`notation:` header, `spec_version:`
 
 ## 4. Fields
 
-| Field | Required | Type | Semantics |
-|---|---|---|---|
-| `view.id` | yes | string | View identifier, canonical-grammar (`SCENARIOS-…`) per [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.2 (`SCENARIOS` document-level TYPE). |
-| `view.name` | yes | string | Human-readable name shown in the renderer. |
-| `view.description` | no | string | Short description of the purpose of this view (which scenarios it groups, why). |
-| `view.scenarios.include` | one of `include`/`filter` | list | Explicit list of `SCENARIO-…` IDs to render, in display order. |
-| `view.scenarios.filter` | one of `include`/`filter` | object | Declarative filter — `arrives_at: TARGET_STATE-…`, `pursues_any: [GOAL-…]`, `pursues_all: [GOAL-…]`. The renderer resolves the filter against the `SCENARIO` catalogue at render time. |
-| `view.order_by` | no | string | Ordering key (`name`, `id`, `arrives_at`, …). Default `name`. |
-| `view.layout` | no | string | `side-by-side` \| `stacked` \| `summary-table`. Default `side-by-side`. |
-| `view.show_steps` | no | bool | Whether to render each scenario's ordered `steps` inline. Default `true`. |
-| `view.show_target_state` | no | bool | Whether to render each scenario's `arrives_at` target-state composition inline. Default `true`. |
-| `view.show_pursues` | no | bool | Whether to render each scenario's `pursues` goal list inline. Default `true`. |
+Every field carries an explicit default, so a view with only the required envelope (`view.id`, `view.name`) renders deterministically — see §4.1.
+
+| Field | Required | Type | Default | Semantics |
+|---|---|---|---|---|
+| `view.id` | yes | string | — (required) | View identifier, canonical-grammar (`SCENARIOS-…`) per [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.2 (`SCENARIOS` document-level TYPE). |
+| `view.name` | yes | string | — (required) | Human-readable name shown in the renderer. |
+| `view.description` | no | string | empty | Short description of the purpose of this view (which scenarios it groups, why). |
+| `view.scenarios.include` | no ¹ | list | unset (use `filter`, or the full set) | Explicit list of `SCENARIO-…` IDs to render, in display order. |
+| `view.scenarios.filter` | no ¹ | object | **no filter — every admitted `SCENARIO` in canon** | Declarative filter — `arrives_at: TARGET_STATE-…`, `pursues_any: [GOAL-…]`, `pursues_all: [GOAL-…]`. The renderer resolves the filter against the `SCENARIO` catalogue at render time. |
+| `view.order_by` | no | string | `name` | Ordering key: `name`, `id`, `arrives_at`, or a custom comparator declared elsewhere. |
+| `view.layout` | no | string | `side-by-side` | Render layout: `side-by-side`, `stacked`, or `summary-table`. |
+| `view.show_steps` | no | bool | `true` | Whether to render each scenario's ordered `steps` inline. |
+| `view.show_target_state` | no | bool | `true` | Whether to render each scenario's `arrives_at` target-state composition inline. |
+| `view.show_pursues` | no | bool | `true` | Whether to render each scenario's `pursues` goal list inline. |
+
+¹ **`scenarios`** — both keys are optional and only ever *narrow* the rendered set. Omitting them is the zero-config default: the renderer renders **every admitted `SCENARIO`** in canon (sorted by the default `order_by: name`). Name `include` or `filter` to narrow to a specific cut. If both `include` and `filter` are present, `include` wins and `filter` is silently ignored — same precedence as the obligation axis in [`21-compliance-impact.md`](21-compliance-impact.md) §4.
 
 All references in `view.scenarios.include`, `view.scenarios.filter.arrives_at`, and `view.scenarios.filter.pursues_*` resolve to canon primitives via the usual cross-reference rule ([IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §5).
+
+### 4.1 Zero-configuration default
+
+A view that carries only the required envelope —
+
+```yaml
+notation: scenarios
+spec_version: "0.3"
+methodology_version: "0.5.0"
+view:
+  id: SCENARIOS-ALL-1
+  name: "All scenarios"
+```
+
+— renders **deterministically**: every admitted `SCENARIO` in canon, side-by-side, with each scenario's `steps`, `arrives_at`, and `pursues` rendered inline, ordered by `name`. This is the fallback the report skill ([ADR 2026-06-09](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md), §4) states back to the user as "all scenarios, no filter". Each field a caller omits falls back to its §4 default; the result is reproducible from canon alone.
+
+Where a named, saved view-config of this notation lives in an adopter repo, and how a reader lists or re-runs it by name, is the registry convention in [`REPORT_VIEW_CONFIG.md`](REPORT_VIEW_CONFIG.md).
 
 ---
 
@@ -146,3 +167,5 @@ The example files under [`../examples/scenarios/`](../examples/scenarios/) (`opt
 - `target_state_satisfies_goal` REL kind (which goals an end-state satisfies): [elements/17-relations.md](../elements/17-relations.md) §3.
 - ID grammar and TYPE registry: [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md).
 - Reconstruction invariant (why view documents are not content homes): [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1.
+- Named view-config convention (where this view's saved configs live, how they're named, listed, and re-run): [REPORT_VIEW_CONFIG.md](REPORT_VIEW_CONFIG.md).
+- ADR — reports rendered from declarative view-configs, with a thin skill on top: [../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md).

--- a/notations/views/21-compliance-impact.md
+++ b/notations/views/21-compliance-impact.md
@@ -163,6 +163,8 @@ view:
 
 — renders **deterministically**: the full obligation × subject matrix over every `PRODUCT` in canon and every `REQUIREMENT` that bears on them, grouped `obligation` × `product-stage-task`, all five statuses shown, proposed assertions hidden, rows ordered by `id`, columns in `process-order`. This is the fallback the report skill ([ADR 2026-06-09](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md), §4) states back to the user as "full matrix, no filters". Each field a caller omits falls back to its §4 default; the result is reproducible from canon alone.
 
+Where a named, saved view-config of this notation lives in an adopter repo, and how a reader lists or re-runs it by name, is the registry convention in [REPORT_VIEW_CONFIG.md](REPORT_VIEW_CONFIG.md).
+
 ---
 
 ## 5. Render contract
@@ -263,3 +265,5 @@ The shared header rules `HDR-001..004` ([CONTRACT.md](../CONTRACT.md) §2) apply
 - Scenarios — the sibling report-config view: [11-scenarios.md](11-scenarios.md).
 - ID grammar and TYPE registry: [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) (`COMPLIANCE_IMPACT` registered in §3.2).
 - Reconstruction invariant (why view documents are not content homes): [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1.
+- Named view-config convention (where this view's saved configs live, how they're named, listed, and re-run): [REPORT_VIEW_CONFIG.md](REPORT_VIEW_CONFIG.md).
+- ADR — reports rendered from declarative view-configs, with a thin skill on top: [../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md).

--- a/notations/views/22-coverage-metric.md
+++ b/notations/views/22-coverage-metric.md
@@ -177,6 +177,8 @@ view:
 
 — renders **deterministically**: per-regime coverage over **every `PRODUCT` in canon** against **every codex artefact** in the `codex/` zone, rows `subject` at `task` grain, columns by `regime`, `any-active-assertion` coverage rule, proposed assertions hidden, all three summary totals shown, rows and columns ordered by `id`. This is the fallback the report skill ([ADR 2026-06-09](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md), §4) states back to the user. Each field a caller omits falls back to its §4 default; the result is reproducible from canon alone.
 
+Where a named, saved view-config of this notation lives in an adopter repo, and how a reader lists or re-runs it by name, is the registry convention in [REPORT_VIEW_CONFIG.md](REPORT_VIEW_CONFIG.md).
+
 ---
 
 ## 5. Render contract
@@ -278,3 +280,5 @@ The shared header rules `HDR-001..004` ([CONTRACT.md](../CONTRACT.md) §2) apply
 - Compliance Impact — the sibling report-config view (same canonical inputs, different read): [21-compliance-impact.md](21-compliance-impact.md).
 - ID grammar and TYPE registry: [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) (`COVERAGE_METRIC` registered in §3.2).
 - Reconstruction invariant (why view documents are not content homes): [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1.
+- Named view-config convention (where this view's saved configs live, how they're named, listed, and re-run): [REPORT_VIEW_CONFIG.md](REPORT_VIEW_CONFIG.md).
+- ADR — reports rendered from declarative view-configs, with a thin skill on top: [../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md).

--- a/notations/views/REPORT_VIEW_CONFIG.md
+++ b/notations/views/REPORT_VIEW_CONFIG.md
@@ -1,0 +1,136 @@
+---
+title: "Named view-config convention — report registry"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-06-12"
+status: "draft"
+---
+
+# Named view-config convention
+
+**Scope:** Where saved, named view-configs live in an adopter repository, how they're named, how a reader lists them, and how a reader (or a tool, or the future report skill) re-runs one by name. This document **extends and codifies the existing report-config shape** declared by the three report-config view specs ([`11-scenarios.md`](11-scenarios.md), [`21-compliance-impact.md`](21-compliance-impact.md), [`22-coverage-metric.md`](22-coverage-metric.md)) — it does not introduce a new notation. Companion to [`ADR 2026-06-09 — Reports are rendered from declarative view-configs`](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md), Decision §1, §5, §7 (Step 1).
+
+The convention is also the natural home for **any view document**, not only report-configs: every view notation in the catalogue ([README.md](../README.md) §Views) follows the same location and naming rule.
+
+---
+
+## 1. What is a "named view-config"
+
+A *named view-config* is a committed view document — one file under [§2](#2-location) whose `view.id` matches the canonical TYPE grammar ([`IDS_AND_REFERENCES.md`](../IDS_AND_REFERENCES.md) §3.2) for its notation, and whose contents declare the parameters of one specific render (filters, scope, grouping, ordering, status display).
+
+A named view-config is **the parameter artefact of a report** ([ADR 2026-06-09](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md) Decision §1):
+
+- versioned in the repository, so the report definition is diffable and attributable;
+- re-runnable on demand, so "the same report next quarter" is a re-render against current canon;
+- discoverable by name, so a reader (or the report skill — see [ADR §7 Step 3](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md)) can list and select reports without inspecting file contents.
+
+A view file that lives anywhere else — an inline example under [`../examples/`](../examples/), a render-config inside a tool's runtime cache — is not a named view-config, even if its YAML shape is identical. Only files under [§2](#2-location) participate in the registry.
+
+---
+
+## 2. Location
+
+```
+<repo-root>/canon/views/<short-name>/<basename>.<short-name>.transitrix.yaml
+```
+
+| Path segment | Rule |
+|---|---|
+| `<repo-root>/canon/views/` | The single root of the registry in an adopter repo. The same root the [`organizations/acme_corp/canon/views/`](../../organizations/acme_corp/canon/views/) example uses. The view document lives under `canon/` for storage convenience — but it carries **no canonical content** of its own ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §1.1 reconstruction invariant): everything it displays is reconstructible from the elements alone. A view document is a presentation surface, not a canonical fact. |
+| `<short-name>/` | One folder per view notation, named exactly as the notation's short name in [README.md](../README.md) §Views (e.g. `scenarios/`, `compliance-impact/`, `coverage-metric/`, `fgca/`, …). Tools list the registry per notation by walking these folders. |
+| `<basename>` | `kebab-case` slug uniquely identifying this saved config within its folder. Typically the slug-form of `view.id`'s middle segment (e.g. `view.id: SCENARIOS-2027-CUT-1` ⇒ basename `2027-cut`), or a `[DOMAIN]-[CONTEXT]` prefix (e.g. `retail-gdpr`, `eu-compliance`). |
+| `.<short-name>.transitrix.yaml` | The canonical file extension per [CONTRACT.md](../CONTRACT.md) §3 and the catalogue in [README.md](../README.md) §Views. The doc-lint [`scripts/check-notations.mjs`](../../scripts/check-notations.mjs) (E1) enforces extension + parent-folder match. |
+
+The convention is uniform across **every** view notation, not only the three report-config notations.
+
+---
+
+## 3. Naming
+
+A named view-config carries **two names**:
+
+| Name | Where it lives | Purpose |
+|---|---|---|
+| **`view.id`** | inside the file | The canonical identifier. Grammar `<DOCUMENT_TYPE>-[<middle>-]<INTEGER>` per [`IDS_AND_REFERENCES.md`](../IDS_AND_REFERENCES.md) §1; `<DOCUMENT_TYPE>` is the spec's registered document-level TYPE (e.g. `SCENARIOS`, `COMPLIANCE_IMPACT`, `COVERAGE_METRIC` per §3.2). Used in cross-references, validation messages, and renderer output. |
+| **File basename** | filesystem | The handle a human (or a tool) types when listing or re-running. Convention: kebab-case slug derived from `view.id`'s middle segment, or a domain-context slug. No grammar enforced beyond filesystem rules + the extension contract in [§2](#2-location). |
+
+The two names are loosely coupled by convention, not by validation. The renderer reads the file by path and trusts `view.id` for cross-reference resolution; a basename mismatch is a readability nit, not a validation error.
+
+`view.name` (the human-readable string under `view.name:`) is a third, free-form label shown in the renderer output — not a registry handle.
+
+---
+
+## 4. Listing
+
+A reader (or a tool, or the future report skill) lists the saved reports a repository carries by walking the registry root:
+
+```
+<repo-root>/canon/views/<short-name>/*.<short-name>.transitrix.yaml
+```
+
+Per notation, the listing entry for each file is the triple `(basename, view.id, view.name)`. Tools that surface a richer listing MAY also display `view.description` and, for report-configs, the subjects / obligations / regimes the view is scoped to.
+
+The folder itself plays the role of the **small report registry** the [ADR](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md) Decision §5 names — no separate index file is maintained. The filesystem walk **is** the listing; this keeps the registry diffable, reviewable, and reproducible without an out-of-band catalogue to keep in sync.
+
+A `README.md` per `canon/views/<short-name>/` folder is recommended for human navigation (the [`acme_corp`](../../organizations/acme_corp/canon/views/) example repo carries one per folder) but is not part of the listing contract — tooling reads the YAML, not the README.
+
+---
+
+## 5. Re-running by name
+
+Re-running a saved view-config is a deterministic re-render — the renderer reads `(view-config, canon)` and emits the report ([ADR](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md) Decision §2). Two re-runs against the same canon produce identical output; two re-runs against a *changed* canon surface the canon change as a diff in the report, never as a configuration drift.
+
+The supported invocations:
+
+1. **By file path** (the power-user / CLI escape hatch — [ADR](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md) Alternative C):
+
+       transitrix-view render canon/views/scenarios/2027-cut.scenarios.transitrix.yaml
+
+2. **By notation + basename** (registry-style lookup):
+
+       transitrix-view render --notation scenarios --name 2027-cut
+
+   The tool resolves the basename to `canon/views/scenarios/2027-cut.scenarios.transitrix.yaml`.
+
+3. **By `view.id`** (cross-reference-style lookup, for tooling that already carries the ID):
+
+       transitrix-view render --id SCENARIOS-2027-CUT-1
+
+   The tool walks `canon/views/scenarios/` and selects the file whose `view.id` matches.
+
+4. **From a conversational front-end** (the thin report skill — [ADR](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md) Decision §3, Step 2): the skill materialises or selects a named view-config under [§2](#2-location), states the defaults it applied per [§6](#6-zero-configuration-default), and shells out to the same CLI. No render logic in the skill.
+
+The CLI surface above is the convention this document fixes. The CLI implementation itself is tooling, delivered separately ([ADR](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md) Decision §7 Step 1 / Step 3).
+
+---
+
+## 6. Zero-configuration default
+
+Every report-producing view spec ([`11-scenarios.md`](11-scenarios.md) §4, [`21-compliance-impact.md`](21-compliance-impact.md) §4 + §4.1, [`22-coverage-metric.md`](22-coverage-metric.md) §4 + §4.1) declares **explicit defaults** for every non-required field. A view-config that carries only the required envelope (`notation:`, `spec_version:`, `methodology_version:`, `view.id`, `view.name`) renders deterministically — each omitted field falls back to its spec default.
+
+This is the surface the report skill leans on for its "what I assumed" message ([ADR](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md) Decision §4): given a free-text request without enough parameters, the skill materialises a minimal view-config under [§2](#2-location), renders it, and **states back** which defaults the spec applied ("full matrix, no jurisdiction filter — showing all"). The skill never invents defaults of its own; it never carries render logic.
+
+Re-running a minimal view-config against a richer canon a quarter later picks up the canon delta automatically — the defaults explicitly cover "every `PRODUCT`", "every `REQUIREMENT`", and so on (per each spec's §4 / §4.1), so the report grows with the model without a configuration edit.
+
+---
+
+## 7. What this document does not change
+
+- **No new notation.** This convention extends the three report-config view specs and the wider view-notation catalogue ([README.md](../README.md) §Views); no new `notation:` header, no new file extension, no new validation rule.
+- **No new validator gate.** The doc-lint [`scripts/check-notations.mjs`](../../scripts/check-notations.mjs) (E1, E2) already covers the extension + header + parent-folder rules this document leans on. The location convention in [§2](#2-location) is a **deployment** convention — the existing extension rule already lets the lint catch most filesystem drift.
+- **No render-logic homing.** The render contract for each view stays in its spec (e.g. [`21-compliance-impact.md`](21-compliance-impact.md) §5). This document is about the registry — where the parameter artefact lives and how it's named, listed, and re-run.
+
+---
+
+## 8. References
+
+- ADR — reports rendered from declarative view-configs, with a thin skill on top: [`docs/decisions/2026-06-09-report-skill-over-declarative-views.md`](../../docs/decisions/2026-06-09-report-skill-over-declarative-views.md).
+- Reconstruction invariant — why a view document carries no canonical fact: [`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §1.1.
+- View-notation catalogue (short names + extensions): [`README.md`](../README.md) §Views.
+- Document-level TYPE registry (`SCENARIOS`, `COMPLIANCE_IMPACT`, `COVERAGE_METRIC`, …): [`IDS_AND_REFERENCES.md`](../IDS_AND_REFERENCES.md) §3.2.
+- File extension + header rules: [`CONTRACT.md`](../CONTRACT.md) §1, §3.
+- Worked example registry: [`organizations/acme_corp/canon/views/`](../../organizations/acme_corp/canon/views/).
+- Report-config view specs:
+  - [`11-scenarios.md`](11-scenarios.md) — Scenarios.
+  - [`21-compliance-impact.md`](21-compliance-impact.md) — Compliance Impact.
+  - [`22-coverage-metric.md`](22-coverage-metric.md) — Coverage Metric.


### PR DESCRIPTION
## Summary

Step 1 of the report/view-skill chain — pin **explicit defaults** on every report-producing view spec, and **define the named view-config convention** the future report skill leans on for its "what I assumed" fallback message. Per local methodology ADR [`docs/decisions/2026-06-09-report-skill-over-declarative-views.md`](../blob/main/docs/decisions/2026-06-09-report-skill-over-declarative-views.md) §7 Step 1.

- **`notations/views/11-scenarios.md`** — bump v0.3 → v0.4: add a Default column to the Fields table and a §4.1 Zero-configuration default section. The `scenarios.include` / `scenarios.filter` pair becomes "no-narrowing by default" so the zero-config render is "every admitted SCENARIO" — matches the precedent already pinned in [`21-compliance-impact.md`](../blob/main/notations/views/21-compliance-impact.md) §4 + §4.1 and [`22-coverage-metric.md`](../blob/main/notations/views/22-coverage-metric.md) §4 + §4.1.
- **`notations/views/REPORT_VIEW_CONFIG.md`** (new) — codifies the named view-config convention:
  - **Location:** `<repo-root>/canon/views/<short-name>/<basename>.<short-name>.transitrix.yaml` (the layout `organizations/acme_corp/canon/views/` already uses; previously undocumented at the methodology-spec level).
  - **Naming:** `view.id` (canonical TYPE grammar) + a kebab-case file basename; loosely coupled by convention.
  - **Listing:** filesystem walk under the registry root — no out-of-band index.
  - **Re-running:** by file path, by `--notation + --name`, by `--id`, or via the future thin report skill.
  - Extends the existing report-config shape — no new notation, no new validation gate. Applies uniformly across every view notation, not only report-configs.
- **`21-compliance-impact.md`, `22-coverage-metric.md`** — cross-link `REPORT_VIEW_CONFIG.md` from §4.1 and §References.
- **`notations/README.md`** — surface `REPORT_VIEW_CONFIG.md` as a cross-cutting document alongside `MANIFEST.md` and `COVERAGE_PROFILES.md`.

## Test plan

- [x] `node scripts/check-notations.mjs` clean — 15 view notations; examples, internal links, and `methodology_version` pins all consistent.
- [x] File-tail integrity verified on every touched file.
- [ ] Open PR; do not merge — Valerii gates.