### PR TITLE
fix(onboard-skill): update stale notation names after FGCA→DGCA and Activity→Action renames

### DIFF
--- a/transitrix/.claude-plugin/plugin.json
+++ b/transitrix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix",
-  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 15 view notations (BPMN, FGCA, FGA, Goals, Capability map, Process landscape map, Process Blueprint, Activities, Nested blocks, Scenarios, Applications, Products, Activity Card, Compliance Impact, Coverage Metric) or a codex artefact.",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 15 view notations (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Actions tree, Nested blocks, Scenarios, Applications, Products, Action Card, Compliance Impact, Coverage Metric) or a codex artefact.",
   "version": "0.1.0",
   "author": {
     "name": "Transitrix"
@@ -16,7 +16,7 @@
     "onboarding",
     "transitrix",
     "bpmn",
-    "fgca",
+    "dgca",
     "capability-map",
     "process-blueprint"
   ]

--- a/transitrix/skills/onboard/README.md
+++ b/transitrix/skills/onboard/README.md
@@ -43,16 +43,16 @@ Once installed, invoke the skill in three ways:
 
 1. **Slash command** — type `/transitrix:onboard` in any Claude Code session.
 2. **Freeform** — say "set up Transitrix for my org", "scaffold a transitrix repo", or "I want to model my architecture as text"; the skill's `when_to_use` triggers should pick it up.
-3. **Mid-session** — already in a project and want to add a new notation file? Say "use the Transitrix onboarding skill to add an FGCA for the retention chain" and the agent will jump in at step 3 (template copy).
+3. **Mid-session** — already in a project and want to add a new notation file? Say "use the Transitrix onboarding skill to add a DGCA for the retention chain" and the agent will jump in at step 3 (template copy).
 
 Once invoked, the agent runs the six-step flow documented in [`SKILL.md`](SKILL.md):
 
 1. **Confirm intent and surface area.** Asks which notation you want to start with (showing the family-selection matrix), and how deep an explanation you want.
 2. **Scaffold the repo.** Creates the canonical zoned tree (`canon/{elements,views}`, `field/{interviews,surveys,observations,drafts}`, `codex/{external/<jurisdiction>,internal}`), drops the `transitrix.yaml` manifest at the root, drops the assistant-neutral `AGENTS.md` agent guide and the `.github/copilot-instructions.md` pointer, and initialises `.gitignore` + a README stub.
 3. **Create the starter notation file from a template.** For view notations, copies the matching template from [`templates/`](templates/) into the right `canon/views/<notation>/` subfolder and renames it to `<DOMAIN>.<short-name>.transitrix.yaml`. For codex artefacts, copies a codex-external or codex-internal template into `codex/external/<jurisdiction>/<ID>.yaml` or `codex/internal/<ID>.yaml`.
-4. **Interactive authoring with inline validation.** Walks the user through the placeholders one at a time and validates after each meaningful edit. Validation errors are surfaced by their canonical code (e.g. `FGCA-009 — change references unknown goal`, `CODEX-001 — jurisdiction folder mismatch`).
+4. **Interactive authoring with inline validation.** Walks the user through the placeholders one at a time and validates after each meaningful edit. Validation errors are surfaced by their canonical code (e.g. `DGCA-009 — change references unknown goal`, `CODEX-001 — jurisdiction folder mismatch`).
 5. **Hand off to Transitrix Studio.** Points the user at the VS Code extension for live preview, or at `npx @transitrix/cli validate` for CLI-only workflows.
-6. **Suggest next steps.** Proposes one — and only one — adjacent artefact in the family (e.g. "you built a Goals tree, the natural next step is an FGCA").
+6. **Suggest next steps.** Proposes one — and only one — adjacent artefact in the family (e.g. "you built a Goals tree, the natural next step is a DGCA").
 
 The agent never silently rewrites the user's content. If a validation rule fails, it surfaces the rule and waits for the user's choice.
 
@@ -81,13 +81,14 @@ One starter YAML per view notation, named `<notation>.<short-name>.transitrix.ya
 | Goals tree | [`goals.goals.transitrix.yaml`](templates/goals.goals.transitrix.yaml) |
 | Capability map | [`capability-map.capability-map.transitrix.yaml`](templates/capability-map.capability-map.transitrix.yaml) |
 | Process landscape map | [`process-map.process-map.transitrix.yaml`](templates/process-map.process-map.transitrix.yaml) |
-| Activities | [`activities.activities.transitrix.yaml`](templates/activities.activities.transitrix.yaml) |
+| Action schedule | [`action.action.transitrix.yaml`](templates/action.action.transitrix.yaml) |
+| Actions tree | [`actions-tree.actions-tree.transitrix.yaml`](templates/actions-tree.actions-tree.transitrix.yaml) |
 | Nested blocks | [`blocks.blocks.transitrix.yaml`](templates/blocks.blocks.transitrix.yaml) |
 | Scenarios | [`scenarios.scenarios.transitrix.yaml`](templates/scenarios.scenarios.transitrix.yaml) |
 | Applications | [`applications.applications.transitrix.yaml`](templates/applications.applications.transitrix.yaml) |
 | Products | [`products.products.transitrix.yaml`](templates/products.products.transitrix.yaml) |
 | Process Blueprint | [`process-blueprint.process-blueprint.transitrix.yaml`](templates/process-blueprint.process-blueprint.transitrix.yaml) |
-| Activity Card | [`activity-card.activity-card.transitrix.yaml`](templates/activity-card.activity-card.transitrix.yaml) |
+| Action Card | [`action-card.action-card.transitrix.yaml`](templates/action-card.action-card.transitrix.yaml) |
 | Compliance Impact | [`compliance-impact.compliance-impact.transitrix.yaml`](templates/compliance-impact.compliance-impact.transitrix.yaml) |
 | Coverage Metric | [`coverage-metric.coverage-metric.transitrix.yaml`](templates/coverage-metric.coverage-metric.transitrix.yaml) |
 

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Transitrix Onboarding
-description: Scaffold a new Transitrix architecture-as-text repository (zoned canon/ + field/ + codex/ layout with assistant-neutral AGENTS.md + transitrix.yaml manifest) and drive a first modelling session — enterprise architecture (BPMN, FGCA / FGA / Goals, capability map, process blueprint, activities network, blocks, scenarios, products, applications) plus codex artefacts (laws, regulations, policies, internal standards). Use when the user wants to start a new Transitrix repo from scratch, or has just cloned one and wants to author their first notation file with validation.
-when_to_use: User says "set up Transitrix", "model my architecture as text", "create a new transitrix repo", "I want to write [FGCA / Goals / capability map / process blueprint / ...] but don't know the schema", or asks to scaffold an organisation-as-text repository following the Transitrix methodology. Also triggers when the user says "I cloned my team's Transitrix repo", "help me get oriented in this model", "make my first change to our architecture repo", or expresses a similar intent to orient in or contribute to a repo that already uses Transitrix.
+description: Scaffold a new Transitrix architecture-as-text repository (zoned canon/ + field/ + codex/ layout with assistant-neutral AGENTS.md + transitrix.yaml manifest) and drive a first modelling session — enterprise architecture (BPMN, DGCA / Goals, capability map, process blueprint, action schedule, actions tree, nested blocks, scenarios, products, applications) plus codex artefacts (laws, regulations, policies, internal standards). Use when the user wants to start a new Transitrix repo from scratch, or has just cloned one and wants to author their first notation file with validation.
+when_to_use: User says "set up Transitrix", "model my architecture as text", "create a new transitrix repo", "I want to write [DGCA / Goals / capability map / process blueprint / ...] but don't know the schema", or asks to scaffold an organisation-as-text repository following the Transitrix methodology. Also triggers when the user says "I cloned my team's Transitrix repo", "help me get oriented in this model", "make my first change to our architecture repo", or expresses a similar intent to orient in or contribute to a repo that already uses Transitrix.
 min_version: "0.5.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
@@ -30,7 +30,7 @@ If neither is found → **greenfield setup** — continue with the two questions
 Ask the user two short questions:
 
 1. **What do you want to model first?** Show the family-selection cheat sheet (§ Cheat sheet below) and offer the most common starting points:
-   - Strategy chain → **FGCA** (Driver → Goal → Change → Activity) or **FGA** (no Changes).
+   - Strategy chain → **DGCA** (Driver → Goal → Change → Action) — use `view_config.layers.changes: off` for DGA mode (no Changes layer).
    - Hierarchy of goals → **Goals tree**.
    - Capability map with CMMI maturity → **Capability Map**.
    - Value chain with operational aspects → **Process Blueprint**.
@@ -62,7 +62,7 @@ Do not assume. If the user picks a notation outside the family-selection table, 
 - Where the agent guide lives (`AGENTS.md` at repo root) and that you have read it.
 
 Example:
-> This is a Transitrix repo at methodology v0.5.0, using FGCA, Goals, and Capability Map.
+> This is a Transitrix repo at methodology v0.5.0, using DGCA, Goals, and Capability Map.
 > Active zones: `canon/` (populated), `field/` (empty), `codex/` (empty).
 > Agent guide: `AGENTS.md` at repo root — read and in effect.
 
@@ -193,7 +193,7 @@ Take the user's chosen notation from step 1. Copy the matching template from `${
 
 ### View notations (canon zone)
 
-For any of the 13 view notations (FGCA / FGA / Goals / Capability map / Process map / BPMN / Action schedule / Blocks / Scenarios / Applications / Products / Issues / Process Blueprint), the destination is `canon/views/<notation-folder>/`. Naming convention: `<DOMAIN>.<short-name>.transitrix.yaml`. Ask the user for a short domain code (e.g. `strategy-2026`, `ORDER_FULFILMENT`, `CUSTOMER_ONBOARDING`). If they give a long name, suggest a kebab-case form.
+For any of the 15 view notations (DGCA / Goals / Capability map / Process map / BPMN / Action schedule / Actions tree / Nested blocks / Scenarios / Applications / Products / Process Blueprint / Action Card / Compliance Impact / Coverage Metric), the destination is `canon/views/<notation-folder>/`. Naming convention: `<DOMAIN>.<short-name>.transitrix.yaml`. Ask the user for a short domain code (e.g. `strategy-2026`, `ORDER_FULFILMENT`, `CUSTOMER_ONBOARDING`). If they give a long name, suggest a kebab-case form.
 
 After the copy:
 - Open the file and read it to the user (or summarise its structure).
@@ -217,11 +217,11 @@ Update the `id:`, `name:`, `description:`, the admission record (`admitted_at`, 
 
 Walk the user through filling the placeholders one at a time. After every meaningful edit, validate the file against the canonical schema:
 
-- **For FGCA / FGA / Goals files**: validate against the canonical-form parsers in `@transitrix/diagrams` (`parseCanonicalFGCA`, `parseCanonicalGoals`; FGA uses an FGCA wrapper inside the Studio extension). If Transitrix Studio is installed, opening the file shows live validation errors.
+- **For DGCA / Goals files**: validate against the canonical-form parsers in `@transitrix/diagrams` (`parseCanonicalDGCA`, `parseCanonicalGoals`). If Transitrix Studio is installed, opening the file shows live validation errors.
 - **For every other notation**: validate against the rules in the relevant `notations/<NN>-<name>.md` spec. Each spec has a "Validation rules" table with the error codes the canonical validator uses. Surface those code names to the user in plain English when an edit produces an error.
 
 If the user makes a change that introduces a canon violation:
-- Explain the violation in one sentence ("you've referenced `GOAL-99` from a change, but no goal with that ID exists in the document — that's `FGCA-009`").
+- Explain the violation in one sentence ("you've referenced `GOAL-99` from a change, but no goal with that ID exists in the document — that's `DGCA-009`").
 - Offer one or two ways to fix it.
 - Don't auto-fix unless the user asks — surface the violation and let the user decide.
 
@@ -237,7 +237,7 @@ Once the user has a working starter file, point them at **Transitrix Studio** (t
 
 > "Install Transitrix Studio from the VS Code Marketplace (search for `transitrix.transitrix-studio`). Open the file you just authored — the preview opens automatically beside the editor and refreshes on every save."
 
-The full notation set previews in Studio: BPMN, Goals, FGCA, FGA, Action schedule (PSND + Gantt), Process Map, Process Blueprint, Capability Map, Scenarios, Applications catalogue, Products catalogue, Nested blocks, Issues register.
+The full notation set previews in Studio: BPMN, Goals, DGCA, Action schedule (PSND + Gantt), Actions tree, Process Map, Process Blueprint, Capability Map, Scenarios, Applications catalogue, Products catalogue, Nested blocks, Action Card, Compliance Impact, Coverage Metric.
 
 Also recommend **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) — available on both the VS Code Marketplace and Open VSX — so Mermaid diagrams in `.md` files (ADRs, architecture notes, `AGENTS.md` diagrams) render inline. Between Studio (Transitrix notation preview) and the Mermaid extension (Markdown diagram preview), the user has full visual coverage of the repo.
 
@@ -254,8 +254,8 @@ npx @transitrix/cli validate path/to/your.dgca.transitrix.yaml
 
 Based on what the user just built, propose the next artefact in the family. Concrete patterns:
 
-- They built a **Goals tree** → suggest an **FGCA** or **FGA** to link goals to their drivers and delivery activities.
-- They built **FGCA** → suggest a **Capability map** for the same domain so they can see which capabilities each goal requires.
+- They built a **Goals tree** → suggest a **DGCA** to link goals to their drivers and delivery activities.
+- They built **DGCA** → suggest a **Capability map** for the same domain so they can see which capabilities each goal requires.
 - They built a **Capability map** → suggest an **Applications catalogue** so each capability has a system inventory.
 - They built **BPMN** for one process → suggest the **Process landscape map** to put it in context.
 - They built **Process Blueprint** → suggest **Action schedule** to plan delivery against the blueprint stages.
@@ -290,7 +290,7 @@ Use the matrix below to pick a notation. Full specs at `notations/<NN>-<name>.md
 | Compliance overlay — which obligations hit which product / process stage / task, with each cell's status | **Compliance Impact** | `*.compliance-impact.transitrix.yaml` |
 | Coverage of canon — which subjects are dark for each regulatory regime, splitting modelling gaps from modelled exclusions | **Coverage Metric** | `*.coverage-metric.transitrix.yaml` |
 
-**Family rule:** all four strategy-chain notations (FGCA, FGA, Goals, Action schedule) use the **flat form** — top-level arrays at the document root, hierarchy via `parent` / cross-references inside the flat array. No nested wrapper keys.
+**Family rule:** all three strategy-chain notations (DGCA, Goals, Action schedule) use the **flat form** — top-level arrays at the document root, hierarchy via `parent` / cross-references inside the flat array. No nested wrapper keys.
 
 ### Zone primitives — not view documents
 

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -173,7 +173,7 @@ For Mermaid diagrams embedded in `.md` files (ADRs, architecture notes), also in
 
 The agent does **not** commit files with `error`-level validation findings. `warning`-level findings are surfaced to the adopter and committed only with explicit acknowledgement. The agent does not auto-suppress validation rules.
 
-Every notation spec carries its own validation-codes table (e.g. `FGCA-001..015`, `GOALS-001..013`, `BL-001..009`, `ISS-001..006`, `CODEX-001..003`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.
+Every notation spec carries its own validation-codes table (e.g. `DGCA-001..018`, `GOALS-001..013`, `BL-001..009`, `CODEX-001..003`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.
 
 ---
 

--- a/transitrix/skills/onboard/templates/action.action.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/action.action.transitrix.yaml
@@ -36,4 +36,4 @@ actions:
     name: "FILL-ME — third action"
     duration_days: 30
     predecessors: [ACTION-DESIGN-1]
-    delivers_changes: [CHANGE-1]  # optional cross-ref to an FGCA change
+    delivers_changes: [CHANGE-1]  # optional cross-ref to a DGCA change

--- a/transitrix/skills/onboard/templates/dgca.dgca.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/dgca.dgca.transitrix.yaml
@@ -3,9 +3,9 @@ spec_version: "0.1"
 
 # DGCA chain. Spec: notations/views/02-dgca.md
 # Replace FILL-ME placeholders. IDs use the canonical grammar:
-# DRIVER-N / GOAL-N / CHANGE-N / ACTIVITY-N (optional middle segments).
+# DRIVER-N / GOAL-N / CHANGE-N / ACTION-N (optional middle segments).
 # Fourth column: "actions:" (canonical). Deprecated alias "activities:" still accepted with warning.
-# Action types: initiative | programme | project | work_package
+# Action types: Initiative | Programme | Project | Task (deprecated alias: work_package)
 # To use DGA mode (no Changes column) add: view_config: { layers: { changes: off } }
 
 id: DGCA-FILL-ME-1
@@ -33,7 +33,7 @@ changes:
     goals: [GOAL-1]
 
 actions:
-  - id: ACTIVITY-1
+  - id: ACTION-DELIVERY-1
     name: "FILL-ME action — initiative / programme / project that delivers the change"
-    type: initiative      # initiative | programme | project | work_package
+    type: Initiative      # Initiative | Programme | Project | Task
     changes: [CHANGE-1]

--- a/transitrix/skills/onboard/templates/transitrix.yaml
+++ b/transitrix/skills/onboard/templates/transitrix.yaml
@@ -6,10 +6,9 @@
 transitrix: 1                       # manifest schema version (integer; 1 today)
 methodology_version: "0.4.x"        # pin a real release once the adopter chooses one
 notations:                          # short names from notations/README.md (+ codex)
-  - fgca
+  - dgca
   - goals
-  - activities
-  - issues
+  - action
   - capability-map
   - codex
 zones: [canon, field, codex]        # any subset of canon / field / codex


### PR DESCRIPTION
## Summary

- SKILL.md: replace FGCA/FGA with DGCA throughout (frontmatter, step 1, orient example, step 3 notation list 13→15, step 4 parser names and error code, step 5 Studio list, step 6 next-steps, Family-rule note)
- README.md: fix usage examples (FGCA→DGCA, FGCA-009→DGCA-009); fix template table — rename Activities→Action schedule and Activity Card→Action Card with correct file paths, add missing Actions tree row
- plugin.json: fix notation list in description; replace `fgca` keyword with `dgca`
- templates/transitrix.yaml: fgca→dgca, activities→action, remove retired `issues` notation
- templates/AGENTS.md: update validation-code examples (DGCA-001..018, remove ISS-*)
- templates/dgca.dgca.transitrix.yaml: use canonical ACTION- ID prefix; Title-case type enum
- templates/action.action.transitrix.yaml: fix comment reference

## Test plan

- [x] `node scripts/check-notations.mjs` passes clean
- [x] `node scripts/check-skill-cheatsheet.mjs` passes clean (15 notations)
- [x] `python transitrix/skills/onboard/tests/test_skill_integrity.py` passes
- [x] File integrity verified (no truncation on any modified file)
- [ ] Valerii reviews and merges

🤖 Generated with [Claude Code](https://claude.ai/claude-code)