### PR TITLE
fix(stakeholders): update stale ACTIVITY→ACTION refs in §3

### DIFF
--- a/notations/elements/20-stakeholders.md
+++ b/notations/elements/20-stakeholders.md
@@ -81,9 +81,9 @@ A stakeholder's stake in a specific canonical object is a first-class relation (
 
 | Relation `type` | From → To | What it records |
 |---|---|---|
-| `stakeholding` | `STAKEHOLDER` → `GOAL` \| `ACTIVITY` \| `CAPABILITY` | This stakeholder has a stake in the target object. Optional per-stake `concern` / `influence` on the relation. The stakeholder→project link (`ACTIVITY`) drives the Activity Card stakeholders block; the stakeholder→goal link is the methodology form of DSM's existing `goal_stakeholder`. |
+| `stakeholding` | `STAKEHOLDER` → `GOAL` \| `ACTION` \| `CAPABILITY` | This stakeholder has a stake in the target object. Optional per-stake `concern` / `influence` on the relation. The stakeholder→action link (`ACTION`) drives the Action Card stakeholders block; the stakeholder→goal link is the methodology form of DSM's existing `goal_stakeholder`. |
 
-v0.1 covers `GOAL`, `ACTIVITY` (project), and `CAPABILITY` targets; stakeholder→change and stakeholder→driver are deferred until a concrete need surfaces.
+v0.1 covers `GOAL`, `ACTION` (work package), and `CAPABILITY` targets; stakeholder→change and stakeholder→driver are deferred until a concrete need surfaces.
 
 ---
 


### PR DESCRIPTION
## Summary

- `20-stakeholders.md §3` relation table and prose still said `ACTIVITY` / `Activity Card` after the ACTIVITY→ACTION rename (PR #265)
- Updated to `ACTION` / `Action Card` in both places

Spotted while responding to a Studio → Methodology question about inline stakeholder fields on Action.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)