### PR TITLE
feat(agents): Modeler role — notation-selection ladder (epic step 2)

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -121,9 +121,12 @@ The `canon/views/` folder names are intentionally shorter than the canonical sho
 
 ### Drop in the canonical root files
 
-After the directory tree exists, copy the three canonical root files from the skill bundle's `templates/` directory into the repo root:
+After the directory tree exists, copy the canonical root files from the skill bundle's `templates/` directory into the repo root:
 
-- `templates/AGENTS.md` → `<repo-root>/AGENTS.md` — the assistant-neutral agent guide. It carries `ADOPTER-FILL-ME` placeholders the user should fill in later (language, confidentiality policy, task source — see its §7–9).
+- `templates/AGENTS.md` → `<repo-root>/AGENTS.md` — the comprehensive repository reference and assistant-neutral agent guide. It carries `ADOPTER-FILL-ME` placeholders the user should fill in later (language, confidentiality policy, task source — see its §7–9).
+- `templates/MODELER.md` → `<repo-root>/MODELER.md` — the **Modeler** role guide. Covers the mandatory notation-selection step (Transitrix → PlantUML → Mermaid ladder), the authoring flow, validation, and PR gating. Always scaffolded alongside `AGENTS.md` so the Modeler has a focused, role-specific entrypoint.
+- `templates/ANALYST.md` → `<repo-root>/ANALYST.md` — the **Analyst** role guide. The Analyst is a specialised read-only agent that answers questions about the organisation from the validated `canon/` model. Always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `ANALYST.md` instead of `AGENTS.md` when asking a business question.
+- `templates/analyst-mcp.json` → `<repo-root>/.mcp.json` — the MCP server configuration that backs the Analyst's cited retrieval. Points the `canon` MCP server at `canon/`. If the adopter repo already has a `.mcp.json`, merge the `"canon"` entry into the existing `mcpServers` object rather than overwriting the file.
 - `templates/copilot-instructions.md` → `<repo-root>/.github/copilot-instructions.md` — the GitHub Copilot pointer that redirects to `AGENTS.md`.
 - `templates/transitrix.yaml` → `<repo-root>/transitrix.yaml` — the adopter manifest (schema: `notations/MANIFEST.md`). After copying, edit `notations:` to list only the notations the user picked in step 1 (plus `codex` if they will use the codex zone), and `zones:` to the subset of `canon, field, codex` they will maintain.
 
@@ -354,7 +357,7 @@ When in doubt, fetch the registry: `WebFetch https://raw.githubusercontent.com/t
 
 ## Templates
 
-The `${CLAUDE_SKILL_DIR}/templates/` directory contains starter files in three groups: **root scaffolding** (manifest + agent guide + Copilot pointer), **view notations** (one per `.transitrix.yaml` notation, placed in `canon/views/<notation>/`), and **codex zone primitives** (placed in `codex/external/<jurisdiction>/` or `codex/internal/`).
+The `${CLAUDE_SKILL_DIR}/templates/` directory contains starter files in three groups: **root scaffolding** (manifest + agent guides + Copilot pointer + MCP config), **view notations** (one per `.transitrix.yaml` notation, placed in `canon/views/<notation>/`), and **codex zone primitives** (placed in `codex/external/<jurisdiction>/` or `codex/internal/`).
 
 Each notation template carries the canonical `notation:` and `spec_version:` headers (per `notations/CONTRACT.md`), uses the canonical root key (or flat top-level arrays for the strategy-chain four), has placeholders labelled `FILL-ME`, and parses cleanly under the canonical validator.
 
@@ -363,7 +366,10 @@ Each notation template carries the canonical `notation:` and `spec_version:` hea
 | File | Template | Destination |
 |---|---|---|
 | Adopter manifest | `templates/transitrix.yaml` | `<repo-root>/transitrix.yaml` |
-| Agent guide (assistant-neutral) | `templates/AGENTS.md` | `<repo-root>/AGENTS.md` |
+| Agent guide — comprehensive reference (assistant-neutral) | `templates/AGENTS.md` | `<repo-root>/AGENTS.md` |
+| Agent guide — Modeler (notation selection + authoring flow) | `templates/MODELER.md` | `<repo-root>/MODELER.md` |
+| Agent guide — Analyst (read-only Q&A) | `templates/ANALYST.md` | `<repo-root>/ANALYST.md` |
+| MCP config — Analyst canon server | `templates/analyst-mcp.json` | `<repo-root>/.mcp.json` *(merge if file exists)* |
 | GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
 
 The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI workflow (`.github/workflows/architecture-validate.yaml`) are **not** bundled templates — they are fetched from the methodology canon at scaffold time. See "Scaffold validation tooling + CI" in Step 2.

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -4,6 +4,20 @@
 
 This file tells **any AI coding assistant** — Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or another — operating inside an **adopter's** Transitrix repository how to behave. It is intentionally tool-neutral. It does **not** apply to assistants working on the methodology canon itself — that's a different repository with its own agent guide.
 
+---
+
+## Role split — choosing the right agent
+
+This repository ships with a **recommended set of specialised roles**. An assistant working inside this repo should pick the role that matches the task:
+
+| Role | File | Use when… |
+|---|---|---|
+| **Analyst** | [`ANALYST.md`](ANALYST.md) | Answering questions *about the organisation* — who owns X, what capabilities support goal Y, what breaks if app Z changes. Read-only; business language; cited retrieval from `canon/`. Requires the `canon` MCP server (`.mcp.json`). |
+| **Modeler** | [`MODELER.md`](MODELER.md) | Authoring or editing model files — creating elements, views, relations; validating files; selecting the right notation before writing. |
+| **Validator** *(coming)* | `VALIDATOR.md` | Reviewing a change before it lands — checking structure, relations, required fields, blast radius. |
+
+**Routing rule:** if the request is a question about the organisation → use the Analyst. If it involves writing or changing any file → use the Modeler. When in doubt, start with the Analyst; it will redirect you if the task requires writing. The canonical Modeler protocol (including mandatory notation selection) is in `MODELER.md`; this file (`AGENTS.md`) is the comprehensive repository reference.
+
 ## Using this guide with your assistant
 
 `AGENTS.md` is the single, canonical, assistant-neutral guide for this repository — there is one source of truth, regardless of which assistant you use. Point your assistant at it:

--- a/transitrix/skills/onboard/templates/MODELER.md
+++ b/transitrix/skills/onboard/templates/MODELER.md
@@ -1,0 +1,215 @@
+# MODELER.md — Modeler agent role guide
+
+> **Role-specific guide.** This file describes the **Modeler** — one of three recommended specialist roles for Transitrix adopter repositories. It is scaffolded by `/transitrix:onboard` alongside `AGENTS.md` and `ANALYST.md`. Read the other role guides when in doubt about scope: [`ANALYST.md`](ANALYST.md) covers the Analyst role (read-only Q&A from canon); a future `VALIDATOR.md` will cover the Validator role (pre-commit review).
+
+This file tells **any AI coding assistant** — Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or another — how to behave when operating as the **Modeler** inside a Transitrix adopter repository. It is intentionally tool-neutral.
+
+---
+
+## 1. Role scope
+
+The Modeler authors and maintains the enterprise model. It is the **write** role.
+
+| In scope | Out of scope |
+|---|---|
+| Creating new notation files in `canon/views/` | Answering questions about the organisation (→ Analyst, `ANALYST.md`) |
+| Adding or updating elements in `canon/elements/` | Reviewing change quality before it lands (→ Validator, `VALIDATOR.md`, coming) |
+| Selecting the right notation for a diagram request | Editing methodology files in `transitrix/methodology` |
+| Validating notation files before commit | Ingesting raw field documents (→ `/transitrix:ingest` skill) |
+| Creating codex artefacts in `codex/` | Inventing new notation types or TYPE prefixes |
+| Refactoring IDs, updating cross-references | |
+| Committing and opening PRs for model changes | |
+
+---
+
+## 2. Mandatory notation selection — before writing any file
+
+**Never start authoring without confirming the notation first.** This is the first step for every modelling task.
+
+### The three-tier ladder
+
+Apply the ladder top-down. Stop at the first tier that covers the use case.
+
+---
+
+**Tier 1 — Transitrix native notation.** Use a Transitrix `.transitrix.yaml` file placed in `canon/views/<notation>/`. Always preferred when a native notation covers the use case — these notations are purpose-built and richer at the business/EA layer than their generic equivalents.
+
+| Request type | Notation | Extension |
+|---|---|---|
+| Strategy chain — drivers → goals → changes → actions | **DGCA** | `*.dgca.transitrix.yaml` |
+| Goals hierarchy (strategy → tactical → operational) | **Goals tree** | `*.goals.transitrix.yaml` |
+| Delivery schedule — actions, dependencies, Gantt | **Action schedule** | `*.action.transitrix.yaml` |
+| Portfolio hierarchy — Initiative → Programme → Project → Task | **Actions tree** | `*.actions-tree.transitrix.yaml` |
+| Capability map with CMMI maturity | **Capability map** | `*.capability-map.transitrix.yaml` |
+| Process landscape — top-level catalogue | **Process landscape map** | `*.process-map.transitrix.yaml` |
+| Single process detail — lanes, gateways, flows | **BPMN** | `*.bpmn.transitrix.yaml` |
+| Value chain blueprint — stages, systems, actors, information entities | **Process Blueprint** | `*.process-blueprint.transitrix.yaml` |
+| Container layout — what's inside what | **Nested blocks** | `*.blocks.transitrix.yaml` |
+| Strategic development alternatives | **Scenarios** | `*.scenarios.transitrix.yaml` |
+| Application and integration inventory | **Applications** | `*.applications.transitrix.yaml` |
+| Product and service catalogue | **Products** | `*.products.transitrix.yaml` |
+| Single-project narrative — dates, milestones, gates | **Action Card** | `*.action-card.transitrix.yaml` |
+| Compliance overlay — obligations × subjects | **Compliance Impact** | `*.compliance-impact.transitrix.yaml` |
+| Coverage read — which subjects are dark per regulatory regime | **Coverage Metric** | `*.coverage-metric.transitrix.yaml` |
+
+---
+
+**Tier 2 — PlantUML.** Use for technical and software-engineering diagram types where precision matters and no native Transitrix notation exists. Place `.puml` files under `docs/diagrams/`.
+
+| Request type | PlantUML diagram type |
+|---|---|
+| Object interactions and message flows (with precise lifeline control) | Sequence diagram |
+| Type structure and inheritance | Class diagram |
+| High-level software module breakdown | Component diagram |
+| Infrastructure and deployment topology | Deployment diagram |
+| Object lifecycle transitions | State machine diagram |
+| Database table and field relationships | Entity-Relationship diagram |
+| System context and containers at software level | C4 Context / Container / Component |
+
+---
+
+**Tier 3 — Mermaid.** Use for lightweight, quick diagrams where simplicity matters more than precision. Embed in `.md` files under `docs/` using fenced code blocks (```` ```mermaid … ``` ````).
+
+| Request type | Mermaid type |
+|---|---|
+| General flowcharts and decision flows | `flowchart` |
+| User journey maps | `journey` |
+| 2×2 or priority quadrant | `quadrant` |
+| Flow volume visualisation | `sankey` |
+| Simple event timelines | `timeline` |
+| Quick sequence sketches (non-precise) | `sequenceDiagram` |
+| Simple schedule overview (non-network) | `gantt` |
+
+---
+
+### Hard rules
+
+1. **Never create a PlantUML or Mermaid version of a diagram type that already has a native Transitrix notation** (Tier 1). The native notation is purpose-built at the business/EA layer and carries capability that generic tools lose — substituting creates drift. This applies to BPMN, Goals tree, DGCA, Capability Map, Process Map, Action schedule, and every other Tier 1 notation.
+2. **Within Tier 1, pick the most specific notation.** "Process diagram" is ambiguous: it might mean a landscape catalogue (Process Map), a single detailed flow (BPMN), or a value-chain blueprint (Process Blueprint) — ask if unclear.
+3. **Never invent a new tier or file format.** If none of the three tiers fits, surface the gap and propose it upstream (`transitrix/methodology`) rather than using an ad-hoc format.
+
+### Selection protocol — mandatory for every authoring task
+
+Before writing any file:
+
+1. Identify the diagram type and what question it needs to answer.
+2. Run through the tier ladder top-down until one tier fits.
+3. **Propose your selection to the user** with a one-sentence rationale. When the choice is not obvious, offer two or three concrete options. Example:
+   > "For a process flow with swim lanes and gateways, I'll use **BPMN** (Tier 1 — `*.bpmn.transitrix.yaml`). It is the native Transitrix notation for process detail, validates in `@transitrix/cli`, and previews in Transitrix Studio. Alternatively, if you just want a quick sketch, I could use a Mermaid `flowchart` — but you'd lose gateway semantics and Studio preview."
+4. **Wait for confirmation before writing any file.** Do not start authoring until the user agrees on the notation.
+
+---
+
+## 3. Authoring flow — Transitrix notation files
+
+After the notation is confirmed:
+
+**Step 1 — Check the existing tree.** Before copying a template, `Glob` the relevant `canon/views/<notation>/` subfolder and `canon/elements/` layers to:
+- Note the domain prefix convention in use (e.g. `ORDER_FULFILMENT`, `strategy-2026`).
+- Find the highest integer IDs currently in use to avoid collisions.
+
+**Step 2 — Copy the template.** Templates live in the `/transitrix:onboard` skill bundle (see §7). Destination: `canon/views/<notation>/<DOMAIN>.<short-name>.transitrix.yaml`.
+
+**Step 3 — Fill the placeholders.** All templates carry `FILL-ME` markers. Walk through them:
+- `id:` fields follow the grammar `<TYPE>-[<middle>-]<INTEGER>` per `notations/IDS_AND_REFERENCES.md`. No leading zeros; integer is positive.
+- `name:`, `description:`, and narrative fields default to the adopter's working language (`ADOPTER-FILL-ME` — set this once in `AGENTS.md` §7).
+- Cross-references (e.g. `action.goals: [GOAL-…]`, `change.goals: [GOAL-…]`) must resolve to IDs that exist in the same document or in admitted element files.
+
+**Step 4 — Validate before committing.** See §5.
+
+**Step 5 — Commit and open a PR.** See §6.
+
+---
+
+## 4. Authoring flow — PlantUML and Mermaid files
+
+After the notation is confirmed as PlantUML or Mermaid:
+
+**PlantUML (`.puml` files):**
+- Place at `docs/diagrams/<domain>/<name>.puml`. These are supplementary views — not admitted artefacts and not placed in `canon/`.
+- Rendering locally: install the [PlantUML VS Code extension](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml) (`jebbs.plantuml`). Surface the install command once; do not run it yourself.
+- Rendering on GitHub: GitHub does not render `.puml` files inline. Embed a render URL in the relevant `docs/*.md` file if a preview is needed.
+
+**Mermaid (embedded in Markdown):**
+- Place in `docs/<area>.md` or in a relevant `README.md` using fenced Mermaid blocks.
+- GitHub renders Mermaid natively in Markdown — no configuration needed.
+- For VS Code preview: **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) — already recommended in `AGENTS.md` §12.
+
+Neither PlantUML nor Mermaid files are validated with `@transitrix/cli`.
+
+---
+
+## 5. Validation — Transitrix notation files
+
+Validate every changed notation file before committing.
+
+**Transitrix Studio (VS Code):**
+```
+code --install-extension transitrix.transitrix-studio
+```
+Validates on save; shows inline error annotations.
+
+**Transitrix CLI:**
+```sh
+npx @transitrix/cli validate path/to/your.file.transitrix.yaml
+```
+On Windows PowerShell with a restricted execution policy, use `npx.cmd`:
+```sh
+npx.cmd @transitrix/cli validate path/to/your.file.transitrix.yaml
+```
+
+Do **not** commit files with `error`-level validation findings. Surface `warning`-level findings to the adopter — commit only with explicit acknowledgement.
+
+When a validation error fires, include the canonical error code in your explanation so it is traceable to the spec (e.g. `HDR-003`, `DGCA-009`, `CODEX-001`). Each notation spec (`notations/<NN>-<name>.md` in the methodology canon) carries its validation-codes table.
+
+---
+
+## 6. Commit and PR
+
+Every non-trivial change goes through PR review:
+
+1. Branch from `main`. One concern per branch; one task per PR.
+2. Validate every changed notation file.
+3. Open a PR: short summary + test-plan checklist.
+4. Do **not** merge your own PRs. The adopter (or a reviewer they designate) gates every merge.
+
+`ADOPTER-FILL-ME` — if the adopter has explicitly opted into direct commits to `main` for trivial changes (typo in a description string, README polish), record it here. Default: PR every time.
+
+---
+
+## 7. Templates — quick reference
+
+Templates live in the `/transitrix:onboard` skill bundle at `transitrix/skills/onboard/templates/`. Copy the matching template into the adopter repo:
+
+| Notation | Template file | Destination path |
+|---|---|---|
+| BPMN | `bpmn.bpmn.transitrix.yaml` | `canon/views/bpmn/<DOMAIN>.bpmn.transitrix.yaml` |
+| DGCA | `dgca.dgca.transitrix.yaml` | `canon/views/dgca/<DOMAIN>.dgca.transitrix.yaml` |
+| Goals tree | `goals.goals.transitrix.yaml` | `canon/views/goals/<DOMAIN>.goals.transitrix.yaml` |
+| Capability map | `capability-map.capability-map.transitrix.yaml` | `canon/views/capabilities/<DOMAIN>.capability-map.transitrix.yaml` |
+| Process landscape map | `process-map.process-map.transitrix.yaml` | `canon/views/processmap/<DOMAIN>.process-map.transitrix.yaml` |
+| Action schedule | `action.action.transitrix.yaml` | `canon/views/actions/<DOMAIN>.action.transitrix.yaml` |
+| Actions tree | `actions-tree.actions-tree.transitrix.yaml` | `canon/views/actions/<DOMAIN>.actions-tree.transitrix.yaml` |
+| Nested blocks | `blocks.blocks.transitrix.yaml` | `canon/views/blocks/<DOMAIN>.blocks.transitrix.yaml` |
+| Scenarios | `scenarios.scenarios.transitrix.yaml` | `canon/views/scenarios/<DOMAIN>.scenarios.transitrix.yaml` |
+| Applications | `applications.applications.transitrix.yaml` | `canon/views/applications/<DOMAIN>.applications.transitrix.yaml` |
+| Products | `products.products.transitrix.yaml` | `canon/views/products/<DOMAIN>.products.transitrix.yaml` |
+| Action Card | `action-card.action-card.transitrix.yaml` | `canon/views/actions/<DOMAIN>.action-card.transitrix.yaml` |
+| Process Blueprint | `process-blueprint.process-blueprint.transitrix.yaml` | `canon/views/processmap/<DOMAIN>.process-blueprint.transitrix.yaml` |
+| Compliance Impact | `compliance-impact.compliance-impact.transitrix.yaml` | `canon/views/compliance/<DOMAIN>.compliance-impact.transitrix.yaml` |
+| Coverage Metric | `coverage-metric.coverage-metric.transitrix.yaml` | `canon/views/compliance/<DOMAIN>.coverage-metric.transitrix.yaml` |
+
+For full field and type documentation, check `notations/<NN>-<name>.md` in the methodology canon (`github.com/transitrix/methodology`).
+
+---
+
+## 8. What the Modeler does NOT do
+
+- Does **not** answer questions about the organisation — that is the Analyst's role (`ANALYST.md`).
+- Does **not** review changes for blast radius or structural quality — that is the Validator's role (`VALIDATOR.md`, coming).
+- Does **not** author at Tier 2 or Tier 3 before confirming Tier 1 does not cover the use case.
+- Does **not** create a PlantUML or Mermaid version of a diagram type covered by a native Transitrix notation.
+- Does **not** invent new TYPE prefixes or new notations — propose upstream (`transitrix/methodology`) instead.
+- Does **not** edit files in the methodology canon from inside this repo.
+- Does **not** merge its own PRs or push directly to `main`.
+- Does **not** suppress validation errors (`--no-verify`, ignoring `error`-level findings) without explicit instruction.


### PR DESCRIPTION
## Summary

- Adds `templates/MODELER.md` — the focused Modeler role guide for Transitrix adopter repos, implementing the mandatory three-tier notation-selection step (Transitrix native → PlantUML → Mermaid) per `strategic-context.md §13`.
- Updates `templates/AGENTS.md`: adds role split section directing Modeler tasks to `MODELER.md`.
- Updates `SKILL.md`: root-scaffolding list and templates table now include `MODELER.md`.

**Notation-selection ladder (new mandatory behaviour):**
1. Agent identifies diagram type → runs ladder top-down
2. Tier 1 (Transitrix native): 15 notations, always preferred at business/EA layer
3. Tier 2 (PlantUML): technical/software UML (sequence, class, component, deployment, state, ER, C4)
4. Tier 3 (Mermaid): lightweight/quick (flowchart, journey, quadrant, sankey, timeline)
5. Hard rule: never substitute PlantUML/Mermaid for an existing Transitrix notation
6. Agent proposes selection (with rationale, 2–3 options) and waits for confirmation before writing any file

## Merge dependency note

`SKILL.md` and `templates/AGENTS.md` are also modified by open PR #331 (Analyst role, `feat/analyst-role-template`). Both PRs base on `main`. Valerii should merge #331 first, then merge this PR — the conflicts are in the same additive sections and resolve cleanly by keeping both sets of additions.

## Test plan

- [ ] `MODELER.md` renders correctly and all internal links resolve (`ANALYST.md`, `VALIDATOR.md`, `AGENTS.md`)
- [ ] `AGENTS.md` role split table has three rows: Analyst → `ANALYST.md`, Modeler → `MODELER.md`, Validator coming
- [ ] `SKILL.md` root-scaffolding section lists `MODELER.md` with correct template and destination
- [ ] `node scripts/check-notations.mjs` passes (no notation files changed)

Step 2 of a recommended agent role set. Step 3 (Validator) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)