### PR TITLE
docs: add patterns/ folder with three Transitrix implementation patterns

### DIFF
--- a/patterns/enterprise-adr-registry.md
+++ b/patterns/enterprise-adr-registry.md
@@ -1,0 +1,78 @@
+# Transitrix + Enterprise ADR Registry
+
+**Pattern type:** three-tier  
+**Complexity:** medium  
+**System-agnostic counterpart:** Enterprise ADR Registry pattern
+
+---
+
+## Problem
+
+Multiple project repos each maintain their own `docs/decisions/` folder. Decisions that affect shared interfaces, positioning, or cross-repo compatibility are made locally, reviewed locally, and never aggregated. There is no enterprise view of architecture decisions, no way to check whether a local ADR conflicts with a prior cross-project decision, and no immutable record of what was decided and why.
+
+## Solution
+
+Transitrix repo as the enterprise Architecture Decision Log (ADL). Three tiers classify decisions by scope and route cross-cutting ones through a structured promotion path into an append-only enterprise registry.
+
+```
+┌────────────────────────────────────────────┐
+│              source tier                   │
+│                                            │
+│  project repos — local ADRs in docs/       │
+│  scope: single-repo decisions              │
+└──────────────────────┬─────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────┐
+│              review tier                   │
+│                                            │
+│  cross-project ADR candidates              │
+│  scope: affects 2+ repos or shared API     │
+└──────────────────────┬─────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────┐
+│               canon tier                   │
+│                                            │
+│  Architecture/INDEX.md — enterprise ADL    │
+│  Architecture/ — immutable, append-only    │
+└────────────────────────────────────────────┘
+```
+
+## Tiers
+
+### Source tier — project repos
+
+Each project repo keeps a `docs/decisions/` folder for local ADRs. Local decisions are those whose scope is entirely contained within one repo: a dependency choice, a local naming convention, a project-specific process. Standard ADR format applies (title, date, status, context, decision, consequences).
+
+### Review tier — cross-project candidates
+
+A decision enters the review tier when its scope extends beyond one repo. Classification criteria:
+
+- Affects the interface or contract between two or more repos.
+- Touches positioning, compatibility, or access policy shared across the enterprise.
+- Overrides or supersedes a prior enterprise-level decision.
+
+Cross-project candidates are nominated in a Transitrix PR. Reviewers validate scope classification and ensure the decision does not conflict with existing enterprise ADRs.
+
+### Canon tier — `Architecture/` in the Transitrix repo
+
+Promoted decisions become enterprise ADRs under `Architecture/` in the Transitrix repo. Key rules:
+
+- **Immutable once merged.** Never edit a merged enterprise ADR. If a decision is superseded, write a new ADR that explicitly references and supersedes the old one. The old ADR's `status:` field is updated to `superseded` — its content is not changed.
+- **Append-only.** No deletions. The record of what was decided, when, and why must survive even when the decision itself does not.
+- **Indexed.** `Architecture/INDEX.md` is the canonical registry — one line per ADR with its number, title, date, and status. Update it with every promotion.
+
+## When to use
+
+- Two or more project repos that share interfaces, shared libraries, or cross-cutting concerns.
+- A governance or compliance requirement to maintain an auditable record of architectural decisions.
+- Recurring coordination overhead from local ADRs that silently diverge on shared concerns.
+- Teams that need a single authoritative place to check "has this been decided before?"
+
+## How to start with Transitrix
+
+1. **Stand up the Transitrix repo first.** Follow the [Transitrix Alone](transitrix-alone.md) pattern. The ADR registry is an additional structure inside an existing Transitrix repo, not a separate one.
+2. **Create `Architecture/`.** Add `Architecture/INDEX.md` with a header row and one seed entry documenting the decision to adopt Transitrix as the enterprise ADL. This is enterprise ADR-0001.
+3. **Define the scope classification criteria.** Write them down in `Architecture/INDEX.md` (or a linked `Architecture/SCOPE.md`). The criteria from the review tier above are a starting point — adjust to your organisation's topology.
+4. **Instrument project repos.** Add a note to each project's `CONTRIBUTING.md`: what qualifies as a cross-project ADR candidate, how to nominate one (open a Transitrix PR), and how to check the enterprise registry before making a local decision.
+5. **Promote existing cross-cutting decisions.** Audit existing `docs/decisions/` across project repos for decisions that already belong in the enterprise registry. Promote them in a single batch PR. Link from the original local ADR to the enterprise record.
+6. **Establish the promotion cadence.** A nomination is a Transitrix pull request; review is the validation gate. Decide who has the authority to promote (enterprise architect, architecture review board, or explicit reviewer set in `CODEOWNERS`).

--- a/patterns/index.md
+++ b/patterns/index.md
@@ -1,0 +1,17 @@
+# Transitrix Implementation Patterns
+
+Concrete deployment guides for common enterprise scenarios. Each pattern covers the problem it solves, the structure it establishes, when to use it, and how to start.
+
+| Pattern | File | Scenario |
+|---|---|---|
+| Transitrix Alone | [transitrix-alone.md](transitrix-alone.md) | One repo as the enterprise architecture source of truth. Simplest deployment — greenfield, small org, single-domain pilot. |
+| Transitrix + Knowledge Store | [knowledge-store.md](knowledge-store.md) | Three-layer architecture: raw sources feed a curated knowledge repo that feeds Transitrix canon. |
+| Transitrix + Enterprise ADR Registry | [enterprise-adr-registry.md](enterprise-adr-registry.md) | Transitrix repo as the enterprise ADL, aggregating cross-project architecture decisions. |
+
+---
+
+## Choosing a pattern
+
+Start with **Transitrix Alone** unless you already have multiple source repos producing content (use Knowledge Store) or multiple project repos making cross-cutting decisions (use ADR Registry).
+
+The patterns are additive. Transitrix canon is always the centre; the other patterns wrap it. You can start with Alone and migrate later — the canon layer does not change shape.

--- a/patterns/knowledge-store.md
+++ b/patterns/knowledge-store.md
@@ -1,0 +1,73 @@
+# Transitrix + Knowledge Store
+
+**Pattern type:** three-layer  
+**Complexity:** medium  
+**System-agnostic counterpart:** Knowledge Refinery pattern
+
+---
+
+## Problem
+
+Raw source material — interview notes, meeting summaries, research documents — accumulates faster than it can be curated into the canonical model. Authors dump directly into `canon/` and quality degrades, or they leave everything in `field/` and canon never grows. There is no structured hand-off between "collected" and "validated".
+
+## Solution
+
+Three explicit layers with clear promotion rules: project repos contribute raw material, a dedicated knowledge repo curates it into OKF-formatted knowledge objects, and Transitrix canon holds only what has been validated and promoted.
+
+```
+┌────────────────────────────────────────────┐
+│              source layer                  │
+│                                            │
+│  project repos — raw notes, docs, data     │
+└──────────────────────┬─────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────┐
+│            refinement layer                │
+│                                            │
+│  knowledge repo — OKF, curated, dated      │
+└──────────────────────┬─────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────┐
+│              canon layer                   │
+│                                            │
+│  Transitrix repo — validated primitives    │
+└────────────────────────────────────────────┘
+```
+
+## Layers
+
+### Source layer — project repos
+
+Each project repo contributes raw material: meeting notes, interview transcripts, survey data, draft documents. Material lives under `field/` in each repo. No Transitrix structure is required at this layer — it is an input feed, not a model.
+
+### Refinement layer — knowledge repository
+
+A dedicated knowledge repository (separate from Transitrix) holds curated knowledge objects in OKF format: Markdown files with structured YAML frontmatter, explicit source citations, and timestamps. Curators pull from the source layer, extract signal, and write knowledge objects. Nothing reaches this layer without a citation and a timestamp.
+
+Key OKF fields per knowledge object:
+- `source:` — URI or repo path of the originating document
+- `created_at:` — date the object was curated
+- `confidence:` — curator's assessment (observed / inferred / assumed)
+- `tags:` — free-form classification
+
+### Canon layer — Transitrix repo
+
+Validated primitives — FACTOR, GOAL, CHANGE, CAPABILITY, and others — promoted from the knowledge repo. Each element in `canon/elements/` corresponds to one or more knowledge objects. The promotion decision is a pull request; review is the validation gate.
+
+Transitrix also distributes canonical vocabulary back downstream: generated `glossary.md` or object-reference stubs committed to project repos keep source-layer teams aligned with the enterprise model.
+
+## When to use
+
+- Multiple project repos producing source material that exceeds one team's capacity to review directly.
+- An explicit curation role exists (knowledge manager, enterprise architect) who is distinct from the project teams.
+- Source material quality is uneven and needs a structured validation stage before reaching canon.
+- Downstream consumers (other tools, teams, systems) need stable, versioned canonical objects with traceable provenance.
+
+## How to start with Transitrix
+
+1. **Stand up the Transitrix repo first.** Follow the [Transitrix Alone](transitrix-alone.md) pattern to establish canon. The knowledge store wraps it — canon does not change shape.
+2. **Create the knowledge repository.** A separate Git repo, not a folder inside Transitrix. Scaffold it with OKF-compatible frontmatter templates. Decide the `confidence:` vocabulary your team will use (observed / inferred / assumed is a reasonable default).
+3. **Instrument source repos.** Add a convention for capturing raw material: `field/` folder, a lightweight template, and a note in each project's `CONTRIBUTING.md` pointing to the knowledge repo as the curation destination.
+4. **Define the promotion criteria.** Document in the knowledge repo's `README.md` what makes a knowledge object ready to promote: minimum confidence level, required fields, review sign-off.
+5. **Promote the first batch.** Create a Transitrix PR for each promoted object. Link the PR back to the knowledge object(s) it was derived from. This establishes the provenance chain.
+6. **Wire the return path.** Set up a process (manual or automated) to publish a `glossary.md` or object-reference stubs from Transitrix back to source repos. This closes the loop and keeps project teams aligned with canon.

--- a/patterns/transitrix-alone.md
+++ b/patterns/transitrix-alone.md
@@ -1,0 +1,56 @@
+# Transitrix Alone
+
+**Pattern type:** standalone  
+**Complexity:** minimal
+
+---
+
+## Problem
+
+Architecture knowledge is scattered across slide decks, wikis, and individuals. There is no single model, no shared vocabulary, and no review process for architectural change. Teams debate from separate mental models rather than from a shared, authoritative artefact.
+
+## Solution
+
+One Transitrix repository holds everything: goals, factors, capabilities, processes, relations, and compliance artefacts as typed YAML files. Diagrams are derived on save — there is no separate diagramming tool. Every change is a pull request; code review is architecture review.
+
+## Structure
+
+```
+┌────────────────────────────────────────────┐
+│              Transitrix repo               │
+│                                            │
+│  transitrix.yaml   manifest, version pin   │
+│  canon/elements/   validated elements      │
+│  canon/views/      derived diagrams        │
+│  canon/relations/  first-class relations   │
+│  field/            raw source material     │
+│  codex/            laws and policies       │
+│  operations/       ADRs and work items     │
+└────────────────────────────────────────────┘
+```
+
+Three canonical zones keep content cleanly separated:
+
+- **`canon/`** — the validated model. Elements here are reviewed and stable. Downstream consumers read only this zone.
+- **`field/`** — raw source material: interview notes, meeting summaries, observations. Not yet validated; never cited directly from views.
+- **`codex/`** — external laws and internal policies. Read into the model; not produced by it.
+
+The `operations/` layer (not a zone) holds the team's ADRs and work items — the governance record of why canon looks the way it does.
+
+`transitrix.yaml` pins the methodology version and declares which notations the repo uses.
+
+## When to use
+
+- Greenfield organisation with no existing architecture knowledge management practice.
+- Small or single-domain team: one squad, one business unit, one platform.
+- Pilot: validating the value of a structured model before expanding scope.
+- Any scenario where all authors have direct access to the repo and raw material volume is low enough to go straight into canon.
+
+## How to start with Transitrix
+
+1. **Scaffold the repo.** Run `/transitrix:onboard` in a Claude Code session with the methodology plugin, or copy `organizations/acme_corp/` as a reference. This creates the `canon/`, `field/`, `codex/`, and `operations/` layout.
+2. **Pin the methodology version.** Set `methodology_version` in `transitrix.yaml` to the current release. This is the version all CI validators check against.
+3. **Author your first Goals tree.** A Goals view (`*.goals.transitrix.yaml`) in `canon/views/` anchors the model. Goals require no other elements to be in place and force the first alignment conversation.
+4. **Add elements top-down.** Goals → Factors → Capabilities → Processes. Each layer elaborates the one above. Copy templates from `.templates/elements/` for each type.
+5. **Run the linter before every PR.** `python3 .validators/lint.py` catches YAML syntax errors, broken cross-references, and missing required fields. Fix all errors before requesting review.
+6. **Establish the ADR convention.** Create `operations/decisions/0001-initial-scope.md` to record the scope and purpose of this Transitrix deployment.


### PR DESCRIPTION
## Summary

- Adds `patterns/` folder with `index.md` catalog and three pattern documents.
- **Transitrix Alone** — standalone repo deployment (greenfield, small org, pilot).
- **Transitrix + Knowledge Store** — three-layer Knowledge Refinery adaptation (source → refinement → canon).
- **Transitrix + Enterprise ADR Registry** — Transitrix as enterprise ADL with three-tier scope classification.

Each document follows the agreed structure: Problem → Solution → Structure → When to use → How to start with 

## Test plan

- [ ] `node scripts/check-notations.mjs` passes (already verified locally — clean).
- [ ] ASCII diagrams render correctly in GitHub Markdown preview.
- [ ] All three pattern files present, index links resolve.
- [ ] No files outside `patterns/` are modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)