### PR TITLE
feat(ingest): wire origin classification into ingest pipeline

### DIFF
--- a/packages/ingest-cli/src/emit-candidates.mjs
+++ b/packages/ingest-cli/src/emit-candidates.mjs
@@ -52,6 +52,7 @@ export function shapeCandidates(derivedFrom, result) {
     if (el.extraction_notes) c.extraction_notes = el.extraction_notes;
     if (el.valid_from !== undefined) c.valid_from = el.valid_from;
     if (el.valid_to !== undefined) c.valid_to = el.valid_to;
+    if (el.origin !== undefined) c.origin = el.origin;
     // Mechanism 1 (CONTRACT §12): source fields the schema does not define ride along
     // in an open `extensions:` bag, candidate -> admitted entity, verbatim. Carried only
     // when it is a non-empty map; the validator passes it through untouched (EXT-001).

--- a/packages/ingest-cli/src/validate.mjs
+++ b/packages/ingest-cli/src/validate.mjs
@@ -14,6 +14,7 @@ import { isValidId, isValidType } from './ids.mjs';
 import { classifyCoverage } from './coverage.mjs';
 
 const EXTRACTION_CONFIDENCE = new Set(['high', 'medium', 'low']);
+const ORIGIN_VALUES = new Set(['legislative', 'process-product', 'project-product']);
 
 // Closed REL `type` enum — notations/elements/17-relations.md §3. The enum is closed
 // in v1; adding a kind is a non-backwards-compatible methodology revision. The CLI
@@ -42,7 +43,7 @@ const DEFINED_FIELDS = new Set([
   'kind', 'id', 'name', 'element_type', 'type', 'aliases',
   'rel_kind', 'from', 'to', 'about', 'subject', 'status', 'realised_via', 'evidence',
   'derived_from', 'admitted_to', 'extraction_confidence', 'extraction_notes',
-  'valid_from', 'valid_to', 'entity_match', 'coverage_flag', 'validation_flags', 'extensions',
+  'valid_from', 'valid_to', 'origin', 'entity_match', 'coverage_flag', 'validation_flags', 'extensions',
 ]);
 
 function typeOf(id) { return typeof id === 'string' ? id.split('-')[0] : null; }
@@ -99,6 +100,10 @@ export function validateCandidate(cand, profile) {
     // Warn (not error) so existing pipelines keep working during the one-release alias window.
     if (type === 'INFORMATION_ENTITY') {
       flags.push('BOBJ-D001 [deprecation]: INFORMATION_ENTITY is a deprecated alias; rename element_type to BUSINESS_OBJECT and update the id prefix (INFORMATION_ENTITY- → BUSINESS_OBJECT-)');
+    }
+    // REQ-004 — origin closed vocabulary (15-requirement.md §4).
+    if (type === 'REQUIREMENT' && 'origin' in cand && !ORIGIN_VALUES.has(cand.origin)) {
+      flags.push(`REQ-004: origin must be legislative|process-product|project-product (got ${JSON.stringify(cand.origin)})`);
     }
   } else if (cand.kind === 'relation') {
     if (!cand.rel_kind) flags.push('relation is missing rel_kind');

--- a/transitrix/skills/ingest/prompts/01_motivation.md
+++ b/transitrix/skills/ingest/prompts/01_motivation.md
@@ -23,7 +23,8 @@ Emit a single JSON object. Nothing else.
     { "id": "<TYPE>-[<middle>-]<N>", "name": "<short name>", "element_type": "<TYPE>",
       "extraction_confidence": "high|medium|low", "extraction_notes": "<optional>",
       "valid_from": "<YYYY-MM-DD or omit>",
-      "parent_goal": "<GOAL-… or omit — placeholder only, see GOAL section below>" }
+      "parent_goal": "<GOAL-… or omit — placeholder only, see GOAL section below>",
+      "origin": "legislative|process-product|project-product (REQUIREMENT only — omit for all other TYPEs)" }
   ],
   "relations": [
     { "rel_kind": "<closed kind>", "from": "<ID>", "to": "<ID>",
@@ -44,6 +45,18 @@ Emit a single JSON object. Nothing else.
 
 `REQUIREMENT` vs `CONSTRAINT`: positive action → REQUIREMENT; restriction → CONSTRAINT. The same source may yield both.
 
+### REQUIREMENT `origin` — source-document context signals
+
+Every extracted REQUIREMENT SHOULD carry `origin` based on the source document you are reading. Use exactly one of the three closed values:
+
+| Value | Use when the source document is… | Typical signals |
+|---|---|---|
+| `legislative` | A law, regulation, standard, or internal policy — an externally-imposed or formally-adopted rule | Numbered articles/clauses; regulatory authority named; compliance/certification framing; references to penalties, audits, or legal enforcement |
+| `process-product` | An SOP, process specification, quality manual, or work instruction — what a PROCESS must deliver | Process steps with defined outputs; quality thresholds; "the process shall produce…"; ISO work instructions |
+| `project-product` | A BRD, project charter, product specification, stakeholder brief, or RFP — what a PROJECT or initiative must produce | Project scope sections; stakeholder "must-haves"; product backlog items; acceptance criteria for a deliverable |
+
+Default rule: when the source is ambiguous or you cannot determine the document type with confidence, leave `origin` out rather than guessing. The pipeline treats omitted `origin` as `legislative` (backward-compatible default per 15-requirement.md §2.1). Only emit a value when the document type is clear.
+
 ### `parent_goal` — placeholder reference on extracted GOALs
 
 When the source names a parent goal for an extracted GOAL ("this team goal supports the company-wide retention objective"), emit `parent_goal: "<GOAL-…>"` on the candidate naming the parent's ID. **This is a placeholder for downstream goal-tree placement, not a canonical field on the admitted GOAL element.** The actual goal-tree wiring uses the first-class time-aware `goal_parent` `REL-…` ([ELEMENT_PRIMITIVES §7.2](https://raw.githubusercontent.com/transitrix/methodology/main/notations/ELEMENT_PRIMITIVES.md), [17-relations.md §3](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/17-relations.md)) and is admitted by a separate DSM step that reads these placeholders; this prompt does not emit `goal_parent` REL candidates.
@@ -60,6 +73,7 @@ Motivation-layer relations you may propose (only above a high bar): `stakeholdin
 - **Two axes, never merged.** `extraction_confidence` = did you read the document correctly (`high` only when the source is explicit; `medium`/`low` when inferred). Never output `source_quality`.
 - **Entity-strong, relation-conservative.** Extract elements readily. Mark a relation `high` only when the source states it outright; otherwise `medium`/`low` (the pipeline holds non-high relations back as suggestions).
 - **Canonical IDs.** `<TYPE>-[<middle>-]<INTEGER>`, uppercase TYPE, terminal positive integer, no leading zeros ([IDS §1](https://raw.githubusercontent.com/transitrix/methodology/main/notations/IDS_AND_REFERENCES.md)). Relations reference element IDs.
+- **REQUIREMENT `origin`.** Emit `origin` on every REQUIREMENT using the three-value closed vocabulary (`legislative | process-product | project-product`) per the table above. Only omit when the document type is genuinely unclear. Never emit `origin` on non-REQUIREMENT elements.
 - **Dates.** When the source dates an obligation/goal, set `valid_from`; otherwise omit it (the human sets it at admission).
 
 ## Anti-goals

--- a/transitrix/skills/ingest/schemas/candidate.schema.json
+++ b/transitrix/skills/ingest/schemas/candidate.schema.json
@@ -68,6 +68,11 @@
         },
         "valid_from": { "type": ["string", "null"], "description": "Lifecycle anchor (CONTRACT.md §7). `pending` or a date when known." },
         "valid_to": { "type": ["string", "null"] },
+        "origin": {
+          "type": "string",
+          "description": "REQUIREMENT elements only — origin taxonomy (15-requirement.md §2.1). Closed vocabulary enforced by REQ-004.",
+          "enum": ["legislative", "process-product", "project-product"]
+        },
         "entity_match": {
           "type": "object",
           "description": "Present when the candidate's name matches an existing canon element's name or alias (F8 cross-source entity resolution). Propose, never auto-merge — the human gate decides whether this candidate is a duplicate of the existing element or genuinely new.",

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -35,6 +35,9 @@ Deterministic, no-API-key guard. Nine parts:
      candidates get no proposal; review-queue surfaces entity_match_proposals.
   P. #434 preset version currency — repo-check reports a version match (no false-negative)
      for a repo correctly pinned to the CLI's built-in preset version (0.7.0).
+  Q. origin pass-through + REQ-004 — emit-candidates carries origin through for all three
+     valid values (legislative/process-product/project-product); validate enforces REQ-004
+     (closed vocabulary) on the candidate origin field.
 
 This is the PR-CI guard. The LLM-driven walk-through lives in drive_ingest_e2e.py,
 gated to the weekly cron. See tests/README.md.
@@ -1178,6 +1181,87 @@ def part_p_preset_version_currency():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part Q — origin pass-through + REQ-004 validation (task #439) ─
+
+def part_q_origin_classification():
+    """emit-candidates carries origin through for REQUIREMENT elements; validate enforces
+    REQ-004 (closed vocabulary) on the origin field; all three valid values pass clean."""
+    if not shutil.which("node"):
+        print("SKIP Part Q: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-origin-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.7.0"\ncoverage_profile: full\n')
+
+        fdir = os.path.join(org, "field", "interviews")
+        os.makedirs(fdir, exist_ok=True)
+        fid = "INTERVIEW-q-20260703-1"
+        with open(os.path.join(fdir, fid + ".yaml"), "w", encoding="utf-8") as fh:
+            fh.write('id: "%s"\nname: "x"\ntype: "INTERVIEW"\nzone: "field"\nnotes: "x"\n' % fid)
+
+        res = os.path.join(work, "res.json")
+        # Three requirements — one per valid origin value; no invalid origin yet.
+        with open(res, "w", encoding="utf-8") as fh:
+            json.dump({"elements": [
+                {"id": "REQUIREMENT-LEG-1", "name": "Annual regulatory report",
+                 "element_type": "REQUIREMENT", "extraction_confidence": "high",
+                 "origin": "legislative"},
+                {"id": "REQUIREMENT-PROC-1", "name": "SOP output specification",
+                 "element_type": "REQUIREMENT", "extraction_confidence": "high",
+                 "origin": "process-product"},
+                {"id": "REQUIREMENT-PROJ-1", "name": "Deliverable acceptance criteria",
+                 "element_type": "REQUIREMENT", "extraction_confidence": "high",
+                 "origin": "project-product"},
+                # Non-REQUIREMENT element — must NOT carry origin.
+                {"id": "GOAL-COMPLIANCE-1", "name": "Compliance goal",
+                 "element_type": "GOAL", "extraction_confidence": "high"},
+            ], "relations": [], "assertions": []}, fh)
+
+        cdir = os.path.join(org, "_intake", "processing", "candidates")
+        r = run_cli("emit-candidates", os.path.join(fdir, fid + ".yaml"), "--from", res, "--candidates-dir", cdir)
+        check(r.returncode == 0, "Q: emit-candidates failed: %s" % r.stderr.strip())
+
+        # origin carried through for each valid value.
+        for cid, expected_origin in [
+            ("REQUIREMENT-LEG-1", "legislative"),
+            ("REQUIREMENT-PROC-1", "process-product"),
+            ("REQUIREMENT-PROJ-1", "project-product"),
+        ]:
+            path = os.path.join(cdir, cid + ".json")
+            if check(os.path.isfile(path), "Q: candidate not emitted: %s" % cid):
+                c = json.load(open(path, encoding="utf-8"))
+                check(c.get("origin") == expected_origin,
+                      "Q: origin not carried through for %s (got %r)" % (cid, c.get("origin")))
+
+        # GOAL candidate must NOT carry origin.
+        goal_path = os.path.join(cdir, "GOAL-COMPLIANCE-1.json")
+        if check(os.path.isfile(goal_path), "Q: GOAL candidate not emitted"):
+            gc = json.load(open(goal_path, encoding="utf-8"))
+            check("origin" not in gc, "Q: non-REQUIREMENT candidate must not carry origin")
+
+        # All three valid-origin REQUIREMENTs pass validate clean.
+        r = run_cli("validate", cdir)
+        check(r.returncode == 0,
+              "Q: valid-origin candidates were flagged by validate: %s" % (r.stdout + r.stderr))
+
+        # REQ-004: an invalid origin value is flagged.
+        with open(os.path.join(cdir, "REQ-BADORIGIN.json"), "w", encoding="utf-8") as fh:
+            json.dump({"kind": "element", "id": "REQUIREMENT-BAD-1", "name": "Bad origin",
+                       "element_type": "REQUIREMENT", "origin": "contractual",
+                       "derived_from": [fid], "admitted_to": "pending",
+                       "extraction_confidence": "high"}, fh)
+        r = run_cli("validate", cdir)
+        out = r.stdout + r.stderr
+        check(r.returncode == 1 and "REQ-004" in out,
+              "Q: validate did not flag REQ-004 for an invalid origin value (got: %r)" % out)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
@@ -1194,6 +1278,7 @@ part_m_id_grammar()
 part_n_entity_resolution()
 part_o_unresolved_extensions()
 part_p_preset_version_currency()
+part_q_origin_classification()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## Summary

- **emit-candidates**: passes `origin` through from the extraction result to candidate JSON for REQUIREMENT elements (same pass-through pattern as `valid_from`/`valid_to`)
- **validate**: enforces REQ-004 (closed-vocabulary check: `legislative|process-product|project-product`) on the candidate `origin` field; adds `origin` to `DEFINED_FIELDS` so EXT-002 fires if it is misplaced in the `extensions` bag
- **01_motivation.md prompt**: adds `origin` to the output schema, a source-document classification table (regulation→`legislative`, SOP→`process-product`, BRD/charter→`project-product`), and a dedicated rule directing the extraction agent to classify based on document type
- **candidate.schema.json**: documents `origin` as an optional element-level field with the closed enum
- **test_ingest_integrity.py (Part Q)**: regression test covers pass-through of all three valid values and REQ-004 flag on an invalid value

## Test plan

- [ ] `python transitrix/skills/ingest/tests/test_ingest_integrity.py` — all parts pass (verified locally: PASS)
- [ ] `node scripts/check-notations.mjs` — notation doc-lint clean (verified locally: clean)
- [ ] Confirm Part Q appears in CI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)