### PR TITLE
feat(ingest): privacy pre-admission gate spec — Step 2b

### DIFF
--- a/transitrix/skills/ingest/README.md
+++ b/transitrix/skills/ingest/README.md
@@ -19,8 +19,8 @@ This directory is the **`ingest` skill** within the `transitrix` plugin (the plu
 
 ## What it ships
 
-- [`SKILL.md`](SKILL.md) — the agent-facing, agent-neutral protocol: a six-step pipeline (`scaffold-intake → convert → admit-source → emit-candidates → validate → review-queue`) plus the hard constraints.
-- [`schemas/`](schemas/) — JSON Schemas for the three artefacts the pipeline produces: a `field` artefact, a canon candidate, and the review queue.
+- [`SKILL.md`](SKILL.md) — the agent-facing, agent-neutral protocol: a seven-step pipeline (`scaffold-intake → convert → privacy-scan → admit-source → emit-candidates → validate → review-queue`) plus the hard constraints.
+- [`schemas/`](schemas/) — JSON Schemas for the artefacts the pipeline produces: a `field` artefact ([`field-artefact.schema.json`](schemas/field-artefact.schema.json)), a canon candidate ([`candidate.schema.json`](schemas/candidate.schema.json)), the review queue ([`review-queue.schema.json`](schemas/review-queue.schema.json)), and the privacy gate report ([`privacy-report.schema.json`](schemas/privacy-report.schema.json)).
 - [`templates/_intake.README.md`](templates/_intake.README.md) — the documentation the CLI drops into an adopter's `_intake/` folder describing the `inbox → processing → processed` flow.
 
 ---
@@ -70,6 +70,7 @@ In v0 this convention is **skill-local** — documented here and in [`templates/
 | **CLI** ✓ landed | `@transitrix/ingest-cli` — the deterministic subcommands (`scaffold-intake`, `convert`, `admit-source`/`field-artefact`/`codex-artefact`, `emit-candidates`, `validate`, `review-queue`) + the forked extraction prompts in `prompts/`. |
 | **Tests + CI** ✓ landed | A no-API-key integrity test (bundle + dry CLI run on a fixture) and a weekly LLM-drive, plus a workflow — mirroring the onboarding skill's test harness. |
 | **Zero information loss** ✓ landed | `extensions:` carry-through + `canon/unresolved/` emission (CONTRACT §12/§13). `emit-candidates` carries `extensions:` onto candidates and parks untyped objects in `canon/unresolved/`; `validate` enforces `EXT-002`; `repo-check` reports the holding count; typed canon walkers skip the holding area (`UNRES-004`). Covered by Part O of the integrity test. |
+| **Privacy gate spec** ✓ landed | Step 2b `privacy-scan`: rule-based fail-closed pre-admission gate with six PII/medical detection categories, a narrow business-contact allowlist, `CLEAN`/`STRIPPED`/`REJECTED`/`ERROR` outcomes, and a per-run `privacy-report.yaml`. CLI implementation (`@transitrix/ingest-cli privacy-scan`) is the downstream delivery. |
 
 ---
 
@@ -80,3 +81,4 @@ In v0 this convention is **skill-local** — documented here and in [`templates/
 - It does **not** fold `extraction_confidence` into `source_quality`, or persist either extraction-confidence value into canon.
 - It does **not** emit TYPEs or REL kinds outside the adopter's coverage profile — out-of-profile material is flagged for review, never silently emitted or dropped.
 - It does **not** auto-admit or move data between zones. `derived_from` is a citation, not a migration.
+- It does **not** bypass the privacy gate. No document reaches `admit-source` unless `privacy-scan` exits `CLEAN` or `STRIPPED`. Disabling the gate requires an explicit adopter decision in `transitrix.yaml`.

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -74,6 +74,84 @@ Markitdown is a Python tool (`pip install "markitdown[all]"`); install it into t
 
 ---
 
+## Step 2b — Privacy pre-admission scan
+
+Before a converted document can be admitted as a field artefact (Step 3), it passes through the **privacy pre-admission gate** — a fail-closed check that detects and blocks personal and medical data by default.
+
+```
+transitrix-ingest privacy-scan <processing/file.md>
+```
+
+**Fail-closed.** The gate must exit with outcome `CLEAN` or `STRIPPED` before `admit-source` is called. A `REJECTED` or `ERROR` outcome halts the pipeline — do not call `admit-source` on a document that has not cleared the gate.
+
+### Detection — Phase 1 (rule-based, deterministic)
+
+The gate applies deterministic pattern + dictionary matching across a closed set of detection categories. Every blocked fragment is tagged with a reason code:
+
+| Code | Category | Examples |
+|---|---|---|
+| `PII-001` | National identifier | SSN, NI number, national-ID-shaped tokens |
+| `PII-002` | Date of birth | DOB phrases combined with date-shaped tokens in a personal context |
+| `PII-003` | Medical / health terms | Diagnosis codes, medication names, clinical and diagnostic vocabulary |
+| `PII-004` | Contact PII beyond allowlist | Personal email, personal phone (non-work) |
+| `PII-005` | Financial personal | Credit / debit card numbers, personal bank account numbers |
+| `PII-006` | Biometric / government identifier | Passport numbers, biometric descriptors |
+
+Reason codes are emitted in the **privacy report** (see below). A scan that fires any code (and the fragment is not cleared by the allowlist) produces a `STRIPPED` or `REJECTED` outcome; a scan that fires none produces `CLEAN`.
+
+### Allowlist — always admitted
+
+A narrow, explicit list of business-contact fields on `ACTOR` / `ORG` element records is never blocked. The default allowlist:
+
+| Field | Permitted on |
+|---|---|
+| `first_name` | `ACTOR`, `ORG` |
+| `last_name` | `ACTOR`, `ORG` |
+| `work_phone` | `ACTOR`, `ORG` |
+| `work_email` | `ACTOR`, `ORG` |
+
+The allowlist is **never inferred from context** — it is extended only by deliberate edit in the config.
+
+### Outcomes
+
+| Outcome | Meaning | Next step |
+|---|---|---|
+| `CLEAN` | No blocked content found | Proceed to `admit-source` (Step 3) |
+| `STRIPPED` | Blocked fragments redacted; clean copy ready | Proceed to `admit-source` on the redacted copy |
+| `REJECTED` | Document blocked entirely (e.g. predominantly PII) | Do not admit; human reviews privacy report |
+| `ERROR` | Scan could not complete (config error, unreadable file) | Do not admit; fix the issue and re-scan |
+
+For `STRIPPED`: the CLI writes `<file>.redacted.md` alongside the original. `admit-source` is run on the redacted copy; `raw_source` on the resulting field artefact still points to the original retained in `_intake/processed/` — the original is never discarded. The privacy report records what was stripped.
+
+### Configuration
+
+The gate is **enabled by default** (`enabled: true`). Configure it in `transitrix.yaml` under `ingest.privacy_gate`:
+
+```yaml
+ingest:
+  privacy_gate:
+    enabled: true          # default: true — fail-closed; set false only with explicit adopter decision
+    on_detection: strip    # strip (default): redact fragments, admit clean copy
+                           # reject: block the entire document
+    allowlist:
+      - field: first_name
+        on: [ACTOR, ORG]
+      - field: last_name
+        on: [ACTOR, ORG]
+      - field: work_phone
+        on: [ACTOR, ORG]
+      - field: work_email
+        on: [ACTOR, ORG]
+```
+
+### Privacy report
+
+The CLI writes a **`privacy-report.yaml`** per ingest run, alongside the `review-queue.yaml`. Schema: [`schemas/privacy-report.schema.json`](schemas/privacy-report.schema.json).
+
+The report lists every document scanned with its outcome. For `STRIPPED` and `REJECTED` outcomes it records the blocked fragments with reason codes — truncated previews only, never verbatim PII — so a human can audit false positives and false negatives and adjust the allowlist or detection rules if needed.
+
+---
+
 ## Step 3 — Emit the field artefact (with proposed source_quality)
 
 Each converted document becomes one `field` artefact carrying a complete **admission record** — provenance (who / when / in what setting) and a **proposed** `source_quality`. The field artefact is what lives in `field/`; the original raw bytes stay in `_intake/processed/` so the artefact is traceable to its source.
@@ -233,7 +311,7 @@ The reviewer resolves each `canon/unresolved/` entry to exactly one of **promote
 
 All deterministic behaviour lives in **`@transitrix/ingest-cli`** — document conversion, coverage-profile read, validator pass, field-artefact + candidate emission, and the `_intake/` moves. This keeps the deterministic guarantees independent of which agent drives the skill (the same principle as the methodology's CI validators): neither Claude nor Copilot reimplements the logic, and both get identical results.
 
-The CLI is resolved as a **standalone package** — installed locally (it provides the `transitrix-ingest` bin) and, once published from its own tooling repo at the ~1.0 extraction, equivalently via `npx @transitrix/ingest-cli`. It is **not** vendored per skill and **not** referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`, `suggest-profile`, `check-placement`, `resolve-placement`.
+The CLI is resolved as a **standalone package** — installed locally (it provides the `transitrix-ingest` bin) and, once published from its own tooling repo at the ~1.0 extraction, equivalently via `npx @transitrix/ingest-cli`. It is **not** vendored per skill and **not** referenced by a sibling path — a sibling-path reference would dangle when only this skill directory ships into a Copilot `.github/skills/` install. Its subcommands are the contract above: `scaffold-intake`, `convert`, `privacy-scan`, `admit-source` (`--zone field|codex`; `field-artefact` / `codex-artefact` remain as deprecated aliases for one release), `emit-candidates`, `validate`, `review-queue`, `suggest-profile`, `check-placement`, `resolve-placement`.
 
 ---
 
@@ -309,3 +387,4 @@ For a **process-product** origin, swap the source: an SOP passage like "the retu
 - It does **not** fold `extraction_confidence` into `source_quality`, or persist either extraction-confidence value into canon.
 - It does **not** emit TYPEs or REL kinds outside the adopter's coverage profile — out-of-profile material is flagged for review.
 - It does **not** auto-admit, auto-reaffirm, or move data between zones. `derived_from` is a citation, not a migration.
+- It does **not** bypass the privacy gate. No document reaches `admit-source` unless `privacy-scan` exits `CLEAN` or `STRIPPED`. The gate is fail-closed and enabled by default; disabling it requires an explicit adopter decision in `transitrix.yaml`.

--- a/transitrix/skills/ingest/schemas/privacy-report.schema.json
+++ b/transitrix/skills/ingest/schemas/privacy-report.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://transitrix.com/schemas/ingest/privacy-report.schema.json",
+  "title": "Transitrix ingest privacy report",
+  "description": "Per-run report from the privacy pre-admission gate (SKILL.md Step 2b). Lists every source document scanned in this ingest run, its gate outcome (CLEAN / STRIPPED / REJECTED / ERROR), and — for non-CLEAN outcomes — the blocked fragments with reason codes. PII content is never reproduced verbatim: fragment_preview is truncated to the first 20 characters followed by '***'. Emitted alongside review-queue.yaml.",
+  "type": "object",
+  "required": ["generated_by", "run_id", "scanned", "summary"],
+  "additionalProperties": true,
+  "properties": {
+    "generated_by": {
+      "type": "string",
+      "description": "Tool identifier and version that produced the report (e.g. 'transitrix-ingest/0.6.0')."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Unique identifier for the ingest run — ISO 8601 timestamp or a UUID. Matches the run_id in the companion review-queue.yaml."
+    },
+    "config_snapshot": {
+      "type": "object",
+      "description": "Snapshot of the active privacy_gate configuration used in this run, for audit reproducibility.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the gate was active. Always true when this report is produced — a disabled gate produces no report."
+        },
+        "on_detection": {
+          "type": "string",
+          "enum": ["strip", "reject"],
+          "description": "'strip': redact fragments and admit the clean copy. 'reject': block the entire document."
+        },
+        "allowlist": {
+          "type": "array",
+          "description": "The allowlist entries active for this run — business-contact fields that are never blocked.",
+          "items": {
+            "type": "object",
+            "required": ["field", "on"],
+            "additionalProperties": false,
+            "properties": {
+              "field": {
+                "type": "string",
+                "description": "Field name that is permitted (e.g. 'work_email')."
+              },
+              "on": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Element TYPEs on which this field is permitted (e.g. ['ACTOR', 'ORG'])."
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "scanned": {
+      "type": "array",
+      "description": "One entry per source document scanned in this ingest run. Order matches the processing sequence.",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "required": ["source_file", "outcome"],
+        "additionalProperties": true,
+        "properties": {
+          "source_file": {
+            "type": "string",
+            "description": "Path to the converted source file that was scanned (relative to the org root or _intake/processing/)."
+          },
+          "outcome": {
+            "type": "string",
+            "enum": ["CLEAN", "STRIPPED", "REJECTED", "ERROR"],
+            "description": "Gate result for this document. CLEAN: no blocked content, proceed to admit-source. STRIPPED: blocked fragments redacted; clean copy admitted. REJECTED: entire document blocked, not admitted. ERROR: scan could not complete — do not admit until resolved."
+          },
+          "redacted_file": {
+            "type": "string",
+            "description": "STRIPPED only — path to the redacted copy that was passed to admit-source. The original file is retained in _intake/processed/ for traceability."
+          },
+          "error_detail": {
+            "type": "string",
+            "description": "ERROR only — actionable description of what prevented the scan from completing (config error, unreadable file, etc.)."
+          },
+          "blocked_fragments": {
+            "type": "array",
+            "description": "Present for STRIPPED and REJECTED outcomes — one entry per detected PII/medical fragment. Absent for CLEAN and ERROR outcomes. Lets the human reviewer audit false positives and false negatives; the reviewer may adjust the allowlist or the detection rules in response.",
+            "items": {
+              "type": "object",
+              "required": ["code", "reason"],
+              "additionalProperties": false,
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "description": "Reason code identifying the detection category that fired.",
+                  "enum": [
+                    "PII-001",
+                    "PII-002",
+                    "PII-003",
+                    "PII-004",
+                    "PII-005",
+                    "PII-006"
+                  ]
+                },
+                "reason": {
+                  "type": "string",
+                  "description": "Human-readable description of what was detected and which rule fired (e.g. 'national-ID pattern matched: SSN-shaped token')."
+                },
+                "fragment_preview": {
+                  "type": "string",
+                  "description": "Truncated preview of the blocked fragment — first 20 characters followed by '***'. The full verbatim content is never reproduced in this report."
+                },
+                "allowlist_cleared": {
+                  "type": "boolean",
+                  "description": "True when a fragment matched a detection rule but was cleared by an allowlist entry. Informational — surfaced so the reviewer can audit that the allowlist is not over-broad. Only present when an allowlist entry applied."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "description": "Aggregate counts across all documents scanned in this run.",
+      "required": ["total", "clean", "stripped", "rejected"],
+      "additionalProperties": true,
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total documents scanned."
+        },
+        "clean": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Documents that passed the gate without any blocked fragments."
+        },
+        "stripped": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Documents where blocked fragments were redacted and the clean copy was admitted."
+        },
+        "rejected": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Documents blocked entirely and not admitted."
+        },
+        "error": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Documents the scan could not complete for — not admitted until the error is resolved."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New **Step 2b** in `SKILL.md`: `transitrix-ingest privacy-scan` — a fail-closed privacy pre-admission gate that runs between document conversion (Step 2) and field-artefact admission (Step 3)
- Phase 1 is rule-based and deterministic: six PII/medical detection categories (PII-001..PII-006), a narrow explicit business-contact allowlist, four outcomes (`CLEAN` / `STRIPPED` / `REJECTED` / `ERROR`)
- Stripped documents are admitted on a redacted copy; originals are always retained in `_intake/processed/` for traceability; gate is fail-closed and enabled by default
- New `schemas/privacy-report.schema.json`: per-run report listing scanned documents, outcomes, and blocked fragments with reason codes (truncated previews only — no verbatim PII)
- `README.md`: pipeline step count updated, schema list expanded, Roadmap updated, "does NOT do" list extended with the gate guarantee

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (15 view notations, no regressions)
- [x] Tail of all three changed/created files verified intact
- [x] Pre-PR grep: no internal hub references in diff
- [x] Schema is valid JSON
- [x] One concern per PR; only `transitrix/skills/ingest/` files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)