### PR TITLE
chore(release): mark v0.6.0 and v0.7.0 as released in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The methodology is **pre-1.0**. MINOR releases (`0.x` → `0.(x+1)`) may carry b
 
 ---
 
-## [0.7.0] — Unreleased
+## [0.7.0] — 2026-06-24
 
 ArchiMate 3.2 terminology alignment: `FACTOR` → `DRIVER`. Renames the element TYPE, canonical ID prefix, and `notation:` field value across all specs, skills, and templates. **YAML structural keys (`factors:`, `goal.factors`) are intentionally unchanged** — existing adopter view files remain valid without edits. Legacy `FACTOR-*` IDs are accepted by validators until the 1.0 cut. Migration recipe: [`migrations/0.6-to-0.7/`](migrations/0.6-to-0.7/).
 
@@ -25,7 +25,7 @@ ArchiMate 3.2 terminology alignment: `FACTOR` → `DRIVER`. Renames the element 
 
 ---
 
-## [0.6.0] — Unreleased
+## [0.6.0] — 2026-06-24
 
 The Actors / Stakeholders identity model (epics #98 / #99). Unifies active-structure identity under one `ACTOR` TYPE and adds the `STAKEHOLDER` interest primitive; retires `UNIT` / `EMPLOYEE`. One pre-1.0 breaking change, called out below.
 


### PR DESCRIPTION
## Summary

- CHANGELOG `[0.6.0] — Unreleased` → `[0.6.0] — 2026-06-24`
- CHANGELOG `[0.7.0] — Unreleased` → `[0.7.0] — 2026-06-24`
- Doc-lint passes clean (`node scripts/check-notations.mjs`)

## What this PR does NOT include

`organizations/acme_corp` is a git submodule — updating the adopter's `methodology_version` pin requires a separate PR to the `transitrix/acme-corp` repo, which is downstream work.

## After merge — steps for the maintainer

1. **Tag v0.6.0** at the last commit before the DRIVER rename landed:
   ```
   git tag v0.6.0 065150c
   git push origin v0.6.0
   ```
2. **Tag v0.7.0** at this release-prep commit (`b09cff2`) or at the merge commit:
   ```
   git tag v0.7.0
   git push origin v0.7.0
   ```
3. **Create GitHub Releases** for both tags with the CHANGELOG text as release notes.
4. **Update downstream repos** (acme-corp-seed and transitrix-studio) to pin methodology `0.7.0` — separate PRs.

## Test plan

- [x] `node scripts/check-notations.mjs` passes
- [x] CHANGELOG dates set to 2026-06-24 for both versions
- [ ] Maintainer pushes git tags after merge
- [ ] GitHub Releases created