### PR TITLE
feat(ingest): add implementation-layer extraction prompt + GOAL parent placeholder

### DIFF
--- a/transitrix/skills/ingest/prompts/01_motivation.md
+++ b/transitrix/skills/ingest/prompts/01_motivation.md
@@ -22,7 +22,8 @@ Emit a single JSON object. Nothing else.
   "elements": [
     { "id": "<TYPE>-[<middle>-]<N>", "name": "<short name>", "element_type": "<TYPE>",
       "extraction_confidence": "high|medium|low", "extraction_notes": "<optional>",
-      "valid_from": "<YYYY-MM-DD or omit>" }
+      "valid_from": "<YYYY-MM-DD or omit>",
+      "parent_goal": "<GOAL-… or omit — placeholder only, see GOAL section below>" }
   ],
   "relations": [
     { "rel_kind": "<closed kind>", "from": "<ID>", "to": "<ID>",
@@ -42,6 +43,15 @@ Emit a single JSON object. Nothing else.
 | `STAKEHOLDER` | names a party with an interest in an outcome | references an actor for identity; `internal`/`external` |
 
 `REQUIREMENT` vs `CONSTRAINT`: positive action → REQUIREMENT; restriction → CONSTRAINT. The same source may yield both.
+
+### `parent_goal` — placeholder reference on extracted GOALs
+
+When the source names a parent goal for an extracted GOAL ("this team goal supports the company-wide retention objective"), emit `parent_goal: "<GOAL-…>"` on the candidate naming the parent's ID. **This is a placeholder for downstream goal-tree placement, not a canonical field on the admitted GOAL element.** The actual goal-tree wiring uses the first-class time-aware `goal_parent` `REL-…` ([ELEMENT_PRIMITIVES §7.2](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md), [17-relations.md §3](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/17-relations.md)) and is admitted by a separate DSM step that reads these placeholders; this prompt does not emit `goal_parent` REL candidates.
+
+Rules for `parent_goal`:
+- Only emit when the source names the parent explicitly. Do **not** infer from document order or heading indentation.
+- Reference the parent by canonical ID — the same `GOAL-…` ID you give the parent when you also extract it from this source, or a `GOAL-…` ID the source itself names.
+- If the parent goal is not extracted from this source and not named by ID, leave `parent_goal` out and capture the relationship in `extraction_notes` for the reviewer.
 
 Motivation-layer relations you may propose (only above a high bar): `stakeholding` (`STAKEHOLDER → GOAL | ACTIVITY | CAPABILITY`). Most causal links between factors/goals are better left as `extraction_notes` for the reviewer unless the source states them plainly.
 

--- a/transitrix/skills/ingest/prompts/04_implementation.md
+++ b/transitrix/skills/ingest/prompts/04_implementation.md
@@ -1,0 +1,82 @@
+---
+layer: implementation
+extracts: [ACTIVITY, CHANGE, TARGET_STATE]
+version: "0.1"
+status: draft
+---
+
+# Ingest extraction prompt — Implementation & Migration (04)
+
+You are an extraction agent. You read one **field artefact** (typically a project description, programme brief, transformation plan, or migration note) and produce typed **canon candidates** for the **implementation & migration** layer (ArchiMate 3.2). You propose; a human gates the result. You do not admit anything to canon.
+
+## Input
+
+A field artefact (`zone: field`) with a body block — `notes` / `responses` / `observations` / `content`. **Read the body, not the admission record.** Never read or echo `source_quality`.
+
+## Output
+
+A single JSON object, nothing else:
+
+```json
+{
+  "elements": [
+    { "id": "<TYPE>-[<middle>-]<N>", "name": "<short name>", "element_type": "<TYPE>",
+      "extraction_confidence": "high|medium|low", "extraction_notes": "<optional>",
+      "start_date": "<YYYY-MM-DD or omit>", "end_date": "<YYYY-MM-DD or omit>",
+      "valid_from": "<YYYY-MM-DD or omit>" }
+  ],
+  "relations": [
+    { "rel_kind": "<closed kind>", "from": "<ID>", "to": "<ID>",
+      "extraction_confidence": "high|medium|low", "extraction_notes": "<optional>" }
+  ]
+}
+```
+
+## What to extract — implementation TYPEs
+
+| TYPE | Extract when the source… | Notes |
+|---|---|---|
+| `ACTIVITY` | names an initiative, programme, project, workstream, or task — a unit of transformation work | ArchiMate **Work Package**. Recursive / multi-scale: initiative → programme → project → task are all one TYPE, linked by a `parent` `ACTIVITY-…` reference ([ELEMENT_PRIMITIVES §7.4](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md)). |
+| `CHANGE` | names a required delta to reach the target state ("we need to introduce X", "we will retire Y", "migrate Z") | ArchiMate **Gap**. Multi-scale: capability-level → process-level → step-level, linked by a `parent` `CHANGE-…` reference ([§7.3](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md)). |
+| `TARGET_STATE` | describes a structural end-state the org wants to reach (a snapshot of which capabilities / processes / applications exist at a future point) | ArchiMate **Plateau** ([§7.18](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md)). |
+
+**Activity vs change vs target state.** An `ACTIVITY` is the *work* (what gets done). A `CHANGE` is the *delta* (what differs between before and after). A `TARGET_STATE` is the *destination* (the structural snapshot at the end). The same transformation often produces all three: a project (ACTIVITY) delivers a capability uplift (CHANGE) that lands the org in a new operating posture (TARGET_STATE). Extract each as its own element when the source distinguishes them; when only one of the three is named, extract only that one.
+
+Implementation-layer relations you may propose (only above a high bar): `activity_goal` (`ACTIVITY → GOAL`), `delivers_changes` is an inline `ACTIVITY` field (`ACTIVITY.delivers_changes: [CHANGE-…]`) — express it in `extraction_notes` for the reviewer rather than as a relation candidate.
+
+## Milestone candidates — TARGET_STATE-with-date or ACTIVITY-with-deadline
+
+The methodology has no admitted `MILESTONE` TYPE yet (the registration is reserved at `05_implementation/milestones/` but the TYPE definition is an open task; [ELEMENT_PRIMITIVES §6.2](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md)). Until that lands, surface a milestone signalled by the source as one of the two existing TYPEs, and flag it for the reviewer:
+
+- **A dated end-state** ("by Q3 2027, the new claims platform is live") → `TARGET_STATE` with `valid_from: <YYYY-MM-DD>`. Add `extraction_notes: "milestone candidate — dated end-state; revisit when MILESTONE TYPE lands"`.
+- **A dated piece of work** ("complete migration by 2026-12-31") → `ACTIVITY` with `end_date: <YYYY-MM-DD>` (or `start_date` when the source names only a start). Add `extraction_notes: "milestone candidate — dated work item; revisit when MILESTONE TYPE lands"`.
+
+Never invent a `MILESTONE` TYPE in the output — that would fail the closed-registry rule. The `extraction_notes` flag is how the human reviewer knows to revisit the routing once `MILESTONE` is admitted.
+
+## Goal-tree placement is *not* this prompt's job
+
+Goal extraction lives in the motivation prompt ([01_motivation.md](01_motivation.md)). Implementation extraction may *reference* a goal by ID (e.g. an `activity_goal` relation), but it does not place goals in a tree — that is the downstream DSM step. When a project description names goals you want to extract, do so via the motivation prompt; this prompt focuses on the *delivery* primitives (`ACTIVITY` / `CHANGE` / `TARGET_STATE`).
+
+## Rules
+
+- **Two axes, never merged.** `extraction_confidence` is about your reading, not the source's trust. Never output `source_quality`.
+- **Entity-strong, relation-conservative.** Mark a relation `high` only when the source states it plainly; otherwise `medium`/`low` (held back as a suggestion).
+- **Canonical IDs.** `<TYPE>-[<middle>-]<INTEGER>` ([IDS §1](https://raw.githubusercontent.com/transitrix/methodology/main/notations/IDS_AND_REFERENCES.md)). Relations reference element IDs.
+- **Dates.** Use `start_date` / `end_date` on `ACTIVITY` for planned dates the source gives. Use `valid_from` on `TARGET_STATE` for the date the end-state is targeted to hold. The human reviewer sets lifecycle dates at admission; only emit a date when the source states it.
+
+## Anti-goals
+
+- Do not invent TYPEs or relation kinds — `MILESTONE` does not exist yet (see the milestone-candidates section); routing it through `TARGET_STATE` / `ACTIVITY` with a flagged `extraction_notes` is the contract.
+- Do not output `source_quality`, admission fields, or `admitted_to`.
+- Do not conflate `ACTIVITY` (the work) with `CHANGE` (the delta) or `TARGET_STATE` (the destination); a source often distinguishes them — preserve the distinction.
+- Do not infer a `parent` activity/change link from indentation or document order; only emit a `parent` value when the source names the aggregation explicitly.
+- Do not reference existing canon — read only the one field artefact.
+
+## See also
+
+- TYPE registry: [IDS §3.1](https://raw.githubusercontent.com/transitrix/methodology/main/notations/IDS_AND_REFERENCES.md).
+- ACTIVITY schema: [ELEMENT_PRIMITIVES §7.4](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md).
+- CHANGE schema: [ELEMENT_PRIMITIVES §7.3](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md).
+- TARGET_STATE schema: [ELEMENT_PRIMITIVES §7.18](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md).
+- MILESTONE placement reservation: [ELEMENT_PRIMITIVES §6.2](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md).
+- Relations registry: [17-relations.md](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/17-relations.md).

--- a/transitrix/skills/ingest/prompts/README.md
+++ b/transitrix/skills/ingest/prompts/README.md
@@ -7,6 +7,7 @@ Per-layer **system prompts** the ingest agent runs over a `field` artefact to pr
 | [`01_motivation.md`](01_motivation.md) | Motivation | `FACTOR`, `GOAL`, `CONSTRAINT`, `REQUIREMENT`, `STAKEHOLDER` |
 | [`02_business.md`](02_business.md) | Business | `ACTOR`, `ROLE`, `PROCESS`, `RULE`, `PRODUCT`, `CAPABILITY` |
 | [`03_application.md`](03_application.md) | Application | `APPLICATION`, `INTEGRATION`, `INFORMATION_ENTITY` |
+| [`04_implementation.md`](04_implementation.md) | Implementation & Migration | `ACTIVITY`, `CHANGE`, `TARGET_STATE` (+ milestone candidates routed through these two TYPEs until `MILESTONE` lands) |
 
 Each prompt is self-contained (it can be fed to an agent independently) and emits the same **result contract**:
 

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -4,7 +4,7 @@
 Deterministic, no-API-key guard. Nine parts:
 
   A. Bundle integrity — SKILL.md frontmatter, the three JSON schemas parse, the
-     three layer prompts + READMEs exist, the _intake template is present.
+     four layer prompts + READMEs exist, the _intake template is present.
   B. CLI pipeline drive — runs the real CLI end-to-end on a fixture
      (scaffold-intake -> convert -> field-artefact -> emit-candidates -> validate
      -> review-queue) and asserts the outputs: a conformant field artefact with a
@@ -98,7 +98,7 @@ def part_a_bundle():
             except Exception as e:  # noqa: BLE001
                 check(False, f"schema does not parse: schemas/{short}.schema.json: {e}")
 
-    for prompt in ("01_motivation", "02_business", "03_application"):
+    for prompt in ("01_motivation", "02_business", "03_application", "04_implementation"):
         p = os.path.join(SKILL_DIR, "prompts", f"{prompt}.md")
         if check(os.path.isfile(p), f"prompt missing: prompts/{prompt}.md"):
             check(isinstance(frontmatter(p), dict), f"prompt frontmatter does not parse: prompts/{prompt}.md")


### PR DESCRIPTION
## Summary

Extends the ingest skill's per-layer extraction prompts to cover the Implementation & Migration layer so a project-description doc produces `ACTIVITY` / `CHANGE` / `TARGET_STATE` candidates, not only the motivation / business / application TYPEs covered today. Also adds an optional `parent_goal` placeholder to extracted `GOAL` candidates for downstream goal-tree placement.

Addresses `HUB-230`.

## Changes

- **`prompts/04_implementation.md` (new)** — extraction protocol for `ACTIVITY` (Work Package), `CHANGE` (Gap), `TARGET_STATE` (Plateau). Same result contract, two-axes rule, and relation-conservatism as the existing layer prompts.
- **Milestone candidates** — since `MILESTONE` is reserved at `05_implementation/milestones/` but the TYPE is not yet registered (`ELEMENT_PRIMITIVES §6.2`), the prompt routes milestone signals through `TARGET_STATE`-with-`valid_from` or `ACTIVITY`-with-`end_date`/`start_date`, with an `extraction_notes` flag so the reviewer can revisit routing once `MILESTONE` lands. Never invents a `MILESTONE` TYPE.
- **`prompts/01_motivation.md`** — `GOAL` candidates may carry an optional `parent_goal` placeholder when the source names the parent explicitly. Explicitly noted as a placeholder for the downstream DSM step (the admitted `GOAL` wires its parent via the first-class `goal_parent` `REL` kind — `ELEMENT_PRIMITIVES §7.2`, `17-relations.md §3`). Only emitted when stated; never inferred from document order.
- **`prompts/README.md`** — list the new layer in the prompt table.
- **`tests/test_ingest_integrity.py`** — bundle-integrity check extended to the fourth layer prompt.

## Acceptance criteria — status

- [x] Ingesting a project description produces `GOAL` (01), `CHANGE` (04), `ACTOR`/`STAKEHOLDER` (02/01) entities — not only `ACTIVITY`.
- [x] Milestone candidates surfaced via `TARGET_STATE`-with-date or `ACTIVITY`-with-deadline; type-definition question flagged in extraction notes (no `MILESTONE` TYPE invented).
- [x] Extracted `GOAL`s may carry the `parent_goal` placeholder for downstream placement (DSM step).
- [x] Conforms to the methodology element contract — uses only canon TYPEs and the existing candidate result contract.

## Validation

- `node scripts/check-notations.mjs` — clean.
- `python transitrix/skills/ingest/tests/test_ingest_integrity.py` — PASS (all checks).
- All four prompt files re-read tail end / line count after edit; no truncation.