### PR TITLE
docs(cli): document canonical extension acceptance in validate

### DIFF
--- a/integration/ci-example.yaml
+++ b/integration/ci-example.yaml
@@ -12,7 +12,9 @@
 #            atomicity, referential integrity, ArchiMate semantics, policy.
 #            Backed by .validators/lint.py (ships in the worked example; scans canon/).
 #   - views  (file scope) — every canon/views/**/*.transitrix.yaml validates/compiles,
-#            one file at a time, via npx @transitrix/cli.
+#            one file at a time, via npx @transitrix/cli. All canonical notation
+#            extensions are accepted without --ext; pass --ext <notation-name>
+#            only for a non-canonical extension outside the built-in registry.
 #
 # The four-way responsibility framing (view / element / relation / structure) is a
 # *reporting* distinction, not separate engines — see methodology ADR

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -167,7 +167,7 @@ Deprecated three-letter abbreviations (`ACT`, `CHG`, `FAC`, `CAP`, `SCN`) — do
 Every notation file is validated before commit. Two sanctioned paths:
 
 - **Transitrix Studio (VS Code extension)** — install from the Marketplace (`transitrix.transitrix-studio`). The extension validates on save and shows error annotations in the editor.
-- **Transitrix CLI** — `npx @transitrix/cli validate path/to/your.dgca.transitrix.yaml`. Use in CI or when working without VS Code.
+- **Transitrix CLI** — `npx @transitrix/cli validate path/to/your.dgca.transitrix.yaml`. Use in CI or when working without VS Code. All canonical `*.transitrix.yaml` notation extensions are accepted without `--ext`; pass `--ext <notation-name>` only for a non-canonical extension outside the built-in registry.
 
 For Mermaid diagrams embedded in `.md` files (ADRs, architecture notes), also install **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) — VS Code Marketplace and Open VSX — to render them inline. Not a validator: a preview aid only.
 


### PR DESCRIPTION
## Summary

- `integration/ci-example.yaml`: adds a note in the `views` job header that all canonical notation extensions are accepted by `@transitrix/cli validate` without `--ext`; `--ext <notation-name>` is only needed for non-canonical extensions.
- `transitrix/skills/onboard/templates/AGENTS.md` (§6 Validation): appends the same clarification to the Transitrix CLI bullet so adopters' `AGENTS.md` files carry the correct guidance.

No behaviour change — documentation only.

## Test plan

- [x] `node scripts/check-notations.mjs` passes clean
- [x] Diff contains no references to internal vocabulary
- [x] Both edited files have intact tails

🤖 Generated with [Claude Code](https://claude.com/claude-code)