### PR TITLE
docs(specs): bump version frontmatter for Phase 4 freeze pass changes

### DIFF
--- a/notations/views/08-blocks.md
+++ b/notations/views/08-blocks.md
@@ -1,8 +1,8 @@
 ---
 notation: "Nested Block Diagrams"
-version: "0.4"
+version: "0.5"
 author: "Valerii Korobeinikov"
-last_updated: "2026-05-25"
+last_updated: "2026-07-05"
 status: "documented"
 file_extension: "*.blocks.transitrix.yaml"
 dsm_status: "not implemented — native TS renderer planned in Transitrix Studio (sibling task)"

--- a/notations/views/13-process-blueprint.md
+++ b/notations/views/13-process-blueprint.md
@@ -1,8 +1,8 @@
 ---
 notation: "Process Blueprint"
-version: "0.3"
+version: "0.4"
 author: "Valerii Korobeinikov"
-last_updated: "2026-06-10"
+last_updated: "2026-07-05"
 status: "draft"
 file_extension: "*.process-blueprint.transitrix.yaml"
 dsm_status: "not implemented — render module planned in Transitrix Studio (sibling task)"


### PR DESCRIPTION
## Summary
\`08-blocks.md\` and \`13-process-blueprint.md\` both had content changes in the Phase 4 freeze pass (stale notation count fix; \`BP-010\` gained \`business_objects[]\` coverage) but their \`version:\` frontmatter wasn't bumped. Bookkeeping per RELEASING.md step 3 (informational only, not enforced by the validator).

## Test plan
- [x] \`node scripts/check-notations.mjs\` — clean