### PR TITLE
feat(notations): rename FACTOR → DRIVER in specs, examples, and ingest skill

### DIFF
--- a/notations/examples/fga/README.md
+++ b/notations/examples/fga/README.md
@@ -1,6 +1,6 @@
 # FGA diagram
 
-**Factor → Goal → Activity** — a three-column strategy view without the Changes column.
+**Driver → Goal → Activity** — a three-column strategy view without the Changes column.
 Use this format when you want a direct mapping from goals to activities without intermediate change items.
 
 **File extension:** `*.fga.transitrix.yaml`
@@ -17,14 +17,14 @@ id: FGA-SAMPLE-1
 name: "Sample FGA chain"
 
 factors:
-  - id: FACTOR-MARKET-1
+  - id: DRIVER-MARKET-1
     name: "Market growth opportunity"
     type: external
 
 goals:
   - id: GOAL-EXPAND-1
     name: "Expand market share"
-    factors: [FACTOR-MARKET-1]   # one or more FACTOR-… IDs
+    factors: [DRIVER-MARKET-1]   # one or more DRIVER-… IDs
 
 activities:
   - id: ACTIVITY-LAUNCH-1
@@ -50,11 +50,11 @@ Use FGCA (`.fgca.transitrix.yaml`) when you need to track discrete change packag
 ## Rules
 
 - All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar per [`../../IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md). IDs are unique within their layer.
-- A goal MAY reference multiple factors via `factors: [FACTOR-…, FACTOR-…]`.
+- A goal MAY reference multiple drivers via `factors: [DRIVER-…, DRIVER-…]`.
 - An activity MAY reference multiple goals via `goals: [GOAL-…, GOAL-…]`.
 
 ## Examples in this folder
 
 | File | Description |
 |---|---|
-| `strategy-2026.fga.transitrix.yaml` | FGA chain (3 factors, 3 goals, 7 activities) |
+| `strategy-2026.fga.transitrix.yaml` | FGA chain (3 drivers, 3 goals, 7 activities) |

--- a/notations/examples/fga/strategy-2026.fga.transitrix.yaml
+++ b/notations/examples/fga/strategy-2026.fga.transitrix.yaml
@@ -3,35 +3,35 @@ spec_version: "0.1"
 
 id: FGA-STRATEGY-2026
 name: "Strategy 2026"
-description: "Factor–Goal–Activity view for the 2026 strategic plan. Changes layer omitted — activities map directly to goals."
+description: "Driver–Goal–Activity view for the 2026 strategic plan. Changes layer omitted — activities map directly to goals."
 period: "2026"
 version: "0.1"
 generated_at: "2026-05-26"
 author: Transitrix
 
 factors:
-  - id: FACTOR-MARKET-1
+  - id: DRIVER-MARKET-1
     name: "Market growth opportunity in new geographies"
     type: external
     category: economic
-  - id: FACTOR-REG-1
+  - id: DRIVER-REG-1
     name: "Increasing regulatory pressure (GDPR, data residency)"
     type: external
     category: legal
-  - id: FACTOR-TECH-1
+  - id: DRIVER-TECH-1
     name: "Internal shift to cloud-native architecture"
     type: internal
 
 goals:
   - id: GOAL-MARKET-1
     name: "Expand market share"
-    factors: [FACTOR-MARKET-1, FACTOR-TECH-1]
+    factors: [DRIVER-MARKET-1, DRIVER-TECH-1]
   - id: GOAL-COMPLIANCE-1
     name: "Achieve full regulatory compliance"
-    factors: [FACTOR-REG-1]
+    factors: [DRIVER-REG-1]
   - id: GOAL-PLATFORM-1
     name: "Modernise platform"
-    factors: [FACTOR-TECH-1]
+    factors: [DRIVER-TECH-1]
 
 activities:
   - id: ACTIVITY-MARKET-1

--- a/notations/examples/fgca/README.md
+++ b/notations/examples/fgca/README.md
@@ -1,7 +1,7 @@
 # FGCA diagram
 
-**Factor → Goal → Change → Activity** — a four-column strategy decomposition chain.
-Shows how external factors drive goals, which require changes, which are delivered through activities.
+**Driver → Goal → Change → Activity** — a four-column strategy decomposition chain.
+Shows how external drivers push goals, which require changes, which are delivered through activities.
 
 **File extension:** `*.fgca.transitrix.yaml`
 
@@ -17,14 +17,14 @@ id: FGCA-SAMPLE-1
 name: "Sample FGCA chain"
 
 factors:
-  - id: FACTOR-1
-    name: "External factor driving change"
+  - id: DRIVER-1
+    name: "External driver pushing change"
     type: external
 
 goals:
   - id: GOAL-1
     name: "Strategic goal"
-    factors: [FACTOR-1]            # one or more FACTOR-… IDs
+    factors: [DRIVER-1]            # one or more DRIVER-… IDs
 
 changes:
   - id: CHANGE-1
@@ -53,7 +53,7 @@ author: "Your Name"
 ## Rules
 
 - All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar per [`../../IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md). IDs are unique within their layer.
-- A goal MAY reference multiple factors via `factors: [FACTOR-…, FACTOR-…]`.
+- A goal MAY reference multiple drivers via `factors: [DRIVER-…, DRIVER-…]`.
 - A change MAY reference multiple goals via `goals: [GOAL-…, GOAL-…]`.
 - An activity MAY reference multiple changes via `changes: [CHANGE-…, CHANGE-…]`.
 - For degenerate paths where a change layer adds no information, an activity MAY link directly via `goals: [GOAL-…]` — see [`../../views/02-fgca.md`](../../views/02-fgca.md) §Fields.
@@ -62,4 +62,4 @@ author: "Your Name"
 
 | File | Description |
 |---|---|
-| `strategy-2026.fgca.transitrix.yaml` | Full FGCA chain (2 factors, 3 goals, 3 changes, 5 activities) |
+| `strategy-2026.fgca.transitrix.yaml` | Full FGCA chain (2 drivers, 3 goals, 3 changes, 5 activities) |

--- a/notations/examples/fgca/constraint-driven.fgca.transitrix.yaml
+++ b/notations/examples/fgca/constraint-driven.fgca.transitrix.yaml
@@ -4,7 +4,7 @@ spec_version: "0.1"
 id: FGCA-DATA-RESIDENCY-1
 name: "EU data-residency FGCA chain"
 description: >
-  Worked example showing FACTOR.references_constraint — a factor that
+  Worked example showing DRIVER.references_constraint — a driver that
   reflects a binding regulatory constraint (GDPR data residency), and the
   goals / changes / activities the organisation runs to comply.
 period: "2026"
@@ -13,7 +13,7 @@ generated_at: "2026-05-26"
 author: Transitrix
 
 factors:
-  - id: FACTOR-DATA-RESIDENCY-1
+  - id: DRIVER-DATA-RESIDENCY-1
     name: "EU customer personal-data residency obligation"
     type: external
     category: legal
@@ -23,7 +23,7 @@ factors:
 goals:
   - id: GOAL-COMPLY-RESIDENCY-1
     name: "Persist EU customer personal data only within EU/EEA"
-    factors: [FACTOR-DATA-RESIDENCY-1]
+    factors: [DRIVER-DATA-RESIDENCY-1]
 
 changes:
   - id: CHANGE-EU-REGION-1

--- a/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
+++ b/notations/examples/fgca/strategy-2026.fgca.transitrix.yaml
@@ -3,18 +3,18 @@ spec_version: "0.1"
 
 id: FGCA-STRAT-1
 name: "Strategy 2026 — FGCA chain"
-description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
+description: "Driver → Goal → Change → Activity decomposition for the 2026 plan."
 period: "2026"
 version: "0.1"
 generated_at: "2026-05-26"
 author: Transitrix
 
 factors:
-  - id: FACTOR-1
+  - id: DRIVER-1
     name: "Competitive market pressure"
     type: external
     category: economic
-  - id: FACTOR-2
+  - id: DRIVER-2
     name: "Digital adoption acceleration"
     type: external
     category: technological
@@ -22,13 +22,13 @@ factors:
 goals:
   - id: GOAL-1
     name: "Grow revenue by 20%"
-    factors: [FACTOR-1, FACTOR-2]
+    factors: [DRIVER-1, DRIVER-2]
   - id: GOAL-2
     name: "Reduce operational costs"
-    factors: [FACTOR-2]
+    factors: [DRIVER-2]
   - id: GOAL-3
     name: "Improve customer retention"
-    factors: [FACTOR-1]
+    factors: [DRIVER-1]
 
 changes:
   - id: CHANGE-1

--- a/notations/views/03-fga.md
+++ b/notations/views/03-fga.md
@@ -86,13 +86,13 @@ spec_version: "0.1"
 id: FGA-STRAT-1
 name: "Strategy 2026 — FGA chain"
 generated_at: "2026-05-26"              # optional per CONTRACT.md §4
-description: "Factor → Goal → Activity decomposition for the 2026 plan."
+description: "Driver → Goal → Activity decomposition for the 2026 plan."
 period: "2026"
 version: "0.1"
 author: Transitrix
 
 factors:
-  - id: FACTOR-1
+  - id: DRIVER-1
     name: "Competitive market pressure"
     type: external          # external | internal
     category: economic      # PESTLE — external only
@@ -100,7 +100,7 @@ factors:
 goals:
   - id: GOAL-1
     name: "Grow revenue by 20%"
-    factors: [FACTOR-1]     # id-references to factors[]
+    factors: [DRIVER-1]     # id-references to factors[]
 
 activities:
   - id: ACTIVITY-1
@@ -179,9 +179,9 @@ ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>` f
 | `FGA-005` | error | every entry in the three arrays must have a non-empty `id` and `name`. |
 | `FGA-006` | error | IDs unique within their layer (and SHOULD be unique across all three layers within a document). |
 | `FGA-007` | error | every ID matches the canonical grammar `<TYPE>-[<middle>-]<INTEGER>` with the right type prefix for its layer. |
-| `FGA-008` | error | `goals[].factors[]` IDs must reference defined factors. |
+| `FGA-008` | error | `goals[].factors[]` IDs must reference defined drivers. |
 | `FGA-009` | error | `activities[].goals[]` IDs must reference defined goals. |
-| `FGA-010` | warn | a factor with no goal referencing it is orphan. |
+| `FGA-010` | warn | a driver with no goal referencing it is orphan. |
 | `FGA-011` | warn | a goal with no activity referencing it is orphan. |
 
 ---
@@ -191,8 +191,8 @@ ID grammar follows the canonical rule `<TYPE>-[<middle segment(s)>-]<INTEGER>` f
 FGCA adds a `changes` layer between goals and activities:
 
 ```
-FGCA: Factor → Goal → Change → Activity
-FGA:  Factor → Goal →          Activity
+FGCA: Driver → Goal → Change → Activity
+FGA:  Driver → Goal →          Activity
 ```
 
 When converting FGA to FGCA: identify the implicit change each goal demands and make it explicit. This is the right move when a goal requires organisational transformation, not just execution.

--- a/transitrix/skills/ingest/schemas/candidate.schema.json
+++ b/transitrix/skills/ingest/schemas/candidate.schema.json
@@ -63,7 +63,7 @@
         "name": { "type": "string", "minLength": 1 },
         "element_type": {
           "type": "string",
-          "description": "Canonical element TYPE (IDS_AND_REFERENCES.md §3.1), e.g. FACTOR, GOAL, ROLE, APPLICATION.",
+          "description": "Canonical element TYPE (IDS_AND_REFERENCES.md §3.1), e.g. DRIVER, GOAL, ROLE, APPLICATION.",
           "pattern": "^[A-Z][A-Z0-9_]*$"
         },
         "valid_from": { "type": ["string", "null"], "description": "Lifecycle anchor (CONTRACT.md §7). `pending` or a date when known." },

--- a/transitrix/skills/ingest/tests/fixtures/extraction-result.json
+++ b/transitrix/skills/ingest/tests/fixtures/extraction-result.json
@@ -2,13 +2,13 @@
   "_comment": "Fixture extraction result — a canned stand-in for what the agent produces by running prompts/ over the sample interview. Used by the deterministic integrity test so emit-candidates has an input without an LLM. Mixes a high relation (-> candidate) and a medium relation (-> held-back suggestion).",
   "elements": [
     { "id": "GOAL-RETENTION-1", "name": "Improve customer retention above 90%", "element_type": "GOAL", "extraction_confidence": "high" },
-    { "id": "FACTOR-CHURN-1", "name": "Rising customer churn", "element_type": "FACTOR", "extraction_confidence": "medium", "extraction_notes": "driver behind the retention goal" },
+    { "id": "DRIVER-CHURN-1", "name": "Rising customer churn", "element_type": "DRIVER", "extraction_confidence": "medium", "extraction_notes": "driver behind the retention goal" },
     { "id": "REQUIREMENT-COMPLIANCE-1", "name": "File a quarterly compliance report", "element_type": "REQUIREMENT", "extraction_confidence": "high" },
     { "id": "CONSTRAINT-DATA-RESIDENCY-1", "name": "Customer data stays in the home jurisdiction", "element_type": "CONSTRAINT", "extraction_confidence": "high" },
     { "id": "APPLICATION-CRM-1", "name": "CRM (customer system of record)", "element_type": "APPLICATION", "extraction_confidence": "high" }
   ],
   "relations": [
     { "rel_kind": "stakeholding", "from": "STAKEHOLDER-OPS-1", "to": "GOAL-RETENTION-1", "extraction_confidence": "high", "extraction_notes": "accountable owner stated the goal directly" },
-    { "rel_kind": "contributes_to", "from": "FACTOR-CHURN-1", "to": "GOAL-RETENTION-1", "extraction_confidence": "medium", "extraction_notes": "inferred causal link — held back as a suggestion" }
+    { "rel_kind": "contributes_to", "from": "DRIVER-CHURN-1", "to": "GOAL-RETENTION-1", "extraction_confidence": "medium", "extraction_notes": "inferred causal link — held back as a suggestion" }
   ]
 }

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -225,7 +225,7 @@ def part_c_ig5():
                           "element_type": "CAPABILITY", "derived_from": [fid],
                           "admitted_to": "pending", "extraction_confidence": "high"})
         cand("RELbad.json", {"kind": "relation", "rel_kind": "contributes_to",
-                             "from": "FACTOR-A-1", "to": "GOAL-B-1", "derived_from": [fid],
+                             "from": "DRIVER-A-1", "to": "GOAL-B-1", "derived_from": [fid],
                              "admitted_to": "pending", "extraction_confidence": "high"})
         cand("RELok.json", {"kind": "relation", "rel_kind": "stakeholding",
                             "from": "STAKEHOLDER-A-1", "to": "GOAL-B-1", "derived_from": [fid],


### PR DESCRIPTION
## Summary

- Renames `FACTOR` TYPE name and `FACTOR-*` ID prefix to `DRIVER` / `DRIVER-*` across all view specs, example YAMLs, example READMEs, and the ingest skill — aligning with the 0.7.0 ArchiMate 3.2 rename declared in CHANGELOG.
- YAML structural keys (`factors:`, `goal.factors[]`) intentionally unchanged per spec (backward-compatible).
- Doc-lint passes clean after these changes.

## Files changed

| File | Change |
|---|---|
| `notations/views/03-fga.md` | Description, inline example IDs, validation rule prose, `Factor →` → `Driver →` comparison block |
| `notations/examples/fgca/README.md` | Heading prose, minimal-structure example IDs, rules line |
| `notations/examples/fgca/strategy-2026.fgca.transitrix.yaml` | Description, `FACTOR-1`/`FACTOR-2` → `DRIVER-1`/`DRIVER-2` |
| `notations/examples/fgca/constraint-driven.fgca.transitrix.yaml` | Description, `FACTOR-DATA-RESIDENCY-1` → `DRIVER-DATA-RESIDENCY-1` |
| `notations/examples/fga/README.md` | Heading prose, minimal-structure example IDs, rules line |
| `notations/examples/fga/strategy-2026.fga.transitrix.yaml` | Description, `FACTOR-MARKET-1`/`FACTOR-REG-1`/`FACTOR-TECH-1` → `DRIVER-*` |
| `transitrix/skills/ingest/schemas/candidate.schema.json` | `element_type` description example: `FACTOR` → `DRIVER` |
| `transitrix/skills/ingest/tests/fixtures/extraction-result.json` | `FACTOR-CHURN-1` / `element_type: FACTOR` → `DRIVER-CHURN-1` / `DRIVER` |
| `transitrix/skills/ingest/tests/test_ingest_integrity.py` | Test relation `from: FACTOR-A-1` → `DRIVER-A-1` |

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (15 view notations, examples, links, version pins all consistent)
- [ ] CI `check-hygiene` — no private-hub references in diff or PR body