### PR TITLE
fix(skills): conform onboard templates to CONTRACT.md §1.1 document metadata

### DIFF
--- a/transitrix/skills/onboard/templates/activities.activities.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/activities.activities.transitrix.yaml
@@ -7,10 +7,10 @@ spec_version: "0.1"
 # the critical path. Optional `project.start_date` + per-activity
 # `duration_days` enable a Gantt projection.
 
-title: "FILL-ME activities network"
+name: "FILL-ME activities network"
 description: "FILL-ME — what this schedule covers"
 version: "0.1"
-date: "2026-05-26"
+generated_at: "YYYY-MM-DD"
 author: "FILL-ME"
 
 project:

--- a/transitrix/skills/onboard/templates/activity-card.activity-card.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/activity-card.activity-card.transitrix.yaml
@@ -6,6 +6,8 @@ spec_version: "0.1"
 # existing project Activity (must resolve; activity_type must be Project).
 # Document-scoped MILESTONE elements in milestones[] for narrative gates.
 
+name: "FILL-ME activity card"          # required per CONTRACT.md §1.1
+
 activity_card:
   id: ACTIVITY_CARD-FILL-ME-1
   project: ACTIVITY-FILL-ME-1                  # existing project Activity ID; must resolve

--- a/transitrix/skills/onboard/templates/applications.applications.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/applications.applications.transitrix.yaml
@@ -4,6 +4,8 @@ spec_version: "0.1"
 # Applications catalogue. Spec: notations/views/10-applications.md
 # Inventory of APPLICATION-… elements + INTEGRATION-… entries.
 
+name: "FILL-ME applications portfolio" # required per CONTRACT.md §1.1
+
 applications_catalogue:
   id: APPLICATIONS_CAT-FILL-ME-1
   name: "FILL-ME applications portfolio"

--- a/transitrix/skills/onboard/templates/blocks.blocks.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/blocks.blocks.transitrix.yaml
@@ -8,6 +8,8 @@ spec_version: "0.1"
 # APPLICATION-OMS-1) or be a free-form local label (e.g. FRONTEND).
 # Recommended max depth: 5 levels.
 
+name: "FILL-ME architecture overview"  # required per CONTRACT.md §1.1
+
 nested_blocks:
   id: BLOCKS-FILL-ME-1
   name: "FILL-ME architecture overview"

--- a/transitrix/skills/onboard/templates/bpmn.bpmn.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/bpmn.bpmn.transitrix.yaml
@@ -6,6 +6,8 @@ spec_version: "0.1"
 # exclusiveGateway, parallelGateway, inclusiveGateway. Flows connect
 # element IDs across lanes.
 
+name: "FILL-ME process name"           # required per CONTRACT.md §1.1
+
 process:
   id: FILL-ME-process-id          # kebab-case slug, e.g. order-fulfilment
   name: "FILL-ME process name"

--- a/transitrix/skills/onboard/templates/capability-map.capability-map.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/capability-map.capability-map.transitrix.yaml
@@ -5,6 +5,8 @@ spec_version: "0.1"
 # Capability IDs use the V/H sub-grammar (CAPABILITY-V1.2, CAPABILITY-H1.2.3).
 # Maturity uses the CMMI 1–5 scale.
 
+name: "FILL-ME capability map"         # required per CONTRACT.md §1.1
+
 capability_map:
   id: CAPABILITY_MAP-FILL-ME-1
   name: "FILL-ME capability map"

--- a/transitrix/skills/onboard/templates/compliance-impact.compliance-impact.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/compliance-impact.compliance-impact.transitrix.yaml
@@ -7,6 +7,8 @@ spec_version: "0.1"
 # process flow + REQUIREMENT status. This file only declares which slice
 # of that matrix to render and how.
 
+name: "FILL-ME compliance impact"      # required per CONTRACT.md §1.1
+
 view:
   id: COMPLIANCE_IMPACT-FILL-ME-1
   name: "FILL-ME — e.g. Retail product — GDPR obligations"

--- a/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
@@ -10,6 +10,8 @@ methodology_version: "0.5.0"
 # subjects with zero admitted obligations, and splits a modelling gap from a
 # modelled exclusion (an admitted ASSERTION with status: n_a).
 
+name: "FILL-ME coverage metric"        # required per CONTRACT.md §1.1
+
 view:
   id: COVERAGE_METRIC-FILL-ME-1
   name: "FILL-ME — e.g. Retail product — regime coverage"

--- a/transitrix/skills/onboard/templates/fga.fga.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/fga.fga.transitrix.yaml
@@ -9,7 +9,7 @@ name: "FILL-ME FGA chain"
 description: "FILL-ME — one-paragraph context"
 period: "FILL-ME"
 version: "0.1"
-date: "2026-05-26"
+generated_at: "YYYY-MM-DD"
 author: "FILL-ME"
 
 factors:

--- a/transitrix/skills/onboard/templates/fgca.fgca.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/fgca.fgca.transitrix.yaml
@@ -10,7 +10,7 @@ name: "FILL-ME FGCA chain"
 description: "FILL-ME — one-paragraph context"
 period: "FILL-ME"            # e.g. "2026" or "2026-Q3"
 version: "0.1"
-date: "2026-05-26"
+generated_at: "YYYY-MM-DD"
 author: "FILL-ME"
 
 factors:

--- a/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
@@ -9,7 +9,7 @@ name: "FILL-ME goals tree"
 description: "FILL-ME — what this tree covers"
 period: "FILL-ME"
 version: "0.1"
-date: "2026-05-26"
+generated_at: "YYYY-MM-DD"
 author: "FILL-ME"
 
 goal_types:

--- a/transitrix/skills/onboard/templates/process-blueprint.process-blueprint.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/process-blueprint.process-blueprint.transitrix.yaml
@@ -6,13 +6,15 @@ spec_version: "0.1"
 # Stages laid out left-to-right; per-stage aspects (systems, actors,
 # equipment, information entities) reference the stages they touch.
 
+name: "FILL-ME process blueprint"      # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"            # optional per CONTRACT.md §4
+
 process_blueprint:
   id: PROCESS_BLUEPRINT-FILL-ME-1
   name: "FILL-ME process blueprint"
   description: "FILL-ME — value chain scope"
   period: "FILL-ME"                    # e.g. "2026"
   version: "0.1"
-  date: "2026-05-26"
   author: "FILL-ME"
 
   stages:

--- a/transitrix/skills/onboard/templates/process-map.process-map.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/process-map.process-map.transitrix.yaml
@@ -6,6 +6,8 @@ spec_version: "0.1"
 # management (governance / oversight). Each entry references a
 # BusinessProcess element by its PROCESS-… ID.
 
+name: "FILL-ME process landscape"      # required per CONTRACT.md §1.1
+
 process_map:
   id: PROCESS_MAP-FILL-ME-1
   name: "FILL-ME process landscape"

--- a/transitrix/skills/onboard/templates/products.products.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/products.products.transitrix.yaml
@@ -5,6 +5,8 @@ spec_version: "0.1"
 # Inventory of digital products / services. Each PRODUCT-… is a
 # canonical element ID; categories group products by domain.
 
+name: "FILL-ME products catalogue"     # required per CONTRACT.md §1.1
+
 products_catalogue:
   id: PRODUCTS_CAT-FILL-ME-1
   name: "FILL-ME products catalogue"

--- a/transitrix/skills/onboard/templates/scenarios.scenarios.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/scenarios.scenarios.transitrix.yaml
@@ -6,9 +6,9 @@ spec_version: "0.1"
 # own goals, capabilities, activities, products, processes, and
 # applications.
 
-title: "FILL-ME scenario set"
+name: "FILL-ME scenario set"
 description: "FILL-ME — what range of futures this set spans"
-date: "2026-05-26"
+generated_at: "YYYY-MM-DD"
 author: "FILL-ME"
 
 scenarios:


### PR DESCRIPTION
## Summary

- All 15 view-notation templates in `transitrix/skills/onboard/templates/` now comply with the document metadata standard added in commit `6b8f1b3` (CONTRACT.md §1.1).
- Root `name:` field is required by §1.1 — it was missing from 10 templates where it existed only inside the notation-specific nested object (`process_blueprint.name`, `nested_blocks.name`, `view.name`, etc.).
- `date:` renamed to `generated_at:` (document-level date field) in 5 templates. `title:` renamed to `name:` in 2 templates.
- `process_blueprint.date` (inside the nested block) removed; superseded by root `generated_at:`.

## Checks

| Check | Result |
|---|---|
| `check-notations.mjs` | ✅ clean — 15 notations |
| `check-skill-cheatsheet.mjs` | ✅ conforms — 15 notations |
| `test_skill_integrity.py` | ✅ PASS |

## Files changed

All changes are in `transitrix/skills/onboard/templates/` — exactly 15 template files, one line or two per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)