### PR TITLE
fix(stakeholders): update stale ACTIVITY refs in §6 evolution notes

### DIFF
--- a/notations/elements/20-stakeholders.md
+++ b/notations/elements/20-stakeholders.md
@@ -113,8 +113,8 @@ The shared header (`HDR-001..004`, [CONTRACT.md](../CONTRACT.md) §2) and primit
 
 - **Concern as a separate primitive.** ArchiMate models a stakeholder's *concern* as its own element. v0.1 inlines `concern` as free text; a `CONCERN` primitive is deferred until needed.
 - **External-organisation reference.** An external stakeholder often *is* an organisation; v0.1 models it as an `ACTOR(business_unit)` with `external_ref`. A dedicated external-org entity is out of scope.
-- **Activity Card stakeholders block.** Once this notation lands, Activity Card v0.2 (#97 follow-up) renders a stakeholders panel from the `stakeholding` relations whose target is the project's activity.
-- DSM formalisation (the `stakeholder.type` enum + `activity_stakeholder` join) is a `proj:transitrix-dsm` track; this spec defines only the methodology side.
+- **Action Card stakeholders block.** Once this notation lands, Action Card v0.2 (#97 follow-up) renders a stakeholders panel from the `stakeholding` relations whose target is the action.
+- DSM formalisation (the `stakeholder.type` enum + `action_stakeholder` join, legacy alias `activity_stakeholder`) is a `proj:transitrix-dsm` track; this spec defines only the methodology side.
 
 ---
 


### PR DESCRIPTION
## Summary

Two stale ACTIVITY→ACTION references missed in #271, both in §6 Evolution:

- `Activity Card stakeholders block` → `Action Card stakeholders block`
- `project's activity` → `the action`
- `activity_stakeholder` join → `action_stakeholder` join (legacy alias noted inline)

## Test plan

- [x] `node scripts/check-notations.mjs` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)