### PR TITLE
docs(skill): update onboard plugin listing to 15 view notations

### DIFF
--- a/transitrix/.claude-plugin/plugin.json
+++ b/transitrix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix",
-  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 13 view notations (BPMN, FGCA, FGA, Goals, Capability map, Process landscape map, Process Blueprint, Activities, Nested blocks, Scenarios, Applications, Products, Activity Card) or a codex artefact.",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 15 view notations (BPMN, FGCA, FGA, Goals, Capability map, Process landscape map, Process Blueprint, Activities, Nested blocks, Scenarios, Applications, Products, Activity Card, Compliance Impact, Coverage Metric) or a codex artefact.",
   "version": "0.1.0",
   "author": {
     "name": "Transitrix"

--- a/transitrix/skills/onboard/README.md
+++ b/transitrix/skills/onboard/README.md
@@ -72,7 +72,7 @@ Three groups: root scaffolding, view notations, and codex zone primitives.
 
 ### View notations (dropped into `canon/views/<notation-folder>/` in Step 3)
 
-One starter YAML per view notation, named `<notation>.<short-name>.transitrix.yaml` so the file extension already matches the canonical Studio recogniser. The 14 view templates are:
+One starter YAML per view notation, named `<notation>.<short-name>.transitrix.yaml` so the file extension already matches the canonical Studio recogniser. The 15 view templates are:
 
 | Notation | Template |
 |---|---|
@@ -87,9 +87,10 @@ One starter YAML per view notation, named `<notation>.<short-name>.transitrix.ya
 | Scenarios | [`scenarios.scenarios.transitrix.yaml`](templates/scenarios.scenarios.transitrix.yaml) |
 | Applications | [`applications.applications.transitrix.yaml`](templates/applications.applications.transitrix.yaml) |
 | Products | [`products.products.transitrix.yaml`](templates/products.products.transitrix.yaml) |
-| Issues | [`issues.issues.transitrix.yaml`](templates/issues.issues.transitrix.yaml) |
 | Process Blueprint | [`process-blueprint.process-blueprint.transitrix.yaml`](templates/process-blueprint.process-blueprint.transitrix.yaml) |
 | Activity Card | [`activity-card.activity-card.transitrix.yaml`](templates/activity-card.activity-card.transitrix.yaml) |
+| Compliance Impact | [`compliance-impact.compliance-impact.transitrix.yaml`](templates/compliance-impact.compliance-impact.transitrix.yaml) |
+| Coverage Metric | [`coverage-metric.coverage-metric.transitrix.yaml`](templates/coverage-metric.coverage-metric.transitrix.yaml) |
 
 ### Codex zone primitives (dropped into `codex/external/<jurisdiction>/` or `codex/internal/` in Step 3)
 


### PR DESCRIPTION
## Summary

- `transitrix/.claude-plugin/plugin.json`: description counted 13 view notations; Compliance Impact and Coverage Metric were missing. Updated to 15 and added both to the parenthetical list.
- `transitrix/skills/onboard/README.md`: template table referenced the archived Issues template and omitted the two newer notations. Removed the archived row, added Compliance Impact and Coverage Metric, corrected count from 14 to 15.

## Verification

- `node scripts/check-notations.mjs` — clean (15 notations)
- `node scripts/check-skill-cheatsheet.mjs` — conforms (15 notations)
- `python transitrix/skills/onboard/tests/test_skill_integrity.py` — PASS

No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)