### PR TITLE
docs(releasing): fix stale organizations/acme_corp reference

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ If a single release combines multiple kinds of change, the bump is the **highest
 For every release, in order:
 
 1. **Confirm the bump category.** Read every PR landed since the previous tag; categorise each change per the table above; pick the bump.
-2. **Update `methodology_version` in `organizations/acme_corp/transitrix.yaml`** to the new version. acme_corp is the fixture adopter and tracks the latest released version.
+2. **Update `methodology_version` in the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo's `transitrix.yaml`** to the new version, via a companion PR in that repo. acme-corp is the fixture adopter and tracks the latest released version.
 3. **Update each notation spec's `version:` frontmatter** if any spec changed in this release. (`spec_version` on individual files is informational — see CONTRACT §10.1 — so this step is bookkeeping for discoverability, not enforcement.)
 4. **Write release notes** describing what changed by category (`Added`, `Changed`, `Fixed`, `Removed`). Reference PR numbers.
 5. **For a `MAJOR` release** — ship a migration recipe under `migrations/<prev>-to-<this>/` (recipe format: see [`migrations/`](migrations/) and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10.4). The recipe is a precondition for the tag.


### PR DESCRIPTION
## Summary
RELEASING.md's per-release checklist still pointed at `organizations/acme_corp/transitrix.yaml`, which no longer exists in this repo since the acme-corp submodule was retired (#306). Points at the `transitrix/acme-corp` reference repo's own `transitrix.yaml` (via a companion PR there) instead — this is in fact exactly what the 1.0.0 release prep already did ([transitrix/acme-corp#25](https://github.com/transitrix/acme-corp/pull/25)).

## Test plan
- [x] `node scripts/check-notations.mjs` — clean