### PR TITLE
chore(skills): bump min_version to 1.0.0 across all skills

### DIFF
--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -2,7 +2,7 @@
 name: Transitrix Ingest
 description: Turn raw organisational material (interviews, policies, org charts, spreadsheets, notes) into Transitrix field artefacts and typed canon candidates at scale, with source-quality scoring and a human review queue. Operates the field→canon derivation pipeline — convert a document, emit a field artefact with provenance and a proposed source_quality, extract typed elements and conservative relations that each cite their field source via derived_from, validate them against the canonical schemas and the adopter's coverage profile, and produce a review queue a human gates before anything is admitted to canon. Never writes canon directly.
 when_to_use: User says "ingest these documents", "extract a model from this interview / policy / spreadsheet", "fill the field zone from raw material", "turn these notes into canon candidates", "set up the intake pipeline", or drops raw files into an adopter repo's `_intake/inbox/` and wants them processed into field artefacts + reviewable canon candidates. BA-facing shortcut — user says "extract requirements from this interview / project brief / SOP", "get REQUIREMENT / CONSTRAINT candidates out of this writeup", or "run the ingest pipeline motivation-only" — same pipeline, agent runs only `prompts/01_motivation.md` (see [BA quickstart](#ba-quickstart--requirements-from-an-interview)).
-min_version: "0.6.0"
+min_version: "1.0.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
 

--- a/transitrix/skills/knowledge-store/SKILL.md
+++ b/transitrix/skills/knowledge-store/SKILL.md
@@ -2,7 +2,7 @@
 name: Transitrix Knowledge Store
 description: Ingest raw source material into the OKF single-repo MVP knowledge store — assess, archive, route to the OKF track (extract knowledge objects → human review → write to knowledge/) and/or the Canon track (extract Transitrix primitives → PR to canon/), and log every decision.
 when_to_use: User says "ingest this document", "add this to the knowledge store", "extract knowledge objects from this", "route this to canon", or drops a file into `_intake/inbox/` and wants it processed.
-min_version: "0.6.0"
+min_version: "1.0.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: Transitrix Onboarding
 description: Scaffold a new Transitrix architecture-as-text repository (zoned canon/ + field/ + codex/ layout with assistant-neutral AGENTS.md + transitrix.yaml manifest) and drive a first modelling session — enterprise architecture (BPMN, DGCA / Goals, capability map, process blueprint, action schedule, actions tree, nested blocks, scenarios, products, applications) plus codex artefacts (laws, regulations, policies, internal standards). Use when the user wants to start a new Transitrix repo from scratch, or has just cloned one and wants to author their first notation file with validation.
 when_to_use: User says "set up Transitrix", "model my architecture as text", "create a new transitrix repo", "I want to write [DGCA / Goals / capability map / process blueprint / ...] but don't know the schema", or asks to scaffold an organisation-as-text repository following the Transitrix methodology. Also triggers when the user says "I cloned my team's Transitrix repo", "help me get oriented in this model", "make my first change to our architecture repo", or expresses a similar intent to orient in or contribute to a repo that already uses Transitrix.
-min_version: "0.5.0"
+min_version: "1.0.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
 

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -2,7 +2,7 @@
 name: Transitrix Reg-Intel
 description: "Collect regulatory-source changes in practice — the operational counterpart to the methodology's codex / SEGMENT / AMENDMENT notation work. Watches codex sources flagged `monitoring_needed: true`, runs a cheap change-signal gate before any expensive extraction, then on signal-moved runs the SCAN → SEGMENT → CLASSIFY → OUTPUT pass: fetches and snapshots the source, slices it into obligation-bearing SEGMENT field artefacts, classifies each segment as a CONSTRAINT or REQUIREMENT candidate (positive obligation → REQUIREMENT by default), emits an AMENDMENT field artefact when an existing source has drifted, updates the codex `scan` block, and stages everything in a review digest for human admission. Never writes canon. Never auto-admits. Never silently drops."
 when_to_use: 'User says "stand up the regulatory watcher", "run the daily reg-intel scan", "scan my codex sources for amendments", "extract obligations from this regulation", "produce the reg-intel review digest", or has a codex repo with `monitoring_needed: true` sources and wants drift detection plus a draft-obligation pipeline routed through a human gate.'
-min_version: "0.6.0"
+min_version: "1.0.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
 

--- a/transitrix/skills/repo-check/SKILL.md
+++ b/transitrix/skills/repo-check/SKILL.md
@@ -2,7 +2,7 @@
 name: Transitrix Repo-Check
 description: "Read-only health check (\"doctor\") for a Transitrix adopter repository. Emits a short, DATA-FREE report — methodology version, resolved coverage profile, per-zone and per-TYPE counts, an adoption-level indicator, integrity red flags (invalid IDs, misplaced canon elements, unresolved profile), and a tooling check. Reports aggregates and statuses only — never object ids, names, or contents — so the report is safe to share outside the organisation. Idempotent and non-mutating: it reads the zones and never writes one."
 when_to_use: 'User says "check my Transitrix repo", "is my model healthy", "run the repo doctor", "give me a status of the canon", "what state is this adopter repo in", or wants a shareable, data-free summary of a repository''s shape and integrity without exposing any model contents.'
-min_version: "0.6.0"
+min_version: "1.0.0"
 allowed-tools: Read, Bash, Glob, Grep
 ---
 

--- a/transitrix/skills/report/SKILL.md
+++ b/transitrix/skills/report/SKILL.md
@@ -2,7 +2,7 @@
 name: Transitrix Report
 description: "Produce a compliance report (obligation × subject impact matrix, or per-regime coverage metric) from a Transitrix repository, by conversation. Resolves the report's parameters — from the request, from the view spec's defaults, or from a named saved view-config — materialises a versioned view-config artefact, and renders it through the deterministic `cervin export-compliance` CLI to Markdown or PDF. The skill never computes a matrix itself; rendering stays in the CLI so the same config re-renders identically next quarter. Reports are reproducible and auditable: every report has a committed parameter artefact, and the skill states which spec defaults it assumed."
 when_to_use: 'User says "give me the compliance report", "show the obligation impact for product X", "what is our GDPR coverage", "export the compliance matrix to PDF", "run the Q3 obligations matrix", "which obligations have no assertion (the gap report)", or wants a reproducible compliance/coverage report rendered from canon rather than hand-assembled.'
-min_version: "0.6.0"
+min_version: "1.0.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 


### PR DESCRIPTION
## Summary
The 1.0 cut closes every pre-1.0 deprecation-window alias as a hard error (`ACTIVITY`, `INFORMATION_ENTITY`, abbreviated ID prefixes, non-`canon/` catalogue paths). All skills already scaffold and operate on the 1.0-canonical forms; running any of them against an adopter repo still pinned below 1.0.0 would produce non-conformant output.

Bumps `min_version` in all six `SKILL.md` files (onboard, ingest, knowledge-store, reg-intel, repo-check, report) to `"1.0.0"`.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean