### PR TITLE
docs(migrations): complete 0.6-to-0.7 recipe — codemod, validate, fixtures

### DIFF
--- a/migrations/0.6-to-0.7/README.md
+++ b/migrations/0.6-to-0.7/README.md
@@ -90,29 +90,39 @@ transitrix-ingest repo-check [org-root]
 
 A clean run shows `tooling.ok: true` with no version-mismatch flag. If `DRIVER-TYPE-LEGACY-001` warnings remain, they point to view files that still reference `FACTOR-*` IDs (Step 2 above).
 
-## Codemod (planned)
+## Codemod
 
-A `codemod.mjs` automating Steps 1–2 is planned. Until available, the steps above are mechanical enough to do by hand or with a one-liner:
+`codemod.mjs` automates Steps 1–2 (element file rewrite + cross-reference substitution).
+It is idempotent — re-running on a fully migrated repo is a no-op.
 
 ```bash
-# Rename element files (Linux / macOS / Git Bash)
-for f in canon/elements/01_motivation/factors/FACTOR-*.yaml; do
-  mv "$f" "${f/FACTOR-/DRIVER-}"
-done
+# Preview — shows what would change without writing any files
+node migrations/0.6-to-0.7/codemod.mjs <adopter-root> --dry-run
 
-# Update notation and id fields inside element files
-sed -i 's/^notation: factor$/notation: driver/' canon/elements/01_motivation/factors/DRIVER-*.yaml
-sed -i 's/^id: FACTOR-/id: DRIVER-/' canon/elements/01_motivation/factors/DRIVER-*.yaml
+# Apply
+node migrations/0.6-to-0.7/codemod.mjs <adopter-root>
 
-# Update ID references in view files (replaces FACTOR- values, not the factors: key)
-grep -rl 'FACTOR-' canon/views/ | xargs sed -i 's/FACTOR-/DRIVER-/g'
+# Post-migration check
+node migrations/0.6-to-0.7/validate.mjs <adopter-root>
 ```
 
-Review the diff carefully before committing — the `factors:` key must not be renamed.
+`validate.mjs` exits 0 if no `notation: factor` / `id: FACTOR-…` element files remain.
+Files that still reference `FACTOR-…` IDs in cross-reference value positions are
+reported as informational notices (valid until 1.0 cut; produces a
+`DRIVER-TYPE-LEGACY-001` warning from the runtime validator, not a failure).
+
+The shell one-liners in the manual steps above remain valid as an alternative for
+adopters who prefer them. Review the diff carefully in either case — the `factors:`
+key must not be renamed.
 
 ## Folder shape
 
 ```
 migrations/0.6-to-0.7/
-└── README.md         # this file; codemod.mjs planned
+├── README.md
+├── codemod.mjs          # idempotent transform; runs Steps 1–2
+├── validate.mjs         # post-migration check; exits 0 on clean repo
+└── fixtures/
+    ├── before/          # minimal adopter repo before migration (FACTOR-* form)
+    └── after/           # the same after running codemod.mjs (DRIVER-* form)
 ```

--- a/migrations/0.6-to-0.7/codemod.mjs
+++ b/migrations/0.6-to-0.7/codemod.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Migration codemod — methodology 0.6 → 0.7.
+//
+// Covers the DRIVER terminology alignment: the FACTOR element TYPE is renamed
+// to DRIVER to match ArchiMate 3.2 motivation-layer terminology.
+//
+//   notation: factor   → notation: driver        (in element files)
+//   id: FACTOR-…       → id: DRIVER-…            (in element files)
+//   FACTOR-*.yaml      → DRIVER-*.yaml            (file rename)
+//   FACTOR-… values    → DRIVER-… values          (cross-refs in any file)
+//
+// YAML structural keys (factors:, goal.factors) are intentionally NOT renamed —
+// the migration is gradual; existing view files stay valid without edits.
+// Legacy FACTOR-… IDs remain accepted by validators until the 1.0 cut.
+//
+// TRANSFORMS:
+//   A. Element rewrite: files with notation: factor or id: FACTOR-… get those
+//      fields rewritten in-place; FACTOR-*.yaml files are renamed to DRIVER-*.yaml.
+//   B. Cross-reference substitution: any remaining FACTOR-… in YAML value positions
+//      across all files is replaced with DRIVER-…. The factors: key is lowercase
+//      and is unaffected (case-sensitive search).
+//
+// Conventions (canonical for every migration recipe):
+//   - Pure-Node, no native deps; Node ≥ 20.
+//   - Idempotent: a repo already on 0.7 form is a no-op.
+//   - CLI: [--dry-run] [target-dir]. Default target = current working dir.
+//   - Diff-style summary of changes. Exit 0 on clean run.
+//
+// Line-based transformation (not js-yaml roundtrip) preserves comments, key
+// order, and formatting on untouched lines.
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, renameSync } from 'node:fs';
+import { join, relative, resolve, basename, dirname } from 'node:path';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const target = resolve(args.find(a => !a.startsWith('--')) ?? process.cwd());
+
+if (!existsSync(target)) {
+  console.error(`error: target directory does not exist: ${target}`);
+  process.exit(2);
+}
+
+function walkYaml(dir, out = []) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return out; }
+  for (const ent of entries) {
+    const full = join(dir, ent);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) walkYaml(full, out);
+    else if (st.isFile() && ent.endsWith('.yaml')) out.push(full);
+  }
+  return out;
+}
+
+// Transform A: rewrite notation: factor → driver and id: FACTOR-… → DRIVER-…
+// Matches only top-level notation and id fields (line anchored with ^).
+function rewriteFactorElement(content) {
+  const isFactorElement =
+    /^notation\s*:\s*factor\b/m.test(content) ||
+    /^id\s*:\s*["']?FACTOR-/m.test(content);
+  if (!isFactorElement) return { content, modified: 0 };
+  let n = 0;
+  const result = content
+    .replace(/^(notation\s*:\s*)factor\b/m, (_, pre) => { n++; return `${pre}driver`; })
+    .replace(/^(id\s*:\s*["']?)FACTOR-/m, (_, pre) => { n++; return `${pre}DRIVER-`; });
+  return { content: result, modified: n };
+}
+
+// Transform B: replace FACTOR-… IDs in value positions.
+// The factors: key is lowercase — no collision with FACTOR- (uppercase).
+function substituteFactorRefs(content) {
+  if (!content.includes('FACTOR-')) return { content, modified: 0 };
+  let n = 0;
+  const result = content.replace(/FACTOR-/g, () => { n++; return 'DRIVER-'; });
+  return { content: result, modified: n };
+}
+
+const files = walkYaml(target);
+let totalModifiedA = 0, totalModifiedB = 0;
+const touched = [];
+
+for (const f of files) {
+  let content;
+  try { content = readFileSync(f, 'utf8'); } catch { continue; }
+
+  let changed = false;
+  let countA = 0, countB = 0;
+
+  const rA = rewriteFactorElement(content);
+  if (rA.modified > 0) {
+    content = rA.content;
+    countA = rA.modified;
+    changed = true;
+    totalModifiedA += rA.modified;
+  }
+
+  const rB = substituteFactorRefs(content);
+  if (rB.modified > 0) {
+    content = rB.content;
+    countB = rB.modified;
+    changed = true;
+    totalModifiedB += rB.modified;
+  }
+
+  if (!changed) continue;
+
+  let dest = f;
+  const bn = basename(f);
+  if (bn.startsWith('FACTOR-')) {
+    dest = join(dirname(f), bn.replace(/^FACTOR-/, 'DRIVER-'));
+  }
+
+  const label = `${relative(target, f)}${dest !== f ? ` → ${relative(target, dest)}` : ''}`;
+  const counts = [countA > 0 ? `A:${countA}` : '', countB > 0 ? `B:${countB}` : ''].filter(Boolean).join(' ');
+  touched.push(`${label} (${counts})`);
+
+  if (!dryRun) {
+    writeFileSync(f, content);
+    if (dest !== f) renameSync(f, dest);
+  }
+}
+
+console.log('Transform A — notation: factor → driver; id: FACTOR-… → DRIVER-…; file rename');
+console.log('Transform B — FACTOR-… → DRIVER-… cross-reference values');
+touched.forEach(x => console.log(`  ~ ${x}`));
+console.log(`  → A: ${totalModifiedA} field(s), B: ${totalModifiedB} ref(s)${dryRun ? ' (dry-run; no files written)' : ''}`);
+console.log('');
+console.log('Summary:');
+console.log(`  files scanned   ${files.length}`);
+console.log(`  files changed   ${touched.length}${dryRun ? ' (dry-run)' : ''}`);
+process.exit(0);

--- a/migrations/0.6-to-0.7/fixtures/after/canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml
+++ b/migrations/0.6-to-0.7/fixtures/after/canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml
@@ -1,0 +1,17 @@
+notation: driver
+id: DRIVER-COMP-1
+name: "Competitive market pressure"
+type: external
+category: economic
+description: >
+  Standing external force — intensifying competition in the core segment.
+
+zone: canon
+admitted_at: "2026-01-01"
+admitted_by: "admin"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-01-01"
+valid_to: null

--- a/migrations/0.6-to-0.7/fixtures/after/canon/elements/01_motivation/goals/GOAL-GROWTH-1.yaml
+++ b/migrations/0.6-to-0.7/fixtures/after/canon/elements/01_motivation/goals/GOAL-GROWTH-1.yaml
@@ -1,0 +1,19 @@
+notation: goal
+id: GOAL-GROWTH-1
+name: "Grow market share"
+type: "Strategic Goal"
+level: 1
+factors:
+  - DRIVER-COMP-1
+description: >
+  Increase market share by 15% in response to competitive pressure.
+
+zone: canon
+admitted_at: "2026-01-01"
+admitted_by: "admin"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-01-01"
+valid_to: null

--- a/migrations/0.6-to-0.7/fixtures/before/canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
+++ b/migrations/0.6-to-0.7/fixtures/before/canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
@@ -1,0 +1,17 @@
+notation: factor
+id: FACTOR-COMP-1
+name: "Competitive market pressure"
+type: external
+category: economic
+description: >
+  Standing external force — intensifying competition in the core segment.
+
+zone: canon
+admitted_at: "2026-01-01"
+admitted_by: "admin"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-01-01"
+valid_to: null

--- a/migrations/0.6-to-0.7/fixtures/before/canon/elements/01_motivation/goals/GOAL-GROWTH-1.yaml
+++ b/migrations/0.6-to-0.7/fixtures/before/canon/elements/01_motivation/goals/GOAL-GROWTH-1.yaml
@@ -1,0 +1,19 @@
+notation: goal
+id: GOAL-GROWTH-1
+name: "Grow market share"
+type: "Strategic Goal"
+level: 1
+factors:
+  - FACTOR-COMP-1
+description: >
+  Increase market share by 15% in response to competitive pressure.
+
+zone: canon
+admitted_at: "2026-01-01"
+admitted_by: "admin"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-01-01"
+valid_to: null

--- a/migrations/0.6-to-0.7/validate.mjs
+++ b/migrations/0.6-to-0.7/validate.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Post-migration validation — methodology 0.6 → 0.7 (DRIVER rename).
+//
+// Asserts that no element files carry the retired FACTOR TYPE:
+//   - no file with notation: factor
+//   - no file with id: FACTOR-… (in element position)
+//
+// Cross-references that still use FACTOR-… IDs in value positions are NOT
+// treated as errors — legacy FACTOR-… IDs are accepted by validators until
+// the 1.0 cut (producing a DRIVER-TYPE-LEGACY-001 warning, not a failure).
+// They are reported as informational notices.
+//
+// Exit 0 = element files clean (migration complete for required steps);
+// Exit 1 = FACTOR element residue found (run codemod again).
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const target = resolve(process.argv.slice(2).find(a => !a.startsWith('--')) ?? process.cwd());
+if (!existsSync(target)) { console.error(`error: no such dir: ${target}`); process.exit(2); }
+
+function walk(dir, out = []) {
+  let ents; try { ents = readdirSync(dir); } catch { return out; }
+  for (const e of ents) {
+    const f = join(dir, e);
+    let st; try { st = statSync(f); } catch { continue; }
+    if (st.isDirectory()) walk(f, out);
+    else if (st.isFile() && e.endsWith('.yaml')) out.push(f);
+  }
+  return out;
+}
+
+const problems = [];
+const legacyRefs = [];
+
+for (const f of walk(target)) {
+  const c = readFileSync(f, 'utf8');
+  const rel = relative(target, f);
+
+  const hasFactorNotation = /^notation\s*:\s*factor\b/m.test(c);
+  const hasFactorId = /^id\s*:\s*["']?FACTOR-/m.test(c);
+
+  if (hasFactorNotation)
+    problems.push(`${rel}: notation: factor — run codemod to migrate to notation: driver`);
+  if (hasFactorId)
+    problems.push(`${rel}: id: FACTOR-… — run codemod to rename to DRIVER-…`);
+
+  if (!hasFactorNotation && !hasFactorId && c.includes('FACTOR-'))
+    legacyRefs.push(rel);
+}
+
+if (problems.length) {
+  console.error(`FAIL — ${problems.length} FACTOR element residue(s):`);
+  problems.forEach(p => console.error(`  ✗ ${p}`));
+  if (legacyRefs.length) {
+    console.error('');
+    console.error(`Note — ${legacyRefs.length} file(s) still have FACTOR-… cross-references (valid until 1.0 cut; produces DRIVER-TYPE-LEGACY-001 warning):`);
+    legacyRefs.forEach(r => console.error(`  ⚠ ${r}`));
+  }
+  process.exit(1);
+}
+
+if (legacyRefs.length) {
+  console.log('PASS — no FACTOR element files remain.');
+  console.log(`Note — ${legacyRefs.length} file(s) still have FACTOR-… cross-references (valid until 1.0 cut):`);
+  legacyRefs.forEach(r => console.log(`  ⚠ ${r}`));
+} else {
+  console.log('PASS — no FACTOR residue; repo is fully on 0.7 form.');
+}
+process.exit(0);


### PR DESCRIPTION
## Summary

- Adds `codemod.mjs` to automate Steps 1–2 of the FACTOR → DRIVER migration: rewrites `notation: factor` → `driver` and `id: FACTOR-…` → `DRIVER-…` in element files, renames `FACTOR-*.yaml` to `DRIVER-*.yaml`, and substitutes `FACTOR-` references in value positions across all YAML files. The `factors:` key (lowercase) is unaffected. Idempotent; supports `--dry-run`.
- Adds `validate.mjs`: exits 0 when no `notation: factor` / `id: FACTOR-…` element files remain. Legacy `FACTOR-…` cross-references in value positions are reported as informational notices (valid until 1.0 cut per the gradual migration policy).
- Adds `fixtures/before/` and `fixtures/after/`: a minimal two-file adopter snippet (DRIVER element + GOAL referencing it) demonstrating the before/after transformation. The codemod converts `before/` to `after/` exactly; verified by dry-run and idempotency test.
- Updates `README.md`: "Codemod (planned)" section replaced with usage instructions; folder shape updated to reflect actual contents.

## Test plan

- [x] `node scripts/check-notations.mjs` passes clean
- [x] `node migrations/0.6-to-0.7/codemod.mjs fixtures/before --dry-run` reports 2 fields (A) + 1 ref (B) changed, matching the `after/` fixtures exactly
- [x] `node migrations/0.6-to-0.7/validate.mjs fixtures/before` exits 1 (FAIL — expected, pre-migration state)
- [x] `node migrations/0.6-to-0.7/validate.mjs fixtures/after` exits 0 (PASS)
- [x] `node migrations/0.6-to-0.7/codemod.mjs fixtures/after --dry-run` exits 0 with 0 changes (idempotent)
- [x] No internal references in diff or commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)