### PR TITLE
docs: clean up post-1.0 tail and completed activities→action rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The fastest way in is the **onboarding Skill** — it scaffolds a clean zoned re
 /transitrix:onboard
 ```
 
-The skill asks what you want to model first, scaffolds the `canon/` + `field/` + `codex/` layout, and authors a starter file with validation. Your **first artefact is a Goals tree** — the simplest notation to start from.
+The skill asks what you want to model first, scaffolds the `canon/` + `field/` + `codex/` layout, and authors a starter file with validation for whichever notation fits — a **Goals tree** is a common starting point, the simplest notation to start from, but any notation is a valid first artefact.
 
-Prefer to do it by hand, or not working in Claude Code? Follow the manual walkthrough in **[`GETTING_STARTED.md`](https://github.com/transitrix/acme-corp/blob/main/GETTING_STARTED.md)** in the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo — same first artefact, against the worked `acme_corp` example. To validate as you go, install **Transitrix Studio** (VS Code) for live preview, or run `npx @transitrix/cli validate <file>` (on Windows PowerShell, use `npx.cmd` — see [Validation](#validation-in-one-paragraph)).
+Prefer to do it by hand, or not working in Claude Code? Follow the manual walkthrough in **[`GETTING_STARTED.md`](https://github.com/transitrix/acme-corp/blob/main/GETTING_STARTED.md)** in the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo — same approach, against the worked `acme_corp` example. To validate as you go, install **Transitrix Studio** (VS Code) for live preview, or run `npx @transitrix/cli validate <file>` (on Windows PowerShell, use `npx.cmd` — see [Validation](#validation-in-one-paragraph)).
 
 New to the ideas behind it? Read **[`method/01-methodology.md`](method/01-methodology.md)** for the *why* — but you don't need it to start.
 
@@ -50,7 +50,7 @@ New to the ideas behind it? Read **[`method/01-methodology.md`](method/01-method
 
 Process & releases:
 
-- **[`CHANGELOG.md`](CHANGELOG.md)** — release history (Keep a Changelog; SemVer with pre-1.0 caveats).
+- **[`CHANGELOG.md`](CHANGELOG.md)** — release history (Keep a Changelog; SemVer per [`notations/CONTRACT.md`](notations/CONTRACT.md) §10).
 - **[`RELEASING.md`](RELEASING.md)** — per-release operational checklist for the maintainer.
 - **[`NOTATIONS_AUDIT.md`](NOTATIONS_AUDIT.md)** — maintainer audit of open shape decisions a linter can't make.
 - **[`migrations/`](migrations/)** — per-release migration recipes.
@@ -118,5 +118,5 @@ Transitrix — including the FGCA / FGA notations that form part of it — is au
 
 ---
 
-**Methodology status:** pre-1.0 — see [`CHANGELOG.md`](CHANGELOG.md) for the current release and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10 for the compatibility policy.
-**Last updated:** 2026-06-11
+**Methodology status:** 1.0 (stable) — see [`CHANGELOG.md`](CHANGELOG.md) for the current release and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10 for the compatibility policy.
+**Last updated:** 2026-07-05

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 This document defines the per-release process for the Transitrix methodology. The compatibility policy itself — what `MAJOR` / `MINOR` / `PATCH` mean for adopters — is in [`notations/CONTRACT.md`](notations/CONTRACT.md) §10. This file describes the **process** the methodology maintainer follows to cut and ship a release.
 
-The methodology is **pre-1.0**. Standard pre-1.0 SemVer applies (see CONTRACT §10.3) — `MINOR` bumps may carry breaking changes until the 1.0 cut. The full versioning-and-compatibility policy lives in CONTRACT §10; this file is the operational checklist.
+The methodology is at **1.0** (stable, first tagged 2026-07-05). Post-1.0 SemVer applies (see CONTRACT §10.3) — `MINOR` releases carry only additive changes; breaking changes require a `MAJOR` bump. The full versioning-and-compatibility policy lives in CONTRACT §10; this file is the operational checklist.
 
 ---
 
@@ -10,9 +10,9 @@ The methodology is **pre-1.0**. Standard pre-1.0 SemVer applies (see CONTRACT §
 
 | Bump | Examples |
 |---|---|
-| **PATCH** (`0.x.0` → `0.x.1`) | Clarification of an existing spec sentence; fixing a broken link; correcting a typo in an example; renumbering subsections without changing rule codes or field names. No schema change of any kind. |
-| **MINOR** (`0.x` → `0.(x+1)`) | New optional field on an existing notation; new validation code at `info` or `warning` severity; new TYPE in `IDS_AND_REFERENCES.md` §3; new section in CONTRACT.md (e.g. §9 sidecar pattern); new notation spec file (e.g. `15-requirement.md`); pre-1.0 may also include changes that are technically breaking but that the maintainer judges low-impact. |
-| **MAJOR** (`0.x` → `1.0`, `1.x` → `2.0`) | Renamed or removed field on an existing notation; changed validation severity (`warning` → `error`); changed enum membership in a closed enum (relations type, status enum, etc.); changed canonical ID grammar; required new field on an existing notation. Post-1.0, anything that breaks a previously-valid adopter file. |
+| **PATCH** (`X.Y.0` → `X.Y.1`) | Clarification of an existing spec sentence; fixing a broken link; correcting a typo in an example; renumbering subsections without changing rule codes or field names. No schema change of any kind. |
+| **MINOR** (`X.Y` → `X.(Y+1)`) | New optional field on an existing notation; new validation code at `info` or `warning` severity; new TYPE in `IDS_AND_REFERENCES.md` §3; new section in CONTRACT.md (e.g. §9 sidecar pattern); new notation spec file (e.g. `15-requirement.md`). Additive only. |
+| **MAJOR** (`X.Y` → `(X+1).0`) | Renamed or removed field on an existing notation; changed validation severity (`warning` → `error`); changed enum membership in a closed enum (relations type, status enum, etc.); changed canonical ID grammar; required new field on an existing notation — anything that breaks a previously-valid adopter file. |
 
 If a single release combines multiple kinds of change, the bump is the **highest** of any individual change in the set.
 
@@ -50,12 +50,12 @@ When an adopter repo moves from one methodology version to another, **three arte
    ```
    transitrix-ingest validate <candidates-dir>
    ```
-4. **Reinstall `@transitrix/ingest-cli`** — the installed binary does not auto-update; it remains pinned to the version it was installed from. Re-run your install command and confirm `--version` reflects the new release. Pre-1.0 the package is not yet on npm, so the install is local from a fresh checkout of this repo:
+4. **Reinstall `@transitrix/ingest-cli`** — the installed binary does not auto-update; it remains pinned to the version it was installed from. Re-run your install command and confirm `--version` reflects the new release. The package is not yet published to npm, so the install is local from a fresh checkout of this repo:
    ```
    npm install -g ./packages/ingest-cli   # or `npm link` from inside the package
    transitrix-ingest --version
    ```
-   Once the CLI is published from its own tooling repo at the ~1.0 extraction, `npm install -g @transitrix/ingest-cli` (or `npx @transitrix/ingest-cli --version`) becomes the equivalent shorthand.
+   Once the CLI is extracted to its own tooling repo and published, `npm install -g @transitrix/ingest-cli` (or `npx @transitrix/ingest-cli --version`) becomes the equivalent shorthand.
 5. **Run `repo-check`** to confirm version currency:
    ```
    transitrix-ingest repo-check [org-root]

--- a/method/01-methodology.md
+++ b/method/01-methodology.md
@@ -467,7 +467,7 @@ This methodology document follows semantic versioning at the methodology level:
 - **Minor** — new notations, new validation rules, additive schema changes.
 - **Patch** — wording, examples, clarifications.
 
-The methodology is **pre-1.0** — see [`notations/CONTRACT.md`](../notations/CONTRACT.md) §10 for the full compatibility policy (pre-1.0 MINOR bumps may carry breaking changes). The current release is recorded in [`CHANGELOG.md`](../CHANGELOG.md) and pinned per adopter repository via `methodology_version` in `transitrix.yaml` (see [`notations/MANIFEST.md`](../notations/MANIFEST.md)); this document does not restate a version number. Tooling versions (Transitrix Studio, etc.) advance independently and declare their compatible methodology version range.
+The methodology is at **1.0** (stable) — see [`notations/CONTRACT.md`](../notations/CONTRACT.md) §10 for the full compatibility policy (post-1.0, MINOR bumps are additive only; breaking changes require a MAJOR bump). The current release is recorded in [`CHANGELOG.md`](../CHANGELOG.md) and pinned per adopter repository via `methodology_version` in `transitrix.yaml` (see [`notations/MANIFEST.md`](../notations/MANIFEST.md)); this document does not restate a version number. Tooling versions (Transitrix Studio, etc.) advance independently and declare their compatible methodology version range.
 
 ## 14. License and contributing
 

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -56,7 +56,7 @@ Every notation's compiler / validator enforces the same four header rules:
 |---|---|---|
 | `HDR-001` | error | Missing `notation` field. |
 | `HDR-002` | error | `notation` value does not match the short name expected for this notation. The file is probably in the wrong format for its extension. |
-| `HDR-003` | error | File extension does not match the canonical extension for the `notation` declared inside the file (extension/content mismatch). Every notation has its own extension: `*.dgca.transitrix.yaml` for `dgca`, `*.goals.transitrix.yaml` for `goals`, `*.activities.transitrix.yaml` for `activities`; for all other notations it is `*.<short-name>.transitrix.yaml`. |
+| `HDR-003` | error | File extension does not match the canonical extension for the `notation` declared inside the file (extension/content mismatch). Every notation has its own extension: `*.dgca.transitrix.yaml` for `dgca`, `*.goals.transitrix.yaml` for `goals`, `*.action.transitrix.yaml` for `action`; for all other notations it is `*.<short-name>.transitrix.yaml`. |
 | `HDR-004` | accepted | `spec_version` is accepted but not enforced until the notation reaches v1.0. |
 
 Additional notation-specific rules (per-field, semantic, structural) live in the respective spec's "Validation rules" section.
@@ -65,7 +65,7 @@ Additional notation-specific rules (per-field, semantic, structural) live in the
 
 ## 3. Extension / content match
 
-Each notation has exactly one canonical file extension: `*.<short-name>.transitrix.yaml`. The `dgca`, `goals`, and `activities` notations are each distinct and each carry their own extension (`*.dgca.transitrix.yaml`, `*.goals.transitrix.yaml`, `*.activities.transitrix.yaml` respectively), even though they describe related layers of the same strategy-execution family. The `notation:` header inside the file identifies the specific notation; the extension mirrors it. The validator enforces this per rule `HDR-003`.
+Each notation has exactly one canonical file extension: `*.<short-name>.transitrix.yaml`. The `dgca`, `goals`, and `action` notations are each distinct and each carry their own extension (`*.dgca.transitrix.yaml`, `*.goals.transitrix.yaml`, `*.action.transitrix.yaml` respectively), even though they describe related layers of the same strategy-execution family. The `notation:` header inside the file identifies the specific notation; the extension mirrors it. The validator enforces this per rule `HDR-003`.
 
 No aliases are accepted: one notation has exactly one extension. The full per-notation mapping lives in [README.md](README.md).
 
@@ -447,11 +447,11 @@ Methodology releases use [SemVer](https://semver.org) (`MAJOR.MINOR.PATCH`) with
 | **`MINOR`** | Additive only: new optional field, new notation, new validation code at `info` / `warning`, new TYPE in the registry, new section in a spec. Existing files validate cleanly against the new release. | None required. Adopter MAY adopt new fields when convenient. May update `methodology_version` in `transitrix.yaml` to make the upgrade explicit. |
 | **`PATCH`** | Clarifications, doc fixes, example fixes, no schema change. | None. |
 
-### 10.3 Pre-1.0 disclaimer
+### 10.3 Pre-1.0 disclaimer (historical — resolved at the 1.0 cut)
 
-> **The methodology is pre-1.0.** Until the methodology reaches `v1.0.0`, `MINOR` bumps **may carry breaking changes** — standard SemVer pre-1.0 rules apply. Adopters pinning a pre-1.0 version with a caret range (`^0.4.x`) may be broken by a subsequent `0.5.0`. **Pin exactly** (`0.4.2`) in production adopter repos until the 1.0 cut.
-
-Once the methodology hits `v1.0.0`, MINOR bumps will be additive only — the policy in §10.2 holds without the pre-1.0 exception.
+> **As of `v1.0.0` (2026-07-05), the methodology is past the 1.0 cut.** The policy in §10.2 now holds without exception: `MINOR` bumps are additive only; breaking changes require a `MAJOR` bump. Adopters on a released version may pin with a caret range (`^1.0.x`) and expect no breaking changes from subsequent `MINOR`/`PATCH` releases.
+>
+> **Historical note.** Before `v1.0.0`, `MINOR` bumps could carry breaking changes — standard SemVer pre-1.0 rules applied, and adopters on a `0.x` release were advised to pin exactly (`0.4.2`) rather than with a caret range. This no longer applies to any release from `1.0.0` onward.
 
 ### 10.4 The release promise
 
@@ -896,4 +896,4 @@ Two terms in the methodology carry closely related names and must not be conflat
 
 **Rule:** the word **Activity** MUST NOT be used to describe project-domain work items. The word **Action** MUST NOT be used to describe process-domain steps. Validators that detect `notation: activity` on a project-schedule document (distinct from `notation: bpmn` / PROCESS `flow` contexts) MUST emit `ACTION-005`.
 
-**Historical note.** Prior to 2026-06-25 the project-domain primitive was called `ACTIVITY`. That name has been deprecated in favour of `ACTION` to enforce this distinction. The deprecated `ACTIVITY` TYPE prefix, `activity_type` field, and `activities:` array name are accepted with `ACTION-005` / `ACT-020` warnings until the 1.0 cut; see [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §6 for the migration checklist.
+**Historical note.** Prior to 2026-06-25 the project-domain primitive was called `ACTIVITY`. That name was deprecated in favour of `ACTION` to enforce this distinction, and as of the 1.0 release (2026-07-05) is fully removed: the `ACTIVITY` TYPE prefix, `activity_type` field, `activities:` array name, and `*.activities.transitrix.yaml` extension are no longer accepted — validators emit `ACTION-005` as an **error**, not a warning. See [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §6 for the migration checklist.

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -30,7 +30,7 @@ A worked example lives at `transitrix.yaml` in the [acme-corp reference repo](ht
 ```yaml
 transitrix: 1                       # manifest schema version (integer)
 methodology_version: "1.0.0"        # the methodology release this repo conforms to
-notations: [dgca, goals, activities, capability-map, codex]
+notations: [dgca, goals, action, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md
 confidence_decay:                   # optional — per-TYPE freshness decay; see CONTRACT.md §11.3

--- a/notations/README.md
+++ b/notations/README.md
@@ -93,7 +93,7 @@ status: draft | documented | stable
 
 ## Family selection
 
-Three notations — DGCA, the Goals tree, and the Activities network — sit on the same strategy-to-execution spectrum. They differ in which layers they carry; the right one for a given task is the one that names exactly the layers you need to talk about, no more.
+Three notations — DGCA, the Goals tree, and the Action schedule — sit on the same strategy-to-execution spectrum. They differ in which layers they carry; the right one for a given task is the one that names exactly the layers you need to talk about, no more.
 
 ### Layer composition
 

--- a/packages/ingest-cli/README.md
+++ b/packages/ingest-cli/README.md
@@ -4,9 +4,9 @@ The deterministic CLI behind the **ingest skill** (`transitrix/skills/ingest/`, 
 
 It lives here — a standalone package at the repo root, **outside** the skill bundle and the plugin payload — because it is consumed as a **standalone package**, not vendored into the skill directory and not referenced by a repo-relative sibling path (which would dangle when only the skill directory ships into a Copilot `.github/skills/` install).
 
-## Install (pre-1.0)
+## Install
 
-The package is not yet published to npm; the planned npm publish rides the ~1.0 extraction to its own tooling repo (`IG-7`). Today the install is local from this checkout:
+The package is not yet published to npm; the planned npm publish rides the CLI's extraction to its own tooling repo (`IG-7`). Today the install is local from this checkout:
 
 ```
 npm install -g ./packages/ingest-cli   # provides the `transitrix-ingest` bin globally

--- a/transitrix/skills/repo-check/README.md
+++ b/transitrix/skills/repo-check/README.md
@@ -21,6 +21,6 @@ Operating a Transitrix repo, you periodically want a quick, shareable answer to 
 transitrix-ingest repo-check [org-root]    # defaults to the current repo; prints YAML to stdout
 ```
 
-The CLI is also reachable as `npx @transitrix/ingest-cli repo-check ...` once the package is published to npm; pre-1.0 the local-install form is primary.
+The CLI is also reachable as `npx @transitrix/ingest-cli repo-check ...` once the package is published to npm; until then, the local-install form is primary.
 
 See [`SKILL.md`](SKILL.md) for the agent-facing protocol and the report's field reference.


### PR DESCRIPTION
## Summary

Follow-up from an internal project review (2026-07-05): the 1.0.0 release and the 2026-06-25 `activities`→`action` rename left several docs asserting stale/contradictory state.

- `README.md`, `RELEASING.md`, `method/01-methodology.md` — dropped "pre-1.0" framing now that `CHANGELOG.md` has a `[1.0.0]` release.
- `notations/CONTRACT.md` §10.3 — the pre-1.0/post-1.0 SemVer distinction is now historical, not current policy; reworded and marked as such. HDR-003 and §3 named `activities` as a canonical, live extension — updated to `action`. The historical note said the deprecated `activities:` forms were "accepted with warnings until the 1.0 cut" — but `CHANGELOG [1.0.0]` already hard-removed them (errors, not warnings). Updated to match.
- `notations/MANIFEST.md` — example `notations:` array still listed `activities` instead of `action`; an adopter copying it would hit a validator error.
- `notations/README.md` — "Activities network" → "Action schedule" in the family-selection intro.
- `README.md` — softened the "first artefact is a Goals tree" claim, which contradicted `onboard/SKILL.md`'s "any notation is a valid first artefact."
- `packages/ingest-cli/README.md`, `transitrix/skills/repo-check/README.md` — reworded npm-publish-pending language that tied "not yet on npm" to a "pre-1.0" milestone that has already passed without the CLI actually being published (extraction to its own tooling repo is still pending, tracked separately as `IG-7`).

**Deliberately not touched:** FGA's `status: documented` (vs. the "(deprecated)" title/body) — `deprecated` isn't yet a valid value in the `status` enum (`notations/README.md` status legend), a separate schema gap, not a doc-drift bug. Tracked separately.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (15 view notations; examples, internal links, methodology_version pins all consistent)
- [x] `python tools/lint.py .` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)