### PR TITLE
feat(requirement): next_review_at field + check-stale CLI

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -296,6 +296,7 @@ The compliance domain spans two notations — **`REQUIREMENT`** (motivation-laye
 | `REQ-002` | error | REQUIREMENT | `derived_from` references an ID that does not resolve | [15-requirement.md](elements/15-requirement.md) §4 |
 | `REQ-003` | error | REQUIREMENT | `derived_from` ID is not of TYPE `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD` | [15-requirement.md](elements/15-requirement.md) §4 |
 | `REQ-COVERAGE-001` | warning | REQUIREMENT (cross-cutting) | REQUIREMENT has no ASSERTION targeting it — compliance gap | [15-requirement.md](elements/15-requirement.md) §4 |
+| `REQ-STALE-001` | warning | REQUIREMENT / CONSTRAINT | `next_review_at` is set and is in the past — obligation due for re-review; applies symmetrically to CONSTRAINT ([ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §7.13) | [15-requirement.md](elements/15-requirement.md) §4 |
 | `ASSERT-001` | error | ASSERTION | a required field is missing, or `id` grammar invalid | [16-assertion.md](elements/16-assertion.md) §5 |
 | `ASSERT-002` | error | ASSERTION | `about` is missing, malformed, or resolves to a non-REQUIREMENT | [16-assertion.md](elements/16-assertion.md) §5 |
 | `ASSERT-003` | error | ASSERTION | `subject` does not resolve, or TYPE not in `{PRODUCT, PROCESS, CAPABILITY}` | [16-assertion.md](elements/16-assertion.md) §5 |

--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -565,6 +565,8 @@ Already shipped (worked example `RULE-DUAL-APPROVAL-1`).
 
 Already shipped (worked example `CONSTRAINT-GDPR-RESIDENCY-1`). Same field set as `RULE` (§7.12) — `statement`, `applies_to`, `source`, `owner_role`, `severity`, `rationale` — distinguished from `RULE` by layer (motivation vs business) and from `REQUIREMENT` by the form of the obligation ([elements/15-requirement.md](elements/15-requirement.md) §1: CONSTRAINT = restriction, REQUIREMENT = positive obligation).
 
+**Review-due signal.** CONSTRAINT MAY carry the same optional `next_review_at` field defined for REQUIREMENT in [elements/15-requirement.md](elements/15-requirement.md) §2.3 (quoted ISO 8601 date; the review-checkpoint convention for obligations whose motivating source is not a monitorable codex artefact). `REQ-STALE-001` ([elements/15-requirement.md](elements/15-requirement.md) §4) applies symmetrically to CONSTRAINT: when `next_review_at` is set and is in the past relative to today, the constraint is stale and due for re-review. The `check-stale` command in `@transitrix/ingest-cli` walks both `01_motivation/requirements/` and `01_motivation/constraints/`.
+
 ### 7.14 `EQUIPMENT` — `04_technology/equipment/`
 
 Physical instrument, device, or facility a process stage depends on (ArchiMate Physical element). Promoted from Process Blueprint view-defined to first-class standalone in the `04_technology` layer (ADR 2026-06-08; first catalogued TYPE for this layer).

--- a/notations/elements/15-requirement.md
+++ b/notations/elements/15-requirement.md
@@ -1,6 +1,6 @@
 ---
 title: "Requirement — motivation-layer positive obligation"
-version: "0.3"
+version: "0.4"
 author: "Valerii Korobeinikov"
 last_updated: "2026-07-03"
 status: "draft"
@@ -85,6 +85,7 @@ description: "On request from a data subject, the controller must erase personal
 # Optional attributes
 origin: legislative             # legislative | process-product | project-product — see §2.1
 severity: high                  # high | medium | low — organisation-defined priority
+next_review_at: "2027-06-01"    # optional; drives REQ-STALE-001 — see §2.3
 derived_from:                   # typed IDs of source documents this requirement is drawn from
   - LAW-PERSONAL-DATA-2017-1
   - REGULATION-GDPR-2016-1
@@ -111,6 +112,7 @@ valid_to: null
 | `description` | yes | string | Longer-form explanation of the obligation, its scope, and the conditions under which it applies. |
 | `origin` | no | string | Origin / kind distinguishing the context from which the requirement was derived. Closed vocabulary — see §2.1. Omitted requirements are treated as `legislative` by tooling that supports filtering. |
 | `severity` | no | string | One of `high`, `medium`, `low`. Organisation-defined priority for planning and reporting. Distinct from `obligation_level` (regulatory force, RFC 2119 — out of scope for v1; see [§5](#5-evolution)). |
+| `next_review_at` | no | string | Date by which the requirement should be re-reviewed — quoted ISO 8601. Drives the `REQ-STALE-001` staleness warning. Origin-agnostic (§2.3). |
 | `derived_from` | no | list | Typed IDs of the codex artefacts this requirement is drawn from. Permitted TYPEs: `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD`. Empty or absent for internal-only requirements with no codex source. |
 | `zone` | yes | string | Always `canon` for REQUIREMENT — see [CONTRACT.md](../CONTRACT.md) §6. |
 | `admitted_at` | yes | string | Date admitted to canon — quoted ISO 8601 per [CONTRACT.md](../CONTRACT.md) §4. |
@@ -184,6 +186,23 @@ Both paths converge at the same human decision: nothing enters admitted canon wi
 
 ---
 
+### 2.3 `next_review_at` — review-due signal for non-codex origins
+
+A `legislative`-origin REQUIREMENT can be kept current by re-scanning its `derived_from` codex source: when the underlying law or regulation is amended, downstream mechanisms (codex change-monitoring, [`AMENDMENT`](22-amendment.md)) surface a `CHANGE`/Gap against the affected REQUIREMENT. A `process-product` or `project-product` REQUIREMENT has no equivalent — its motivating source (an SOP, a BRD, a stakeholder brief) is a field artefact, not a monitorable codex document, so there is nothing for a scanner to re-scan.
+
+**`next_review_at`** closes that gap with a lightweight authoring convention: the author records the date on which the requirement is next due for human review, and tooling surfaces requirements whose review date has arrived.
+
+- **Semantics.** `next_review_at` is the date by which the author expects the requirement to be re-examined against its motivating source — checked for continued applicability, updated wording, or retirement. It is **not** `valid_to` (which retires the obligation) and **not** `assessed_at` (which records when an ASSERTION's status was last determined).
+- **Origin-agnostic.** The field is available on any REQUIREMENT regardless of `origin`; the taxonomy in §2.1 does not restrict its use. In practice the field is primarily useful for `process-product` and `project-product` origins (no codex to scan). `legislative`-origin requirements typically rely on codex change-monitoring instead — but MAY carry `next_review_at` where codex monitoring is not (yet) in place, or where a periodic Legal / DPO re-review is required regardless of amendments.
+- **Optional.** Absent or `null`, the requirement is not evaluated for staleness. Existing admitted requirements without the field are unaffected.
+- **Authoring guidance.** For `process-product` requirements, align with the SOP's revision cadence (annual, biennial). For `project-product`, use the project close-out or a stakeholder sign-off milestone. Backfilling the field on legacy requirements is optional; new admissions of non-codex origins SHOULD set it.
+- **Stale = today ≥ `next_review_at`.** A requirement is **stale** when today's date is greater than or equal to its `next_review_at`. Stale requirements are surfaced by `REQ-STALE-001` (§4) and by the `check-stale` CLI command (§5). Being stale is a signal, not an error: the author is asked to review, not to change anything by default.
+- **Relation to codex change-monitoring (#153).** These are **two independent mechanisms**, deliberately separate. Codex change-monitoring re-scans a `derived_from` source and stays `legislative`-only; `next_review_at` is a review-checkpoint convention that stays origin-agnostic. A `legislative` REQUIREMENT covered by codex monitoring does not need `next_review_at`; a `process-product` REQUIREMENT (with no codex source) uses `next_review_at` as its only staleness signal.
+
+The same convention applies symmetrically to **CONSTRAINT** ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §7.13): authors MAY set `next_review_at` on a CONSTRAINT and the `check-stale` command surfaces overdue CONSTRAINTs alongside overdue REQUIREMENTs.
+
+---
+
 ## 3. File location and naming
 
 ```
@@ -208,12 +227,16 @@ The folder sits alongside `canon/elements/01_motivation/constraints/` — the tw
 | `REQ-003` | error | A value in `derived_from` resolves to an artefact whose TYPE is not one of `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD`. Requirements derive only from codex source documents. |
 | `REQ-004` | error | `origin` is present but its value is not one of `legislative \| process-product \| project-product`. |
 | `REQ-COVERAGE-001` | warning | A REQUIREMENT has no ASSERTION targeting it — no file under `canon/assertions/` carries `about: <this REQ id>`. Surfaces a compliance gap: the obligation exists in the model but the organisation makes no recorded claim about whether any subject satisfies it. The rule is `warning` rather than `error` because a newly admitted REQUIREMENT legitimately has no assertion yet. Cross-cutting — fires on the REQUIREMENT but is computed by scanning the assertions catalogue. |
+| `REQ-STALE-001` | warning | `next_review_at` is set and is in the past relative to today (§2.3). The requirement is due for re-review. Time-dependent — the same file may pass on one day and fire on the next; surfaced by the `check-stale` CLI command (§5) so evaluation is explicit rather than embedded in every validate pass. Applies symmetrically to CONSTRAINT ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §7.13). Malformed / unparseable `next_review_at` values silently skip evaluation (the CLI flags them in a separate line rather than firing a false stale). Mirrors `ASSERT-008` ([16-assertion.md](16-assertion.md) §5). |
 
 The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](../CONTRACT.md) §7.3) and header (`HDR-001..004`, [CONTRACT.md](../CONTRACT.md) §2) rules apply to REQUIREMENT files in addition to the REQ-* rules above. The aggregated compliance-domain rules table (covering both REQUIREMENT and ASSERTION) lives in [CONTRACT.md](../CONTRACT.md) §8.
 
 ---
 
 ## 5. Evolution
+
+**Landed (v0.4, 2026-07-03):**
+- §2.3 + §4 — `next_review_at` review-checkpoint field (optional ISO 8601 date, origin-agnostic) and `REQ-STALE-001` warning. Closes the "Maintain" gap for `process-product` / `project-product` origins that have no monitorable codex source — codex change-monitoring (#153 track) stays `legislative`-only by design; `next_review_at` is a lightweight orthogonal mechanism. Surfaced by the `check-stale` CLI command in `@transitrix/ingest-cli` (walks `canon/elements/01_motivation/requirements/` and `.../constraints/`, reports overdue by ID). The same convention applies symmetrically to CONSTRAINT via [`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §7.13.
 
 **Landed (v0.3, 2026-07-03):**
 - §2.2 — documented the two admission entry points (ingest-skill `pending` path and codex-collector `proposed` path) and confirmed that `emit-candidates` is origin-agnostic: `process-product` and `project-product` requirements pass through the same pipeline steps as `legislative` ones. The codex-collector `proposed` path is deliberately `legislative`-only (codex artefacts are structured and near-final; field material is not).

--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -30,6 +30,7 @@ import { emitCandidates } from './src/emit-candidates.mjs';
 import { emitCodexArtefact } from './src/codex-artefact.mjs';
 import { resolvePlacement, checkCanonPlacement } from './src/placement.mjs';
 import { repoCheck } from './src/repo-check.mjs';
+import { checkStale } from './src/check-stale.mjs';
 import { dump } from './src/yaml.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -79,6 +80,7 @@ function usage() {
     '  suggest-profile <candidates-dir>  Propose a coverage-profile delta for out-of-profile TYPEs (read-only; prints to stdout)',
     '  repo-check [org-root]          Data-free health report (version, profile, zone/TYPE counts, integrity flags); read-only',
     '  check-placement [org-root]     Flag admitted elements sitting outside their ELEMENT_PRIMITIVES §4 folder',
+    '  check-stale [org-root]         List REQUIREMENT/CONSTRAINT elements whose next_review_at has passed (REQ-STALE-001)',
     '  resolve-placement <TYPE>       Print a TYPE\'s §4 materialisation mode + layer + folder',
     '  --version, -v                  Print the CLI version',
     '  --help, -h                     Show this help',
@@ -344,6 +346,31 @@ async function cmdResolvePlacement(args) {
   return 0;
 }
 
+// List REQUIREMENT / CONSTRAINT files whose next_review_at is in the past
+// (REQ-STALE-001; 15-requirement.md §2.3, §4). Read-only over canon/.
+async function cmdCheckStale(args) {
+  const { _ } = parseArgs(args);
+  const orgRoot = _[0]
+    ? (await findOrgRoot(resolve(_[0])) || resolve(_[0]))
+    : (await findOrgRoot(process.cwd()));
+  if (!orgRoot) { console.error('check-stale: not inside a Transitrix workspace (no _intake/ found); pass <org-root>.'); return 2; }
+
+  const { scanned, stale, malformed, today } = await checkStale(orgRoot);
+  if (stale.length === 0 && malformed.length === 0) {
+    console.log(`check-stale  ${scanned} REQUIREMENT/CONSTRAINT file(s) scanned as of ${today} — none stale (REQ-STALE-001).`);
+    return 0;
+  }
+  if (stale.length > 0) {
+    console.error(`check-stale  ${stale.length} of ${scanned} REQUIREMENT/CONSTRAINT element(s) stale as of ${today} (REQ-STALE-001):`);
+    for (const s of stale) console.error(`  STALE  ${s.id}  next_review_at: ${s.next_review_at}`);
+  }
+  if (malformed.length > 0) {
+    console.error(`check-stale  ${malformed.length} file(s) with an unparseable next_review_at (skipped — evaluation elided per 15-requirement.md §4):`);
+    for (const m of malformed) console.error(`  UNPARSED  ${m.id}  next_review_at: ${JSON.stringify(m.next_review_at)}`);
+  }
+  return stale.length > 0 ? 1 : 0;
+}
+
 // Flag admitted elements sitting outside their §4 folder (read-only over canon/).
 async function cmdCheckPlacement(args) {
   const { _ } = parseArgs(args);
@@ -380,6 +407,7 @@ async function main(argv) {
     case 'suggest-profile': return cmdSuggestProfile(args);
     case 'repo-check':      return cmdRepoCheck(args);
     case 'check-placement': return cmdCheckPlacement(args);
+    case 'check-stale':     return cmdCheckStale(args);
     case 'resolve-placement': return cmdResolvePlacement(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);

--- a/packages/ingest-cli/src/check-stale.mjs
+++ b/packages/ingest-cli/src/check-stale.mjs
@@ -1,0 +1,80 @@
+// `check-stale` — read-only report of REQUIREMENT / CONSTRAINT elements whose
+// `next_review_at` is set and has passed. Mirrors the check-placement idiom:
+// walks canon/ (never writes it), reports by ID + review date so the author can
+// act. Not data-free (it names IDs) — the caller is the author, not an external
+// audience.
+//
+// Sources of truth:
+//   - notations/elements/15-requirement.md §2.3, §4 (REQ-STALE-001)
+//   - notations/ELEMENT_PRIMITIVES.md §7.13 (CONSTRAINT peers)
+//
+// The staleness rule is intentionally lightweight and orthogonal to codex
+// change-monitoring (which stays legislative-only): today ≥ next_review_at
+// means the obligation is due for human review, regardless of `origin`.
+
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { readTopScalar } from './yaml.mjs';
+
+// ISO 8601 date (YYYY-MM-DD, no timestamp — CONTRACT.md §7.5 "sub-day precision"
+// is out of scope for canon dates). A value that does not match this shape is
+// treated as unparseable (surfaced separately from the stale list, per §4).
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+// The two motivation-obligation folders §7.13 / §2.2 park artefacts under.
+// Suffix-matched so a canon-root prefix change (open item, ELEMENT_PRIMITIVES §4)
+// does not need this file updated in lockstep.
+const OBLIGATION_FOLDERS = [
+  '01_motivation/requirements',
+  '01_motivation/constraints',
+];
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+async function walkYaml(dir) {
+  const out = [];
+  let entries;
+  try { entries = await readdir(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...await walkYaml(p));
+    else if (e.isFile() && e.name.endsWith('.yaml')) out.push(p);
+  }
+  return out;
+}
+
+// Today as an ISO 8601 date string (YYYY-MM-DD). Injectable via `today` for
+// deterministic callers.
+function isoToday() { return new Date().toISOString().slice(0, 10); }
+
+// Scan canon/ for obligation files carrying `next_review_at`. Returns
+// { scanned, stale: [{ id, file, next_review_at }], malformed: [{ id, file, next_review_at }] }.
+// A file with no `next_review_at` is scanned but contributes to neither list.
+// `today` defaults to the current UTC date; pass a string to override in tests.
+export async function checkStale(orgRoot, today = isoToday()) {
+  const canonDir = join(resolve(orgRoot), 'canon');
+  const stale = [];
+  const malformed = [];
+  let scanned = 0;
+  if (!(await exists(canonDir))) return { scanned, stale, malformed, today };
+
+  for (const folder of OBLIGATION_FOLDERS) {
+    const dir = join(canonDir, 'elements', folder);
+    if (!(await exists(dir))) continue;
+    for (const file of await walkYaml(dir)) {
+      scanned++;
+      let text;
+      try { text = await readFile(file, 'utf8'); } catch { continue; }
+      const nra = readTopScalar(text, 'next_review_at');
+      if (!nra || nra === 'null') continue;
+      const id = readTopScalar(text, 'id') || file.split(/[\\/]/).pop().replace(/\.yaml$/, '');
+      if (!ISO_DATE.test(nra)) { malformed.push({ id, file, next_review_at: nra }); continue; }
+      // Lexicographic compare is correct for YYYY-MM-DD.
+      if (nra <= today) stale.push({ id, file, next_review_at: nra });
+    }
+  }
+
+  stale.sort((a, b) => a.next_review_at.localeCompare(b.next_review_at) || a.id.localeCompare(b.id));
+  malformed.sort((a, b) => a.id.localeCompare(b.id));
+  return { scanned, stale, malformed, today };
+}


### PR DESCRIPTION
## Summary

Adds an origin-agnostic review-checkpoint field for motivation-layer obligations, closing the "Maintain" gap for `REQUIREMENT`/`CONSTRAINT` elements whose motivating source is not a monitorable codex artefact (process-product SOPs, project-product BRDs, and similar field-artefact-sourced obligations). Codex change-monitoring stays legislative-only by design; this mechanism is orthogonal.

- **Spec** — `notations/elements/15-requirement.md`:
  - §2.3 defines the semantics of "stale" for non-codex origins, adds optional `next_review_at` (ISO 8601 date) with authoring guidance, and separates it cleanly from `valid_to` (retires the obligation) and `assessed_at` (an ASSERTION's status timestamp).
  - §4 adds `REQ-STALE-001` (warning) — mirrors `ASSERT-008` for ASSERTION. Malformed dates are reported separately rather than firing false stales.
  - §5 (Evolution) records the v0.4 addition.
- **CONSTRAINT peers** — `notations/ELEMENT_PRIMITIVES.md` §7.13 notes the same convention applies to CONSTRAINT symmetrically.
- **Rule index** — `notations/CONTRACT.md` §8 gains a `REQ-STALE-001` row.
- **CLI** — `@transitrix/ingest-cli` gains `check-stale [org-root]`, mirroring the `check-placement` read-only idiom: walks `canon/elements/01_motivation/{requirements,constraints}/`, names overdue IDs by `next_review_at`, exit 1 when any are stale. Malformed / unparseable dates are surfaced in a separate section.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean.
- [x] `transitrix-ingest --help` lists the new command.
- [x] `transitrix-ingest check-stale organizations/acme_corp` — 8 files scanned, 0 stale (no `next_review_at` in worked example yet).
- [x] Fixture run against a temp org root with 5 files (stale REQ, fresh REQ, no-field REQ, stale CONSTRAINT, malformed CONSTRAINT) — 2 stale (sorted by review date), 1 malformed, other paths ignored as intended.
- [ ] Optional adopter-side follow-up: worked-example REQUIREMENT / CONSTRAINT with `next_review_at` under `organizations/acme_corp/` (deliberately out of scope here — same-shape addition on the demo repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)