### PR TITLE
onboard: surface extension install earlier, canon-first sourcing rule

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -72,7 +72,7 @@ Example:
 
 - **Add a new notation file** → jump to **Step 3** (template copy → authoring → validate → PR). Before copying a template, use `Glob`/`Grep` over the existing tree to pick the right domain prefix and avoid ID clashes.
 - **Modify an existing file** → `Read` it first, summarise its current structure, then enter **Step 4** (interactive authoring with inline validation).
-- **"Where is X?"** → `Grep` the repo and answer directly; no authoring loop needed.
+- **"Where is X?" / any question about the organization itself** → follow `AGENTS.md` §13 (canon-first sourcing): check `canon/` first, then `codex/`, cite the artefact ID/path; only fall back to `field/` with an explicit "unvalidated" caveat, and don't grep ad hoc top-level folders (scratch notes, `_intake/`) as if they were authoritative. If canon/codex genuinely don't cover it, say so rather than guessing from whatever's nearby.
 
 After the first change is authored and validated, continue to **Step 6** (suggest next steps).
 
@@ -132,6 +132,17 @@ Additionally, write one generated file (no template — author it inline):
 - `<repo-root>/README.md` — a minimal org stub. Three sections: (1) one-paragraph intro naming the repo purpose and linking to `github.com/transitrix/methodology`; (2) "Getting started" pointing newcomers at `AGENTS.md` and the `/transitrix:onboard` skill; (3) "Tooling" recommending both VS Code extensions — **Transitrix Studio** (`transitrix.transitrix-studio`, VS Code Marketplace) for live Transitrix notation preview, and **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`, VS Code Marketplace and Open VSX) for Mermaid diagram preview in Markdown files. Leave `ADOPTER-FILL-ME` placeholders for org name, purpose, and team.
 
 **Do not scaffold a Claude-specific `CLAUDE.md` agent guide.** The canonical guide for every assistant is `AGENTS.md`. If the user is on a tool that doesn't read `AGENTS.md` natively (e.g. Claude Code looks for `CLAUDE.md`, Cursor looks for `.cursor/rules/`), drop a one-line pointer file in that tool's location that reads *"Read `AGENTS.md` in the repo root and follow it."* The guidance itself stays in `AGENTS.md` only — see `AGENTS.md` §"Using this guide with your assistant".
+
+### Suggest editor tooling — right after scaffolding, don't wait for Step 5
+
+As soon as the root files exist, check what's already installed: `code --list-extensions` (swap `code` for `cursor` / `codium` if that's the detected editor; on Windows PowerShell with a restricted execution policy use `code.cmd` / `cursor.cmd`). If **Transitrix Studio** (`transitrix.transitrix-studio`) or **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) is missing, surface the install command(s) prominently now, before Step 3:
+
+```
+code --install-extension transitrix.transitrix-studio
+code --install-extension bierner.markdown-mermaid
+```
+
+The agent does **not** run these itself — it shows the command and lets the user run it (see `AGENTS.md` §12, scaffolded into the new repo, for the standing rule this session-start check follows going forward). Step 5 below is a reminder to actually open the file in Studio once one exists, not the first time this comes up.
 
 ### Three zones — what gets scaffolded
 
@@ -233,13 +244,13 @@ Once a few files exist, the whole-repo linter scaffolded in Step 2 catches cross
 
 ## Step 5 — Hand off to Studio
 
-Once the user has a working starter file, point them at **Transitrix Studio** (the VS Code extension) for live preview:
+The install suggestion already happened right after scaffolding (see "Suggest editor tooling" in Step 2). Now that the user has a working starter file, close the loop — point them at **Transitrix Studio** for live preview:
 
-> "Install Transitrix Studio from the VS Code Marketplace (search for `transitrix.transitrix-studio`). Open the file you just authored — the preview opens automatically beside the editor and refreshes on every save."
+> "Open the file you just authored — the preview opens automatically beside the editor and refreshes on every save." (If they skipped the earlier install prompt, repeat the `code --install-extension transitrix.transitrix-studio` command once here.)
 
 The full notation set previews in Studio: BPMN, Goals, DGCA, Action schedule (PSND + Gantt), Actions tree, Process Map, Process Blueprint, Capability Map, Scenarios, Applications catalogue, Products catalogue, Nested blocks, Action Card, Compliance Impact, Coverage Metric.
 
-Also recommend **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) — available on both the VS Code Marketplace and Open VSX — so Mermaid diagrams in `.md` files (ADRs, architecture notes, `AGENTS.md` diagrams) render inline. Between Studio (Transitrix notation preview) and the Mermaid extension (Markdown diagram preview), the user has full visual coverage of the repo.
+Between Studio (Transitrix notation preview) and the Mermaid extension (Markdown diagram preview), the user has full visual coverage of the repo.
 
 If the user is on a system without VS Code, they can use the CLI for compile / validate:
 

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -232,3 +232,32 @@ Every non-trivial change goes through PR review by the adopter:
 5. The adopter — or a reviewer the adopter designates — merges. The agent does **not** merge its own PRs, even when permissions allow it.
 
 Trivial changes (typo fixes inside a description string, README polish) may be committed directly to `main` if the adopter has explicitly opted into a direct-commit workflow. Default: PR every time.
+
+---
+
+## 12. Recommended IDE extensions
+
+Two VS Code extensions make this repo far more usable:
+
+| Extension | Purpose | Install |
+|---|---|---|
+| **Transitrix Studio** (`transitrix.transitrix-studio`) | Live preview + validation for every Transitrix notation | `code --install-extension transitrix.transitrix-studio` |
+| **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) | Renders Mermaid diagrams embedded in `.md` files (ADRs, architecture notes) | `code --install-extension bierner.markdown-mermaid` |
+
+**Surface this proactively, once per session — don't wait for the user to hit a wall.** At the start of a session (or the first time the agent opens or edits a notation file), check what's already installed with `code --list-extensions` (swap `code` for `cursor` / `codium` if that's the detected editor; on Windows PowerShell with a restricted execution policy use `code.cmd` / `cursor.cmd`). If either extension is missing, show the exact install command(s) above right away, before doing any other work in the session.
+
+The agent does **not** run the install command itself — it surfaces it prominently and lets the adopter run it. Both extensions are read-only with respect to the model: they render and validate, they never modify files.
+
+---
+
+## 13. Answering questions about the organization
+
+When the adopter (or anyone else) asks a question *about the organization itself* — "what does capability X depend on", "are we covered for GDPR", "what's our biggest process risk" — the agent answers from the **zoned sources of truth**, in this order:
+
+1. **`canon/`** first — the validated model (`canon/elements/`, `canon/views/`). This is the authoritative answer. Cite the specific artefact ID(s) and file path(s) so the answer is verifiable.
+2. **`codex/`** for anything about external obligations (laws, regulations) or internal policy — cite the artefact's canonical ID.
+3. **`field/`** only if canon/codex don't cover the question, and only with an explicit caveat that it's raw, unvalidated material, not an organizational fact (see §3.1). Never present a `field/` artefact's content as if it were admitted truth.
+
+**Do not** answer by grepping arbitrary top-level folders (scratch notes, an adopter's personal `docs/`, `_intake/`, chat logs) as if they were canon — those are not zoned sources and carry no admission record. If the question genuinely isn't covered by `canon/` or `codex/`, say so explicitly ("not modelled yet" / "no admitted artefact answers this") rather than synthesizing an answer from whatever files happen to be nearby.
+
+If a broader repo search is genuinely needed (e.g. "where is X mentioned anywhere in this repo"), that's fine as an explicit, separate action — just don't let it substitute for checking canon/codex first, and don't present unzoned matches with the same confidence as an admitted canon fact.


### PR DESCRIPTION
## Summary
- Move the Studio/Mermaid extension install suggestion from Step 5 to right after scaffolding (SKILL.md Step 2) — surfaced before authoring the first file, not just when a feature turns out unavailable. Still suggestion-only, agent never runs the install.
- Add a canon-first sourcing rule to the AGENTS.md template (new §12 IDE extensions, §13 answering org questions) and to SKILL.md's Orient/Contribute mode: answer organizational questions from `canon/` then `codex/`, flag `field/` as unvalidated, never treat ad hoc top-level folders as authoritative.

Note: `organizations/acme_corp/AGENTS.md` (the submodule pointing at the public `transitrix/acme-corp` demo repo) is intentionally left untouched in this PR — that's a separate sync since it's the public repo, not an internal methodology copy.

## Test plan
- [ ] Re-run `/transitrix:onboard` greenfield flow and confirm the extension-install suggestion appears right after scaffolding, before Step 3
- [ ] Skim new AGENTS.md §12/§13 for tone/consistency with the rest of the doc
- [ ] Decide whether/when to port the same two additions into `transitrix/acme-corp` (submodule) separately