### PR TITLE
feat(process): declare maturity time-varying, migrate to sidecar

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -376,6 +376,7 @@ A notation spec MAY declare specific attributes as `time_varying`. v1 candidate 
 |---|---|
 | Capability map ([05-capability-map.md](views/05-capability-map.md)) | `maturity_level` (current/target), `responsible_role`, `target_date` |
 | Applications catalogue ([10-applications.md](views/10-applications.md)) | `lifecycle_stage` (planned / active / sunset), `responsible_unit`, `vendor` (when an organisation switches vendors mid-life) |
+| Process map ([06-process-map.md](views/06-process-map.md)) | `maturity` |
 | Organisational unit (future) | `headcount`, `head_role` |
 
 Each notation's "Element lifecycle" or "Fields" section will, in a follow-up PR, mark its `time_varying` attributes and remove inline syntax for them. Adopters with existing inline values migrate by moving the value into a single-entry sidecar with `valid_from` set to the primitive's `valid_from`.

--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -320,7 +320,7 @@ The `PROCESS` element is the **complete, self-sufficient definition** of a busin
 |---|---|---|---|
 | `owner_role` | no | string | `ROLE-…` accountable for the process as a whole. |
 | `capability` | no | string | `CAPABILITY-…` this process realises. |
-| `maturity` | no | integer | CMM level 1–5. |
+| `maturity` | no | integer | CMM level 1–5. **Time-varying** — sidecar ([CONTRACT.md](CONTRACT.md) §9), not inline. |
 | `participants` | no | list | The process's lanes — each a reference to a canonical active-structure element, `ROLE-…` or `ACTOR-…` (person / business_unit / system). A participant's lane caption is **derived** from the referenced element's `name`; no caption text is stored here. List order is the rendered top-to-bottom lane order. |
 | `flow` | no | object | The canonical process graph — steps, gateways, and sequence flows (see below). Sufficient to regenerate a BPMN diagram; the view adds only layout, which is computed deterministically. |
 | `description` | recommended | string | One-paragraph elaboration. |

--- a/notations/examples/process-map/README.md
+++ b/notations/examples/process-map/README.md
@@ -41,7 +41,7 @@ notation: process-map
 |---|---|
 | `owner_role` | Responsible role |
 | `capability` | Capability ID this process realises (canonical form, e.g. `CAPABILITY-V1`, `CAPABILITY-H1`) |
-| `maturity` | Integer 1–5 |
+| `maturity` | **Time-varying** — resolved from `<process_id>.history.yaml` sidecar ([CONTRACT.md](../../CONTRACT.md) §9), not inline on the view. |
 | `description` | Short description |
 
 ## Preview

--- a/notations/examples/process-map/enterprise.process-map.transitrix.yaml
+++ b/notations/examples/process-map/enterprise.process-map.transitrix.yaml
@@ -22,20 +22,20 @@ process_map:
           name: Order Fulfilment
           owner_role: ROLE-OPS-001
           capability: CAPABILITY-V1
-          maturity: 3
+          # maturity — time-varying, resolved from PROC-ORD-FULFILL-001.history.yaml (CONTRACT.md §9)
           status: Active
           description: End-to-end fulfilment from order placement to delivery.
         - process_id: PROC-CUST-ONBOARD-001
           name: Customer Onboarding
           owner_role: ROLE-SALES-001
           capability: CAPABILITY-V2
-          maturity: 2
+          # maturity — time-varying, resolved from PROC-CUST-ONBOARD-001.history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-DELIV-001
           name: Last-mile Delivery
           owner_role: ROLE-LOG-001
           capability: CAPABILITY-V1
-          maturity: 1
+          # maturity — time-varying, resolved from PROC-DELIV-001.history.yaml (CONTRACT.md §9)
           status: Draft
 
     - id: GRP-SUPPORTING
@@ -47,17 +47,17 @@ process_map:
           name: Recruitment
           owner_role: ROLE-HR-001
           status: Active
-          maturity: 3
+          # maturity — time-varying, resolved from PROC-HR-RECRUIT-001.history.yaml (CONTRACT.md §9)
         - process_id: PROC-FIN-CLOSE-001
           name: Monthly Financial Close
           owner_role: ROLE-FIN-001
           status: Active
-          maturity: 4
+          # maturity — time-varying, resolved from PROC-FIN-CLOSE-001.history.yaml (CONTRACT.md §9)
         - process_id: PROC-IT-INCIDENT-001
           name: IT Incident Response
           owner_role: ROLE-IT-001
           status: Active
-          maturity: 2
+          # maturity — time-varying, resolved from PROC-IT-INCIDENT-001.history.yaml (CONTRACT.md §9)
 
     - id: GRP-MANAGEMENT
       name: Management Processes
@@ -68,12 +68,12 @@ process_map:
           name: Annual Strategy Planning
           owner_role: ROLE-CEO-001
           status: Active
-          maturity: 3
+          # maturity — time-varying, resolved from PROC-STRAT-PLAN-001.history.yaml (CONTRACT.md §9)
         - process_id: PROC-RISK-MGT-001
           name: Risk Management Review
           owner_role: ROLE-RISK-001
           status: Active
-          maturity: 2
+          # maturity — time-varying, resolved from PROC-RISK-MGT-001.history.yaml (CONTRACT.md §9)
         - process_id: PROC-COMPLIANCE-001
           name: Compliance Audit
           owner_role: ROLE-LEGAL-001

--- a/notations/examples/process-map/northbay-retail.process-map.transitrix.yaml
+++ b/notations/examples/process-map/northbay-retail.process-map.transitrix.yaml
@@ -22,64 +22,64 @@ process_map:
           name: Strategic Sourcing
           owner_role: ROLE-SOURCING-001
           capability: CAPABILITY-V2.1.1
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
           description: Identify, evaluate, and onboard strategic suppliers.
         - process_id: PROC-NB-PURCHASE-001
           name: Purchase Order Processing
           owner_role: ROLE-PROC-001
           capability: CAPABILITY-V2.1
-          maturity: 4
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-INV-FORECAST-001
           name: Demand Forecasting
           owner_role: ROLE-SUPPLY-001
           capability: CAPABILITY-V2.2.1
-          maturity: 2
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
           description: AI-assisted SKU-level demand prediction.
         - process_id: PROC-NB-INV-REPLEN-001
           name: Store Replenishment
           owner_role: ROLE-INV-001
           capability: CAPABILITY-V2.2.2
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-RECEIVE-001
           name: Inbound Receiving
           owner_role: ROLE-WH-001
           capability: CAPABILITY-V2.3.1
-          maturity: 4
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-ORD-FULFILL-001
           name: Online Order Fulfilment
           owner_role: ROLE-FULFILL-001
           capability: CAPABILITY-V1.2.2
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-DELIVERY-001
           name: Last-mile Delivery
           owner_role: ROLE-LOG-001
           capability: CAPABILITY-V2.3.2
-          maturity: 2
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
           description: Self-operated and 3PL hybrid delivery to home and pickup points.
         - process_id: PROC-NB-CUST-ONBOARD-001
           name: Customer Onboarding & Account Creation
           owner_role: ROLE-DIGITAL-001
           capability: CAPABILITY-V1.2
-          maturity: 2
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-RETURNS-001
           name: Returns & Refunds Processing
           owner_role: ROLE-CS-001
           capability: CAPABILITY-V1.3.3
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-LOYALTY-001
           name: Loyalty Programme Operations
           owner_role: ROLE-LOYALTY-001
           capability: CAPABILITY-V1.1.2
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
 
     - id: GRP-SUPPORTING
@@ -90,48 +90,48 @@ process_map:
         - process_id: PROC-NB-HR-RECRUIT-001
           name: Recruitment
           owner_role: ROLE-HR-001
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-HR-PAYROLL-001
           name: Payroll Operations
           owner_role: ROLE-PAYROLL-001
-          maturity: 4
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-FIN-CLOSE-001
           name: Monthly Financial Close
           owner_role: ROLE-CONTROLLER-001
           capability: CAPABILITY-V3.2
-          maturity: 4
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-IT-INCIDENT-001
           name: IT Incident Response
           owner_role: ROLE-IT-001
           capability: CAPABILITY-H2
-          maturity: 2
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
           description: 24/7 incident response with severity-based escalation.
         - process_id: PROC-NB-MKT-CAMPAIGN-001
           name: Marketing Campaign Management
           owner_role: ROLE-MKTG-001
           capability: CAPABILITY-V1.1.1
-          maturity: 2
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-LEGAL-REVIEW-001
           name: Contract Legal Review
           owner_role: ROLE-LEGAL-001
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-VENDOR-MGT-001
           name: Vendor Management
           owner_role: ROLE-VENDOR-001
           capability: CAPABILITY-V2.1.1
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-DATA-QUALITY-001
           name: Master Data Quality Reviews
           owner_role: ROLE-DATAGOV-001
           capability: CAPABILITY-H1
-          maturity: 1
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Draft
           description: Quarterly product, customer, and supplier MDM audits.
 
@@ -143,38 +143,38 @@ process_map:
         - process_id: PROC-NB-STRAT-PLAN-001
           name: Annual Strategy Planning
           owner_role: ROLE-CEO-001
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-BUDGET-001
           name: Annual Budget Cycle
           owner_role: ROLE-FIN-001
           capability: CAPABILITY-V3.3
-          maturity: 4
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-RISK-001
           name: Enterprise Risk Review
           owner_role: ROLE-RISK-001
-          maturity: 2
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-COMPLIANCE-001
           name: Compliance Audit
           owner_role: ROLE-LEGAL-001
           capability: CAPABILITY-H3
-          maturity: 2
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-PERF-REVIEW-001
           name: Quarterly Business Performance Review
           owner_role: ROLE-COO-001
-          maturity: 3
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-BOARD-REPORT-001
           name: Board Reporting
           owner_role: ROLE-CEO-001
-          maturity: 4
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Active
         - process_id: PROC-NB-MA-PIPELINE-001
           name: M&A Pipeline Review
           owner_role: ROLE-CORPDEV-001
-          maturity: 1
+          # maturity — time-varying, resolved from sidecar .history.yaml (CONTRACT.md §9)
           status: Deprecated
           description: Paused in 2026 — reactivation pending strategy refresh.

--- a/notations/views/06-process-map.md
+++ b/notations/views/06-process-map.md
@@ -2,7 +2,7 @@
 notation: "Process Landscape Map"
 version: "0.2"
 author: "Valerii Korobeinikov"
-last_updated: "2026-05-19"
+last_updated: "2026-06-24"
 status: "draft"
 file_extension: "*.process-map.transitrix.yaml"
 ---
@@ -110,14 +110,14 @@ process_map:
           name: "Order Fulfilment"
           owner_role: "ROLE-OPS-001"
           capability: "CAPABILITY-V1"
-          maturity: 2
+          # maturity — time-varying, resolved from PROC-ORD-FULFILL-001.history.yaml (CONTRACT.md §9)
           status: "Active"
 
         - process_id: "PROC-CUST-ONBOARD-001"
           name: "Customer Onboarding"
           owner_role: "ROLE-SALES-001"
           capability: "CAPABILITY-V2"
-          maturity: 1
+          # maturity — time-varying, resolved from PROC-CUST-ONBOARD-001.history.yaml (CONTRACT.md §9)
           status: "Draft"
 
     - id: "GRP-SUPPORTING"
@@ -154,7 +154,7 @@ process_map:
 | `processes[].name` | Yes | Process name (should match the element) |
 | `processes[].owner_role` | No | Reference to BusinessRole element ID |
 | `processes[].capability` | No | Capability ID this process realises (V1, H1, etc.) |
-| `processes[].maturity` | No | Current CMM level (1–5) |
+| `processes[].maturity` | No | Current CMM level (1–5). **Time-varying** — lives in the sidecar `<process_id>.history.yaml` ([CONTRACT.md](../CONTRACT.md) §9), not inline. Inline placement triggers `VERSIONED-004`. |
 | `processes[].status` | Yes | `Draft` / `Active` / `Deprecated` |
 
 > **No `bpmn_file` pointer.** Earlier revisions carried an optional `processes[].bpmn_file` path to "the detailed BPMN diagram." It is **removed**: a BPMN file is a *derived projection* of the referenced `PROCESS` element's `flow` ([ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §7.5, [views/01-bpmn.md](01-bpmn.md)), not a source artefact. Storing a path to generated output in the inventory would violate the view-purity corollary ([ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1). The map references the process by `process_id`; the diagram is regenerated from that element's `flow` and located by convention, so no separate pointer is held here.
@@ -180,3 +180,29 @@ Process Landscape Map    →  lists all processes
 - Capabilities map: `notations/05-capability-map.md`
 - ID grammar and TYPE registry: `notations/IDS_AND_REFERENCES.md`
 - Methodology section 6.4: `method/methodology.md`
+
+---
+
+## 8. Time-varying attributes — sidecar history
+
+A process's `maturity` evolves within the process's overall lifetime. Per [CONTRACT.md](../CONTRACT.md) §9, this field is stored in a sidecar file co-located with the process's element file, **not inline** on the process-map view or on the element file:
+
+```
+canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml          # stable fields
+canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.history.yaml  # time-varying fields
+```
+
+Sidecar shape:
+
+```yaml
+target: PROCESS-ORD-FULFILL-1
+attribute_versions:
+  maturity:
+    - { valid_from: "2024-01-01", value: 1 }
+    - { valid_from: "2025-06-01", value: 2 }
+    - { valid_from: "2026-09-15", value: 3 }
+```
+
+Current-value resolution: pick the entry with the largest `valid_from <= today`. See [CONTRACT.md](../CONTRACT.md) §9.2.
+
+Migration: adopters with existing inline values move each value into a single-entry sidecar with `valid_from = process.valid_from`. The `VERSIONED-001..005` rules apply ([CONTRACT.md](../CONTRACT.md) §9.3).


### PR DESCRIPTION
## Summary

- **ELEMENT_PRIMITIVES.md §7.5**: mark `maturity` as time-varying — sidecar (CONTRACT.md §9), not inline
- **CONTRACT.md §9.4**: add Process map to the candidate `time_varying` attributes table
- **notations/views/06-process-map.md**: update §5 fields table, remove inline maturity from §4 example, add new §8 sidecar section (shape, migration path, example YAML)
- **notations/examples/process-map**: remove inline `maturity:` from both standalone examples (enterprise + northbay-retail); README updated
- **organizations/acme_corp** (submodule bump): five PROCESS element files migrated, five `*.history.yaml` sidecars created, enterprise process-map view updated

## Why

`PROCESS.maturity` was the only maturity field in the methodology that lacked timestamp tracking. CAPABILITY and APPLICATION both use the `*.history.yaml` sidecar mechanism (CONTRACT.md §9). Bringing PROCESS in line means maturity assessments are now dated and the history is preserved, consistent with the rest of the model.

## Submodule PR

acme-corp changes: https://github.com/transitrix/acme-corp/pull/new/feat/process-maturity-sidecar  
Merge that first, then this PR's submodule pointer will be correct.

## Test plan

- [ ] `node scripts/check-notations.mjs` passes (doc-lint clean)
- [ ] No `maturity:` field appears inline in any process-map notation example
- [ ] §9.4 table in CONTRACT.md lists Process map
- [ ] §8 of 06-process-map.md describes the sidecar shape and migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)