### PR TITLE
docs(adopter): document Windows-safe CLI invocation + canonical-extension acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The fastest way in is the **onboarding Skill** — it scaffolds a clean zoned re
 
 The skill asks what you want to model first, scaffolds the `canon/` + `field/` + `codex/` layout, and authors a starter file with validation. Your **first artefact is a Goals tree** — the simplest notation to start from.
 
-Prefer to do it by hand, or not working in Claude Code? Follow the manual walkthrough in **[`organizations/acme_corp/GETTING_STARTED.md`](organizations/acme_corp/GETTING_STARTED.md)** — same first artefact, against the worked `acme_corp` example. To validate as you go, install **Transitrix Studio** (VS Code) for live preview, or run `npx @transitrix/cli validate <file>`.
+Prefer to do it by hand, or not working in Claude Code? Follow the manual walkthrough in **[`organizations/acme_corp/GETTING_STARTED.md`](organizations/acme_corp/GETTING_STARTED.md)** — same first artefact, against the worked `acme_corp` example. To validate as you go, install **Transitrix Studio** (VS Code) for live preview, or run `npx @transitrix/cli validate <file>` (on Windows PowerShell, use `npx.cmd` — see [Validation](#validation-in-one-paragraph)).
 
 New to the ideas behind it? Read **[`method/methodology.md`](method/methodology.md)** for the *why* — but you don't need it to start.
 
@@ -71,7 +71,7 @@ See **[`notations/README.md`](notations/README.md)** for the canonical index of 
 
 ## Validation in one paragraph
 
-Transitrix separates validation by responsibility — **view notations**, **element primitives**, **relations**, and **repo structure**. As you author, a single view file validates inline in **Transitrix Studio** (on save) or with `npx @transitrix/cli validate <file>`. Across the whole repository, the model-integrity linter `.validators/lint.py` runs the element/relation/structure checks — atomicity (no relations inside element files), referential integrity (every relation endpoint exists), ArchiMate semantics (layer-respecting connections), and policy (Active status requires an owner; deprecated elements reference successors) — over `canon/` and gates pull requests in CI. See [`integration/ci-example.yaml`](integration/ci-example.yaml) for the pipeline.
+Transitrix separates validation by responsibility — **view notations**, **element primitives**, **relations**, and **repo structure**. As you author, a single view file validates inline in **Transitrix Studio** (on save) or with `npx @transitrix/cli validate <file>`. All canonical `*.<short-name>.transitrix.yaml` extensions are accepted without `--ext`; pass `--ext <notation-name>` only for a non-canonical extension outside the built-in registry. **On Windows PowerShell** with a restricted execution policy (the default on many workstations), invoke as `npx.cmd @transitrix/cli validate <file>` — the unsuffixed `npx` resolves to a `.ps1` wrapper that the policy refuses to launch. Across the whole repository, the model-integrity linter `.validators/lint.py` runs the element/relation/structure checks — atomicity (no relations inside element files), referential integrity (every relation endpoint exists), ArchiMate semantics (layer-respecting connections), and policy (Active status requires an owner; deprecated elements reference successors) — over `canon/` and gates pull requests in CI. See [`integration/ci-example.yaml`](integration/ci-example.yaml) for the pipeline.
 
 ## Use cases
 

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -167,7 +167,7 @@ Deprecated three-letter abbreviations (`ACT`, `CHG`, `FAC`, `CAP`, `SCN`) — do
 Every notation file is validated before commit. Two sanctioned paths:
 
 - **Transitrix Studio (VS Code extension)** — install from the Marketplace (`transitrix.transitrix-studio`). The extension validates on save and shows error annotations in the editor.
-- **Transitrix CLI** — `npx @transitrix/cli validate path/to/your.dgca.transitrix.yaml`. Use in CI or when working without VS Code. All canonical `*.transitrix.yaml` notation extensions are accepted without `--ext`; pass `--ext <notation-name>` only for a non-canonical extension outside the built-in registry.
+- **Transitrix CLI** — `npx @transitrix/cli validate path/to/your.dgca.transitrix.yaml`. Use in CI or when working without VS Code. All canonical `*.transitrix.yaml` notation extensions are accepted without `--ext`; pass `--ext <notation-name>` only for a non-canonical extension outside the built-in registry. On Windows PowerShell with a restricted execution policy, invoke as `npx.cmd @transitrix/cli validate <file>` — plain `npx` resolves to a `.ps1` wrapper that the policy refuses to launch.
 
 For Mermaid diagrams embedded in `.md` files (ADRs, architecture notes), also install **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) — VS Code Marketplace and Open VSX — to render them inline. Not a validator: a preview aid only.
 


### PR DESCRIPTION
## Summary

Adopters running pre-commit validation on Windows with a restricted PowerShell execution policy (the default on many workstations) hit a false failure: plain `npx @transitrix/cli validate <file>` resolves to a `.ps1` wrapper that the policy refuses to launch. The fix on the adopter side is to invoke `npx.cmd` instead — same arguments, same behaviour, no policy change required.

This change documents that path in the two adopter entry-point docs in the methodology repo, and makes explicit (alongside the Windows note) that the CLI already accepts all canonical `*.<short-name>.transitrix.yaml` extensions without `--ext`.

- `README.md` — Quick-start CLI mention + "Validation in one paragraph" both call out `npx.cmd` for Windows PowerShell and the canonical-extension default.
- `transitrix/skills/onboard/templates/AGENTS.md` — the adopter-repo agent guide template (flows into every new adopter repo via the onboard skill) gets the same Windows note next to the existing canonical-extension paragraph.

The CLI side already supports canonical-extension recognition end-to-end; this PR only documents it from the entry-point surfaces. No spec or schema change.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (15 view notations; examples, internal links, methodology_version pins consistent).
- [x] Re-read tail of both edited files to confirm integrity (no truncation; EOF intact).
- [ ] Smoke-test on a Windows workstation with restricted PowerShell execution policy: `npx.cmd @transitrix/cli validate canon/views/goals/<file>.dgca.transitrix.yaml` returns a successful validation (no extension flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)