### PR TITLE
fix(scenarios): migrate deprecated FAC-/CAP- IDs to canonical DRIVER-/CAPABILITY- form

### DIFF
--- a/notations/examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml
+++ b/notations/examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml
@@ -21,22 +21,22 @@ scenario:
     ahead of the new EU regulatory regime taking effect in 2028.
 
   factors_view:
-    - factor_id: FAC-MARKET-CEE-001
+    - factor_id: DRIVER-MARKET-CEE-1
       relevance: High
       impact: 30% YoY e-commerce growth in CEE region opens room for two new market entries.
-    - factor_id: FAC-TECH-AI-001
+    - factor_id: DRIVER-TECH-AI-1
       relevance: High
       impact: Mature AI/ML tooling makes SKU-level demand forecasting and personalisation economically viable.
-    - factor_id: FAC-REG-NIS2-2028
+    - factor_id: DRIVER-REG-NIS2-2028
       relevance: High
       impact: NIS2 directive requires uplift of cyber controls — affects every digital touchpoint and supplier integration.
-    - factor_id: FAC-SUPPLY-DISRUPTION-001
+    - factor_id: DRIVER-SUPPLY-DISRUPTION-1
       relevance: Medium
       impact: Continued geopolitical instability requires sourcing diversification and inventory buffer reviews.
-    - factor_id: FAC-TALENT-TECH-001
+    - factor_id: DRIVER-TALENT-TECH-1
       relevance: Medium
       impact: Tech talent shortage in CEE — partnership-based delivery and upskilling preferred over hiring.
-    - factor_id: FAC-ESG-CARBON-001
+    - factor_id: DRIVER-ESG-CARBON-1
       relevance: Low
       impact: Carbon reporting becomes table stakes by 2028 but does not yet constrain strategic moves.
 
@@ -48,15 +48,15 @@ scenario:
     - goal_id: GOAL-CYBER-L4-2027
 
   capabilities:
-    - capability_id: V1.1
-    - capability_id: V1.1.2
-    - capability_id: V1.2.2
-    - capability_id: V1.2.3
-    - capability_id: V1.3.2
-    - capability_id: V2.2.1
-    - capability_id: V2.3.2
-    - capability_id: H1
-    - capability_id: H2
+    - capability_id: CAPABILITY-V1.1
+    - capability_id: CAPABILITY-V1.1.2
+    - capability_id: CAPABILITY-V1.2.2
+    - capability_id: CAPABILITY-V1.2.3
+    - capability_id: CAPABILITY-V1.3.2
+    - capability_id: CAPABILITY-V2.2.1
+    - capability_id: CAPABILITY-V2.3.2
+    - capability_id: CAPABILITY-H1
+    - capability_id: CAPABILITY-H2
 
   activities:
     - activity_id: ACT-UNIFIED-LOYALTY-PLATFORM

--- a/notations/examples/scenarios/optimistic-2027.scenarios.transitrix.yaml
+++ b/notations/examples/scenarios/optimistic-2027.scenarios.transitrix.yaml
@@ -18,13 +18,13 @@ scenario:
     across all core capabilities.
 
   factors_view:
-    - factor_id: FAC-MARKET-001
+    - factor_id: DRIVER-MARKET-1
       relevance: High
       impact: Revenue growth opportunity in CEE region
-    - factor_id: FAC-TECH-001
+    - factor_id: DRIVER-TECH-1
       relevance: Medium
       impact: AI adoption accelerates product differentiation
-    - factor_id: FAC-REG-001
+    - factor_id: DRIVER-REG-1
       relevance: Low
       impact: Minor compliance friction, manageable in current quarter
 
@@ -34,9 +34,9 @@ scenario:
     - goal_id: GOAL-CUST-001
 
   capabilities:
-    - capability_id: CAP-ECOMM-001
-    - capability_id: CAP-DATA-001
-    - capability_id: CAP-MARKETING-001
+    - capability_id: CAPABILITY-ECOMM-1
+    - capability_id: CAPABILITY-DATA-1
+    - capability_id: CAPABILITY-MARKETING-1
 
   activities:
     - activity_id: ACT-EXPAND-CEE-001


### PR DESCRIPTION
## Summary

- Migrates all `FAC-*` driver IDs to `DRIVER-*` canonical prefix per IDS §6 migration table in both scenario examples.
- Converts bare capability tree labels (`V1.1`, `H1`, etc.) to `CAPABILITY-V1.1` / `CAPABILITY-H1` canonical form.
- Converts abbreviated `CAP-*` capability IDs to `CAPABILITY-*` canonical form.
- Removes leading zeros on terminal integers where present (`-001` → `-1`).

## Test plan

- [x] `node scripts/check-notations.mjs` passes.
- [ ] Reviewer verifies each ID rename is consistent with IDS §6 migration table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)