### PR TITLE
docs(glossary): add ArchiMate 3.2 alignment notes

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -3,7 +3,7 @@
 **Location:** Project root
 **Purpose:** Single source of truth for all project terms and abbreviations
 **Format:** English
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-06-20
 
 ---
 
@@ -182,6 +182,25 @@
 | **GLOSSARY** | This document |
 | **ROADMAP** | Project phases and tasks |
 
+## ArchiMate 3.2 Alignment Notes
+
+Transitrix is grounded in ArchiMate 3.2 but uses deliberately simplified or domain-friendly names in several places. The table below records where Transitrix terms differ from the standard and the rationale.
+
+| Transitrix TYPE | ArchiMate 3.2 term | Status |
+|---|---|---|
+| `DRIVER` (was `FACTOR`) | Driver | Aligned — rename in progress (pre-1.0) |
+| `GOAL` | Goal | Aligned |
+| `ASSESSMENT` | Assessment | Aligned |
+| `STAKEHOLDER` | Stakeholder | Aligned |
+| `CONSTRAINT` | Constraint | Aligned |
+| `REQUIREMENT` | Requirement | Aligned |
+| `BUSINESS_OBJECT` | Business Object | Aligned (renamed from `INFORMATION_ENTITY`) |
+| `EQUIPMENT` | Equipment | Aligned |
+| `TARGET_STATE` | Plateau | Intentional divergence — "Target State" is more accessible to business stakeholders; the ArchiMate Plateau correspondence is noted in the element spec |
+| `CHANGE` | Gap | Intentional divergence — "Change" better reflects the BDN transformation concept in practice; the ArchiMate Gap correspondence is noted in the element spec |
+| `SCENARIO` | Course of Action | Intentional divergence — "Scenario" is more intuitive for practitioners; the ArchiMate Course of Action correspondence is noted in the element spec |
+| `ACTIVITY` | Work Package | Intentional divergence — "Activity" is broader and covers initiatives, workstreams, and phases; the ArchiMate Work Package correspondence is noted in the element spec |
+
 ---
 
 ## Notes
@@ -192,6 +211,6 @@
 
 ---
 
-**Version:** 1.2.0
+**Version:** 1.3.0
 **Status:** Active
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-06-20


### PR DESCRIPTION
Adds a new **ArchiMate 3.2 Alignment Notes** section to `glossary.md` documenting which Transitrix TYPEs correspond to which ArchiMate terms, and the rationale for intentional divergences.

## What changed

New section with a mapping table:

- **Aligned** — `DRIVER` (was `FACTOR`, rename in progress), `GOAL`, `ASSESSMENT`, `STAKEHOLDER`, `CONSTRAINT`, `REQUIREMENT`, `BUSINESS_OBJECT`, `EQUIPMENT`
- **Intentional divergence** — `TARGET_STATE` (Plateau), `CHANGE` (Gap), `SCENARIO` (Course of Action), `ACTIVITY` (Work Package) — each notes the ArchiMate equivalent for reference without renaming

Also bumps `Last Updated` to 2026-06-20 and version to 1.3.0.

## Why

Practitioners familiar with ArchiMate 3.2 should be able to find the mapping in one place. Divergences are documented with rationale so they are not mistaken for oversights.