### PR TITLE
docs(readme): link the Personal Memory guide from Enterprise Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Transitrix is the foundation for building an **Enterprise Memory** — a durable
 
 Because the memory is built on a formal enterprise model at the motivation, strategy, and business layers — not free-form notes or opaque embeddings — it is structured enough to validate, version, and query precisely. The same model projects into every ArchiMate layer; derived views (sequence, ER, C4, journey) are generated from the same source rather than authored separately.
 
-**Personal scale:** a single Transitrix repo doubles as a personal second brain — decisions, goals, and observations accumulate incrementally with no extra infrastructure.
+**Personal scale:** a single Transitrix repo doubles as a [personal second brain](patterns/personal-memory.md) — decisions, goals, and observations accumulate incrementally with no extra infrastructure.
 
 **Enterprise scale:** add the [Knowledge Store](patterns/knowledge-store.md) pattern for multi-project environments where raw material volume needs a curation layer before reaching canon.
 


### PR DESCRIPTION
## Summary
The README's Enterprise Memory section named the "personal second brain" scale in prose but didn't link to `patterns/personal-memory.md` (added in #317). Closes the methodology-repo scope of the "Reframe Transitrix surfaces around Enterprise Memory" epic — both audience-facing implementation guides (personal + enterprise) are now linked from the entry-point section.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean