### PR TITLE
fix(ingest-cli): align built-in presets with methodology 0.7.0 vocabulary

### DIFF
--- a/packages/ingest-cli/src/coverage-presets.mjs
+++ b/packages/ingest-cli/src/coverage-presets.mjs
@@ -7,8 +7,14 @@
 // Stored per layer (so a custom profile can `disabled:`/`remove:` a whole layer and
 // resolve correctly); the resolver flattens to membership sets. `full` is the sentinel
 // "everything" — it carries no allowlist because every registry TYPE / REL kind is in.
+//
+// RELEASE DISCIPLINE: on every methodology MINOR or MAJOR bump, update PRESETS_VERSION
+// to match the new methodology_version and re-state each preset's element + relation
+// lists against COVERAGE_PROFILES.md §3 / §3.1 for that release. This is a manual
+// release step — run `node packages/ingest-cli/ingest.mjs repo-check <repo>` on a repo
+// pinned to the new version to confirm no false-negative mismatch before tagging.
 
-export const PRESETS_VERSION = '0.5.0';
+export const PRESETS_VERSION = '0.7.0';
 
 export const LAYERS = ['01_motivation', '02_business', '03_application', '04_technology', '05_implementation'];
 
@@ -16,25 +22,25 @@ export const LAYERS = ['01_motivation', '02_business', '03_application', '04_tec
 export const PRESETS = {
   minimal: {
     elements: {
-      '01_motivation': ['FACTOR', 'GOAL'],
-      '05_implementation': ['ACTIVITY'],
+      '01_motivation': ['DRIVER', 'GOAL'],
+      '05_implementation': ['ACTION'],
     },
     relations: {
       '01_motivation': ['goal_parent'],
-      '05_implementation': ['activity_goal'],
+      '05_implementation': ['action_goal'],
     },
   },
   core: {
     elements: {
-      '01_motivation': ['FACTOR', 'GOAL', 'CONSTRAINT', 'REQUIREMENT', 'STAKEHOLDER'],
+      '01_motivation': ['DRIVER', 'GOAL', 'CONSTRAINT', 'REQUIREMENT', 'STAKEHOLDER'],
       '02_business': ['CAPABILITY', 'PROCESS', 'ACTOR', 'ROLE', 'RULE'],
       '03_application': ['APPLICATION', 'INTEGRATION'],
-      '05_implementation': ['ACTIVITY', 'CHANGE', 'MILESTONE'],
+      '05_implementation': ['ACTION', 'CHANGE', 'MILESTONE'],
     },
     relations: {
       '01_motivation': ['goal_parent', 'stakeholding'],
       '02_business': ['parent', 'unit_parent', 'employment'],
-      '05_implementation': ['activity_goal'],
+      '05_implementation': ['action_goal'],
     },
   },
   // `full` is intentionally the sentinel — see resolveProfile(). No allowlist needed.

--- a/packages/ingest-cli/src/placement.mjs
+++ b/packages/ingest-cli/src/placement.mjs
@@ -27,7 +27,8 @@ import { join, resolve, dirname } from 'node:path';
 // means the TYPE has no own catalogue folder (view-defined, document-local).
 export const PLACEMENT = {
   // 01_motivation
-  FACTOR:             { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/factors/' },
+  DRIVER:             { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/factors/' },
+  FACTOR:             { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/factors/' }, // grandfathered IDs; canonical name is DRIVER
   GOAL:               { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/goals/' },
   CONSTRAINT:         { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/constraints/' },
   REQUIREMENT:        { mode: 'standalone',   layer: '01_motivation',    folder: '01_motivation/requirements/' },
@@ -46,8 +47,9 @@ export const PLACEMENT = {
   APPLICATION:        { mode: 'standalone',   layer: '03_application',   folder: '03_application/applications/' },
   INTEGRATION:        { mode: 'view-defined', layer: '03_application',   folder: '03_application/integrations/', promotable: true },
   // 05_implementation
+  ACTION:             { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/actions/' },
+  ACTIVITY:           { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/activities/', deprecated: true, replacedBy: 'ACTION' },
   CHANGE:             { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/changes/' },
-  ACTIVITY:           { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/activities/' },
   TARGET_STATE:       { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/target-states/' },
   SCENARIO:           { mode: 'standalone',   layer: '05_implementation', folder: '05_implementation/scenarios/' },
   // 04_technology — first catalogued TYPE in this layer (ADR 2026-06-08)

--- a/packages/ingest-cli/src/validate.mjs
+++ b/packages/ingest-cli/src/validate.mjs
@@ -22,7 +22,8 @@ const EXTRACTION_CONFIDENCE = new Set(['high', 'medium', 'low']);
 // candidate.schema.json names "closed REL kinds" among what validation_flags covers.
 const CLOSED_REL_KINDS = new Set([
   'parent', 'goal_parent', 'target_state_satisfies_goal', 'assessment_influences_goal',
-  'activity_goal', 'unit_parent', 'employment', 'candidacy', 'alumni_membership',
+  'action_goal', 'activity_goal', // action_goal is canonical; activity_goal is deprecated alias (ACTION-005)
+  'unit_parent', 'employment', 'candidacy', 'alumni_membership',
   'community_membership', 'contracting', 'stakeholding',
 ]);
 

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -33,6 +33,8 @@ Deterministic, no-API-key guard. Nine parts:
   N. F8 entity resolution — emit-candidates attaches entity_match when a candidate's
      name matches an existing canon element by primary name or alias; genuinely new
      candidates get no proposal; review-queue surfaces entity_match_proposals.
+  P. #434 preset version currency — repo-check reports a version match (no false-negative)
+     for a repo correctly pinned to the CLI's built-in preset version (0.7.0).
 
 This is the PR-CI guard. The LLM-driven walk-through lives in drive_ingest_e2e.py,
 gated to the weekly cron. See tests/README.md.
@@ -1140,6 +1142,42 @@ def part_o_unresolved_extensions():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part P — #434 regression: preset version currency ────────────
+
+def part_p_preset_version_currency():
+    """repo-check reports a version match for a repo pinned to the CLI's built-in
+    preset version (currently 0.7.0). Regression for the false-negative mismatch
+    caused by stale built-in presets frozen at an old methodology version."""
+    if not shutil.which("node"):
+        print("SKIP Part P: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-p434-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.7.0"\ncoverage_profile: core\n')
+
+        r = run_cli("repo-check", org)
+        check(r.returncode == 0, "P: repo-check failed on a 0.7.0 repo: %s" % (r.stderr or r.stdout))
+        rep = yaml.safe_load(r.stdout)
+
+        tooling = rep.get("tooling", {})
+        check(tooling.get("methodology_version_match") is True,
+              "P: repo-check must report methodology_version_match: true for a 0.7.0 repo "
+              "(false-negative regression from stale built-in presets); got tooling=%r" % tooling)
+        check(tooling.get("ok") is True,
+              "P: repo-check tooling.ok must be true for a 0.7.0 repo; got tooling=%r" % tooling)
+        red_flags = rep.get("integrity", {}).get("red_flags", [])
+        version_flags = [f for f in red_flags if "does not match" in f and "CLI built-in" in f]
+        check(len(version_flags) == 0,
+              "P: repo-check must not emit a version-mismatch red flag for a 0.7.0 repo; "
+              "got red_flags=%r" % red_flags)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
@@ -1155,6 +1193,7 @@ part_l_repo_check()
 part_m_id_grammar()
 part_n_entity_resolution()
 part_o_unresolved_extensions()
+part_p_preset_version_currency()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## Problem

`transitrix-ingest repo-check` was reporting a false-negative `methodology_version` mismatch for repositories correctly pinned to `0.7.0`, because `PRESETS_VERSION` in `coverage-presets.mjs` was frozen at `0.5.0`. The repos and their content were valid — the false flag came entirely from stale tooling.

## Changes

**`packages/ingest-cli/src/coverage-presets.mjs`**
- `PRESETS_VERSION`: `0.5.0` → `0.7.0`
- `minimal` preset: `FACTOR` → `DRIVER`, `ACTIVITY` → `ACTION`, `activity_goal` → `action_goal`
- `core` preset: same renames — `FACTOR` → `DRIVER`, `ACTIVITY` → `ACTION`, `activity_goal` → `action_goal`
- Added release-discipline comment explaining the manual update step on future methodology bumps

**`packages/ingest-cli/src/validate.mjs`**
- Added `action_goal` to `CLOSED_REL_KINDS` (canonical rel kind; `activity_goal` remains as deprecated alias per `ACTION-005`)

**`packages/ingest-cli/src/placement.mjs`**
- Added `DRIVER` entry (`01_motivation/factors/` — same folder as grandfathered `FACTOR-…` IDs)
- Added `ACTION` entry (`05_implementation/actions/`)
- Marked `ACTIVITY` deprecated with `replacedBy: 'ACTION'`

**`transitrix/skills/ingest/tests/test_ingest_integrity.py`**
- Added Part P regression: `repo-check` reports `tooling.methodology_version_match: true` for a 0.7.0 repo (confirms the specific false-negative cannot regress)

## Verification

```
python transitrix/skills/ingest/tests/test_ingest_integrity.py
# PASS — Transitrix Ingest skill + CLI pipeline test: all checks passed.

node scripts/check-notations.mjs
# Notations doc-lint clean
```