### PR TITLE
feat(ci): add workflow-script integrity check

### DIFF
--- a/.github/workflows/workflow-script-integrity.yml
+++ b/.github/workflows/workflow-script-integrity.yml
@@ -1,0 +1,31 @@
+name: Workflow script integrity
+
+# Guards against stale workflow task definitions that reference local scripts
+# which no longer exist. Runs scripts/check-workflow-scripts.mjs, which scans
+# every .github/workflows/*.yml for `node <path>` and `python <path>` run:
+# steps and verifies the referenced files are present in the repo.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/**'
+      - 'transitrix/skills/**/tests/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/**'
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Verify workflow script references
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Check workflow script references
+        run: node scripts/check-workflow-scripts.mjs

--- a/scripts/check-workflow-scripts.mjs
+++ b/scripts/check-workflow-scripts.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Verifies that every local script path referenced in CI workflow run: blocks
+// exists in the repository. Prevents stale task definitions from silently
+// breaking CI.
+//
+// What we check:
+//   A. `node <path>` and `node scripts/<file>` references in run: steps
+//   B. `python[3] <path>` references in run: steps (ignoring -c/-m inline code)
+//   C. `npx` invocations are NOT checked — they reference published packages,
+//      not local scripts.
+//
+// What we do NOT check:
+//   - Inline python/node code (python3 -c "...", eval constructs)
+//   - Shell built-ins (bash, set, echo, etc.)
+//   - Scripts in integration/ — these are adopter-facing examples and may
+//     legitimately reference tools not yet in this repo (e.g. @transitrix/cli)
+//
+// Exit codes:
+//   0 — every referenced local script exists
+//   1 — one or more referenced scripts are missing
+//   2 — script-internal error (file not found, parse failure)
+
+import { readFile, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = join(dirname(__filename), '..');
+const WORKFLOWS_DIR = join(REPO_ROOT, '.github', 'workflows');
+
+// Patterns that indicate a local script reference in a run: block.
+// Each returns { path } when it matches, or null when it doesn't.
+const EXTRACTORS = [
+  // node scripts/foo.mjs [args...]
+  // node scripts/foo.mjs
+  line => {
+    const m = line.match(/\bnode\s+((?:scripts\/|transitrix\/|packages\/|tools\/)[^\s]+\.[mc]?js)\b/);
+    return m ? m[1] : null;
+  },
+  // python3 path/to/script.py [args...] — but not `python3 -c` or `python3 -m`
+  line => {
+    const m = line.match(/\bpython3?\s+(?!-[cm]\s)([^\s]+\.py)\b/);
+    return m ? m[1] : null;
+  },
+];
+
+async function findWorkflowFiles() {
+  let entries;
+  try {
+    entries = await readdir(WORKFLOWS_DIR);
+  } catch {
+    throw new Error(`Cannot read ${WORKFLOWS_DIR}`);
+  }
+  return entries
+    .filter(f => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .map(f => join(WORKFLOWS_DIR, f));
+}
+
+function extractScriptRefs(workflowText) {
+  const refs = [];
+  for (const line of workflowText.split('\n')) {
+    const stripped = line.trim().replace(/^\|/, '').trim(); // handle YAML block scalars
+    for (const extractor of EXTRACTORS) {
+      const path = extractor(stripped);
+      if (path) refs.push(path);
+    }
+  }
+  return refs;
+}
+
+async function main() {
+  let workflowFiles;
+  try {
+    workflowFiles = await findWorkflowFiles();
+  } catch (e) {
+    console.error(`error: ${e.message}`);
+    process.exit(2);
+  }
+
+  if (workflowFiles.length === 0) {
+    console.log('No workflow files found — nothing to check.');
+    process.exit(0);
+  }
+
+  const missing = [];
+
+  for (const wf of workflowFiles) {
+    let text;
+    try {
+      text = await readFile(wf, 'utf8');
+    } catch (e) {
+      console.error(`error: cannot read ${wf}: ${e.message}`);
+      process.exit(2);
+    }
+
+    const refs = extractScriptRefs(text);
+    const wfName = wf.replace(REPO_ROOT + '/', '').replace(REPO_ROOT + '\\', '');
+
+    for (const ref of refs) {
+      const abs = resolve(REPO_ROOT, ref);
+      if (!existsSync(abs)) {
+        missing.push({ workflow: wfName, script: ref });
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error(
+      `\nWorkflow script integrity check failed — ${missing.length} missing reference(s):\n`
+    );
+    for (const { workflow, script } of missing) {
+      console.error(`  [WFSCRIPT-001] ${workflow}: references '${script}' which does not exist in the repo.`);
+    }
+    console.error(
+      `\nEither add the missing script to the repo, or remove the stale workflow step.\n`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Workflow script integrity check passed — ${workflowFiles.length} workflow file(s) checked, ` +
+    `no missing local script references.`
+  );
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error(`error: ${e.message}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/check-workflow-scripts.mjs`: scans every `.github/workflows/*.yml` for `node <path>` and `python <path>` run-step references, verifies each local path exists in the repo, and exits 1 with a `WFSCRIPT-001` diagnostic per missing file.
- Adds `.github/workflows/workflow-script-integrity.yml`: runs the check on pull_request (when workflows or scripts change) and on push to main.

All current workflow-referenced scripts resolve cleanly (8 workflow files, 0 missing references). The guard prevents future breakage from stale task definitions.

## Test plan

- [x] `node scripts/check-workflow-scripts.mjs` passes with "8 workflow file(s) checked, no missing local script references"
- [x] `node scripts/check-notations.mjs` clean: "14 view notations; examples, internal links, and methodology_version pins all consistent"
- [x] Pre-PR hygiene: no private hub references in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)