### PR TITLE
feat(skills): add min_version frontmatter to all skills + document convention in RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,6 +67,37 @@ Steps 1–3 handle the **spec and canon**; step 4 handles the **CLI**; steps 5�
 
 ---
 
+## Skill `min_version` convention
+
+Every skill file (`transitrix/skills/<name>/SKILL.md`) carries a `min_version` field in its YAML frontmatter declaring the minimum methodology version required to use the skill:
+
+```yaml
+---
+name: Transitrix Ingest
+# ...
+min_version: "0.6.0"
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
+---
+```
+
+**Rules:**
+
+- `min_version` is the first methodology version in which the skill was added or last had a **breaking change** (new required step, changed CLI interface, removed capability). Additive improvements to an existing skill do not require a bump.
+- `min_version` is a hard floor: the adopter's agent uses the table in `AGENTS.md §14` to refuse a skill invocation when the adopter's pinned version is below the floor.
+- When a release changes a skill in a breaking way, **update `min_version` in that skill's `SKILL.md`** as part of the same PR. This is a precondition for tagging, alongside the migration recipe (for MAJOR) and the changelog entry.
+
+**Administrator note — updating skills in adopter repos:**
+
+Skills are not auto-synced to adopter repos. When the methodology releases a version that updates one or more skills, the adopter's administrator must:
+
+1. Copy the updated skill files from `transitrix/skills/<name>/` into the adopter repo (at whatever path the adopter's `AGENTS.md §14` table references).
+2. Update the `Min version` column in the adopter's `AGENTS.md §14` to match the new `min_version` value.
+3. Commit the update as a separate PR titled `chore: update skills to methodology vX.Y.Z`.
+
+For MAJOR releases, skills are updated **after** the migration recipe is applied and `transitrix.yaml` reflects the new version — not before.
+
+---
+
 ## What this file does NOT cover
 
 - **Compatibility semantics** — what each bump promises adopters. See [`notations/CONTRACT.md`](notations/CONTRACT.md) §10.

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -2,6 +2,7 @@
 name: Transitrix Ingest
 description: Turn raw organisational material (interviews, policies, org charts, spreadsheets, notes) into Transitrix field artefacts and typed canon candidates at scale, with source-quality scoring and a human review queue. Operates the field→canon derivation pipeline — convert a document, emit a field artefact with provenance and a proposed source_quality, extract typed elements and conservative relations that each cite their field source via derived_from, validate them against the canonical schemas and the adopter's coverage profile, and produce a review queue a human gates before anything is admitted to canon. Never writes canon directly.
 when_to_use: User says "ingest these documents", "extract a model from this interview / policy / spreadsheet", "fill the field zone from raw material", "turn these notes into canon candidates", "set up the intake pipeline", or drops raw files into an adopter repo's `_intake/inbox/` and wants them processed into field artefacts + reviewable canon candidates.
+min_version: "0.6.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
 

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -2,6 +2,7 @@
 name: Transitrix Onboarding
 description: Scaffold a new Transitrix architecture-as-text repository (zoned canon/ + field/ + codex/ layout with assistant-neutral AGENTS.md + transitrix.yaml manifest) and drive a first modelling session — enterprise architecture (BPMN, FGCA / FGA / Goals, capability map, process blueprint, activities network, blocks, scenarios, products, applications) plus codex artefacts (laws, regulations, policies, internal standards). Use when the user wants to start a new Transitrix repo from scratch, or has just cloned one and wants to author their first notation file with validation.
 when_to_use: User says "set up Transitrix", "model my architecture as text", "create a new transitrix repo", "I want to write [FGCA / Goals / capability map / process blueprint / ...] but don't know the schema", or asks to scaffold an organisation-as-text repository following the Transitrix methodology. Also triggers when the user says "I cloned my team's Transitrix repo", "help me get oriented in this model", "make my first change to our architecture repo", or expresses a similar intent to orient in or contribute to a repo that already uses Transitrix.
+min_version: "0.5.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
 

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -2,6 +2,7 @@
 name: Transitrix Reg-Intel
 description: "Collect regulatory-source changes in practice — the operational counterpart to the methodology's codex / SEGMENT / AMENDMENT notation work. Watches codex sources flagged `monitoring_needed: true`, runs a cheap change-signal gate before any expensive extraction, then on signal-moved runs the SCAN → SEGMENT → CLASSIFY → OUTPUT pass: fetches and snapshots the source, slices it into obligation-bearing SEGMENT field artefacts, classifies each segment as a CONSTRAINT or REQUIREMENT candidate (positive obligation → REQUIREMENT by default), emits an AMENDMENT field artefact when an existing source has drifted, updates the codex `scan` block, and stages everything in a review digest for human admission. Never writes canon. Never auto-admits. Never silently drops."
 when_to_use: 'User says "stand up the regulatory watcher", "run the daily reg-intel scan", "scan my codex sources for amendments", "extract obligations from this regulation", "produce the reg-intel review digest", or has a codex repo with `monitoring_needed: true` sources and wants drift detection plus a draft-obligation pipeline routed through a human gate.'
+min_version: "0.6.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
 

--- a/transitrix/skills/repo-check/SKILL.md
+++ b/transitrix/skills/repo-check/SKILL.md
@@ -2,6 +2,7 @@
 name: Transitrix Repo-Check
 description: "Read-only health check (\"doctor\") for a Transitrix adopter repository. Emits a short, DATA-FREE report — methodology version, resolved coverage profile, per-zone and per-TYPE counts, an adoption-level indicator, integrity red flags (invalid IDs, misplaced canon elements, unresolved profile), and a tooling check. Reports aggregates and statuses only — never object ids, names, or contents — so the report is safe to share outside the organisation. Idempotent and non-mutating: it reads the zones and never writes one."
 when_to_use: 'User says "check my Transitrix repo", "is my model healthy", "run the repo doctor", "give me a status of the canon", "what state is this adopter repo in", or wants a shareable, data-free summary of a repository''s shape and integrity without exposing any model contents.'
+min_version: "0.6.0"
 allowed-tools: Read, Bash, Glob, Grep
 ---
 

--- a/transitrix/skills/report/SKILL.md
+++ b/transitrix/skills/report/SKILL.md
@@ -2,6 +2,7 @@
 name: Transitrix Report
 description: "Produce a compliance report (obligation × subject impact matrix, or per-regime coverage metric) from a Transitrix repository, by conversation. Resolves the report's parameters — from the request, from the view spec's defaults, or from a named saved view-config — materialises a versioned view-config artefact, and renders it through the deterministic `cervin export-compliance` CLI to Markdown or PDF. The skill never computes a matrix itself; rendering stays in the CLI so the same config re-renders identically next quarter. Reports are reproducible and auditable: every report has a committed parameter artefact, and the skill states which spec defaults it assumed."
 when_to_use: 'User says "give me the compliance report", "show the obligation impact for product X", "what is our GDPR coverage", "export the compliance matrix to PDF", "run the Q3 obligations matrix", "which obligations have no assertion (the gap report)", or wants a reproducible compliance/coverage report rendered from canon rather than hand-assembled.'
+min_version: "0.6.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 


### PR DESCRIPTION
## What

Adds version-pinning to every skill and documents the convention for maintainers and administrators.

## Changes

**`min_version` on all 5 skills**

Each `SKILL.md` gains a `min_version` field in its YAML frontmatter declaring the minimum methodology version required to invoke the skill:

| Skill | `min_version` |
|-------|--------------|
| onboard | `0.5.0` |
| ingest | `0.6.0` |
| repo-check | `0.6.0` |
| report | `0.6.0` |
| reg-intel | `0.6.0` |

The adopter's agent reads this field (via the skills table in `AGENTS.md §14`) to gate skill invocations against the adopter's pinned methodology version.

**`RELEASING.md` — new "Skill `min_version` convention" section**

Documents:
- What `min_version` means and when it must be bumped (breaking change to the skill, not additive improvements)
- Admin note: how and when to copy updated skill files into adopter repos (after MAJOR migration recipe has been applied; as a separate `chore:` PR)

## Related

- Paired PR: transitrix/acme-corp#7 — `AGENTS.md` §12–16 (user identity, skill routing table with version gate, feedback channel, IDE extensions)

## Verification

- `node scripts/check-notations.mjs` → clean
- All 5 SKILL.md tails intact (1-line frontmatter addition each)
- RELEASING.md tail intact, no truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)