### PR TITLE
docs(tooling): validator ownership matrix, deprecated status enum, FGA status fix

### DIFF
--- a/integration/tooling.md
+++ b/integration/tooling.md
@@ -1,7 +1,7 @@
 # Transitrix Tooling & Integration
 
-**Version:** 1.0.0
-**Date:** 2026-05-03
+**Version:** 1.0.1
+**Date:** 2026-07-06
 **Status:** Active
 
 ---
@@ -9,6 +9,30 @@
 ## Overview
 
 The Transitrix methodology is supported by specialised tools for various aspects of architectural modelling. This document describes the available tools and their integration.
+
+---
+
+## Validation tools — ownership matrix
+
+Transitrix separates validation into two canonical axes (file scope and repo scope), each with a designated tool. A third tool covers the knowledge store. A fourth tool is deprecated. The table names each, its scope, what it checks, and its lifecycle status.
+
+| Tool | Scope | What it checks | When to run | Status |
+|---|---|---|---|---|
+| `npx @transitrix/cli validate <file>` | **File** — one `*.transitrix.yaml` at a time | Schema, required fields, notation-specific rules for all 15 canonical extensions (no `--ext` flag needed for canonical notations) | On every save; pre-commit hook; CI per-file job | **Active — canonical** |
+| `python3 .validators/lint.py` | **Repo** — whole `canon/` tree at once | Atomicity (no relations inside element files), referential integrity, ArchiMate semantics, policy (Active status requires an owner) | Before every PR; CI repo-integrity job | **Active — canonical.** Fetched from `tools/lint.py` at scaffold time; lives at `.validators/lint.py` in the adopter repo |
+| `python3 tools/knowledge_store_lint.py <root>` | **Knowledge store** — `_intake/processed/` + `knowledge/` | Quality Gates 1–4: quarantine, canonical-definition, blast-radius tiering, provenance/confidence — per `patterns/knowledge-store.md` | When promoting knowledge objects; when reviewing the store for drift | **Methodology-internal reference implementation.** Adopters may copy and adapt it; the methodology owns the rules, not this script. Documented in [`patterns/knowledge-store.md`](../patterns/knowledge-store.md) |
+| `python3 tools/check_views_compliance.py` | Methodology-repo only | Notation-specific rules on the methodology's own example files | Not for adopters | **Deprecated** — superseded by `@transitrix/cli`. Kept for migration reference only |
+
+### What to run when
+
+| Situation | Run |
+|---|---|
+| Editing or reviewing a single view notation file (`*.transitrix.yaml`) | `npx @transitrix/cli validate <file>` (or `npx.cmd` on Windows — see §"Windows PowerShell" below) |
+| Before opening a PR (any `canon/` change) | `python3 .validators/lint.py` |
+| Scaffold + batch changes | Both: CLI per file, then `lint.py` for the whole repo |
+| Promoting knowledge objects or auditing the knowledge store | `python3 tools/knowledge_store_lint.py <knowledge-store-root>` (only if your repo has a knowledge store) |
+
+**Planned evolution:** when `@transitrix/cli` gains `--scope=repo`, the repo-integrity job in [`integration/ci-example.yaml`](ci-example.yaml) will move fully onto the CLI runtime and `lint.py` will be retired, collapsing the two-tool model to one. That step is tracked in the CLI roadmap; adopter pipelines following `ci-example.yaml` will need no changes until then.
 
 ---
 
@@ -528,6 +552,6 @@ exit $status
 
 Make it executable (`chmod +x .git/hooks/pre-commit` on Unix; Git Bash on Windows respects this). The hook validates only staged `*.transitrix.yaml` files, so it runs quickly on typical commits. It uses `npx.cmd` so it works under a restricted PowerShell execution policy without any policy change.
 
-**Document version:** 1.0.2
-**Updated:** 2026-07-01
+**Document version:** 1.0.3
+**Updated:** 2026-07-06
 **Next update:** When new tools are added

--- a/notations/README.md
+++ b/notations/README.md
@@ -58,8 +58,9 @@ The `status:` field in each spec's front-matter describes the **spec's maturity*
 | `draft` | The spec is incomplete or has known open structural questions; content may change in non-backwards-compatible ways. |
 | `documented` | The spec is complete and internally consistent. No open structural questions. Minor additive revisions are expected. |
 | `stable` | The schema is locked. Future changes must be backwards-compatible (additive only). |
+| `deprecated` | The notation is retired. No new artefacts should use it; existing adopters must migrate. The spec file is kept for migration reference only. |
 
-The vocabulary is intentionally small. A future `deprecated` value will be added when a notation is retired.
+The vocabulary is intentionally small.
 
 ## Front-matter conventions
 
@@ -72,7 +73,7 @@ notation: "Human-readable diagram name"
 version: "X.Y"
 author: "..."
 last_updated: "YYYY-MM-DD"
-status: draft | documented | stable
+status: draft | documented | stable | deprecated
 file_extension: "*.short-name.transitrix.yaml"
 dsm_status: "..."          # see rule below
 ```
@@ -84,7 +85,7 @@ title: "Element Name — one-line summary"
 version: "X.Y"
 author: "..."
 last_updated: "YYYY-MM-DD"
-status: draft | documented | stable
+status: draft | documented | stable | deprecated
 ```
 
 **`dsm_status:` rule:** required for all view notations with `status: documented`. Optional for `draft` views — add when there is something specific to say about Studio implementation. Describes Transitrix Studio implementation state, not spec completeness.

--- a/notations/views/03-fga.md
+++ b/notations/views/03-fga.md
@@ -3,7 +3,7 @@ notation: "FGA Strategy-to-Execution Chain (deprecated)"
 version: "0.3"
 author: "Valerii Korobeinikov"
 last_updated: "2026-06-23"
-status: "documented"
+status: "deprecated"
 file_extension: "*.fga.transitrix.yaml"
 dsm_status: "not implemented — superseded by dgca with layers.changes: off"
 ---

--- a/tools/check_views_compliance.py
+++ b/tools/check_views_compliance.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 """
+DEPRECATED — superseded by `npx @transitrix/cli validate <file>` (file-scope)
+and `python3 .validators/lint.py` (repo-scope). Kept for migration reference
+only; do not use in new adopter pipelines. See integration/tooling.md §"Validation
+tools — ownership matrix" for the current two-tool validation model.
+
 Transitrix Views Compliance Checker
 Validates view notation files against notation-specific rules.
 


### PR DESCRIPTION
## Summary

Addresses a tracked internal task on validator ownership clarity + doc consolidation.

- **Validator ownership matrix** — new §"Validation tools — ownership matrix" in `integration/tooling.md`: four-row table naming each tool, its scope, what it checks, when to run it, and its lifecycle status. Includes a "what to run when" quick-reference. Closes the gap the `ci-example.yaml` header comments partially filled.
- **`deprecated` status enum** — added to `notations/README.md` status vocabulary table (and both front-matter schema snippets); stale "A future `deprecated` value will be added…" note removed.
- **FGA status fix** — `notations/views/03-fga.md` now carries `status: "deprecated"` to match its title and body (confirmed with the maintainer: FGA needs no further retirement work, only this schema-gap close).
- **`check_views_compliance.py` resolved** — decision: deprecated. Deprecation notice added to the file docstring; documented in the matrix as superseded by `@transitrix/cli`. File kept for migration reference per archiving convention.
- **`knowledge_store_lint.py` resolved** — decision: document-and-keep. Documented in the matrix as the methodology-internal reference implementation for Gates 1–4 (per `patterns/knowledge-store.md`).
- **Consolidation of triple-defined concepts** (lower-priority item) — explicitly deferred: the `method/01-methodology.md` §3a TYPE-table already carries an explicit "canonical source is `IDS_AND_REFERENCES.md`" disclaimer; the memory-types and zone-description duplication is a soft drift-risk with partial mitigation in place, not blocking any adoption path. Surfacing via `NOTATIONS_AUDIT.md` if it reaches actionable threshold.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (15 view notations; examples, internal links, methodology_version pins all consistent)
- [x] `python tools/lint.py .` — 0 errors, 0 warnings
- [x] File tails verified for all four changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
