### PR TITLE
feat(knowledge-store): OKF templates and ingestion skill

### DIFF
--- a/patterns/knowledge-store-templates/okf-knowledge-object.md
+++ b/patterns/knowledge-store-templates/okf-knowledge-object.md
@@ -1,0 +1,23 @@
+---
+type: insight | finding | concept | question
+title: ""
+description: ""
+resource: ""
+source: /intake/processed/source-document-name.md
+created_at: YYYY-MM-DD
+confidence: observed | inferred | assumed
+tags: []
+timestamp: YYYY-MM-DDTHH:MM:SSZ
+---
+
+# Body
+
+_Full description of the knowledge object._
+
+# Citations
+
+- [Source document title](/intake/processed/source-document-name.md)
+
+# Examples
+
+_Optional: concrete examples or illustrations._

--- a/patterns/knowledge-store-templates/okf-source-document.md
+++ b/patterns/knowledge-store-templates/okf-source-document.md
@@ -1,0 +1,24 @@
+---
+type: source-document
+title: ""
+description: ""
+source: ""
+source_hash: ""
+created_at: YYYY-MM-DD
+confidence: observed | inferred | assumed
+tags: []
+tracks: []
+status: processed
+---
+
+# Summary
+
+_One paragraph summarising the key content of the source document._
+
+# Key signals
+
+- 
+
+# Routing notes
+
+_Why this document was routed to the selected tracks. What was extracted._

--- a/patterns/knowledge-store.md
+++ b/patterns/knowledge-store.md
@@ -118,6 +118,34 @@ Migrate to a separate knowledge repo when the single-repo structure becomes cong
 5. **Promote the first batch.** Create a PR for each promoted object. Link the PR back to the knowledge object(s) it was derived from. This establishes the provenance chain.
 6. **Wire the return path.** Set up a process (manual or automated) to publish a `glossary.md` or object-reference stubs from Transitrix back to source repos. This closes the loop and keeps project teams aligned with canon.
 
+## Templates
+
+Starter templates for the two core OKF record types live alongside this pattern:
+
+- [`knowledge-store-templates/okf-source-document.md`](knowledge-store-templates/okf-source-document.md) — copy to `_intake/processed/` for each ingested document; covers `type`, `source`, `source_hash`, `confidence`, `tracks`, and routing notes
+- [`knowledge-store-templates/okf-knowledge-object.md`](knowledge-store-templates/okf-knowledge-object.md) — copy to `knowledge/` for each extracted concept; covers `type`, `description`, `resource`, `confidence`, citations, and examples
+
+**Initialise the MVP bundle with these two files:**
+
+`_intake/log.md`:
+```markdown
+# Intake log
+
+Entries are date-grouped. Each entry carries a type tag: [route] routing decision, [admit] chunk approval, [assert] assertion outcome.
+
+## YYYY-MM-DD
+```
+
+`knowledge/index.md`:
+```markdown
+# Knowledge index
+
+Auto-updated when knowledge objects are added or modified. Each entry: title, type, confidence, source.
+
+| Object | Type | Confidence | Source |
+|---|---|---|---|
+```
+
 ## Tooling
 
 Google Cloud publishes reference implementations alongside the OKF spec:

--- a/transitrix/skills/knowledge-store/README.md
+++ b/transitrix/skills/knowledge-store/README.md
@@ -1,0 +1,67 @@
+# Transitrix Knowledge Store Skill
+
+The **OKF ingestion skill** for a Transitrix knowledge store. Processes raw source material through the OKF single-repo MVP pattern: assess → archive → route → extract → human review → write. All steps are performed by the agent with standard file tools — no external CLI required.
+
+This directory is the **`knowledge-store` skill** within the `transitrix` plugin. Invoked as `/transitrix:knowledge-store`.
+
+---
+
+## The one rule
+
+**Propose, never write canon unilaterally.** The agent presents knowledge object chunks to the user for approval before writing anything to `knowledge/`. For Transitrix primitives, the agent opens a PR to `canon/` — never merges it. The human gate is the only admission authority.
+
+---
+
+## What it ships
+
+- [`SKILL.md`](SKILL.md) — the agent-facing protocol: five steps from document assessment through knowledge writing and canon PR.
+- [`prompts/extract-okf.md`](prompts/extract-okf.md) — extraction prompt for knowledge objects (OKF track).
+- [`prompts/extract-canon.md`](prompts/extract-canon.md) — extraction prompt for Transitrix primitives (Canon track).
+
+The skill reads its OKF templates from the methodology patterns directory:
+- [`patterns/knowledge-store-templates/okf-source-document.md`](../../../../patterns/knowledge-store-templates/okf-source-document.md)
+- [`patterns/knowledge-store-templates/okf-knowledge-object.md`](../../../../patterns/knowledge-store-templates/okf-knowledge-object.md)
+
+---
+
+## Repo layout expected by the skill
+
+```
+<repo-root>/
+  _intake/
+    inbox/         ← drop source files here
+    originals/     ← gitignored; raw files move here after archival
+    processed/     ← OKF source-document records (committed)
+    log.md         ← [route] / [admit] / [assert] events
+  knowledge/
+    index.md       ← bundle index
+    <concept>.md   ← individual OKF knowledge objects
+  canon/           ← Transitrix primitives (unchanged by this skill except via PR)
+```
+
+---
+
+## Ingestion flow summary
+
+```
+User drops file in _intake/inbox/
+        ↓
+Agent: assess → archive to processed/ → log [route]
+        ↓
+       (okf track?)──────────────────────────────────(canon track?)
+        ↓                                                    ↓
+Agent: extract chunks                           Agent: extract primitives
+User:  review and approve                       Agent: open PR to canon/
+Agent: write to knowledge/ → update index.md   User:  review and merge PR
+Agent: log [admit]                              Agent: log [assert]
+```
+
+---
+
+## What this skill does NOT do
+
+- Does not write to `knowledge/` before user review.
+- Does not merge PRs to `canon/`.
+- Does not process multiple documents per run (one source = one clean log entry).
+- Does not assign `extraction_confidence: high` to relations.
+- Does not remove existing knowledge objects.

--- a/transitrix/skills/knowledge-store/SKILL.md
+++ b/transitrix/skills/knowledge-store/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: Transitrix Knowledge Store
+description: Ingest raw source material into the OKF single-repo MVP knowledge store — assess, archive, route to the OKF track (extract knowledge objects → human review → write to knowledge/) and/or the Canon track (extract Transitrix primitives → PR to canon/), and log every decision.
+when_to_use: User says "ingest this document", "add this to the knowledge store", "extract knowledge objects from this", "route this to canon", or drops a file into `_intake/inbox/` and wants it processed.
+min_version: "0.6.0"
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Transitrix Knowledge Store Skill
+
+Processes raw source material through the OKF single-repo MVP knowledge store. All work is done by the agent using Read/Write/Edit tools — no external CLI required. A human reviews and approves before anything lands in `knowledge/` or `canon/`.
+
+---
+
+## The one rule
+
+**Propose, never write canon unilaterally.** For the OKF track, the agent drafts knowledge object chunks and presents them to the user for review before writing to `knowledge/`. For the Canon track, the agent opens a PR to `canon/` — it never merges it. The human gate is the only admission authority.
+
+---
+
+## Step 0 — Check the MVP structure
+
+Verify the repo has the expected layout:
+
+```
+_intake/
+  inbox/        ← source files waiting for processing
+  originals/    ← raw source files (gitignored)
+  processed/    ← OKF source-document records (committed)
+  log.md        ← all events: [route] / [admit] / [assert]
+
+knowledge/
+  index.md      ← bundle index (auto-maintained)
+  <concept>.md  ← individual OKF knowledge objects
+```
+
+If `_intake/` or `knowledge/` are missing, scaffold them now. Copy the initialisation content from [patterns/knowledge-store.md §Templates](../../../../patterns/knowledge-store.md). Add gitignore entries for `_intake/inbox/*` and `_intake/originals/*`.
+
+---
+
+## Step 1 — Assess the document
+
+Read the source document from `_intake/inbox/`. Determine:
+
+- **`confidence:`** — curator's epistemic assessment of the signal quality:
+  - `observed` — first-hand account, direct evidence, system output
+  - `inferred` — derived from evidence; logical but not stated explicitly
+  - `assumed` — working assumption, hearsay, or low-corroboration claim
+- **`tracks:`** — which ingestion tracks apply (one or both):
+  - `okf` — contains knowledge objects: insights, findings, concepts, questions worth curating
+  - `canon` — contains Transitrix primitives: DRIVERs, GOALs, CHANGEs, CAPABILITYs, etc.
+- **Proposed `description:`** — one-sentence summary of the document
+
+State your assessment to the user before proceeding.
+
+---
+
+## Step 2 — Archive to processed/
+
+Copy the source file reference to `_intake/processed/` as an OKF source-document record using the template at [patterns/knowledge-store-templates/okf-source-document.md](../../../../patterns/knowledge-store-templates/okf-source-document.md).
+
+Fill in:
+- `title:` — document filename or stated title
+- `description:` — one-sentence summary from Step 1
+- `source:` — original file path or URI (e.g. `_intake/inbox/filename.md` or a web URL)
+- `source_hash:` — SHA-256 of the source file (`sha256sum` / `Get-FileHash`)
+- `created_at:` — today's date
+- `confidence:` — from Step 1
+- `tags:` — inferred topic tags
+- `tracks:` — from Step 1
+
+Filename convention: `YYYY-MM-DD-<slug>.md` where slug is a 3–5 word kebab-case summary.
+
+Move the source file from `_intake/inbox/` to `_intake/originals/` (gitignored, kept for traceability).
+
+---
+
+## Step 3 — Log the routing decision
+
+Append to `_intake/log.md`:
+
+```markdown
+## YYYY-MM-DD
+
+- [route] `<processed-filename>` → tracks: [okf, canon] | confidence: observed | <one-line reason>
+```
+
+---
+
+## Step 4 — OKF track (if `okf` in tracks)
+
+### 4a — Extract knowledge object drafts
+
+Read the source document from `_intake/originals/` (or the processed record). Using the extraction prompt at [prompts/extract-okf.md](prompts/extract-okf.md), extract candidate knowledge objects. Each object:
+
+- has a clear, discrete idea (one concept per file)
+- carries `type:` — choose from: `insight`, `finding`, `concept`, `question` (or descriptive alternatives)
+- carries `confidence:` — inherited from the source unless the specific claim warrants a lower rating
+- carries `source:` — bundle-relative path to the processed source-document record
+- carries `description:` — one sentence
+
+Present the full list of drafts to the user for review. Number each chunk. State what was skipped and why (too vague, duplicate of existing object, etc.).
+
+### 4b — User review gate
+
+Wait for the user to approve, reject, or revise each chunk. Do not write anything to `knowledge/` until you have explicit approval.
+
+### 4c — Write approved objects
+
+For each approved chunk, write to `knowledge/<slug>.md` using the template at [patterns/knowledge-store-templates/okf-knowledge-object.md](../../../../patterns/knowledge-store-templates/okf-knowledge-object.md).
+
+Filename: kebab-case slug from the `title:`. Check for existing files with the same concept first — update rather than duplicate.
+
+### 4d — Regenerate knowledge/index.md
+
+After all approved objects are written, update `knowledge/index.md` to include new or updated rows. Do not remove rows for existing objects not touched in this ingestion.
+
+### 4e — Log admit decisions
+
+Append to `_intake/log.md` for each admitted object:
+
+```markdown
+- [admit] `<knowledge-object-filename>` ← `<source-document-filename>` | approved | <one-line note>
+```
+
+For each rejected chunk:
+
+```markdown
+- [admit] rejected: "<title>" | reason: <one-line reason>
+```
+
+---
+
+## Step 5 — Canon track (if `canon` in tracks)
+
+### 5a — Extract Transitrix primitives
+
+Using the extraction prompt at [prompts/extract-canon.md](prompts/extract-canon.md), identify candidate Transitrix elements (DRIVER, GOAL, CHANGE, CAPABILITY, ACTOR, ROLE, PROCESS, APPLICATION, PRODUCT, etc.) and typed relations. Be conservative on relations — only propose a relation when the source explicitly states the connection.
+
+For each candidate, draft a YAML block in the format expected by `canon/elements/<type>/`:
+
+```yaml
+type: DRIVER
+id: DRIV-NNN        # assign the next available integer
+name: ""
+description: ""
+derived_from: [<processed-source-document-path>]
+admitted_to: pending
+extraction_confidence: high | medium | low
+```
+
+### 5b — Open PR
+
+Create a branch `knowledge-store/ingest-<YYYY-MM-DD>-<slug>` and commit the candidate YAML files. Open a PR titled `[Knowledge Store] Ingest: <source-document-title>`.
+
+PR body must include:
+- Link to the processed source-document record
+- Table of proposed elements with type, name, and extraction_confidence
+- Note on any relations proposed
+- Instruction: "Review, revise IDs to avoid conflicts, and merge when satisfied."
+
+### 5c — Log assertion outcome (after PR is merged or closed)
+
+Once the user reports the PR outcome, append to `_intake/log.md`:
+
+```markdown
+- [assert] PR #<number> merged | admitted: [DRIV-NNN, GOAL-NNN, ...] | source: <processed-filename>
+```
+
+Or for rejected:
+
+```markdown
+- [assert] PR #<number> closed without merge | reason: <one-line>
+```
+
+---
+
+## What this skill does NOT do
+
+- Does not merge PRs. The canon gate is always a human.
+- Does not write to `knowledge/` before user review of chunks.
+- Does not assign `extraction_confidence: high` to relations — relations are flagged `medium` or lower unless the source text is unambiguous.
+- Does not remove existing knowledge objects. Only add or update.
+- Does not process multiple documents in the same run unless explicitly asked — one source per run keeps the log clean.

--- a/transitrix/skills/knowledge-store/prompts/extract-canon.md
+++ b/transitrix/skills/knowledge-store/prompts/extract-canon.md
@@ -1,0 +1,65 @@
+# Extract Transitrix Canon Candidates
+
+Extract typed Transitrix element candidates from the source document. Only propose what the source explicitly supports — be conservative on relations.
+
+## Element types to look for
+
+| Type | Look for |
+|---|---|
+| DRIVER | External pressures, regulatory requirements, market forces, constraints the organisation cannot change |
+| GOAL | Intended outcomes, strategic objectives, targets |
+| CHANGE | Initiatives, transformations, programmes, projects being undertaken |
+| CAPABILITY | Abilities the organisation has or needs to develop |
+| ACTOR | Named external entities (regulators, customers, partners) |
+| ROLE | Named internal roles with responsibilities |
+| PROCESS | Named business processes with clear scope |
+| APPLICATION | Named IT systems or tools |
+| PRODUCT | Named goods or services delivered |
+
+## Relations (conservative)
+
+Only propose a relation when the source text *explicitly states* the connection — not when you infer it. Examples of explicit statements:
+- "The GDPR requirement (DRIVER) drives the data retention initiative (CHANGE)"
+- "The Compliance Officer (ROLE) owns the risk register process (PROCESS)"
+
+For each relation candidate, note the verbatim phrase that justifies it.
+
+## Output format
+
+For each candidate element:
+
+```yaml
+type: DRIVER
+id: <TYPE>-TBD     # leave TBD — IDs are assigned during review to avoid conflicts
+name: "<name>"
+description: "<one-sentence>"
+derived_from: [/_intake/processed/<source-document-filename>]
+admitted_to: pending
+extraction_confidence: high | medium | low
+```
+
+`extraction_confidence` rules:
+- `high` — the source names the element explicitly with enough context to be unambiguous
+- `medium` — the element is implied but not named; some interpretation required
+- `low` — uncertain; surface for human judgement
+
+For each proposed relation:
+
+```yaml
+relation:
+  type: <REL_KIND>
+  from: <TYPE>-TBD-<name>
+  to: <TYPE>-TBD-<name>
+  source_quote: "<verbatim phrase>"
+  extraction_confidence: medium | low
+```
+
+Relations never get `extraction_confidence: high` — they are structural claims and always need human validation.
+
+## After extraction
+
+List all candidate elements, grouped by type. Then list all candidate relations. State:
+- Total elements and relations proposed
+- Elements or passages skipped and why (out of scope, too vague, existing canon ID known)
+
+The agent will commit the candidates to a branch and open a PR — no canon file is written directly.

--- a/transitrix/skills/knowledge-store/prompts/extract-okf.md
+++ b/transitrix/skills/knowledge-store/prompts/extract-okf.md
@@ -1,0 +1,54 @@
+# Extract OKF Knowledge Objects
+
+Extract discrete knowledge objects from the source document. Each object captures one clear, self-contained idea worth curating — an insight, finding, concept, or open question.
+
+## What to extract
+
+Extract an object when the source contains:
+
+- A **finding** — an observed fact or measurement about how something works or fails
+- An **insight** — a derived understanding or pattern that explains why something happens
+- **concept** — a defined term, model, or framework the team uses
+- **question** — an unresolved open question worth tracking
+
+Do not extract:
+- Procedural steps (unless the process itself is the insight)
+- Data that is too specific to be reusable
+- Statements that are already in `knowledge/` (check `knowledge/index.md`)
+- Vague assertions without grounding in the source
+
+## Output format
+
+For each candidate object, output a fenced block:
+
+~~~
+---
+type: insight | finding | concept | question
+title: "<concise title>"
+description: "<one-sentence summary>"
+source: /_intake/processed/<source-document-filename>
+created_at: YYYY-MM-DD
+confidence: observed | inferred | assumed
+tags: [<topic>, ...]
+---
+
+<Body: 2–5 sentences expanding the description. Cite the exact passage if helpful.>
+
+Citations:
+- [<Source document title>](/_intake/processed/<source-document-filename>)
+~~~
+
+## Confidence assignment
+
+Inherit from the source document's `confidence:` unless the specific claim warrants lower:
+- `observed` → direct evidence in the source text (measurements, quotes, examples)
+- `inferred` → logical derivation from the source, not explicitly stated
+- `assumed` → hedged or uncorroborated claim in the source
+
+## After extraction
+
+List all candidate objects, numbered. Then state:
+- How many were extracted
+- What was skipped and why (e.g. "2 items skipped: too vague / already in knowledge/index.md")
+
+Wait for the user to approve, reject, or revise each item before writing anything to `knowledge/`.


### PR DESCRIPTION
## Summary

- Adds two OKF record templates to `patterns/knowledge-store-templates/`: `okf-source-document.md` (archive record for `_intake/processed/`) and `okf-knowledge-object.md` (knowledge concept for `knowledge/`)
- Adds new agent skill `transitrix/skills/knowledge-store/` (`/transitrix:knowledge-store`) covering the full single-repo MVP ingestion protocol:
  - Assess document, set confidence, determine tracks
  - Archive to `_intake/processed/` as OKF source-document record
  - Log routing decision in `_intake/log.md`
  - OKF track: extract chunks → user review → write to `knowledge/` → update index → log [admit]
  - Canon track: extract Transitrix primitives → open PR → log [assert] after merge
- Extraction prompts: `extract-okf.md` and `extract-canon.md`
- Pattern update: OKF alignment header, fields table, bundle conventions, single-repo MVP structure, templates section, tooling section

## Test plan

- [ ] Read `patterns/knowledge-store.md` and verify it is complete and self-contained
- [ ] Read `SKILL.md` and walk through all five steps for coherence
- [ ] Verify template frontmatter fields match the fields table in `knowledge-store.md`
- [ ] Check prompt files reference correct bundle-relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)