### PR TITLE
feat(knowledge-store): add structural/referential/dedup validator

### DIFF
--- a/patterns/knowledge-store.md
+++ b/patterns/knowledge-store.md
@@ -140,6 +140,8 @@ What a conformant implementation MAY vary:
 
 What it MAY NOT vary: the four admission rules, the risk-tier table, and the mandatory-field requirements.
 
+**Reference implementation:** [`tools/knowledge_store_lint.py`](../tools/knowledge_store_lint.py) is a proof-point enforcement of Gates 1-4 over `_intake/processed/` and `knowledge/` — structural validation (required fields, the `confidence` enum), referential integrity (dangling bundle-relative links), duplicate-title detection (Gate 2), and blast-radius tiering with the assumed-confidence review flag (Gate 3-4). It is one conformant implementation, not the only one; a different tool MAY use a different shape/dedup engine as long as it satisfies the same four gates. Run it with `python3 tools/knowledge_store_lint.py <knowledge-store-root>`.
+
 ---
 
 

--- a/tools/knowledge_store_lint.py
+++ b/tools/knowledge_store_lint.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Transitrix Knowledge Store Linter - structural validation, referential
+integrity, and duplicate detection over OKF knowledge objects.
+
+Companion to tools/lint.py (which validates canon/ YAML elements). This
+script validates the knowledge store's refinement layer instead:
+_intake/processed/ (OKF source-document records) and knowledge/ (OKF
+knowledge objects), per the Quality gates in patterns/knowledge-store.md.
+
+This is the "proof point" reference implementation for the four quality
+gates: the methodology owns the rules (documented in
+patterns/knowledge-store.md), this script is one conformant enforcement
+of them. A different implementation (Studio, DSM, a custom pipeline) MAY
+use a different shape/dedup engine as long as it satisfies the same rules.
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+
+import yaml
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+BUNDLE_LINK_RE = re.compile(r"\]\((/knowledge/[^)\s]+\.md)\)")
+CONFIDENCE_ENUM = {"observed", "inferred", "assumed"}
+DUP_TITLE_SIMILARITY_THRESHOLD = 0.85
+HIGH_DEPENDENTS_THRESHOLD = 10
+MEDIUM_DEPENDENTS_THRESHOLD = 2
+ASSUMED_REVIEW_THRESHOLD = 3
+
+
+@dataclass
+class Finding:
+    file: str
+    code: str
+    severity: str  # "error", "warning", "info"
+    message: str
+
+
+@dataclass
+class KnowledgeObject:
+    path: Path
+    rel_path: str
+    frontmatter: Dict
+    body: str
+    zone: str  # "intake" or "knowledge"
+
+
+class KnowledgeStoreLinter:
+    def __init__(self, root: str = "."):
+        self.root = Path(root)
+        self.intake_dir = self.root / "_intake" / "processed"
+        self.knowledge_dir = self.root / "knowledge"
+        self.findings: List[Finding] = []
+        self.objects: List[KnowledgeObject] = []
+
+    def run(self) -> bool:
+        print("Transitrix Knowledge Store Linter")
+        print(f"Scanning: {self.root}")
+        print()
+
+        self._load_objects()
+        if not self.objects:
+            print("No knowledge-store objects found under _intake/processed/ or knowledge/ — nothing to check.")
+            return True
+
+        self._check_structural()
+        self._check_referential_integrity()
+        self._check_duplicates()
+        self._check_blast_radius_and_confidence()
+
+        self._report()
+        errors = [f for f in self.findings if f.severity == "error"]
+        return len(errors) == 0
+
+    # --- loading -------------------------------------------------------
+
+    def _load_objects(self):
+        for zone, directory in (("intake", self.intake_dir), ("knowledge", self.knowledge_dir)):
+            if not directory.exists():
+                continue
+            for path in sorted(directory.rglob("*.md")):
+                if path.name in ("index.md", "log.md"):
+                    continue
+                rel = str(path.relative_to(self.root)).replace("\\", "/")
+                text = path.read_text(encoding="utf-8")
+                m = FRONTMATTER_RE.match(text)
+                if not m:
+                    self.findings.append(Finding(
+                        file=rel, code="KS-001", severity="error",
+                        message="No YAML frontmatter block found. Every OKF object requires a --- frontmatter --- header.",
+                    ))
+                    continue
+                try:
+                    fm = yaml.safe_load(m.group(1)) or {}
+                except yaml.YAMLError as e:
+                    self.findings.append(Finding(
+                        file=rel, code="KS-001", severity="error",
+                        message=f"Frontmatter is not valid YAML: {e}",
+                    ))
+                    continue
+                self.objects.append(KnowledgeObject(
+                    path=path, rel_path=rel, frontmatter=fm, body=m.group(2), zone=zone,
+                ))
+
+    # --- structural (Gate 1, Gate 4, item 5) ----------------------------
+
+    def _check_structural(self):
+        for obj in self.objects:
+            fm = obj.frontmatter
+
+            if not fm.get("type"):
+                self.findings.append(Finding(
+                    obj.rel_path, "KS-002", "error",
+                    "Missing required field `type:`.",
+                ))
+
+            if obj.zone == "intake":
+                if fm.get("type") != "source-document":
+                    self.findings.append(Finding(
+                        obj.rel_path, "KS-003", "error",
+                        f"_intake/processed/ record must carry `type: source-document` (Gate 1 quarantine); found `{fm.get('type')!r}`.",
+                    ))
+                if not fm.get("source"):
+                    self.findings.append(Finding(
+                        obj.rel_path, "KS-004", "error",
+                        "Missing `source:` — required before admission to _intake/processed/ (Gate 4).",
+                    ))
+
+            if obj.zone == "knowledge":
+                confidence = fm.get("confidence")
+                if not confidence:
+                    self.findings.append(Finding(
+                        obj.rel_path, "KS-005", "error",
+                        "Missing `confidence:` — required before promotion to knowledge/ (Gate 4). No default is permitted.",
+                    ))
+                elif confidence not in CONFIDENCE_ENUM:
+                    self.findings.append(Finding(
+                        obj.rel_path, "KS-005", "error",
+                        f"`confidence: {confidence}` is not one of {sorted(CONFIDENCE_ENUM)}.",
+                    ))
+                if not fm.get("timestamp"):
+                    self.findings.append(Finding(
+                        obj.rel_path, "KS-006", "warning",
+                        "Missing `timestamp:` (recommended — tracks last modification).",
+                    ))
+
+    # --- referential integrity (item 6a) --------------------------------
+
+    def _check_referential_integrity(self):
+        existing = {obj.rel_path for obj in self.objects if obj.zone == "knowledge"}
+        # Bundle-relative links are rooted at the knowledge store root, e.g. /knowledge/foo.md.
+        for obj in self.objects:
+            for target in BUNDLE_LINK_RE.findall(obj.body):
+                target_rel = target.lstrip("/")
+                if target_rel not in existing:
+                    self.findings.append(Finding(
+                        obj.rel_path, "KS-007", "error",
+                        f"Dangling link to `{target}` — no such file under knowledge/.",
+                    ))
+
+    # --- duplicate detection (item 6b, Gate 2) --------------------------
+
+    def _check_duplicates(self):
+        knowledge_objs = [o for o in self.objects if o.zone == "knowledge"]
+        titles = []
+        for obj in knowledge_objs:
+            title = obj.frontmatter.get("title") or obj.path.stem
+            titles.append((obj, str(title).strip().lower()))
+
+        seen_pairs = set()
+        for i, (obj_a, title_a) in enumerate(titles):
+            for obj_b, title_b in titles[i + 1:]:
+                pair = frozenset((obj_a.rel_path, obj_b.rel_path))
+                if pair in seen_pairs:
+                    continue
+                ratio = SequenceMatcher(None, title_a, title_b).ratio()
+                if ratio >= DUP_TITLE_SIMILARITY_THRESHOLD:
+                    seen_pairs.add(pair)
+                    self.findings.append(Finding(
+                        obj_a.rel_path, "KS-008", "warning",
+                        f"Title looks like a possible duplicate of `{obj_b.rel_path}` "
+                        f"(similarity {ratio:.0%}) — confirm this Confirms/Extends an existing "
+                        f"concept rather than silently minting a new one (Gate 2).",
+                    ))
+
+    # --- blast radius + confidence cross-check (Gate 3, Gate 4) ---------
+
+    def _check_blast_radius_and_confidence(self):
+        # Dependent count = how many other knowledge/ objects link to this one.
+        dependents: Dict[str, int] = {o.rel_path: 0 for o in self.objects if o.zone == "knowledge"}
+        for obj in self.objects:
+            for target in BUNDLE_LINK_RE.findall(obj.body):
+                target_rel = target.lstrip("/")
+                if target_rel in dependents and target_rel != obj.rel_path:
+                    dependents[target_rel] += 1
+
+        for obj in self.objects:
+            if obj.zone != "knowledge":
+                continue
+            count = dependents.get(obj.rel_path, 0)
+            if count >= HIGH_DEPENDENTS_THRESHOLD:
+                tier = "High"
+            elif count >= MEDIUM_DEPENDENTS_THRESHOLD:
+                tier = "Medium"
+            else:
+                tier = "Low"
+            self.findings.append(Finding(
+                obj.rel_path, "KS-009", "info",
+                f"Blast radius: {tier} ({count} dependent object(s)). "
+                f"{'Human sign-off required before promotion.' if tier == 'High' else ''}".strip(),
+            ))
+
+            confidence = obj.frontmatter.get("confidence")
+            if confidence == "assumed" and count >= ASSUMED_REVIEW_THRESHOLD:
+                self.findings.append(Finding(
+                    obj.rel_path, "KS-010", "warning",
+                    f"`confidence: assumed` with {count} dependents (>= {ASSUMED_REVIEW_THRESHOLD}) — "
+                    f"MUST NOT be promoted without a review note in _intake/log.md explaining the "
+                    f"assumption (Gate 4).",
+                ))
+
+    # --- reporting -------------------------------------------------------
+
+    def _report(self):
+        errors = [f for f in self.findings if f.severity == "error"]
+        warnings = [f for f in self.findings if f.severity == "warning"]
+        infos = [f for f in self.findings if f.severity == "info"]
+
+        if errors:
+            print("ERRORS:\n")
+            for f in errors:
+                print(f"  {f.file}  [{f.code}]")
+                print(f"  -> {f.message}\n")
+
+        if warnings:
+            print("WARNINGS:\n")
+            for f in warnings:
+                print(f"  {f.file}  [{f.code}]")
+                print(f"  -> {f.message}\n")
+
+        if infos:
+            print("INFO:\n")
+            for f in infos:
+                print(f"  {f.file}  [{f.code}] {f.message}")
+            print()
+
+        print(f"Objects scanned: {len(self.objects)}")
+        print(f"Errors: {len(errors)}  Warnings: {len(warnings)}")
+
+        if errors:
+            print("\nKnowledge store validation FAILED.")
+        else:
+            print("\nKnowledge store validation passed" + (" with warnings." if warnings else "."))
+
+
+if __name__ == "__main__":
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    root_arg = sys.argv[1] if len(sys.argv) > 1 else os.getenv("KNOWLEDGE_STORE_ROOT", ".")
+    linter = KnowledgeStoreLinter(root_arg)
+    ok = linter.run()
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
## Summary
Closes the "First build — proof point" scope (items 5-6) of the "Knowledge-base quality gates" epic, deferred by #318: a reference enforcement of the four Quality Gates documented in `patterns/knowledge-store.md`, over OKF knowledge objects (Markdown + YAML frontmatter) in `_intake/processed/` and `knowledge/`.

**`tools/knowledge_store_lint.py`** checks:
- **KS-001/002** — frontmatter present and parses; `type:` required.
- **KS-003/004** — `_intake/processed/` records carry `type: source-document` (Gate 1 quarantine) and `source:` (Gate 4 admission).
- **KS-005/006** — `knowledge/` objects carry a valid `confidence:` enum value (Gate 4 promotion) and a `timestamp:`.
- **KS-007** — bundle-relative links (`/knowledge/*.md`) resolve to an existing file (referential integrity, item 6a).
- **KS-008** — near-duplicate titles flagged for review (Gate 2 — one canonical definition per concept), not auto-rejected (item 6b).
- **KS-009** — blast-radius tier (Low/Medium/High) reported per object from reverse-link dependent counts (Gate 3).
- **KS-010** — `confidence: assumed` objects at or above the high-dependents threshold flagged for a review note (Gate 4).

This is one conformant implementation, not the only one — per the methodology/implementation boundary already documented in `patterns/knowledge-store.md`, a different tool MAY use a different shape/dedup engine as long as it satisfies the same four gates. Added a reference to the tool in that section.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] Manually verified against ad hoc fixtures (not committed) covering: a fully clean pass, each individual violation (KS-003 through KS-008), and the assumed+high-dependents case (KS-010)