### PR TITLE
feat(migrations): add 0.7→1.0 migration recipe

### DIFF
--- a/migrations/0.7-to-1.0/README.md
+++ b/migrations/0.7-to-1.0/README.md
@@ -1,0 +1,247 @@
+# Migration recipe — methodology 0.7 → 1.0
+
+The on-disk migration recipe an adopter follows when upgrading from methodology
+version 0.7 to 1.0. Format per [`notations/CONTRACT.md`](../../notations/CONTRACT.md)
+§10.4 and [`RELEASING.md`](../../RELEASING.md); see also
+[`CHANGELOG.md`](../../CHANGELOG.md) (1.0.0).
+
+---
+
+## What this recipe covers
+
+1.0.0 is the first stable release. All deprecation-window aliases introduced in
+pre-1.0 releases now become **hard errors**. Adopters who stayed on the canonical
+forms throughout the pre-1.0 period have nothing to migrate. Adopters who used
+any of the deprecated forms must apply the transforms below before bumping
+`methodology_version` to `"1.0.0"`.
+
+| Transform | Old (deprecated) | Canonical (required at 1.0) |
+|---|---|---|
+| **A** | `ACTIVITY-*` IDs, `notation: activity`, `activities:` root key, `*.activities.transitrix.yaml` files | `ACTION-*`, `notation: action`, `actions:`, `*.action.transitrix.yaml` |
+| **A** | `activity-card` notation, `ACTIVITY_CARD` doc type, `*.activity-card.transitrix.yaml`, `activity_card:` | `action-card`, `ACTION_CARD`, `*.action-card.transitrix.yaml`, `action_card:` |
+| **B** | `INFORMATION_ENTITY-*` IDs, `information_entities:` field | `BUSINESS_OBJECT-*`, `business_objects:` |
+| **C** | `compliance-impact` files without `report_type` | `view.report_type: product \| process \| combined` (required) |
+| **D** | Abbreviated prefix IDs: `ACT-`, `CHG-`, `FAC-`, `FACTOR-`, `SCEN-`, `SCN-` | Canonical TYPEs: `ACTION-`, `CHANGE-`, `DRIVER-`, `DRIVER-`, `SCENARIO-`, `SCENARIO-` |
+
+**Adopters who only use elements that post-date the deprecated forms** (i.e. who
+started with 0.7.0 and only used canonical forms from the start) have nothing
+to migrate — run the validator to confirm:
+
+```bash
+node migrations/0.7-to-1.0/validate.mjs <adopter-root>   # exit 0 = clean
+```
+
+---
+
+## Transform A — Complete the ACTIVITY → ACTION rename
+
+The `ACTIVITY` primitive was renamed to `ACTION` during the 0.7 pre-release cycle
+(aligning with ArchiMate 3.2 Work Package terminology). At 1.0 the deprecated
+`ACTIVITY-` prefix ID form, `notation: activity`, `activities:` root array,
+`activity_type:` field, and `*.activities.transitrix.yaml` file extension are
+all removed.
+
+### A.1 — Element files
+
+For each element file in `canon/elements/05_implementation/actions/` that
+carries the old form:
+
+```yaml
+# Before (deprecated; ACTIVITY-NAME-001 or ACTIVITY-001 form)
+notation: action        # was: notation: activity  — correct form already landed mid-cycle
+id: ACTIVITY-LAUNCH-1   # wrong prefix
+
+# After
+notation: action
+id: ACTION-LAUNCH-1
+```
+
+File name must match the `id:` field. Rename:
+
+```bash
+mv canon/elements/05_implementation/actions/ACTIVITY-LAUNCH-1.yaml \
+   canon/elements/05_implementation/actions/ACTION-LAUNCH-1.yaml
+```
+
+### A.2 — View files (`*.action.transitrix.yaml`)
+
+In `*.action.transitrix.yaml` files:
+
+```yaml
+# Before
+notation: activities    # deprecated alias
+activities:             # deprecated root array
+  - id: ACT-001
+    activity_type: project
+
+# After
+notation: action
+actions:
+  - id: ACTION-LAUNCH-1
+    type: project
+```
+
+### A.3 — File extension (`*.activities.transitrix.yaml`)
+
+Rename to `*.action.transitrix.yaml` and update the `notation:` field inside
+the file.
+
+### A.4 — Action-card files
+
+In `*.action-card.transitrix.yaml` files:
+
+```yaml
+# Before
+notation: activity-card
+activity_card:
+  id: ACTION_CARD-EU-1
+
+# After
+notation: action-card
+action_card:
+  id: ACTION_CARD-EU-1
+```
+
+Rename `*.activity-card.transitrix.yaml` → `*.action-card.transitrix.yaml`.
+
+### A.5 — Cross-references
+
+Wherever `ACTIVITY-*` IDs appear as reference values (not in the file that
+defines the element), update them to `ACTION-*`. Key locations: `delivers_changes:`,
+`actions:`, `goal.actions:`, and any other cross-reference arrays.
+
+---
+
+## Transform B — Complete the INFORMATION_ENTITY → BUSINESS_OBJECT rename
+
+`INFORMATION_ENTITY` was renamed to `BUSINESS_OBJECT` (aligning with ArchiMate
+3.2 Business Object terminology) in the 0.5–0.6 pre-release cycle. The one-release
+alias window closes at 1.0.
+
+### B.1 — Element files
+
+Rename element files and update their fields:
+
+```yaml
+# Before
+notation: business_object    # rename: information_entity was the old value
+id: INFORMATION_ENTITY-ORDER-1
+
+# After
+notation: business_object
+id: BUSINESS_OBJECT-ORDER-1
+```
+
+File rename:
+
+```bash
+mv canon/elements/02_business/business-objects/INFORMATION_ENTITY-ORDER-1.yaml \
+   canon/elements/02_business/business-objects/BUSINESS_OBJECT-ORDER-1.yaml
+```
+
+### B.2 — Process-blueprint views
+
+```yaml
+# Before
+information_entities:
+  - id: INFORMATION_ENTITY-ORDER-1
+    name: "Customer order"
+
+# After
+business_objects:
+  - id: BUSINESS_OBJECT-ORDER-1
+    name: "Customer order"
+```
+
+---
+
+## Transform C — Add `report_type` to compliance-impact files (manual)
+
+Every `*.compliance-impact.transitrix.yaml` file must now declare
+`view.report_type`. The codemod cannot infer the intent — add it manually:
+
+```yaml
+view:
+  report_type: product        # product | process | combined
+  # ...rest of view config
+```
+
+Choose `product` if the file's `subjects.products` list (or default all-products)
+is the intended scope; `process` if `subjects.processes` are listed; `combined`
+if both subject types are present. Validation code `COMPIMP-011` fires (error)
+if the field is absent.
+
+---
+
+## Transform D — Deprecated abbreviated prefix IDs (hard errors at 1.0)
+
+Several abbreviated ID prefixes were deprecated in earlier releases. At 1.0 they
+are hard errors. Replace each wherever it appears in ID values:
+
+| Deprecated prefix | Canonical form |
+|---|---|
+| `ACT-` | `ACTION-` |
+| `CHG-` | `CHANGE-` |
+| `FAC-` | `DRIVER-` |
+| `FACTOR-` | `DRIVER-` (grace period from 0.7 closes at 1.0) |
+| `SCEN-` | `SCENARIO-` |
+| `SCN-` | `SCENARIO-` |
+
+> **`FACTOR-*` note.** The 0.6 → 0.7 migration renamed element files and IDs from
+> `FACTOR-` to `DRIVER-`. The 0.7 recipe gave a grace period for cross-reference
+> *values* (allowing `factors: [FACTOR-EU-REG-1]` without a hard error until 1.0).
+> That grace period now ends — replace all remaining `FACTOR-` values with `DRIVER-`.
+
+---
+
+## Step 1 — Run the codemod
+
+`codemod.mjs` automates Transforms A, B, and D. Transform C (report_type) is
+manual — the codemod reports compliance-impact files missing the field but does
+not add it.
+
+```bash
+# Preview
+node migrations/0.7-to-1.0/codemod.mjs <adopter-root> --dry-run
+
+# Apply
+node migrations/0.7-to-1.0/codemod.mjs <adopter-root>
+
+# Post-migration check
+node migrations/0.7-to-1.0/validate.mjs <adopter-root>
+```
+
+## Step 2 — Fix any `COMPIMP-011` warnings
+
+Add `view.report_type` manually to each compliance-impact file listed by the
+codemod output (Transform C above).
+
+## Step 3 — Bump `methodology_version`
+
+```yaml
+# transitrix.yaml
+methodology_version: "1.0.0"
+```
+
+## Step 4 — Re-run `repo-check`
+
+```bash
+transitrix-ingest repo-check [org-root]
+```
+
+A clean run shows `tooling.ok: true` with no version-mismatch flag and no
+deprecated-ID warnings.
+
+---
+
+## Folder shape
+
+```
+migrations/0.7-to-1.0/
+├── README.md
+├── codemod.mjs       # idempotent; Transforms A, B, D; reports C misses
+├── validate.mjs      # post-migration check; exits 0 on clean repo
+└── fixtures/
+    ├── before/       # minimal adopter repo in 0.7 deprecated form
+    └── after/        # the same after codemod.mjs (C applied manually)
+```

--- a/migrations/0.7-to-1.0/codemod.mjs
+++ b/migrations/0.7-to-1.0/codemod.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+// Migration codemod — methodology 0.7 → 1.0.
+//
+// Applies four transforms to an adopter repo. Run with --dry-run first.
+//
+// TRANSFORMS (automated — idempotent):
+//   A. ACTIVITY → ACTION rename
+//      - notation: activity  → notation: action      (element files)
+//      - id: ACTIVITY-…     → id: ACTION-…           (element files)
+//      - ACTIVITY-*.yaml    → ACTION-*.yaml           (file rename)
+//      - ACTIVITY-… values  → ACTION-… values         (cross-refs in any file)
+//      - activities: (root array) → actions:
+//      - activity_type:     → type:                  (in action element/view files)
+//      - notation: activity-card → notation: action-card
+//      - activity_card:     → action_card:
+//      - *.activities.transitrix.yaml → *.action.transitrix.yaml
+//      - *.activity-card.transitrix.yaml → *.action-card.transitrix.yaml
+//
+//   B. INFORMATION_ENTITY → BUSINESS_OBJECT rename
+//      - id: INFORMATION_ENTITY-… → id: BUSINESS_OBJECT-…  (element files)
+//      - INFORMATION_ENTITY-*.yaml → BUSINESS_OBJECT-*.yaml (file rename)
+//      - INFORMATION_ENTITY-… values → BUSINESS_OBJECT-… values (cross-refs)
+//      - information_entities: → business_objects:          (field key)
+//
+//   C. report_type check (NOT auto-fixed — compliance-impact files only)
+//      - Detects *.compliance-impact.transitrix.yaml files missing view.report_type
+//      - Prints a list; add report_type manually (product | process | combined)
+//
+//   D. Deprecated abbreviated prefix IDs (hard errors at 1.0)
+//      - ACT-…    → ACTION-…
+//      - CHG-…    → CHANGE-…
+//      - FAC-…    → DRIVER-…
+//      - FACTOR-… → DRIVER-… (grace period from 0.7 closes)
+//      - SCEN-…   → SCENARIO-…
+//      - SCN-…    → SCENARIO-…
+//
+// Conventions:
+//   - Pure-Node, no native deps; Node ≥ 20.
+//   - Idempotent: a repo already on canonical 1.0 form is a no-op.
+//   - CLI: [--dry-run] [target-dir]. Default target = current working dir.
+//   - Line-based transformation — preserves comments, key order, untouched lines.
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, renameSync } from 'node:fs';
+import { join, relative, resolve, basename, dirname, extname } from 'node:path';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const target = resolve(args.find(a => !a.startsWith('--')) ?? process.cwd());
+
+if (!existsSync(target)) {
+  console.error(`error: target directory does not exist: ${target}`);
+  process.exit(2);
+}
+
+// ── File discovery ────────────────────────────────────────────────────────────
+
+function walkYaml(dir, out = []) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return out; }
+  for (const ent of entries) {
+    if (ent.startsWith('.')) continue;
+    const full = join(dir, ent);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) walkYaml(full, out);
+    else if (st.isFile() && ent.endsWith('.yaml')) out.push(full);
+  }
+  return out;
+}
+
+const files = walkYaml(target);
+
+// ── Transform helpers ─────────────────────────────────────────────────────────
+
+// Replace top-level `notation:` field value (line-anchored).
+function replaceNotation(content, oldVal, newVal) {
+  const re = new RegExp(`^(notation\\s*:\\s*["']?)${escRe(oldVal)}(["']?)\\s*$`, 'mg');
+  let n = 0;
+  const result = content.replace(re, (_, pre, suf) => { n++; return `${pre}${newVal}${suf}`; });
+  return { content: result, count: n };
+}
+
+// Replace top-level `id:` field prefix (line-anchored).
+function replaceIdPrefix(content, oldPfx, newPfx) {
+  const re = new RegExp(`^(id\\s*:\\s*["']?)${escRe(oldPfx)}`, 'mg');
+  let n = 0;
+  const result = content.replace(re, (_, pre) => { n++; return `${pre}${newPfx}`; });
+  return { content: result, count: n };
+}
+
+// Replace all value-position occurrences of a TYPE prefix.
+// Requires that the prefix is NOT preceded by a capital letter or underscore
+// (i.e. it is the start of an ID token, not embedded in a longer TYPE like IMPACT-).
+function replaceTypePrefix(content, oldPfx, newPfx) {
+  if (!content.includes(oldPfx)) return { content, count: 0 };
+  const re = new RegExp(`(?<![A-Z_])${escRe(oldPfx)}(?=[A-Z0-9])`, 'g');
+  let n = 0;
+  const result = content.replace(re, () => { n++; return newPfx; });
+  return { content: result, count: n };
+}
+
+// Replace a YAML field key (line-anchored, leading whitespace preserved).
+function replaceKey(content, oldKey, newKey) {
+  const re = new RegExp(`^(\\s*)${escRe(oldKey)}(\\s*:)`, 'mg');
+  let n = 0;
+  const result = content.replace(re, (_, indent, colon) => { n++; return `${indent}${newKey}${colon}`; });
+  return { content: result, count: n };
+}
+
+function escRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ── Transform A — ACTIVITY → ACTION ──────────────────────────────────────────
+
+function transformA(content, filename) {
+  let total = 0;
+  let c = content;
+
+  // A1: notation: activity → notation: action
+  { const r = replaceNotation(c, 'activity', 'action'); c = r.content; total += r.count; }
+  // A2: id: ACTIVITY-… → id: ACTION-…
+  { const r = replaceIdPrefix(c, 'ACTIVITY-', 'ACTION-'); c = r.content; total += r.count; }
+  // A3: ACTIVITY-… cross-refs
+  { const r = replaceTypePrefix(c, 'ACTIVITY-', 'ACTION-'); c = r.content; total += r.count; }
+  // A4: activities: root key → actions:
+  { const r = replaceKey(c, 'activities', 'actions'); c = r.content; total += r.count; }
+  // A5: activity_type: → type: (only in action / element context — safe because
+  //     activity_type was defined only on the ACTIVITY/ACTION element type)
+  { const r = replaceKey(c, 'activity_type', 'type'); c = r.content; total += r.count; }
+  // A6: notation: activity-card → notation: action-card
+  { const r = replaceNotation(c, 'activity-card', 'action-card'); c = r.content; total += r.count; }
+  // A7: activity_card: → action_card:
+  { const r = replaceKey(c, 'activity_card', 'action_card'); c = r.content; total += r.count; }
+
+  return { content: c, count: total };
+}
+
+function fileRenameA(filepath) {
+  const bn = basename(filepath);
+  const dir = dirname(filepath);
+  // ACTIVITY-*.yaml → ACTION-*.yaml
+  if (bn.startsWith('ACTIVITY-')) {
+    return join(dir, bn.replace(/^ACTIVITY-/, 'ACTION-'));
+  }
+  // *.activities.transitrix.yaml → *.action.transitrix.yaml
+  if (bn.endsWith('.activities.transitrix.yaml')) {
+    return join(dir, bn.replace(/\.activities\.transitrix\.yaml$/, '.action.transitrix.yaml'));
+  }
+  // *.activity-card.transitrix.yaml → *.action-card.transitrix.yaml
+  if (bn.endsWith('.activity-card.transitrix.yaml')) {
+    return join(dir, bn.replace(/\.activity-card\.transitrix\.yaml$/, '.action-card.transitrix.yaml'));
+  }
+  return filepath;
+}
+
+// ── Transform B — INFORMATION_ENTITY → BUSINESS_OBJECT ───────────────────────
+
+function transformB(content) {
+  let total = 0;
+  let c = content;
+
+  // B1: id: INFORMATION_ENTITY-… → id: BUSINESS_OBJECT-…
+  { const r = replaceIdPrefix(c, 'INFORMATION_ENTITY-', 'BUSINESS_OBJECT-'); c = r.content; total += r.count; }
+  // B2: INFORMATION_ENTITY-… cross-refs
+  { const r = replaceTypePrefix(c, 'INFORMATION_ENTITY-', 'BUSINESS_OBJECT-'); c = r.content; total += r.count; }
+  // B3: information_entities: → business_objects:
+  { const r = replaceKey(c, 'information_entities', 'business_objects'); c = r.content; total += r.count; }
+
+  return { content: c, count: total };
+}
+
+function fileRenameB(filepath) {
+  const bn = basename(filepath);
+  const dir = dirname(filepath);
+  if (bn.startsWith('INFORMATION_ENTITY-')) {
+    return join(dir, bn.replace(/^INFORMATION_ENTITY-/, 'BUSINESS_OBJECT-'));
+  }
+  return filepath;
+}
+
+// ── Transform D — Deprecated abbreviated prefix IDs ───────────────────────────
+
+function transformD(content) {
+  let total = 0;
+  let c = content;
+
+  // Order matters: longer/more-specific prefixes first to avoid double-hit.
+  // FACTOR- before FAC- (FAC- ⊂ FACTOR- by prefix but FACTOR has no sub-risk).
+  const subs = [
+    ['ACTIVITY-', 'ACTION-'],    // covered by A; included here for safety
+    ['INFORMATION_ENTITY-', 'BUSINESS_OBJECT-'],  // covered by B; included for safety
+    ['FACTOR-', 'DRIVER-'],
+    ['ACT-', 'ACTION-'],
+    ['CHG-', 'CHANGE-'],
+    ['FAC-', 'DRIVER-'],
+    ['SCEN-', 'SCENARIO-'],
+    ['SCN-', 'SCENARIO-'],
+  ];
+
+  for (const [old, neo] of subs) {
+    const r = replaceTypePrefix(c, old, neo);
+    c = r.content;
+    total += r.count;
+  }
+
+  return { content: c, count: total };
+}
+
+// ── Transform C — compliance-impact report_type check ────────────────────────
+
+const ciMissing = [];
+
+function checkC(filepath, content) {
+  const bn = basename(filepath);
+  if (!bn.endsWith('.compliance-impact.transitrix.yaml')) return;
+  if (!/^\s*report_type\s*:/m.test(content)) {
+    ciMissing.push(relative(target, filepath));
+  }
+}
+
+// ── Main pass ─────────────────────────────────────────────────────────────────
+
+const touched = [];
+
+for (const filepath of files) {
+  let content;
+  try { content = readFileSync(filepath, 'utf8'); } catch { continue; }
+
+  const original = content;
+
+  checkC(filepath, content);
+
+  const rA = transformA(content, filepath);
+  content = rA.content;
+
+  const rB = transformB(content);
+  content = rB.content;
+
+  const rD = transformD(content);
+  content = rD.content;
+
+  const totalCount = rA.count + rB.count + rD.count;
+  const contentChanged = content !== original;
+
+  // Determine new file path (file renames take lowest-priority rename wins;
+  // A-rename has priority over B-rename since a file can only match one prefix).
+  let dest = filepath;
+  const destA = fileRenameA(filepath);
+  const destB = fileRenameB(filepath);
+  if (destA !== filepath) dest = destA;
+  else if (destB !== filepath) dest = destB;
+
+  const pathChanged = dest !== filepath;
+
+  if (!contentChanged && !pathChanged) continue;
+
+  const label = `${relative(target, filepath)}${pathChanged ? ` → ${relative(target, dest)}` : ''}`;
+  touched.push({ label, count: totalCount });
+
+  if (!dryRun) {
+    writeFileSync(filepath, content);
+    if (pathChanged) renameSync(filepath, dest);
+  }
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+console.log('=== methodology 0.7 → 1.0 codemod ===');
+console.log('');
+
+if (touched.length > 0) {
+  console.log(`Transforms A/B/D — ${dryRun ? 'would change' : 'changed'} ${touched.length} file(s):`);
+  touched.forEach(({ label, count }) => console.log(`  ~ ${label} (${count} substitution(s))`));
+} else {
+  console.log('Transforms A/B/D — no files to change (repo already on canonical form).');
+}
+
+console.log('');
+
+if (ciMissing.length > 0) {
+  console.log(`Transform C — ${ciMissing.length} compliance-impact file(s) missing \`report_type\` (manual fix required):`);
+  ciMissing.forEach(f => console.log(`  ! ${f}`));
+  console.log('  Add `view.report_type: product | process | combined` to each file.');
+} else {
+  console.log('Transform C — all compliance-impact files carry `report_type`. ✓');
+}
+
+console.log('');
+console.log(`files scanned   ${files.length}`);
+console.log(`files changed   ${touched.length}${dryRun ? ' (dry-run; no files written)' : ''}`);
+console.log(`CI missing      ${ciMissing.length} compliance-impact file(s) need manual report_type`);
+if (dryRun) console.log('(dry-run — no files written)');
+
+process.exit(0);

--- a/migrations/0.7-to-1.0/fixtures/after/canon/elements/02_business/business-objects/BUSINESS_OBJECT-ORDER-1.yaml
+++ b/migrations/0.7-to-1.0/fixtures/after/canon/elements/02_business/business-objects/BUSINESS_OBJECT-ORDER-1.yaml
@@ -1,0 +1,12 @@
+notation: business_object
+id: BUSINESS_OBJECT-ORDER-1
+name: "Customer order"
+type: "BusinessObject"
+layer: "Business"
+metadata:
+  status: Active
+  owner: ROLE-OPS-1
+  created_at: "2026-01-10"
+  updated_at: "2026-06-01"
+properties:
+  description: "A customer purchase order."

--- a/migrations/0.7-to-1.0/fixtures/after/canon/elements/05_implementation/actions/ACTION-LAUNCH-1.yaml
+++ b/migrations/0.7-to-1.0/fixtures/after/canon/elements/05_implementation/actions/ACTION-LAUNCH-1.yaml
@@ -1,0 +1,12 @@
+notation: action
+id: ACTION-LAUNCH-1
+name: "Platform launch"
+type: project
+metadata:
+  status: Active
+  owner: ACTOR-PRODUCT-1
+  created_at: "2026-01-10"
+  updated_at: "2026-06-01"
+properties:
+  description: "Execute the platform launch programme."
+  delivers_changes: [CHANGE-PLATFORM-1]

--- a/migrations/0.7-to-1.0/fixtures/after/canon/views/compliance-impact/retail.compliance-impact.transitrix.yaml
+++ b/migrations/0.7-to-1.0/fixtures/after/canon/views/compliance-impact/retail.compliance-impact.transitrix.yaml
@@ -1,0 +1,10 @@
+notation: compliance-impact
+methodology_version: "0.7.0"
+id: COMPLIANCE_IMPACT-RETAIL-1
+name: "Retail GDPR compliance matrix"
+view:
+  report_type: product      # added manually (Transform C)
+  grouping:
+    columns: product-by-name
+  subjects:
+    products: []

--- a/migrations/0.7-to-1.0/fixtures/before/canon/elements/02_business/business-objects/INFORMATION_ENTITY-ORDER-1.yaml
+++ b/migrations/0.7-to-1.0/fixtures/before/canon/elements/02_business/business-objects/INFORMATION_ENTITY-ORDER-1.yaml
@@ -1,0 +1,12 @@
+notation: business_object
+id: INFORMATION_ENTITY-ORDER-1
+name: "Customer order"
+type: "BusinessObject"
+layer: "Business"
+metadata:
+  status: Active
+  owner: ROLE-OPS-1
+  created_at: "2026-01-10"
+  updated_at: "2026-06-01"
+properties:
+  description: "A customer purchase order."

--- a/migrations/0.7-to-1.0/fixtures/before/canon/elements/05_implementation/actions/ACTIVITY-LAUNCH-1.yaml
+++ b/migrations/0.7-to-1.0/fixtures/before/canon/elements/05_implementation/actions/ACTIVITY-LAUNCH-1.yaml
@@ -1,0 +1,12 @@
+notation: activity
+id: ACTIVITY-LAUNCH-1
+name: "Platform launch"
+type: project
+metadata:
+  status: Active
+  owner: ACTOR-PRODUCT-1
+  created_at: "2026-01-10"
+  updated_at: "2026-06-01"
+properties:
+  description: "Execute the platform launch programme."
+  delivers_changes: [CHANGE-PLATFORM-1]

--- a/migrations/0.7-to-1.0/fixtures/before/canon/views/compliance-impact/retail.compliance-impact.transitrix.yaml
+++ b/migrations/0.7-to-1.0/fixtures/before/canon/views/compliance-impact/retail.compliance-impact.transitrix.yaml
@@ -1,0 +1,10 @@
+notation: compliance-impact
+methodology_version: "0.7.0"
+id: COMPLIANCE_IMPACT-RETAIL-1
+name: "Retail GDPR compliance matrix"
+view:
+  # report_type is absent — COMPIMP-011 error at 1.0; add manually
+  grouping:
+    columns: product-by-name
+  subjects:
+    products: []

--- a/migrations/0.7-to-1.0/validate.mjs
+++ b/migrations/0.7-to-1.0/validate.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Post-migration validator — methodology 0.7 → 1.0.
+//
+// Checks that the adopter repo is free of all deprecated forms that were
+// accepted in pre-1.0 releases but are hard errors at 1.0.
+//
+// Usage:
+//   node migrations/0.7-to-1.0/validate.mjs <adopter-root>
+//
+// Exit 0 = clean (no deprecated forms found).
+// Exit 1 = one or more violations found; list printed to stdout.
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative, resolve, basename } from 'node:path';
+
+const target = resolve(process.argv[2] ?? process.cwd());
+
+if (!existsSync(target)) {
+  console.error(`error: target directory does not exist: ${target}`);
+  process.exit(2);
+}
+
+function walkYaml(dir, out = []) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return out; }
+  for (const ent of entries) {
+    if (ent.startsWith('.')) continue;
+    const full = join(dir, ent);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) walkYaml(full, out);
+    else if (st.isFile() && ent.endsWith('.yaml')) out.push(full);
+  }
+  return out;
+}
+
+const files = walkYaml(target);
+const errors = [];
+
+function err(filepath, msg) {
+  errors.push(`  ${relative(target, filepath)}: ${msg}`);
+}
+
+for (const filepath of files) {
+  const bn = basename(filepath);
+  let content;
+  try { content = readFileSync(filepath, 'utf8'); } catch { continue; }
+
+  // ── A: ACTIVITY → ACTION must be complete ──────────────────────────────────
+
+  if (bn.startsWith('ACTIVITY-') && bn.endsWith('.yaml')) {
+    err(filepath, 'file name still uses ACTIVITY- prefix; rename to ACTION-*.yaml');
+  }
+  if (bn.endsWith('.activities.transitrix.yaml')) {
+    err(filepath, 'file still uses .activities.transitrix.yaml extension; rename to .action.transitrix.yaml');
+  }
+  if (bn.endsWith('.activity-card.transitrix.yaml')) {
+    err(filepath, 'file still uses .activity-card.transitrix.yaml extension; rename to .action-card.transitrix.yaml');
+  }
+  if (/^notation\s*:\s*["']?activity["']?\s*$/m.test(content)) {
+    err(filepath, '`notation: activity` found; update to `notation: action`');
+  }
+  if (/^notation\s*:\s*["']?activity-card["']?\s*$/m.test(content)) {
+    err(filepath, '`notation: activity-card` found; update to `notation: action-card`');
+  }
+  if (/\bACTIVITY-[A-Z0-9]/g.test(content)) {
+    err(filepath, 'ACTIVITY-* ID values found; replace with ACTION-*');
+  }
+  if (/^\s*activities\s*:/m.test(content)) {
+    err(filepath, '`activities:` key found; rename to `actions:`');
+  }
+  if (/^\s*activity_type\s*:/m.test(content)) {
+    err(filepath, '`activity_type:` key found; rename to `type:`');
+  }
+  if (/^\s*activity_card\s*:/m.test(content)) {
+    err(filepath, '`activity_card:` key found; rename to `action_card:`');
+  }
+
+  // ── B: INFORMATION_ENTITY → BUSINESS_OBJECT must be complete ───────────────
+
+  if (bn.startsWith('INFORMATION_ENTITY-') && bn.endsWith('.yaml')) {
+    err(filepath, 'file name still uses INFORMATION_ENTITY- prefix; rename to BUSINESS_OBJECT-*.yaml');
+  }
+  if (/\bINFORMATION_ENTITY-[A-Z0-9]/g.test(content)) {
+    err(filepath, 'INFORMATION_ENTITY-* ID values found; replace with BUSINESS_OBJECT-*');
+  }
+  if (/^\s*information_entities\s*:/m.test(content)) {
+    err(filepath, '`information_entities:` key found; rename to `business_objects:`');
+  }
+
+  // ── C: compliance-impact must carry report_type ────────────────────────────
+
+  if (bn.endsWith('.compliance-impact.transitrix.yaml')) {
+    if (!/^\s*report_type\s*:/m.test(content)) {
+      err(filepath, 'compliance-impact file missing `view.report_type` (required at 1.0); add `report_type: product | process | combined`');
+    }
+  }
+
+  // ── D: Deprecated abbreviated prefix IDs must be gone ─────────────────────
+
+  const abbrev = [
+    [/\bFACTOR-[A-Z0-9]/g, 'FACTOR-* (grace period closed; replace with DRIVER-*)'],
+    [/\bACT-[A-Z0-9]/g,    'ACT-* abbreviated ID (replace with ACTION-*)'],
+    [/\bCHG-[A-Z0-9]/g,    'CHG-* abbreviated ID (replace with CHANGE-*)'],
+    [/\bFAC-[A-Z0-9]/g,    'FAC-* abbreviated ID (replace with DRIVER-*)'],
+    [/\bSCEN-[A-Z0-9]/g,   'SCEN-* abbreviated ID (replace with SCENARIO-*)'],
+    [/\bSCN-[A-Z0-9]/g,    'SCN-* abbreviated ID (replace with SCENARIO-*)'],
+  ];
+
+  for (const [re, msg] of abbrev) {
+    if (re.test(content)) err(filepath, msg);
+  }
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+if (errors.length === 0) {
+  console.log(`=== 0.7 → 1.0 post-migration validation: CLEAN ===`);
+  console.log(`Scanned ${files.length} YAML file(s) — no deprecated forms found.`);
+  process.exit(0);
+} else {
+  console.log(`=== 0.7 → 1.0 post-migration validation: ${errors.length} VIOLATION(S) ===`);
+  console.log(`Scanned ${files.length} YAML file(s). Run codemod.mjs first, then fix the remainder manually.\n`);
+  errors.forEach(e => console.log(e));
+  process.exit(1);
+}

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -41,6 +41,9 @@ const VERSION_SOT = join(REPO_ROOT, 'notations', 'CURRENT_VERSION.yaml');
 const VERSION_PIN_ALLOWLIST = new Set([
   'transitrix/skills/onboard/templates/transitrix.yaml', // "pin a real release once the adopter chooses one"
   'migrations/0.6-to-0.7/README.md',                    // documents the target version, not the current pin
+  'migrations/0.7-to-1.0/README.md',                    // documents the source version, not the current pin
+  'migrations/0.7-to-1.0/fixtures/before/canon/views/compliance-impact/retail.compliance-impact.transitrix.yaml',  // pre-migration fixture
+  'migrations/0.7-to-1.0/fixtures/after/canon/views/compliance-impact/retail.compliance-impact.transitrix.yaml',   // post-migration fixture
 ]);
 
 // Directories never walked.


### PR DESCRIPTION
## Summary

- Adds `migrations/0.7-to-1.0/` — the MAJOR-release migration recipe covering all breaking changes whose deprecation windows close at the 1.0 cut
- `README.md` — manual migration guide (four transforms, step-by-step)
- `codemod.mjs` — idempotent automated script for Transforms A/B/D; detects Transform C misses
- `validate.mjs` — post-migration check; exits 0 on a clean repo
- `fixtures/before` + `fixtures/after` — minimal adopter-repo snapshots demonstrating each transform
- `scripts/check-notations.mjs` — allowlist extended for the new recipe files (which intentionally carry non-current version pins)

**Breaking changes covered:**
- **A** ACTIVITY → ACTION rename (element type, IDs, file names, root array key, `activity_type` field, action-card files)
- **B** INFORMATION_ENTITY → BUSINESS_OBJECT rename (IDs, file names, `information_entities:` key)
- **C** `report_type` required on `*.compliance-impact.transitrix.yaml` (detected; manual fix)
- **D** Deprecated abbreviated prefix IDs now hard errors: `ACT-`, `CHG-`, `FAC-`, `FACTOR-` (grace period closes), `SCEN-`, `SCN-`

## Test plan

- [x] `node migrations/0.7-to-1.0/codemod.mjs fixtures/before --dry-run` correctly identifies 2 files to change and 1 compliance-impact miss
- [x] `node migrations/0.7-to-1.0/validate.mjs fixtures/before` exits 1 with 6 violations
- [x] `node migrations/0.7-to-1.0/validate.mjs fixtures/after` exits 0 (clean)
- [x] `node scripts/check-notations.mjs` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)