### PR TITLE
fix(audit): bump all methodology_version pins from 0.5.0 to 0.7.0

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -721,7 +721,7 @@ Structural layout of a view document:
 ```yaml
 notation: dgca                # §1 — required header
 spec_version: "0.1"           # §1 — optional header
-methodology_version: "0.5.0"  # manifest-pinned methodology version
+methodology_version: "0.7.0"  # manifest-pinned methodology version
 name: "Retail strategy chain" # §1.1 — required document name
 
 view:                         # view identity block — id only; name lives at root per §1.1

--- a/notations/COVERAGE_PROFILES.md
+++ b/notations/COVERAGE_PROFILES.md
@@ -22,7 +22,7 @@ A profile is declared at the repository root in `transitrix.yaml` under the `cov
 
 ```yaml
 transitrix: 1
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core         # short form — name a shipped preset
@@ -248,7 +248,7 @@ The shipped presets (`minimal`, `core`, `full`) are *re-defined per methodology 
 ```yaml
 # transitrix.yaml
 transitrix: 1
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 notations: [dgca, goals, activities, capability-map, applications]
 zones: [canon, field]
 # coverage_profile omitted → defaults to `full`

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -29,7 +29,7 @@ In this methodology repo the worked example lives at `organizations/acme_corp/tr
 
 ```yaml
 transitrix: 1                       # manifest schema version (integer)
-methodology_version: "0.5.0"        # the methodology release this repo conforms to
+methodology_version: "0.7.0"        # the methodology release this repo conforms to
 notations: [dgca, goals, activities, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md

--- a/notations/examples/compliance-impact/README.md
+++ b/notations/examples/compliance-impact/README.md
@@ -25,7 +25,7 @@ A compliance-impact view file carries the shared envelope (`notation:`, `spec_ve
 ```yaml
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 
 view:
   id: COMPLIANCE_IMPACT-<NAME>-1

--- a/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
+++ b/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 name: "Retail product — GDPR obligations"
 
 view:

--- a/notations/examples/scenarios/README.md
+++ b/notations/examples/scenarios/README.md
@@ -26,7 +26,7 @@ A post-reclassification scenarios view file carries no canonical content. It dec
 ```yaml
 notation: scenarios
 spec_version: "0.3"
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 
 view:
   id: SCENARIOS-2027-CUT-1

--- a/notations/views/02-dgca.md
+++ b/notations/views/02-dgca.md
@@ -149,7 +149,7 @@ notation: dgca
 spec_version: "0.1"
 name: "Retail strategy chain 2026"      # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"              # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 
 view:
   id: DGCA-RETAIL-1

--- a/notations/views/11-scenarios.md
+++ b/notations/views/11-scenarios.md
@@ -45,7 +45,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 view:
   # ... see §3
 ```
@@ -95,7 +95,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Optimistic vs Conservative — 2027 cut"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                       # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 
 view:
   id: SCENARIOS-<NAME>-1
@@ -152,7 +152,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "All scenarios"                   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 view:
   id: SCENARIOS-ALL-1
   name: "All scenarios"

--- a/notations/views/21-compliance-impact.md
+++ b/notations/views/21-compliance-impact.md
@@ -45,7 +45,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 view:
   # ... see §3
 ```
@@ -103,7 +103,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Retail product — GDPR obligations"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 
 view:
   id: COMPLIANCE_IMPACT-RETAIL-GDPR-1
@@ -186,7 +186,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Full compliance matrix"          # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 view:
   id: COMPLIANCE_IMPACT-ALL-1
   name: "Full compliance matrix"

--- a/notations/views/22-coverage-metric.md
+++ b/notations/views/22-coverage-metric.md
@@ -45,7 +45,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Retail product — regime coverage"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 
 view:
   id: COVERAGE_METRIC-RETAIL-1
@@ -195,7 +195,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Full coverage metric"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 view:
   id: COVERAGE_METRIC-ALL-1
   name: "Full coverage metric"

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -116,7 +116,7 @@ The root `transitrix.yaml` pins which methodology release this repo conforms to 
 
 ```yaml
 transitrix: 1
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 notations: [dgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```

--- a/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: coverage-metric
 spec_version: "0.1"
-methodology_version: "0.5.0"
+methodology_version: "0.7.0"
 
 # Coverage Metric. Spec: notations/views/22-coverage-metric.md
 # Report-config over the coverage read of canon (sibling of Compliance Impact).


### PR DESCRIPTION
## Summary

- `acme_corp/transitrix.yaml` (the V1 source-of-truth) was stuck at `0.5.0`, two MINOR releases behind. Bumped to `0.7.0` and synced the notations list (added `actor`, `stakeholder`, `compliance-impact`; removed retired `issues`).
- 11 additional files in the methodology repo were pinned to `0.5.0` and are now `0.7.0`.
- The `notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml` example was particularly wrong — the `compliance-impact` notation was introduced in v0.6.0, so it cannot credibly carry `methodology_version: "0.5.0"`.

**Note:** This PR also updates the `organizations/acme_corp` submodule pointer. The matching acme-corp PRs are `transitrix/acme-corp#16` (transitrix.yaml + AGENTS.md bump).

## Test plan

- [x] `node scripts/check-notations.mjs` passes with no V1 findings
- [x] `acme_corp/transitrix.yaml` reads `methodology_version: "0.7.0"`
- [x] No `methodology_version: "0.5.0"` remains anywhere in the repo (checked by V1)