### PR TITLE
docs(adr): redact internal agent codename from public ADRs

### DIFF
--- a/docs/decisions/2026-06-09-compliance-impact-as-blueprint-lane.md
+++ b/docs/decisions/2026-06-09-compliance-impact-as-blueprint-lane.md
@@ -70,6 +70,6 @@ None — both prior open points were resolved on 2026-06-09 (deadline source →
 
 ### Decision record
 
-- **Proposed by Win-Claude, 2026-06-09**, from a report-shape discussion with Valerii: render compliance impact in Process-Blueprint form with a configurable, derived law lane and optional assertion/requirement drill-down.
+- **Proposed by the maintainer, 2026-06-09**, from a report-shape discussion with Valerii: render compliance impact in Process-Blueprint form with a configurable, derived law lane and optional assertion/requirement drill-down.
 - **Refined with Valerii, 2026-06-09:** cell decoration is three orthogonal signals — *new* (since last snapshot; dashed border), *known gap* (`ASSERTION.status` non-conformance), and *gap with a deadline* (urgent); deadline source = `REQUIREMENT.deadline` (external regulatory date; an internal `ASSERTION` remediation target is a separate optional overlay) surfaced via a temporal status (`past_due` / `in_force` / `upcoming`); adopted the three entry-modes framing (by object / by obligation / by event).
 - **Accepted by Valerii, 2026-06-09:** display preferences (lane toggles, decoration prefs) are **per-user and local** — kept in a dedicated settings folder tracked by `.gitkeep` while its contents are `.gitignore`d (empty for other users), never committed, not canon. Named reports still pin their lane-set in the versioned report definition. With this and the deadline-source resolution, all open points are closed and the ADR is **Accepted**.

--- a/docs/decisions/2026-06-09-report-skill-over-declarative-views.md
+++ b/docs/decisions/2026-06-09-report-skill-over-declarative-views.md
@@ -60,5 +60,5 @@ Surfaced 2026-06-09 while discussing report UX. Within the Transitrix family; no
 
 ### Decision record
 
-- **Proposed by Win-Claude, 2026-06-09**, from a report-UX discussion.
+- **Proposed by the maintainer, 2026-06-09**, from a report-UX discussion.
 - **Accepted by Valerii, 2026-06-09:** direction confirmed (view-config as the parameter artefact + thin skill over a deterministic renderer CLI). Delivery sequenced CLI-first then thin skill (Decision §7); no standalone tooling repo now — report tooling rides the ingest tooling-extraction. Open point resolved.

--- a/docs/decisions/2026-06-11-extract-acme-corp-reference-repo.md
+++ b/docs/decisions/2026-06-11-extract-acme-corp-reference-repo.md
@@ -43,7 +43,7 @@ for every consumer.
 2. **Doubles as the product demo.** Beyond the bare adopter shape it carries a **named demo
    scenario + narrative** — the success story the product shows. The narrative is **public-facing**,
    so its voice/positioning is owned by the strategy/comms layer (STYLE_GUIDE §3, no retired terms,
-   no client names) — **not** a Win-Claude solo authoring call.
+   no client names) — **not** a maintainer solo authoring call.
 3. **methodology** removes `organizations/acme_corp/`, leaving a short pointer/README; the front-door
    README + onboarding `SKILL.md` re-point to the new repo. Coordinate with the onboarding front door
    and with [`2026-06-11-validation-two-axis-model.md`] follow-up #202 (the validator's canonical
@@ -74,7 +74,7 @@ ref. Avoid floating `main`. Final choice recorded as a follow-up before T3.
 ## Consequences
 
 - **New repo = new family member.** Needs its own `CLAUDE.md`, CI, and (optionally) a per-repo agent.
-  Creating the repo is **Valerii's gate** (outside Win-Claude's existing writable areas).
+  Creating the repo is **Valerii's gate** (outside the maintainer's existing writable areas).
 - **Public-facing demo surface.** The success-story narrative is a comms/positioning surface — file a
   hub heads-up so the strategy/comms layer shapes the story to canon voice. The structural extraction
   itself is within-family (methodology ↔ studio) and stays a local ADR; only the narrative/voice


### PR DESCRIPTION
## Why

Three public ADRs named an internal agent codename in their Decision records
("Proposed by …" / "outside …'s writable areas"). Same class of issue as the
2026-06-06 agent-name-redaction convention. Replace with the human maintainer.

## What

One-line redaction in each (no other content change; +4 bytes each, verified
byte-identical otherwise):

- `2026-06-09-report-skill-over-declarative-views.md`
- `2026-06-09-compliance-impact-as-blueprint-lane.md`
- `2026-06-11-extract-acme-corp-reference-repo.md`

## Scope note

ADRs stay public — only the agent identifier is redacted. The codename remains
in git history; for a low-sensitivity codename a HEAD redaction is proportionate
(no history rewrite). Two remaining low-value mentions are code/config comments
(`methodology/.gitignore`, `transitrix-studio/.../resolver.ts`, both pointing at
an internal tracker path) — left for a one-line local pass to avoid full-file
rewrites of large files via the API.

Valerii gates the merge.