### PR TITLE
docs(tests): tidy inline comment references in skill test headers

### DIFF
--- a/.github/workflows/onboarding-skill-test.yml
+++ b/.github/workflows/onboarding-skill-test.yml
@@ -1,6 +1,6 @@
 name: Onboarding Skill install test
 
-# From-scratch install test for the Transitrix Onboarding Skill (strategy#56).
+# From-scratch install test for the Transitrix Onboarding Skill.
 # Proves a first-time user can install the Skill against a clean workspace and
 # end up with a working, canon-valid repo. Implementation + harness rationale:
 # transitrix/skills/onboard/tests/README.md.

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -1049,7 +1049,7 @@ def part_n_entity_resolution():
         shutil.rmtree(work, ignore_errors=True)
 
 
-# ── Part O — extensions carry-through + canon/unresolved/ emission (strategy#197/#198) ──
+# ── Part O — extensions carry-through + canon/unresolved/ emission ──
 
 def part_o_unresolved_extensions():
     if not shutil.which("node"):

--- a/transitrix/skills/onboard/tests/drive_skill_e2e.py
+++ b/transitrix/skills/onboard/tests/drive_skill_e2e.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""True end-to-end LLM drive of the Transitrix Onboarding Skill (strategy#56).
+"""True end-to-end LLM drive of the Transitrix Onboarding Skill.
 
 Unlike test_skill_integrity.py (deterministic, no key), this script drives the
 Skill the way a real newcomer would: it installs the bundle into an ephemeral

--- a/transitrix/skills/onboard/tests/test_skill_integrity.py
+++ b/transitrix/skills/onboard/tests/test_skill_integrity.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""From-scratch install test for the Transitrix Onboarding Skill (strategy#56).
+"""From-scratch install test for the Transitrix Onboarding Skill.
 
 Deterministic, no-API-key "Skill-correctness" guard. Proves the Skill works
 against a clean install: the bundle is intact, every template the SKILL.md

--- a/transitrix/skills/reg-intel/tests/test_reg_intel_prompts.py
+++ b/transitrix/skills/reg-intel/tests/test_reg_intel_prompts.py
@@ -4,7 +4,7 @@
 Deterministic, no-API-key, no-network. Checks the segmentation + classification
 prompts are present, their frontmatter parses, and they encode the contracts the
 SKILL.md run loop depends on — in particular the CLASSIFY default rule
-(positive obligation → REQUIREMENT) that strategy#153 / #152 require.
+(positive obligation → REQUIREMENT) that the ingest contract requires.
 
 Run:  python transitrix/skills/reg-intel/tests/test_reg_intel_prompts.py
 Exit: 0 = all pass; 1 = a check failed.


### PR DESCRIPTION
## Summary
- Simplifies a handful of doc-comment headers across skill test/workflow files that carried informal cross-references, replacing them with plain descriptive text.
- No behavioral or test-logic changes.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] `node scripts/check-adl.mjs` — clean