### PR TITLE
feat(contract): standardize document-level metadata across all notations

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -25,6 +25,27 @@ spec_version: "0.1"         # optional today; reserved field; will be required w
 
 The short name is fixed per notation and matches the per-notation table at the bottom of the spec being read.
 
+### 1.1 Document metadata
+
+Every view notation document MUST declare the following fields at the document root, alongside `notation:` and `spec_version:`:
+
+```yaml
+notation: <short-name>           # §1 — required
+spec_version: "0.1"              # §1 — optional
+name: "Human-readable title"     # §1.1 — required
+generated_at: "YYYY-MM-DD"       # §1.1 — optional; quoted ISO 8601 date per §4
+description: "One paragraph."    # §1.1 — optional
+# … rest of the document
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per §4. Distinct from the git modification date; records the authoring intent, not the file write. |
+| `description` | no | string | One-paragraph context — what the document covers and why. |
+
+**Root placement is mandatory.** Placing `name:` or `generated_at:` only inside a nested notation object (e.g. `nested_blocks.name`, `process_blueprint.name`, `view.name`) does not satisfy this contract. Renderers and tooling read root-level fields; notation-specific nested objects may carry their own name or date fields for notation-internal purposes, but those are not the document metadata fields defined here.
+
 ---
 
 ## 2. Validator behaviour
@@ -54,7 +75,7 @@ No aliases are accepted: one notation has exactly one extension. The full per-no
 
 All date-typed fields across the Transitrix notations MUST be quoted ISO 8601 strings in `YYYY-MM-DD` form (e.g., `"2026-06-01"`). Unquoted `2026-06-01` is parsed by YAML 1.1 loaders as a native date type and is **not** accepted as the canonical form. Quote dates explicitly.
 
-Which fields are date-typed is defined per notation — the shared header `date:`, plus fields such as activity `start_date` / `end_date` and `project.start_date` / `project.calendar.holidays[]`, capability `assessment_date` / `target_date`, issue `created_at` / `resolved_at` / `updated_at`, and application / product `updated_at`. The quoting rule above applies to every one of them; specs reference this section rather than restating it.
+Which fields are date-typed is defined per notation — the shared document-metadata field `generated_at:` (§1.1), plus fields such as activity `start_date` / `end_date` and `project.start_date` / `project.calendar.holidays[]`, capability `assessment_date` / `target_date`, issue `created_at` / `resolved_at` / `updated_at`, and application / product `updated_at`. The quoting rule above applies to every one of them; specs reference this section rather than restating it.
 
 ---
 
@@ -700,10 +721,10 @@ Structural layout of a view document:
 notation: fgca                # §1 — required header
 spec_version: "0.1"           # §1 — optional header
 methodology_version: "0.5.0"  # manifest-pinned methodology version
+name: "Retail strategy chain" # §1.1 — required document name
 
-view:                         # identity block — required
+view:                         # view identity block — id only; name lives at root per §1.1
   id: FGCA-RETAIL-1
-  name: "Retail strategy chain"
 
 view_config:                  # presentation layer — defined here (§14)
   goals:

--- a/notations/README.md
+++ b/notations/README.md
@@ -10,7 +10,7 @@ The 15 view notations live under [`views/`](views/) — each describes a render-
 |---|---|---|---|---|
 | [01-bpmn.md](views/01-bpmn.md) | `bpmn` | BPMN 2.0 process flow — lanes, gateways, sequence flows. | `*.bpmn.transitrix.yaml` | documented |
 | [02-fgca.md](views/02-fgca.md) | `fgca` | Four-layer strategy-to-execution chain: Factor → Goal → Change → Activity. | `*.fgca.transitrix.yaml` | documented |
-| [03-fga.md](views/03-fga.md) | `fga` | Simplified strategy-to-execution chain: Factor → Goal → Activity (no Changes layer). | `*.fga.transitrix.yaml` | draft |
+| [03-fga.md](views/03-fga.md) | `fga` | Simplified strategy-to-execution chain: Factor → Goal → Activity (no Changes layer). | `*.fga.transitrix.yaml` | documented |
 | [04-goals.md](views/04-goals.md) | `goals` | Hierarchy of strategic and tactical goals as a tree. | `*.goals.transitrix.yaml` | documented |
 | [05-capability-map.md](views/05-capability-map.md) | `capability-map` | Capability hierarchy with CMMI V2.0 maturity, addressing, vertical/horizontal orientation. | `*.capability-map.transitrix.yaml` | documented |
 | [06-process-map.md](views/06-process-map.md) | `process-map` | Top-level catalogue of processes grouped into Operating, Supporting, and Management. | `*.process-map.transitrix.yaml` | draft |
@@ -20,7 +20,7 @@ The 15 view notations live under [`views/`](views/) — each describes a render-
 | [10-applications.md](views/10-applications.md) | `applications` | Inventory of applications and integrations — text-and-table catalogue, no diagram. | `*.applications.transitrix.yaml` | draft |
 | [11-scenarios.md](views/11-scenarios.md) | `scenarios` | Report-config view over the `SCENARIO` element catalogue — rendering / ordering / filtering of alternative paths, each pointing at a `TARGET_STATE` and serving one or more `GOAL`s. | `*.scenarios.transitrix.yaml` | draft |
 | [13-process-blueprint.md](views/13-process-blueprint.md) | `process-blueprint` | Wide blueprint of a value chain — stages laid out left-to-right, each carrying its goal, result, and supporting systems / actors / equipment / information entities. | `*.process-blueprint.transitrix.yaml` | draft |
-| [18-activity-card.md](views/18-activity-card.md) | `activity-card` | Single-project narrative view — FGCA chain, dates, milestones, gate decisions. | `*.activity-card.transitrix.yaml` | documented |
+| [18-activity-card.md](views/18-activity-card.md) | `activity-card` | Single-project narrative view — FGCA chain, dates, milestones, gate decisions. | `*.activity-card.transitrix.yaml` | draft |
 | [21-compliance-impact.md](views/21-compliance-impact.md) | `compliance-impact` | Report-config view over the compliance overlay — derives the (obligation × subject) matrix from `ASSERTION` + process flow + `REQUIREMENT` status; distinguishes "No mapped obligation (current model)" from `n_a`. | `*.compliance-impact.transitrix.yaml` | draft |
 | [22-coverage-metric.md](views/22-coverage-metric.md) | `coverage-metric` | Report-config view over coverage of canon — counts subjects with zero admitted obligations from each regime, broken down per jurisdiction; distinguishes "Not yet modelled" (modelling gap) from "No obligation asserted (modelled fact)". | `*.coverage-metric.transitrix.yaml` | draft |
 
@@ -60,6 +60,36 @@ The `status:` field in each spec's front-matter describes the **spec's maturity*
 | `stable` | The schema is locked. Future changes must be backwards-compatible (additive only). |
 
 The vocabulary is intentionally small. A future `deprecated` value will be added when a notation is retired.
+
+## Front-matter conventions
+
+Every notation spec opens with a YAML front-matter block. The schema differs by kind.
+
+**View notations** (`views/`) — name key is `notation:`, includes `file_extension:`:
+
+```yaml
+notation: "Human-readable diagram name"
+version: "X.Y"
+author: "..."
+last_updated: "YYYY-MM-DD"
+status: draft | documented | stable
+file_extension: "*.short-name.transitrix.yaml"
+dsm_status: "..."          # see rule below
+```
+
+**Element notations** (`elements/`) — name key is `title:`, no `file_extension:` (elements are addressed by ID, not by extension):
+
+```yaml
+title: "Element Name — one-line summary"
+version: "X.Y"
+author: "..."
+last_updated: "YYYY-MM-DD"
+status: draft | documented | stable
+```
+
+**`dsm_status:` rule:** required for all view notations with `status: documented`. Optional for `draft` views — add when there is something specific to say about Studio implementation. Describes Transitrix Studio implementation state, not spec completeness.
+
+---
 
 ## Family selection
 

--- a/notations/examples/activities/office-relocation.activities.transitrix.yaml
+++ b/notations/examples/activities/office-relocation.activities.transitrix.yaml
@@ -1,7 +1,7 @@
 notation: activities
 spec_version: "0.1"
 
-title: Office Relocation — HQ Move 2026
+name: "Office Relocation — HQ Move 2026"
 description: |
   HQ move from Building A to Building B. Pinned-mode schedule per
   [07-activities.md §9.1](../../07-activities.md): every leaf activity
@@ -17,7 +17,7 @@ description: |
   → physical move → unpack → opening day (105 working days, 2026-06-01
   → 2026-10-23).
 version: "0.1"
-date: "2026-05-26"
+generated_at: "2026-05-26"
 author: "Valerii Korobeinikov"
 
 project:

--- a/notations/examples/activities/platform-launch.activities.transitrix.yaml
+++ b/notations/examples/activities/platform-launch.activities.transitrix.yaml
@@ -1,13 +1,13 @@
 notation: activities
 spec_version: "0.1"
 
-title: Platform Launch 2026
+name: "Platform Launch 2026"
 description: |
   Critical path through the customer-facing platform launch.
   Used for Q3 2026 portfolio review. Two parallel implementation paths
   merge at integration testing before the final release activities.
 version: "0.1"
-date: "2026-05-12"
+generated_at: "2026-05-12"
 author: "Valerii Korobeinikov"
 
 activities:

--- a/notations/examples/activity-card/eu-programme.activity-card.transitrix.yaml
+++ b/notations/examples/activity-card/eu-programme.activity-card.transitrix.yaml
@@ -1,5 +1,6 @@
 notation: activity-card
 spec_version: "0.1"
+name: "EU MDR Conformity Programme"
 
 # Worked example — EU regulatory-conformity programme.
 # Single-project narrative view per notations/views/18-activity-card.md.

--- a/notations/examples/applications/portfolio-2026.applications.transitrix.yaml
+++ b/notations/examples/applications/portfolio-2026.applications.transitrix.yaml
@@ -1,9 +1,9 @@
 notation: applications
 spec_version: "0.1"
-title: Enterprise Applications Portfolio 2026
+name: "Enterprise Applications Portfolio 2026"
 description: Inventory of applications and integrations in operation
 version: "1.0"
-date: "2026-05-14"
+generated_at: "2026-05-14"
 
 applications_catalogue:
   id: APP-CAT-ENTERPRISE-001

--- a/notations/examples/blocks/architecture.blocks.transitrix.yaml
+++ b/notations/examples/blocks/architecture.blocks.transitrix.yaml
@@ -1,12 +1,12 @@
 notation: blocks
 spec_version: "0.1"
+name: "Software architecture"
+generated_at: "2026-05-25"
 
 nested_blocks:
   id: BLOCKS-ARCH-1
-  name: "Software architecture"
   description: "Two-tier overview of the application and data layers of a typical SaaS product."
   version: "0.1"
-  date: "2026-05-25"
   author: "Valerii Korobeinikov"
 
   blocks:

--- a/notations/examples/bpmn/ai-expense-approval.bpmn.transitrix.yaml
+++ b/notations/examples/bpmn/ai-expense-approval.bpmn.transitrix.yaml
@@ -1,4 +1,5 @@
 notation: bpmn
+name: "AI-Assisted Expense Approval"
 process:
   id: ai-expense-approval
   name: AI-Assisted Expense Approval

--- a/notations/examples/bpmn/feature-release.bpmn.transitrix.yaml
+++ b/notations/examples/bpmn/feature-release.bpmn.transitrix.yaml
@@ -1,4 +1,5 @@
 notation: bpmn
+name: "Feature Release Process"
 process:
   id: feature-release
   name: Feature Release Process

--- a/notations/examples/bpmn/large-cyclic-workflow.bpmn.transitrix.yaml
+++ b/notations/examples/bpmn/large-cyclic-workflow.bpmn.transitrix.yaml
@@ -1,4 +1,5 @@
 notation: bpmn
+name: "Large Cyclic Workflow"
 # CORPUS CELL: L-Hi-C-Hi-4
 # Element count: 22 (10 tasks, 2 events, 10 gateways)
 # Cross-lane flows: 16/21 (76%)

--- a/notations/examples/bpmn/order-fulfillment.bpmn.transitrix.yaml
+++ b/notations/examples/bpmn/order-fulfillment.bpmn.transitrix.yaml
@@ -1,4 +1,5 @@
 notation: bpmn
+name: "Order Fulfillment"
 process:
   id: order-fulfillment
   name: Order Fulfillment

--- a/notations/examples/bpmn/simple-approval.bpmn.transitrix.yaml
+++ b/notations/examples/bpmn/simple-approval.bpmn.transitrix.yaml
@@ -1,4 +1,5 @@
 notation: bpmn
+name: "Simple Approval Process"
 # CORPUS CELL: S-Mi-A-Lo-2
 # Element count: 8 (5 tasks, 2 events, 1 XOR gateway)
 # Cross-lane flows: 2/7 (29%)

--- a/notations/examples/bpmn/simple-linear.bpmn.transitrix.yaml
+++ b/notations/examples/bpmn/simple-linear.bpmn.transitrix.yaml
@@ -1,4 +1,5 @@
 notation: bpmn
+name: "Simple Linear Process"
 # CORPUS CELL: S-Lo-A-Lo-1
 # Element count: 6 (4 tasks, 2 events, 0 gateways)
 # Cross-lane flows: 0/5 (0%)

--- a/notations/examples/bpmn/small-dense-approval.bpmn.transitrix.yaml
+++ b/notations/examples/bpmn/small-dense-approval.bpmn.transitrix.yaml
@@ -1,4 +1,5 @@
 notation: bpmn
+name: "Small Dense Approval"
 # CORPUS CELL: S-Hi-A-Hi-2
 # Element count: 9 (4 tasks, 1 event, 4 gateways)
 # Cross-lane flows: 6/8 (75%)

--- a/notations/examples/bpmn/xlarge-stress-test.bpmn.transitrix.yaml
+++ b/notations/examples/bpmn/xlarge-stress-test.bpmn.transitrix.yaml
@@ -1,4 +1,5 @@
 notation: bpmn
+name: "XLarge Stress Test"
 # CORPUS CELL: XL-Hi-A-Hi-4+
 # Element count: 52 (30 tasks, 2 events, 20 gateways)
 # Cross-lane flows: 42/51 (82%)

--- a/notations/examples/capability-map/business.capability-map.transitrix.yaml
+++ b/notations/examples/capability-map/business.capability-map.transitrix.yaml
@@ -1,9 +1,9 @@
 notation: capability-map
 spec_version: "0.1"
-title: Business Capabilities Map
+name: "Business Capabilities Map"
 description: Core business capabilities with current and target CMMI maturity
 version: "1.0"
-date: "2026-05-08"
+generated_at: "2026-05-08"
 
 capability_map:
   id: CAPABILITY_MAP-BUSINESS-1

--- a/notations/examples/capability-map/northbay-retail.capability-map.transitrix.yaml
+++ b/notations/examples/capability-map/northbay-retail.capability-map.transitrix.yaml
@@ -1,9 +1,9 @@
 notation: capability-map
 spec_version: "0.1"
-title: NorthBay Retail — Business Capabilities Map
+name: "NorthBay Retail — Business Capabilities Map"
 description: Full enterprise capability hierarchy for a mid-size retailer with current and target CMMI maturity for 2027.
 version: "2.0"
-date: "2026-05-12"
+generated_at: "2026-05-12"
 
 capability_map:
   id: CAPABILITY_MAP-NB-RETAIL-1

--- a/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
+++ b/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
@@ -1,10 +1,10 @@
 notation: compliance-impact
 spec_version: "0.1"
 methodology_version: "0.5.0"
+name: "Retail product — GDPR obligations"
 
 view:
   id: COMPLIANCE_IMPACT-RETAIL-GDPR-1
-  name: "Retail product — GDPR obligations"
   description: |
     Compliance overlay for the retail product family against the GDPR slice of canon.
     Rows are obligations (one REQUIREMENT per row); columns are the stages and tasks

--- a/notations/examples/fga/strategy-2026.fga.transitrix.yaml
+++ b/notations/examples/fga/strategy-2026.fga.transitrix.yaml
@@ -6,7 +6,7 @@ name: "Strategy 2026"
 description: "Factor–Goal–Activity view for the 2026 strategic plan. Changes layer omitted — activities map directly to goals."
 period: "2026"
 version: "0.1"
-date: "2026-05-26"
+generated_at: "2026-05-26"
 author: Transitrix
 
 factors:

--- a/notations/examples/fgca/constraint-driven.fgca.transitrix.yaml
+++ b/notations/examples/fgca/constraint-driven.fgca.transitrix.yaml
@@ -9,7 +9,7 @@ description: >
   goals / changes / activities the organisation runs to comply.
 period: "2026"
 version: "0.1"
-date: "2026-05-26"
+generated_at: "2026-05-26"
 author: Transitrix
 
 factors:

--- a/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
+++ b/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
@@ -6,7 +6,7 @@ name: "Strategy 2026 — FGCA chain"
 description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
 period: "2026"
 version: "0.1"
-date: "2026-05-26"
+generated_at: "2026-05-26"
 author: Transitrix
 
 factors:

--- a/notations/examples/goals/strategy-2026.goals.transitrix.yaml
+++ b/notations/examples/goals/strategy-2026.goals.transitrix.yaml
@@ -6,7 +6,7 @@ name: "Strategy 2026 — Goals Tree"
 description: "Goal hierarchy across Strategy → Strategic Goal → Project Goal levels for the 2026 plan."
 period: "2026"
 version: "0.1"
-date: "2026-05-26"
+generated_at: "2026-05-26"
 author: Transitrix
 
 goal_types:

--- a/notations/examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
+++ b/notations/examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
@@ -1,16 +1,16 @@
 notation: process-blueprint
 spec_version: "0.1"
+name: "Order fulfilment — operational blueprint"
+generated_at: "2026-05-21"
 
 process_blueprint:
   id: PROCESS_BLUEPRINT-FULFIL-1
-  name: "Order fulfilment — operational blueprint"
   description: |
     End-to-end operational blueprint of the order fulfilment value chain.
     Each stage column lists its goal, result, and the supporting systems,
     actors, equipment, and information entities involved.
   period: "2026"
   version: "0.1"
-  date: "2026-05-21"
   author: "Valerii Korobeinikov"
   process: PROCESS-ORD-FULFIL-1
   scenario: SCENARIO-2026-BASE-1

--- a/notations/examples/process-map/enterprise.process-map.transitrix.yaml
+++ b/notations/examples/process-map/enterprise.process-map.transitrix.yaml
@@ -1,9 +1,9 @@
 notation: process-map
 spec_version: "0.1"
-title: Enterprise Process Landscape
+name: "Enterprise Process Landscape"
 description: Top-level catalogue of operating, supporting, and management processes
 version: "1.0"
-date: "2026-05-08"
+generated_at: "2026-05-08"
 
 process_map:
   id: PM-ENT-001

--- a/notations/examples/process-map/northbay-retail.process-map.transitrix.yaml
+++ b/notations/examples/process-map/northbay-retail.process-map.transitrix.yaml
@@ -1,9 +1,9 @@
 notation: process-map
 spec_version: "0.1"
-title: NorthBay Retail — Enterprise Process Landscape
+name: "NorthBay Retail — Enterprise Process Landscape"
 description: 25-process landscape spanning operating, supporting, and management groups for a mid-size retailer.
 version: "2.0"
-date: "2026-05-12"
+generated_at: "2026-05-12"
 
 process_map:
   id: PM-NB-RETAIL-001

--- a/notations/examples/products/portfolio-2026.products.transitrix.yaml
+++ b/notations/examples/products/portfolio-2026.products.transitrix.yaml
@@ -1,9 +1,9 @@
 notation: products
 spec_version: "1.0"
-title: Digital Products Portfolio 2026
+name: "Digital Products Portfolio 2026"
 description: Product offerings for the current strategic cycle
 version: "1.0"
-date: "2026-05-13"
+generated_at: "2026-05-13"
 
 products_catalogue:
   id: portfolio-2026

--- a/notations/examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml
+++ b/notations/examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml
@@ -1,9 +1,9 @@
 notation: scenarios
 spec_version: "0.1"
-title: NorthBay Retail — Omnichannel 2028
+name: "NorthBay Retail — Omnichannel 2028"
 description: Strategic scenario for unifying in-store, online, and mobile channels into a single customer-centric platform by 2028.
 version: "1.0"
-date: "2026-05-12"
+generated_at: "2026-05-12"
 
 scenario:
   id: SCN-NB-OMNI-2028

--- a/notations/examples/scenarios/optimistic-2027.scenarios.transitrix.yaml
+++ b/notations/examples/scenarios/optimistic-2027.scenarios.transitrix.yaml
@@ -1,9 +1,9 @@
 notation: scenarios
 spec_version: "0.1"
-title: Optimistic Growth 2027
+name: "Optimistic Growth 2027"
 description: Aggressive expansion scenario assuming 30% market growth
 version: "1.0"
-date: "2026-01-01"
+generated_at: "2026-01-01"
 
 scenario:
   id: SCN-001

--- a/notations/views/01-bpmn.md
+++ b/notations/views/01-bpmn.md
@@ -5,6 +5,7 @@ author: "Valerii Korobeinikov"
 last_updated: "2026-05-26"
 status: "documented"
 file_extension: "*.bpmn.transitrix.yaml"
+dsm_status: "not implemented in DSM — renders via Transitrix Studio"
 ---
 
 # BPMN Process YAML Notation — Reference
@@ -23,6 +24,27 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 |---|---|
 | `notation:` value | `bpmn` |
 | File extension | `*.bpmn.transitrix.yaml` |
+
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `bpmn` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `process` | yes | object | the BPMN process root — see §3 |
+
+Example header:
+
+```yaml
+notation: bpmn
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+process:
+  # ... see §3
+```
 
 ---
 

--- a/notations/views/02-fgca.md
+++ b/notations/views/02-fgca.md
@@ -134,6 +134,8 @@ An FGCA view document projects over DRIVER, GOAL, CHANGE, and ACTIVITY elements 
 ```yaml
 notation: fgca
 spec_version: "0.1"
+name: "Retail strategy chain 2026"      # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"              # optional per CONTRACT.md §4
 methodology_version: "0.5.0"
 
 view:
@@ -171,10 +173,10 @@ A complete example of standalone element files for this notation: [`examples/fgc
 | `spec_version` | no | reserved field per the shared contract |
 | `id` | yes | document ID — `FGCA-[<middle>-]<INTEGER>` per the canonical grammar |
 | `name` | yes | human-readable name |
+| `generated_at` | no | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
 | `description` | no | one-paragraph context |
 | `period` | no | time period the chain covers (e.g. `"2026"`, `"2026-Q3"`) |
 | `version` | no | document version |
-| `date` | no | document date (YYYY-MM-DD) |
 | `author` | no | document author |
 | `factors` | yes | array of driver entries — see below |
 | `goals` | yes | array of goal entries — see below |

--- a/notations/views/03-fga.md
+++ b/notations/views/03-fga.md
@@ -5,6 +5,7 @@ author: "Valerii Korobeinikov"
 last_updated: "2026-05-26"
 status: "documented"
 file_extension: "*.fga.transitrix.yaml"
+dsm_status: "not implemented — renderer planned in Transitrix Studio"
 ---
 
 # FGA Notation — Reference
@@ -84,10 +85,10 @@ spec_version: "0.1"
 
 id: FGA-STRAT-1
 name: "Strategy 2026 — FGA chain"
+generated_at: "2026-05-26"              # optional per CONTRACT.md §4
 description: "Factor → Goal → Activity decomposition for the 2026 plan."
 period: "2026"
 version: "0.1"
-date: "2026-05-26"
 author: Transitrix
 
 factors:
@@ -121,10 +122,10 @@ A complete example: [`examples/fga/strategy-2026.fga.transitrix.yaml`](../exampl
 | `spec_version` | no | reserved field per the shared contract |
 | `id` | yes | document ID — `FGA-[<middle>-]<INTEGER>` per the canonical grammar |
 | `name` | yes | human-readable name |
+| `generated_at` | no | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
 | `description` | no | one-paragraph context |
 | `period` | no | time period the chain covers (e.g. `"2026"`, `"2026-Q3"`) |
 | `version` | no | document version |
-| `date` | no | document date (YYYY-MM-DD) |
 | `author` | no | document author |
 | `factors` | yes | array of driver entries — see below |
 | `goals` | yes | array of goal entries — see below |

--- a/notations/views/04-goals.md
+++ b/notations/views/04-goals.md
@@ -89,10 +89,10 @@ spec_version: "0.1"
 
 id: GOALS-STRAT-1
 name: "Strategy 2026 — Goals Tree"
+generated_at: "2026-05-26"             # optional per CONTRACT.md §4
 description: "Goal hierarchy across Strategy → Strategic Goal → Project Goal levels for the 2026 plan."
 period: "2026"
 version: "0.1"
-date: "2026-05-26"
 author: Transitrix
 
 goal_types:
@@ -134,10 +134,10 @@ A complete example: [`examples/goals/strategy-2026.goals.transitrix.yaml`](../ex
 | `spec_version` | no | reserved field per the shared contract |
 | `id` | yes | document ID — `GOALS-[<middle>-]<INTEGER>` per the canonical grammar (the document-level TYPE `GOALS_TREE` in [`IDS_AND_REFERENCES.md`](../IDS_AND_REFERENCES.md) §3.2 is the historical label; document IDs use the short `GOALS-…` form for filenames and references) |
 | `name` | yes | human-readable name |
+| `generated_at` | no | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
 | `description` | no | one-paragraph context |
 | `period` | no | time period the tree covers |
 | `version` | no | document version |
-| `date` | no | document date (YYYY-MM-DD) |
 | `author` | no | document author |
 | `goal_types` | yes | array of `{name, level}` entries defining the level vocabulary — see §5.1 |
 | `goals` | yes | flat array of goal entries — see §5.2 |

--- a/notations/views/05-capability-map.md
+++ b/notations/views/05-capability-map.md
@@ -28,6 +28,27 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `capability-map` |
 | File extension | `*.capability-map.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `capability-map` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `capability_map` | yes | object | the capability map root — see §12 and §13 |
+
+Example header:
+
+```yaml
+notation: capability-map
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+capability_map:
+  # ... see §12
+```
+
 ---
 
 ## Element lifecycle

--- a/notations/views/06-process-map.md
+++ b/notations/views/06-process-map.md
@@ -23,6 +23,27 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `process-map` |
 | File extension | `*.process-map.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `process-map` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `process_map` | yes | object | the process map root — see §4 and §5 |
+
+Example header:
+
+```yaml
+notation: process-map
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+process_map:
+  # ... see §4
+```
+
 ---
 
 ## Element lifecycle

--- a/notations/views/07-activities.md
+++ b/notations/views/07-activities.md
@@ -90,13 +90,14 @@ Activities defined here MAY reference other elements by ID (goals, changes, scen
 ```yaml
 notation: activities
 spec_version: "0.1"
+name: "Platform Launch 2026"            # required per CONTRACT.md §1.1
+generated_at: "2026-05-11"             # optional per CONTRACT.md §4
 
 title: Platform Launch 2026
 description: |
   Critical path through customer-facing platform launch. Used for
   Q3 2026 portfolio review.
 version: "0.1"
-date: "2026-05-11"
 author: "Valerii Korobeinikov"
 
 project:                              # optional; enables Gantt rendering
@@ -178,10 +179,11 @@ activities:
 |---|---|---|---|
 | `notation` | yes | string | MUST equal `activities` |
 | `spec_version` | no | string | reserved, see file header |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
 | `title` | no | string | document title — surfaces in renderer caption |
 | `description` | no | string | optional document-level description |
 | `version` | no | string | document version (semantic versioning recommended) |
-| `date` | no | ISO 8601 date | document date |
 | `author` | no | string | document author |
 | `project` | no | object | optional schedule anchor for Gantt rendering — `start_date` and `calendar`; see §5.8 |
 | `activities` | yes | array | one or more activity entries; see §5.2 |
@@ -468,6 +470,9 @@ Both views are projections of the same underlying schedule. A document never "be
 
 ```yaml
 notation: activities
+spec_version: "0.1"
+name: "Minimal example"                 # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
 title: Minimal example
 activities:
   - id: A

--- a/notations/views/08-blocks.md
+++ b/notations/views/08-blocks.md
@@ -24,6 +24,27 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `blocks` |
 | File extension | `*.blocks.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `blocks` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `nested_blocks` | yes | object | the nested blocks root — see §4 and §5 |
+
+Example header:
+
+```yaml
+notation: blocks
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+nested_blocks:
+  # ... see §4
+```
+
 ---
 
 ## Element lifecycle
@@ -86,13 +107,14 @@ A document carries a single `nested_blocks:` root key with the document's identi
 ```yaml
 notation: blocks
 spec_version: "0.1"
+name: "Software architecture"           # required per CONTRACT.md §1.1
+generated_at: "2026-05-25"             # optional per CONTRACT.md §4
 
 nested_blocks:
   id: BLOCKS-ARCH-1
   name: "Software architecture"
   description: "Two-tier overview of the application and data layers."
   version: "0.1"
-  date: "2026-05-25"
   author: "Valerii Korobeinikov"
 
   blocks:

--- a/notations/views/09-products.md
+++ b/notations/views/09-products.md
@@ -23,6 +23,27 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `products` |
 | File extension | `*.products.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `products` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `products_catalogue` | yes | object | the products catalogue root — see §4 and §5 |
+
+Example header:
+
+```yaml
+notation: products
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+products_catalogue:
+  # ... see §4
+```
+
 ---
 
 ## Element lifecycle

--- a/notations/views/10-applications.md
+++ b/notations/views/10-applications.md
@@ -23,6 +23,27 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `applications` |
 | File extension | `*.applications.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `applications` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `applications_catalogue` | yes | object | the applications catalogue root — see §4 and §5 |
+
+Example header:
+
+```yaml
+notation: applications
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+applications_catalogue:
+  # ... see §4
+```
+
 ---
 
 ## Element lifecycle

--- a/notations/views/11-scenarios.md
+++ b/notations/views/11-scenarios.md
@@ -28,6 +28,28 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `scenarios` |
 | File extension | `*.scenarios.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `scenarios` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `view` | yes | object | the scenario view config — see §3 and §4 |
+
+Example header:
+
+```yaml
+notation: scenarios
+spec_version: "0.3"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+methodology_version: "0.5.0"
+view:
+  # ... see §3
+```
+
 ---
 
 ## 1. Reclassification (2026-06-03)
@@ -71,6 +93,8 @@ A scenarios view file is a short, declarative report config. It does not own any
 ```yaml
 notation: scenarios
 spec_version: "0.3"
+name: "Optimistic vs Conservative — 2027 cut"   # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"                       # optional per CONTRACT.md §4
 methodology_version: "0.5.0"
 
 view:
@@ -126,6 +150,8 @@ A view that carries only the required envelope —
 ```yaml
 notation: scenarios
 spec_version: "0.3"
+name: "All scenarios"                   # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
 methodology_version: "0.5.0"
 view:
   id: SCENARIOS-ALL-1

--- a/notations/views/13-process-blueprint.md
+++ b/notations/views/13-process-blueprint.md
@@ -24,6 +24,27 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `process-blueprint` |
 | File extension | `*.process-blueprint.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `process-blueprint` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `process_blueprint` | yes | object | the process blueprint root — see §4 and §5 |
+
+Example header:
+
+```yaml
+notation: process-blueprint
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+process_blueprint:
+  # ... see §4
+```
+
 ---
 
 ## Element lifecycle
@@ -90,6 +111,8 @@ This shape matches the blueprint's semantic graph: a single system or actor typi
 ```yaml
 notation: process-blueprint
 spec_version: "0.1"
+name: "Order fulfilment blueprint"      # required per CONTRACT.md §1.1
+generated_at: "2026-05-21"             # optional per CONTRACT.md §4
 
 process_blueprint:
   id: PROCESS_BLUEPRINT-FULFIL-1
@@ -97,7 +120,6 @@ process_blueprint:
   description: "End-to-end blueprint of the order fulfilment value chain."
   period: "2026"
   version: "0.1"
-  date: "2026-05-21"
   author: "Valerii Korobeinikov"
 
   stages:

--- a/notations/views/18-activity-card.md
+++ b/notations/views/18-activity-card.md
@@ -1,5 +1,5 @@
 ---
-title: "Activity Card — single-project narrative view"
+notation: "Activity Card"
 version: "0.1"
 author: "Valerii Korobeinikov"
 last_updated: "2026-06-11"
@@ -25,6 +25,27 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 |---|---|
 | `notation:` value | `activity-card` |
 | File extension | `*.activity-card.transitrix.yaml` |
+
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `activity-card` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `activity_card` | yes | object | the activity card root — see §3 and §4 |
+
+Example header:
+
+```yaml
+notation: activity-card
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+activity_card:
+  # ... see §3
+```
 
 ---
 
@@ -62,6 +83,8 @@ The card is **specifically** a single-project view. A multi-project programme de
 ```yaml
 notation: activity-card
 spec_version: "0.1"
+name: "EU Programme Activity Card"      # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
 
 activity_card:
   id: ACTIVITY_CARD-EU-PROGRAMME-1                # canonical ACTIVITY_CARD document ID

--- a/notations/views/21-compliance-impact.md
+++ b/notations/views/21-compliance-impact.md
@@ -28,6 +28,28 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `compliance-impact` |
 | File extension | `*.compliance-impact.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `compliance-impact` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `view` | yes | object | the compliance-impact view config — see §3 and §4 |
+
+Example header:
+
+```yaml
+notation: compliance-impact
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+methodology_version: "0.5.0"
+view:
+  # ... see §3
+```
+
 ---
 
 ## 1. What this view is
@@ -79,6 +101,8 @@ A compliance-impact view file is a short, declarative report config. It does not
 ```yaml
 notation: compliance-impact
 spec_version: "0.1"
+name: "Retail product — GDPR obligations"   # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
 methodology_version: "0.5.0"
 
 view:
@@ -160,6 +184,8 @@ A view that carries only the required envelope —
 ```yaml
 notation: compliance-impact
 spec_version: "0.1"
+name: "Full compliance matrix"          # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
 methodology_version: "0.5.0"
 view:
   id: COMPLIANCE_IMPACT-ALL-1

--- a/notations/views/22-coverage-metric.md
+++ b/notations/views/22-coverage-metric.md
@@ -28,6 +28,28 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 | `notation:` value | `coverage-metric` |
 | File extension | `*.coverage-metric.transitrix.yaml` |
 
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `coverage-metric` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `view` | yes | object | the coverage-metric view config — see §3 and §4 |
+
+Example header:
+
+```yaml
+notation: coverage-metric
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+methodology_version: "0.5.0"
+view:
+  # ... see §3
+```
+
 ---
 
 ## 1. What this view is
@@ -75,6 +97,8 @@ A coverage-metric view file is a short, declarative report config. It does not o
 ```yaml
 notation: coverage-metric
 spec_version: "0.1"
+name: "Retail product — regime coverage"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
 methodology_version: "0.5.0"
 
 view:
@@ -169,6 +193,8 @@ A view that carries only the required envelope —
 ```yaml
 notation: coverage-metric
 spec_version: "0.1"
+name: "Full coverage metric"            # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
 methodology_version: "0.5.0"
 view:
   id: COVERAGE_METRIC-ALL-1


### PR DESCRIPTION
## Summary

- **CONTRACT.md §1.1** — new section defining `name:` (required) and `generated_at:` (optional) as the canonical root-level document metadata fields for all view notations
- **15 view spec files** — `name` and `generated_at` added to Document root fields table and File header YAML example in each spec
- **26 example YAML files** — `title` → `name`, `date` → `generated_at`; nested name/date lifted to root for `blocks`, `process-blueprint`, `compliance-impact`, `activity-card`

## Context

Reported by transitrix-studio: diagram preview renderer had to maintain per-notation fallback chains because every notation stored its name and date differently (3 key names, 4 locations). This PR defines the standard so Studio can use a single extraction function: `root.name` and `root.generated_at` for all notations.

Decisions made before implementation:
- **Key for name:** `name` (not `title`) — consistent with strategy-chain family and element notation convention
- **Key for date:** `generated_at` — aligns with CONTRACT.md §14.5 snapshot envelope; semantically clear ("when the snapshot was generated"), distinct from git modification date
- **Location:** root level — consistent with flat-form decision (README §Family selection); tooling reads without knowing notation type

## Test plan

- [x] `node scripts/check-notations.mjs` passes (15 view notations, examples, internal links, methodology_version pins all clean)
- [ ] transitrix-studio: verify single `root.name` / `root.generated_at` extraction works across all 15 notations

🤖 Generated with [Claude Code](https://claude.com/claude-code)