### PR TITLE
fix(ci): extend hygiene guard to read HYGIENE_BLOCKLIST_HUB

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -30,6 +30,7 @@ jobs:
         shell: bash
         env:
           BLOCKLIST: ${{ secrets.HYGIENE_BLOCKLIST }}
+          BLOCKLIST_HUB: ${{ secrets.HYGIENE_BLOCKLIST_HUB }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -41,6 +42,8 @@ jobs:
             echo "HYGIENE_BLOCKLIST secret not available (unset, or a fork PR) - skipping."
             exit 0
           fi
+
+          PATTERN="${BLOCKLIST}${BLOCKLIST_HUB:+|${BLOCKLIST_HUB}}"
 
           fail=0
 
@@ -59,18 +62,18 @@ jobs:
             [ -f "$f" ] || continue
             if git diff "$BASE_SHA" "$HEAD_SHA" -- "$f" \
                  | grep -E '^\+[^+]' \
-                 | grep -qiE -e "$BLOCKLIST"; then
+                 | grep -qiE -e "$PATTERN"; then
               echo "::error file=$f::public-surface hygiene check failed on file diff"
               fail=1
             fi
           done
 
           # 2) PR title/body scan.
-          if printf '%s' "$PR_TITLE" | grep -qiE -e "$BLOCKLIST"; then
+          if printf '%s' "$PR_TITLE" | grep -qiE -e "$PATTERN"; then
             echo "::error::public-surface hygiene check failed on PR title"
             fail=1
           fi
-          if printf '%s' "$PR_BODY" | grep -qiE -e "$BLOCKLIST"; then
+          if printf '%s' "$PR_BODY" | grep -qiE -e "$PATTERN"; then
             echo "::error::public-surface hygiene check failed on PR body"
             fail=1
           fi


### PR DESCRIPTION
## What

The existing guard reads only `HYGIENE_BLOCKLIST`. The new `HYGIENE_BLOCKLIST_HUB` secret (added 2026-06-17) blocks references to the private strategy hub in PR/commit surfaces. This PR wires it in.

## Changes

- `.github/workflows/public-surface-hygiene.yml` — expose `BLOCKLIST_HUB` in `env:`, assemble `PATTERN="${BLOCKLIST}${BLOCKLIST_HUB:+|${BLOCKLIST_HUB}}"`, replace all three grep calls to use `$PATTERN`

## Behaviour

- If `HYGIENE_BLOCKLIST_HUB` is unset: `PATTERN` equals `BLOCKLIST` only (no regression for fork PRs)
- Existing committed ADR cross-refs to the strategy hub are grandfathered (fail only when next touched in a PR diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)