### PR TITLE
docs(skills): rename FACTOR → DRIVER in skills, templates, and patterns

### DIFF
--- a/patterns/knowledge-store.md
+++ b/patterns/knowledge-store.md
@@ -52,7 +52,7 @@ Key OKF fields per knowledge object:
 
 ### Canon layer — Transitrix repo
 
-Validated primitives — FACTOR, GOAL, CHANGE, CAPABILITY, and others — promoted from the knowledge repo. Each element in `canon/elements/` corresponds to one or more knowledge objects. The promotion decision is a pull request; review is the validation gate.
+Validated primitives — DRIVER, GOAL, CHANGE, CAPABILITY, and others — promoted from the knowledge repo. Each element in `canon/elements/` corresponds to one or more knowledge objects. The promotion decision is a pull request; review is the validation gate.
 
 Transitrix also distributes canonical vocabulary back downstream: generated `glossary.md` or object-reference stubs committed to project repos keep source-layer teams aligned with the enterprise model.
 

--- a/patterns/transitrix-alone.md
+++ b/patterns/transitrix-alone.md
@@ -11,7 +11,7 @@ Architecture knowledge is scattered across slide decks, wikis, and individuals. 
 
 ## Solution
 
-One Transitrix repository holds everything: goals, factors, capabilities, processes, relations, and compliance artefacts as typed YAML files. Diagrams are derived on save — there is no separate diagramming tool. Every change is a pull request; code review is architecture review.
+One Transitrix repository holds everything: goals, drivers, capabilities, processes, relations, and compliance artefacts as typed YAML files. Diagrams are derived on save — there is no separate diagramming tool. Every change is a pull request; code review is architecture review.
 
 ## Structure
 
@@ -51,6 +51,6 @@ The `operations/` layer (not a zone) holds the team's ADRs and work items — th
 1. **Scaffold the repo.** Run `/transitrix:onboard` in a Claude Code session with the methodology plugin, or copy `organizations/acme_corp/` as a reference. This creates the `canon/`, `field/`, `codex/`, and `operations/` layout.
 2. **Pin the methodology version.** Set `methodology_version` in `transitrix.yaml` to the current release. This is the version all CI validators check against.
 3. **Author your first Goals tree.** A Goals view (`*.goals.transitrix.yaml`) in `canon/views/` anchors the model. Goals require no other elements to be in place and force the first alignment conversation.
-4. **Add elements top-down.** Goals → Factors → Capabilities → Processes. Each layer elaborates the one above. Copy templates from `.templates/elements/` for each type.
+4. **Add elements top-down.** Goals → Drivers → Capabilities → Processes. Each layer elaborates the one above. Copy templates from `.templates/elements/` for each type.
 5. **Run the linter before every PR.** `python3 .validators/lint.py` catches YAML syntax errors, broken cross-references, and missing required fields. Fix all errors before requesting review.
 6. **Establish the ADR convention.** Create `operations/decisions/0001-initial-scope.md` to record the scope and purpose of this Transitrix deployment.

--- a/transitrix/skills/ingest/prompts/01_motivation.md
+++ b/transitrix/skills/ingest/prompts/01_motivation.md
@@ -1,6 +1,6 @@
 ---
 layer: motivation
-extracts: [FACTOR, GOAL, CONSTRAINT, REQUIREMENT, STAKEHOLDER]
+extracts: [DRIVER, GOAL, CONSTRAINT, REQUIREMENT, STAKEHOLDER]
 version: "0.1"
 status: draft
 ---
@@ -36,7 +36,7 @@ Emit a single JSON object. Nothing else.
 
 | TYPE | Extract when the source… | Notes |
 |---|---|---|
-| `FACTOR` | states a driver, trend, or force acting on the organisation | the *why behind* a goal; not the goal itself |
+| `DRIVER` | states a driver, trend, or force acting on the organisation | the *why behind* a goal; not the goal itself |
 | `GOAL` | names a desired outcome the organisation wants to reach | concrete enough to be pursued |
 | `CONSTRAINT` | states a restriction (“must not …”, “cannot exceed …”) | a limit on the solution space |
 | `REQUIREMENT` | states a positive obligation (“must …”, “shall …”) | a positive action the org must take |
@@ -53,7 +53,7 @@ Rules for `parent_goal`:
 - Reference the parent by canonical ID — the same `GOAL-…` ID you give the parent when you also extract it from this source, or a `GOAL-…` ID the source itself names.
 - If the parent goal is not extracted from this source and not named by ID, leave `parent_goal` out and capture the relationship in `extraction_notes` for the reviewer.
 
-Motivation-layer relations you may propose (only above a high bar): `stakeholding` (`STAKEHOLDER → GOAL | ACTIVITY | CAPABILITY`). Most causal links between factors/goals are better left as `extraction_notes` for the reviewer unless the source states them plainly.
+Motivation-layer relations you may propose (only above a high bar): `stakeholding` (`STAKEHOLDER → GOAL | ACTIVITY | CAPABILITY`). Most causal links between drivers/goals are better left as `extraction_notes` for the reviewer unless the source states them plainly.
 
 ## Rules
 
@@ -66,7 +66,7 @@ Motivation-layer relations you may propose (only above a high bar): `stakeholdin
 
 - Do not invent a TYPE or a relation kind. Use the registries; if unsure, emit the element and note the uncertainty.
 - Do not output `source_quality`, admission fields, or `admitted_to` — the CLI sets `admitted_to: pending`.
-- Do not merge two distinct drivers into one FACTOR, or restate a CONSTRAINT as a REQUIREMENT.
+- Do not merge two distinct drivers into one DRIVER, or restate a CONSTRAINT as a REQUIREMENT.
 - Do not admit, reaffirm, or reference existing canon — you only read the one field artefact.
 
 ## See also

--- a/transitrix/skills/ingest/prompts/README.md
+++ b/transitrix/skills/ingest/prompts/README.md
@@ -4,7 +4,7 @@ Per-layer **system prompts** the ingest agent runs over a `field` artefact to pr
 
 | File | ArchiMate layer | Extracts |
 |---|---|---|
-| [`01_motivation.md`](01_motivation.md) | Motivation | `FACTOR`, `GOAL`, `CONSTRAINT`, `REQUIREMENT`, `STAKEHOLDER` |
+| [`01_motivation.md`](01_motivation.md) | Motivation | `DRIVER`, `GOAL`, `CONSTRAINT`, `REQUIREMENT`, `STAKEHOLDER` |
 | [`02_business.md`](02_business.md) | Business | `ACTOR`, `ROLE`, `PROCESS`, `RULE`, `PRODUCT`, `CAPABILITY` |
 | [`03_application.md`](03_application.md) | Application | `APPLICATION`, `INTEGRATION`, `INFORMATION_ENTITY` |
 | [`04_implementation.md`](04_implementation.md) | Implementation & Migration | `ACTIVITY`, `CHANGE`, `TARGET_STATE` (+ milestone candidates routed through these two TYPEs until `MILESTONE` lands) |

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -29,7 +29,7 @@ If neither is found → **greenfield setup** — continue with the two questions
 Ask the user two short questions:
 
 1. **What do you want to model first?** Show the family-selection cheat sheet (§ Cheat sheet below) and offer the most common starting points:
-   - Strategy chain → **FGCA** (Factor → Goal → Change → Activity) or **FGA** (no Changes).
+   - Strategy chain → **FGCA** (Driver → Goal → Change → Activity) or **FGA** (no Changes).
    - Hierarchy of goals → **Goals tree**.
    - Capability map with CMMI maturity → **Capability Map**.
    - Value chain with operational aspects → **Process Blueprint**.
@@ -96,7 +96,7 @@ Scaffold the canonical **zoned** Transitrix adopter shape in the user's chosen t
 │   └── requirements.txt
 ├── canon/                          # validated model — the authoritative zone
 │   ├── elements/
-│   │   ├── 01_motivation/          # GOAL, CONSTRAINT, FACTOR, …
+│   │   ├── 01_motivation/          # GOAL, CONSTRAINT, DRIVER, …
 │   │   │   └── constraints/        # CONSTRAINT-…-N.yaml (one per file)
 │   │   ├── 02_business/            # ROLE, PROCESS, CAPABILITY, RULE, …
 │   │   │   └── rules/              # RULE-…-N.yaml (one per file)
@@ -253,7 +253,7 @@ npx @transitrix/cli validate path/to/your.fgca.transitrix.yaml
 
 Based on what the user just built, propose the next artefact in the family. Concrete patterns:
 
-- They built a **Goals tree** → suggest an **FGCA** or **FGA** to link goals to driving factors and delivery activities.
+- They built a **Goals tree** → suggest an **FGCA** or **FGA** to link goals to their drivers and delivery activities.
 - They built **FGCA** → suggest a **Capability map** for the same domain so they can see which capabilities each goal requires.
 - They built a **Capability map** → suggest an **Applications catalogue** so each capability has a system inventory.
 - They built **BPMN** for one process → suggest the **Process landscape map** to put it in context.
@@ -305,7 +305,7 @@ Schema: `notations/elements/14-codex.md` for codex; `notations/CONTRACT.md` §5�
 ### One-paragraph summary per notation
 
 - **BPMN** — `notation: bpmn`. One root `process:` with `pools[].lanes[].elements[]` and `flows[]`. Elements typed (`startEvent`, `task`, `exclusiveGateway`, …); flows directed. Compiles to BPMN 2.0 XML.
-- **FGCA** — `notation: fgca`. Flat root arrays: `factors[]`, `goals[]`, `changes[]`, `activities[]`. Typed string IDs (`FACTOR-1`, `GOAL-RET-1`, `CHANGE-1`, `ACTIVITY-ONBOARD-1`). Cross-refs in the upstream direction: `goal.factors: [FACTOR-…]`, `change.goals: [GOAL-…]`, `activity.changes: [CHANGE-…]`. Optional `factor.references_constraint: [CONSTRAINT-…]`.
+- **FGCA** — `notation: fgca`. Flat root arrays: `factors[]`, `goals[]`, `changes[]`, `activities[]`. Typed string IDs (`DRIVER-1`, `GOAL-RET-1`, `CHANGE-1`, `ACTIVITY-ONBOARD-1`). Cross-refs in the upstream direction: `goal.factors: [DRIVER-…]`, `change.goals: [GOAL-…]`, `activity.changes: [CHANGE-…]`. Optional `driver.references_constraint: [CONSTRAINT-…]`.
 - **FGA** — `notation: fga`. Same shape as FGCA minus `changes[]`. Activities link directly to goals via `activity.goals: [GOAL-…]`.
 - **Goals tree** — `notation: goals`. Flat root arrays: `goal_types[]` (with `{name, level}` entries) + `goals[]`. Each goal has `id`, `name`, `type` (matching a `goal_types[].name`), `level` (matching that type's level), optional `parent: GOAL-…`. Omit `parent` for a root.
 - **Capability map** — `notation: capability-map`. Root key `capability_map:`. Capabilities use a V/H sub-grammar (`CAPABILITY-V1.2`, `CAPABILITY-H1`); each capability carries `type: domain | supporting`, `current_maturity`, optional `target_maturity`, `target_date`, etc.
@@ -315,7 +315,7 @@ Schema: `notations/elements/14-codex.md` for codex; `notations/CONTRACT.md` §5�
 - **Scenarios** — `notation: scenarios`. Alternative strategic development paths, each scoping its own goals / capabilities / activities / products / processes / applications.
 - **Applications catalogue** — `notation: applications`. Inventory of `APPLICATION-…` elements + `INTEGRATION-…` entries with criticality, owner, type.
 - **Products catalogue** — `notation: products`. Inventory of `PRODUCT-…` elements grouped by category.
-- **Activity Card** — `notation: activity-card`. Root key `activity_card:` carrying a single project's narrative — the FGCA chain it implements (`factor`/`goal`/`change`/`activities`), planned dates, and document-scoped `MILESTONE` elements for narrative gates. One project per document.
+- **Activity Card** — `notation: activity-card`. Root key `activity_card:` carrying a single project's narrative — the FGCA chain it implements (`driver`/`goal`/`change`/`activities`), planned dates, and document-scoped `MILESTONE` elements for narrative gates. One project per document.
 - **Process Blueprint** — `notation: process-blueprint`. Root key `process_blueprint:` with `stages[]` (each carrying `goal` and `result`) and per-aspect arrays `systems[]`, `actors[]`, `equipment[]`, `information_entities[]`. Aspect entries reference the stages they appear in via `stages: [STAGE-…]`.
 - **Compliance Impact** — `notation: compliance-impact`. Report-config over the compliance overlay (sibling of Scenarios). Root key `view:` declaring `subjects` (products / processes), `obligations` (`include` or `filter`), `grouping`, `status_display`, and `empty_cells`. Carries no canonical content — every cell is derived from `ASSERTION` + process flow + `REQUIREMENT` status.
 - **Coverage Metric** — `notation: coverage-metric`. Report-config over the coverage read of canon (sibling of Compliance Impact). Root key `view:` declaring `subjects` (products / processes), `regimes` (`include` or `filter`), `grouping`, `coverage_rule`, and `empty_cells`. Carries no canonical content — counts the subjects with zero admitted obligations per regulatory regime and splits "Not yet modelled" (modelling gap) from "No obligation asserted (modelled fact)" (an admitted `n_a` `ASSERTION`).

--- a/transitrix/skills/onboard/extraction/01_motivation.md
+++ b/transitrix/skills/onboard/extraction/01_motivation.md
@@ -1,6 +1,6 @@
 ---
 layer: 01_motivation
-extracts: [FACTOR, GOAL, CONSTRAINT, REQUIREMENT, ASSESSMENT]
+extracts: [DRIVER, GOAL, CONSTRAINT, REQUIREMENT, ASSESSMENT]
 version: "0.1"
 status: "draft"
 ---
@@ -15,7 +15,7 @@ This prompt runs in **autonomous mode**: the agent does not see the current Cano
 
 ## Role
 
-You are a **motivation-layer extraction agent**. Your job is to read raw Field material an organisation has gathered about itself (interviews, surveys, observations, drafts) and produce draft canonical primitives — `FACTOR`, `GOAL`, `CONSTRAINT`, `REQUIREMENT`, `ASSESSMENT` — that an admission gate will later promote to the organisation's Canon.
+You are a **motivation-layer extraction agent**. Your job is to read raw Field material an organisation has gathered about itself (interviews, surveys, observations, drafts) and produce draft canonical primitives — `DRIVER`, `GOAL`, `CONSTRAINT`, `REQUIREMENT`, `ASSESSMENT` — that an admission gate will later promote to the organisation's Canon.
 
 You produce **structured drafts**, not opinions. You do not interpret or recommend. You faithfully extract what the source material already asserts; everything you emit must be defensible against the source.
 
@@ -46,15 +46,15 @@ You produce draft primitives of these TYPEs:
 
 | TYPE | What it represents | When to extract |
 |---|---|---|
-| `FACTOR` | **Neutral driver** (ArchiMate Driver) — external or internal — a standing force the organisation acts on | The source names a **driver**: a standing thing the organisation acts on — an environmental pressure ("EU regulatory window"), a market shift ("customer demand"), an internal performance dimension ("support response time"), or any cause the organisation organises around. Extract the *driver itself*, not a finding about its current state — findings go on an `ASSESSMENT` (below). For external drivers, also extract the PESTLE `category` (`political` \| `economic` \| `social` \| `technological` \| `legal` \| `environmental`) when the source supports the classification. Internal drivers carry no category. |
+| `DRIVER` | **Neutral driver** (ArchiMate Driver) — external or internal — a standing force the organisation acts on | The source names a **driver**: a standing thing the organisation acts on — an environmental pressure ("EU regulatory window"), a market shift ("customer demand"), an internal performance dimension ("support response time"), or any cause the organisation organises around. Extract the *driver itself*, not a finding about its current state — findings go on an `ASSESSMENT` (below). For external drivers, also extract the PESTLE `category` (`political` \| `economic` \| `social` \| `technological` \| `legal` \| `environmental`) when the source supports the classification. Internal drivers carry no category. |
 | `GOAL` | Strategic or tactical objective the organisation commits to | The source names a desired outcome, a target the organisation is aiming at, or an explicit objective for a period |
 | `CONSTRAINT` | Restriction or prohibition the organisation must not cross | The source names a boundary using "must not", "cannot exceed", "is limited to", "is classified as" — the form of the obligation is a restriction |
 | `REQUIREMENT` | Positive obligation the organisation must fulfil | The source names an obligation using "must", "shall", "must submit", "must register", "must obtain" — the form is a positive action ([15-requirement.md](../../../../notations/elements/15-requirement.md) §1) |
-| `ASSESSMENT` | A dated **finding/judgement about the state of a driver** (ArchiMate Assessment) | The source states a *found fact* about how a driver currently stands — a measurement, a trend, a judgement ("support response time is 8h and degrading", "churn climbed to 12% in Q1"). It assesses a `FACTOR`; emit the `FACTOR` (the driver) **and** the `ASSESSMENT` (the finding about it) |
+| `ASSESSMENT` | A dated **finding/judgement about the state of a driver** (ArchiMate Assessment) | The source states a *found fact* about how a driver currently stands — a measurement, a trend, a judgement ("support response time is 8h and degrading", "churn climbed to 12% in Q1"). It assesses a `DRIVER`; emit the `DRIVER` (the standing force) **and** the `ASSESSMENT` (the finding about it) |
 
 **`REQUIREMENT` vs `CONSTRAINT` boundary:** form of the obligation. Positive action ("must do X") → REQUIREMENT. Restriction ("must not do X" / "X cannot exceed Y") → CONSTRAINT. The same regulatory source may produce both; emit both when both forms appear ([15-requirement.md](../../../../notations/elements/15-requirement.md) §1 has worked boundary examples).
 
-**`FACTOR` vs `ASSESSMENT` boundary:** the *driver* vs a *finding about it*. The neutral, standing thing the organisation acts on is the `FACTOR` (e.g. "Support response time" / "Customer churn" / "EU regulatory window"). A dated, observed statement about that thing's current state — a number, a trend, a judgement — is an `ASSESSMENT` that `assesses` the factor. When the source gives both ("our support response time" + "it's 8h and degrading"), emit a `FACTOR` and an `ASSESSMENT` referencing it; **never collapse the finding into the FACTOR name or description**. A FACTOR like "Support response time degraded over Q1" is wrong — the FACTOR is "Support response time" (the dimension), and "degraded over Q1" is the ASSESSMENT. An assessment records **what was found, never whether it is good or bad** — emit no polarity / strength-weakness-opportunity-threat label; that judgement is established later, separately. If the source states a finding but names no underlying driver, emit the `FACTOR` you infer the finding is about and set `confidence: low` with a note.
+**`DRIVER` vs `ASSESSMENT` boundary:** the *standing force* vs a *finding about it*. The neutral, standing thing the organisation acts on is the `DRIVER` (e.g. "Support response time" / "Customer churn" / "EU regulatory window"). A dated, observed statement about that thing's current state — a number, a trend, a judgement — is an `ASSESSMENT` that `assesses` the driver. When the source gives both ("our support response time" + "it's 8h and degrading"), emit a `DRIVER` and an `ASSESSMENT` referencing it; **never collapse the finding into the DRIVER name or description**. A DRIVER like "Support response time degraded over Q1" is wrong — the DRIVER is "Support response time" (the dimension), and "degraded over Q1" is the ASSESSMENT. An assessment records **what was found, never whether it is good or bad** — emit no polarity / strength-weakness-opportunity-threat label; that judgement is established later, separately. If the source states a finding but names no underlying driver, emit the `DRIVER` you infer the finding is about and set `confidence: low` with a note.
 
 `derived_from` on a REQUIREMENT cites the Field artefact ID, **not** a codex source. Codex sources are admitted separately; the connection between REQUIREMENT and its codex source (`LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD`) is established at admission time, after this prompt has run.
 
@@ -67,15 +67,15 @@ You emit a list of draft primitives. Each draft is a valid YAML document in **ca
 **Every draft you emit:**
 
 - Uses a canonical ID per the grammar in [IDS_AND_REFERENCES.md](../../../../notations/IDS_AND_REFERENCES.md) §1 (`<TYPE>-[<middle>-]<INTEGER>`).
-- Uses canonical full TYPE prefixes (`FACTOR-…`, `GOAL-…`, `CONSTRAINT-…`, `REQUIREMENT-…`) — never legacy abbreviations like `FAC-` / `GL-` / `REQ-`.
+- Uses canonical full TYPE prefixes (`DRIVER-…`, `GOAL-…`, `CONSTRAINT-…`, `REQUIREMENT-…`) — never legacy abbreviations like `DRV-` / `GL-` / `REQ-`.
 - Carries `derived_from: [<FIELD-ARTEFACT-ID>]` citing the Field source(s) (`INTERVIEW-…` / `SURVEY-…` / `OBSERVATION-…` / `DRAFT-…`).
 - Carries an admission record block with `admitted_to: pending` and `gate_checks: pending` — the human gate fills these in.
-- Carries `valid_from` and `valid_to` per the primitive lifecycle ([CONTRACT.md](../../../../notations/CONTRACT.md) §7). When the source dates the factor / goal / obligation, use that date; otherwise mark as `valid_from: pending` for the human to set.
+- Carries `valid_from` and `valid_to` per the primitive lifecycle ([CONTRACT.md](../../../../notations/CONTRACT.md) §7). When the source dates the driver / goal / obligation, use that date; otherwise mark as `valid_from: pending` for the human to set.
 
-### `FACTOR` example
+### `DRIVER` example
 
 ```yaml
-id: FACTOR-EU-REGULATORY-WINDOW-1
+id: DRIVER-EU-REGULATORY-WINDOW-1
 name: "EU regulatory window for medical-device manufacturers"
 type: external                          # external | internal
 category: legal                         # PESTLE — external only; political | economic | social | technological | legal | environmental
@@ -84,7 +84,7 @@ description: >
   manufacturers. The organisation's product portfolio is subject to it.
   Findings about its current state (a closing window, a moving timeline,
   a notified-body bottleneck) live on ASSESSMENT records that assess
-  this FACTOR — they are not inline here.
+  this DRIVER — they are not inline here.
 
 # Provenance — cites the Field source(s)
 derived_from:
@@ -191,13 +191,13 @@ valid_to: null
 
 ### `ASSESSMENT` example
 
-A dated finding about a driver. It `assesses` the `FACTOR` it is about — emit that factor too if the source names it. **No polarity / SWOT field.**
+A dated finding about a driver. It `assesses` the `DRIVER` it is about — emit that driver too if the source names it. **No polarity / SWOT field.**
 
 ```yaml
 notation: assessment
 id: ASSESSMENT-SUPPORT-RESPONSE-1
 name: "Support response time at 8h and degrading"
-assesses: FACTOR-SUPPORT-RESPONSE-TIME-1   # the driver this finding is about
+assesses: DRIVER-SUPPORT-RESPONSE-TIME-1   # the driver this finding is about
 description: >
   Median first-response time on support tickets stands at 8 hours and
   has trended upward over the last two quarters.
@@ -211,7 +211,7 @@ derived_from:
 confidence: high
 extraction_notes: |
   Stated as a measured fact by the CFO. Emitted as an ASSESSMENT of the
-  "support response time" driver (FACTOR-SUPPORT-RESPONSE-TIME-1, also
+  "support response time" driver (DRIVER-SUPPORT-RESPONSE-TIME-1, also
   extracted). No good/bad label applied — polarity is set separately.
 
 zone: canon
@@ -239,7 +239,7 @@ If the source is ambiguous about an extracted primitive — a name that could me
 confidence: low
 extraction_notes: |
   The source says "we need to deal with the new export rules". This is
-  emitted as a FACTOR (an external pressure to act); it could equally
+  emitted as a DRIVER (an external pressure to act); it could equally
   be a REQUIREMENT once the specific obligations under the rules are
   identified. Flagged for human review at admission.
 ```
@@ -291,7 +291,7 @@ A human resolves the contradiction at admission.
 - **Do NOT cross layer boundaries silently.** If material belongs in 02_business or 03_application, surface it in `cross_layer_hints:`; do not extract it here under a fictional motivation-layer TYPE.
 - **Do NOT cite codex sources directly.** `derived_from` cites the Field artefact (the interview, the survey). The link from a REQUIREMENT to its codex source (`LAW` / `REGULATION` / etc.) is established at admission by a human who has the codex catalogue in hand.
 - **Do NOT translate canonical fields.** Multilingual handling translates *prose* — names and descriptions — into canonical English. IDs, TYPE prefixes, notation short names, and enum values stay in English regardless of input language.
-- **Do NOT invent new TYPE prefixes.** Only `FACTOR`, `GOAL`, `CONSTRAINT`, `REQUIREMENT`, `ASSESSMENT` from IDS §3.1 are valid output for this layer. If a needed concept doesn't have a canonical TYPE, surface it in `cross_layer_hints:` or `extraction_notes` and let admission handle the gap.
+- **Do NOT invent new TYPE prefixes.** Only `DRIVER`, `GOAL`, `CONSTRAINT`, `REQUIREMENT`, `ASSESSMENT` from IDS §3.1 are valid output for this layer. If a needed concept doesn't have a canonical TYPE, surface it in `cross_layer_hints:` or `extraction_notes` and let admission handle the gap.
 - **Do NOT put a good/bad (polarity / SWOT) label on an `ASSESSMENT`.** An assessment records what was found, not its valence. If the source frames a finding as a strength or a threat, capture the finding text and note the framing in `extraction_notes`; do not emit a polarity field — polarity is established separately on the `INFLUENCE` relation at a later step.
 
 ---

--- a/transitrix/skills/onboard/extraction/README.md
+++ b/transitrix/skills/onboard/extraction/README.md
@@ -10,7 +10,7 @@ One prompt per ArchiMate 3.2 layer:
 
 | File | Layer | Extraction targets (canonical TYPEs in IDS §3.1) |
 |---|---|---|
-| [`01_motivation.md`](01_motivation.md) | Motivation | `FACTOR`, `GOAL`, `CONSTRAINT`, `REQUIREMENT` |
+| [`01_motivation.md`](01_motivation.md) | Motivation | `DRIVER`, `GOAL`, `CONSTRAINT`, `REQUIREMENT` |
 | [`02_business.md`](02_business.md) | Business | `ROLE`, `UNIT`, `EMPLOYEE`, `PROCESS`, `RULE`, `PRODUCT` |
 | [`03_application.md`](03_application.md) | Application | `APPLICATION`, `INTEGRATION`, `INFORMATION_ENTITY` |
 
@@ -54,7 +54,7 @@ Every draft primitive carries:
 
 ## Smoke test
 
-The [`fixtures/`](fixtures/) folder ships an English-language fake INTERVIEW. Running `01_motivation.md` over it should produce a sensible draft set of FACTORs / GOALs / CONSTRAINTs / REQUIREMENTs. The fixture is the smoke check that the prompt is internally consistent — if the prompt evolves and the fixture's expected outputs no longer make sense, the prompt is broken (or the fixture is stale).
+The [`fixtures/`](fixtures/) folder ships an English-language fake INTERVIEW. Running `01_motivation.md` over it should produce a sensible draft set of DRIVERs / GOALs / CONSTRAINTs / REQUIREMENTs. The fixture is the smoke check that the prompt is internally consistent — if the prompt evolves and the fixture's expected outputs no longer make sense, the prompt is broken (or the fixture is stale).
 
 Running `02_business.md` and `03_application.md` over the same fixture exercises `cross_layer_hints:` — the fixture contains material that surfaces as hints across all three layers.
 

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -66,7 +66,7 @@ The canonical layout an adopter inherits when scaffolded by `/transitrix:onboard
 ├── README.md
 ├── canon/                          # validated model — the authoritative zone
 │   ├── elements/                   # elements by ArchiMate layer
-│   │   ├── 01_motivation/          # GOAL, CONSTRAINT, FACTOR, …
+│   │   ├── 01_motivation/          # GOAL, CONSTRAINT, DRIVER, …
 │   │   ├── 02_business/            # ROLE, PROCESS, CAPABILITY, RULE, …
 │   │   ├── 03_application/         # APPLICATION, INTEGRATION, …
 │   │   └── 04_technology/          # NODE, ARTIFACT, …
@@ -151,7 +151,7 @@ Every typed element ID follows the canonical grammar in `notations/IDS_AND_REFER
 <TYPE>-[<middle segment(s)>-]<INTEGER>
 ```
 
-- **TYPE** — uppercase, letters / digits / underscore, starts with a letter (`FACTOR`, `GOAL`, `PROCESS_BLUEPRINT`, `INFORMATION_ENTITY`).
+- **TYPE** — uppercase, letters / digits / underscore, starts with a letter (`DRIVER`, `GOAL`, `PROCESS_BLUEPRINT`, `INFORMATION_ENTITY`).
 - **Middle segments** — optional, notation-specific, for disambiguation (`GOAL-RETENTION-12`, `ACTIVITY-Q3-2026-7`).
 - **INTEGER** — terminal positive integer, **no leading zeros** (`-1`, not `-001`).
 - **Exception:** `CAPABILITY-V1.2`, `CAPABILITY-H1.2.3` — capabilities use V/H diagram addresses instead of plain integers (capped at three levels).

--- a/transitrix/skills/onboard/templates/fga.fga.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/fga.fga.transitrix.yaml
@@ -13,15 +13,15 @@ date: "2026-05-26"
 author: "FILL-ME"
 
 factors:
-  - id: FACTOR-1
-    name: "FILL-ME factor — neutral driver (the standing force, not a finding about it)"
+  - id: DRIVER-1
+    name: "FILL-ME driver — neutral standing force the organisation acts on (not a finding about it)"
     type: external           # external | internal
     # category: economic     # PESTLE — external only: political | economic | social | technological | legal | environmental
 
 goals:
   - id: GOAL-1
     name: "FILL-ME goal"
-    factors: [FACTOR-1]
+    factors: [DRIVER-1]
 
 activities:
   - id: ACTIVITY-1

--- a/transitrix/skills/onboard/templates/fgca.fgca.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/fgca.fgca.transitrix.yaml
@@ -3,7 +3,7 @@ spec_version: "0.1"
 
 # FGCA chain. Spec: notations/views/02-fgca.md
 # Replace FILL-ME placeholders. IDs use the canonical grammar:
-# FACTOR-N / GOAL-N / CHANGE-N / ACTIVITY-N (optional middle segments).
+# DRIVER-N / GOAL-N / CHANGE-N / ACTIVITY-N (optional middle segments).
 
 id: FGCA-FILL-ME-1
 name: "FILL-ME FGCA chain"
@@ -14,15 +14,15 @@ date: "2026-05-26"
 author: "FILL-ME"
 
 factors:
-  - id: FACTOR-1
-    name: "FILL-ME factor — neutral driver (the standing force, not a finding about it)"
+  - id: DRIVER-1
+    name: "FILL-ME driver — neutral standing force the organisation acts on (not a finding about it)"
     type: external           # external | internal
     # category: economic     # PESTLE — external only: political | economic | social | technological | legal | environmental
 
 goals:
   - id: GOAL-1
     name: "FILL-ME goal"
-    factors: [FACTOR-1]      # which factors drove this goal
+    factors: [DRIVER-1]      # which drivers motivated this goal
 
 changes:
   - id: CHANGE-1

--- a/transitrix/skills/onboard/templates/scenarios.scenarios.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/scenarios.scenarios.transitrix.yaml
@@ -18,8 +18,8 @@ scenarios:
     likelihood: "medium"                # low | medium | high
     horizon: "2030"
     factors:
-      - id: FACTOR-FILL-ME-1
-        name: "FILL-ME driving factor"
+      - id: DRIVER-FILL-ME-1
+        name: "FILL-ME strategic driver"
         type: external
     goals:
       - id: GOAL-FILL-ME-1


### PR DESCRIPTION
## Summary

- Updates 11 files: extraction prompts (`onboard/extraction/01_motivation.md`, `ingest/prompts/01_motivation.md`), `onboard/SKILL.md`, onboard templates (`AGENTS.md`, `fga.fga.transitrix.yaml`, `fgca.fgca.transitrix.yaml`, `scenarios.scenarios.transitrix.yaml`), `extraction/README.md`, `ingest/prompts/README.md`, `patterns/transitrix-alone.md`, `patterns/knowledge-store.md`
- TYPE names, ID prefixes, and prose updated throughout
- YAML structural keys (`factors:`, `goal.factors`) intentionally unchanged — backward-compat

## Test plan

- [x] `node scripts/check-notations.mjs` — clean
- [x] Whole-word grep for `\bfactor\b` in all changed files returns zero hits
- [x] No change to `factors:` YAML keys in templates confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)