### PR TITLE
docs(adl): tighten TOGAF positioning per strategy-layer caveats

### DIFF
--- a/docs/decisions/2026-06-11-architecture-decision-log.md
+++ b/docs/decisions/2026-06-11-architecture-decision-log.md
@@ -15,7 +15,7 @@ An autonomous agent on a production environment self-discovered the public metho
 
 The methodology already has the single-repo half of the answer — the [Team Operations](../../method/team-operations.md) convention defines `operations/decisions/ADR-NNNN-*.md` records that are immutable-once-accepted and superseded rather than rewritten. What it lacks is (a) a multi-repo story — an adopter runs many internal project repos and needs one enterprise view of their decisions; and (b) a safe way for an agent (not only a human) to author a decision.
 
-This is the decision-recording part of the TOGAF Architecture Repository (the *Governance Log → Decision Log* of "architecturally significant" decisions). The strategy hub was notified for visibility as a public-facing/positioning matter ([vkgeorgia/strategy#200](https://github.com/vkgeorgia/strategy/issues/200)); the mechanism itself is a within-family methodology-engineering decision.
+This realises TOGAF's *Governance Log → Decision Log* — the log of "architecturally significant" decisions — git-natively. The structure mirrors TOGAF's Decision Log; the agent-authored dimension is a Transitrix extension the standard does not mandate. The strategy hub was notified for visibility as a public-facing/positioning matter ([vkgeorgia/strategy#200](https://github.com/vkgeorgia/strategy/issues/200)); the mechanism itself is a within-family methodology-engineering decision.
 
 ## Decision
 

--- a/method/architecture-decision-log.md
+++ b/method/architecture-decision-log.md
@@ -11,7 +11,7 @@ tags: [transitrix, methodology, operations, adr, adl, togaf, governance]
 
 > How architecture decisions made across **many repositories** are aggregated into one enterprise-level **Architecture Decision Log**, and how an autonomous agent may author decisions safely. The ADL is the multi-repo layer on top of the single-repo [Team Operations](team-operations.md) convention — not a separate, parallel system.
 
-This is a git-native, agent-operable realisation of the decision-recording part of the **TOGAF Architecture Repository**: TOGAF keeps a *Governance Log → Decision Log* of "architecturally significant" decisions; the ADL is that log, expressed as Markdown records under version control, aggregated across an organisation's repositories. (The reference-catalog half of the Architecture Repository — the *Standards Information Base* — is a separate, later component; see §9.)
+This is a git-native, agent-operable realisation of **TOGAF's *Governance Log → Decision Log*** — the log of "architecturally significant" decisions, expressed as Markdown records under version control and aggregated across an organisation's repositories. The **structure** mirrors TOGAF's Decision Log; the **agent-authored** dimension (§3.1.1, §6) is a **Transitrix extension** the standard does not mandate. The companion construct TOGAF places alongside it — the *Standards Information Base* (the reference-catalog) — is out of scope for this release; see §9.
 
 ## 1. The two layers
 


### PR DESCRIPTION
## Summary

Tightens the TOGAF positioning of the Architecture Decision Log so the public spec anchors on the specific construct it realises (TOGAF's *Governance Log → Decision Log*) rather than the whole *Architecture Repository*. The latter framing implied full-framework conformance, which is broader than what this component does.

## Changes

- `method/architecture-decision-log.md` §intro — reframe from "decision-recording part of the TOGAF Architecture Repository" to "TOGAF's *Governance Log → Decision Log*". Add the honest attribution (structure mirrors TOGAF; agent-authored dimension is a Transitrix extension) **co-located** with the main claim, so a reader who only scans the intro still sees it. §11 keeps the full mapping.
- `docs/decisions/2026-06-11-architecture-decision-log.md` Context — same reframe in the source ADR (still `status: Proposed`, so editorially open). Strategy-hub backlink unchanged.

No code or behaviour change; the `Standards Information Base` reference in §9 already names the specific construct and is left as-is.

## Verification

- `node scripts/check-notations.mjs` — clean.
- `node scripts/check-adl.mjs` — clean.
- Diff is exactly the two intended lines.

Leaving open — maintainer gates the merge.