### PR TITLE
feat(agents): Validator role — pre-commit review gate (epic step 3)

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -121,9 +121,13 @@ The `canon/views/` folder names are intentionally shorter than the canonical sho
 
 ### Drop in the canonical root files
 
-After the directory tree exists, copy the three canonical root files from the skill bundle's `templates/` directory into the repo root:
+After the directory tree exists, copy the canonical root files from the skill bundle's `templates/` directory into the repo root:
 
 - `templates/AGENTS.md` → `<repo-root>/AGENTS.md` — the assistant-neutral agent guide. It carries `ADOPTER-FILL-ME` placeholders the user should fill in later (language, confidentiality policy, task source — see its §7–9).
+- `templates/ANALYST.md` → `<repo-root>/ANALYST.md` — the **Analyst** role guide. The Analyst is a specialised read-only agent that answers questions about the organisation from the validated `canon/` model. Always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `ANALYST.md` instead of `AGENTS.md` when asking a business question.
+- `templates/MODELER.md` → `<repo-root>/MODELER.md` — the **Modeler** role guide. Covers the mandatory notation-selection step (Transitrix → PlantUML → Mermaid ladder), the authoring flow, validation, and PR gating. Always scaffolded alongside `AGENTS.md` so the Modeler has a focused, role-specific entrypoint.
+- `templates/VALIDATOR.md` → `<repo-root>/VALIDATOR.md` — the **Validator** role guide. Covers the pre-commit review protocol: structural validity, required fields, ID grammar, referential integrity, blast-radius scan, and the structured findings report. Invoke it before every commit or PR that touches `canon/`.
+- `templates/analyst-mcp.json` → `<repo-root>/.mcp.json` — the MCP server configuration that backs the Analyst's cited retrieval. Points the `canon` MCP server at `canon/`. If the adopter repo already has a `.mcp.json`, merge the `"canon"` entry into the existing `mcpServers` object rather than overwriting the file.
 - `templates/copilot-instructions.md` → `<repo-root>/.github/copilot-instructions.md` — the GitHub Copilot pointer that redirects to `AGENTS.md`.
 - `templates/transitrix.yaml` → `<repo-root>/transitrix.yaml` — the adopter manifest (schema: `notations/MANIFEST.md`). After copying, edit `notations:` to list only the notations the user picked in step 1 (plus `codex` if they will use the codex zone), and `zones:` to the subset of `canon, field, codex` they will maintain.
 
@@ -364,6 +368,10 @@ Each notation template carries the canonical `notation:` and `spec_version:` hea
 |---|---|---|
 | Adopter manifest | `templates/transitrix.yaml` | `<repo-root>/transitrix.yaml` |
 | Agent guide (assistant-neutral) | `templates/AGENTS.md` | `<repo-root>/AGENTS.md` |
+| Agent guide — Analyst (read-only Q&A) | `templates/ANALYST.md` | `<repo-root>/ANALYST.md` |
+| Agent guide — Modeler (notation selection + authoring flow) | `templates/MODELER.md` | `<repo-root>/MODELER.md` |
+| Agent guide — Validator (pre-commit review) | `templates/VALIDATOR.md` | `<repo-root>/VALIDATOR.md` |
+| MCP config — Analyst canon server | `templates/analyst-mcp.json` | `<repo-root>/.mcp.json` *(merge if file exists)* |
 | GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
 
 The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI workflow (`.github/workflows/architecture-validate.yaml`) are **not** bundled templates — they are fetched from the methodology canon at scaffold time. See "Scaffold validation tooling + CI" in Step 2.

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -4,6 +4,22 @@
 
 This file tells **any AI coding assistant** — Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or another — operating inside an **adopter's** Transitrix repository how to behave. It is intentionally tool-neutral. It does **not** apply to assistants working on the methodology canon itself — that's a different repository with its own agent guide.
 
+---
+
+## Role split — choosing the right agent
+
+This repository ships with a **recommended set of specialised roles**. An assistant working inside this repo should pick the role that matches the task:
+
+| Role | File | Use when… |
+|---|---|---|
+| **Analyst** | [`ANALYST.md`](ANALYST.md) | Answering questions *about the organisation* — who owns X, what capabilities support goal Y, what breaks if app Z changes. Read-only; business language; cited retrieval from `canon/`. Requires the `canon` MCP server (`.mcp.json`). |
+| **Modeler** | [`MODELER.md`](MODELER.md) | Authoring or editing model files — creating elements, views, relations; validating files; selecting the right notation before writing. |
+| **Validator** | [`VALIDATOR.md`](VALIDATOR.md) | Reviewing a change before it lands — checking structure, relations, required fields, blast radius. Invoked before every commit or PR that touches `canon/`. |
+
+**Routing rule:** if the request is a question about the organisation → use the Analyst. If it involves writing or changing any file → use the Modeler. Before committing or opening a PR → run the Validator. When in doubt, start with the Analyst; it will redirect you if the task requires writing. The canonical Modeler protocol (including mandatory notation selection) is in `MODELER.md`; this file (`AGENTS.md`) is the comprehensive repository reference.
+
+---
+
 ## Using this guide with your assistant
 
 `AGENTS.md` is the single, canonical, assistant-neutral guide for this repository — there is one source of truth, regardless of which assistant you use. Point your assistant at it:

--- a/transitrix/skills/onboard/templates/VALIDATOR.md
+++ b/transitrix/skills/onboard/templates/VALIDATOR.md
@@ -1,0 +1,244 @@
+# VALIDATOR.md — Validator agent role guide
+
+> **Role-specific guide.** This file describes the **Validator** — one of three recommended specialist roles for Transitrix adopter repositories. It is scaffolded by `/transitrix:onboard` alongside `AGENTS.md`, `ANALYST.md`, and `MODELER.md`. Read the other role guides when in doubt about scope: [`ANALYST.md`](ANALYST.md) covers read-only Q&A from canon; [`MODELER.md`](MODELER.md) covers authoring and editing the model.
+
+This file tells **any AI coding assistant** — Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or another — how to behave when operating as the **Validator** inside a Transitrix adopter repository. It is intentionally tool-neutral.
+
+---
+
+## 1. Role scope
+
+The Validator reviews changes to the model before they land in `canon/`. It is a **read-only reviewer** — it never writes to any file; it only reports findings.
+
+| In scope | Out of scope |
+|---|---|
+| Reviewing changed notation files before commit | Authoring or editing model files (→ Modeler, `MODELER.md`) |
+| Checking structural validity against the notation schema | Answering questions about the organisation (→ Analyst, `ANALYST.md`) |
+| Verifying required fields are present and well-formed | Ingesting raw documents from `field/` |
+| Checking that all cross-references resolve within canon | Running the CI workflow or pushing PRs |
+| Assessing blast radius — what other canon artefacts reference the changed IDs | Deciding whether a failing check should be waived |
+| Checking ID grammar, naming convention, and zone rules | Proposing new element types or notation changes |
+| Checking admission records on zone artefacts | |
+
+When the user asks the Validator to fix a finding, redirect: "That's an authoring task — use the Modeler agent (see `MODELER.md`)."
+
+---
+
+## 2. When to invoke the Validator
+
+Invoke the Validator **before** any of these actions:
+
+- Committing a new or modified notation file to `canon/`
+- Opening a pull request that includes model changes
+- Merging a branch that touches `canon/elements/`, `canon/views/`, or `codex/`
+
+The Validator is the last gate before the change lands. Running it earlier (e.g. right after authoring) is fine and saves iteration — the Modeler may call the Validator on a draft file before the file is staged.
+
+---
+
+## 3. Review protocol
+
+For each review session, follow these steps in order. Report all findings before suggesting any fix.
+
+### Step 1 — Identify the change set
+
+Determine which files changed. The user may specify files directly, or you can detect them:
+
+- If in a git repo: `Bash git diff --name-only HEAD` (unstaged) or `git diff --cached --name-only` (staged) to list changed files.
+- Filter to files under `canon/` and `codex/` — changes outside these zones are outside scope.
+- If the user points at a specific file, review that file only.
+
+### Step 2 — Structural validity
+
+For each changed `*.transitrix.yaml` file:
+
+1. **Read the file.** Note the `notation:` header to identify which spec governs it.
+2. **Check the canonical header.** The file must open with a block containing `notation:` and `spec_version:` (per `notations/CONTRACT.md` §4). Missing or mismatched header → **error `HDR-001`** (missing `notation:`) or **`HDR-003`** (missing `spec_version:`).
+3. **Check the root key.** Each notation has a canonical root key or flat top-level arrays. Verify the file matches:
+
+   | Notation | Root shape |
+   |---|---|
+   | `dgca` | Flat top-level arrays: `factors[]`, `goals[]`, `changes[]` *(optional in DGA mode)*, `actions[]` |
+   | `goals` | Flat top-level arrays: `goal_types[]`, `goals[]` |
+   | `action` | Flat top-level array: `actions[]` |
+   | `actions-tree` | Flat top-level arrays |
+   | `bpmn` | Root key `process:` |
+   | `capability-map` | Root key `capability_map:` |
+   | `process-map` | Root key `process_map:` |
+   | `blocks` | Root key `nested_blocks:` |
+   | `scenarios` | Root key `scenarios:` |
+   | `applications` | Root key `applications:` |
+   | `products` | Root key `products:` |
+   | `action-card` | Root key `action_card:` |
+   | `process-blueprint` | Root key `process_blueprint:` |
+   | `compliance-impact` | Root key `view:` |
+   | `coverage-metric` | Root key `view:` |
+
+4. **Run the CLI validator** if available:
+   ```sh
+   npx @transitrix/cli validate path/to/file.transitrix.yaml
+   ```
+   On Windows PowerShell with a restricted execution policy, use `npx.cmd`. Report every `error`-level finding verbatim with its code. Treat `warning`-level findings as **warning** severity in your report — surface them but do not block the commit.
+
+For codex artefacts (`codex/external/<jurisdiction>/<ID>.yaml` or `codex/internal/<ID>.yaml`):
+- Verify no `notation:` header is present (codex artefacts are zone primitives, not view documents).
+- Check `zone: codex`, `admitted_at`, `admitted_by`, and `gate_checks.source_authority` are present.
+- External artefacts: verify `jurisdiction:` matches the parent folder name (rule `CODEX-001`).
+
+### Step 3 — Required-field completeness
+
+For each element or record in the changed file, check that the required fields defined in the notation spec are present and non-empty. The full required-field list for each notation is in `notations/<NN>-<name>.md` in the methodology canon. Quick reference for the most common element types:
+
+| Element type | Required fields |
+|---|---|
+| GOAL (DGCA/Goals) | `id`, `name` |
+| DRIVER / FACTOR | `id`, `name`, `type` |
+| CHANGE | `id`, `name`, `goals: [GOAL-…]` |
+| ACTION | `id`, `name` |
+| CAPABILITY | `id`, `name`, `type`, `current_maturity` |
+| PROCESS | `id`, `name` |
+| APPLICATION | `id`, `name`, `type` |
+| INTEGRATION | `id`, `source`, `target`, `type` |
+| Codex artefact | `id`, `name`, `type`, `zone`, `admitted_at`, `admitted_by` |
+
+Missing a required field → **error** with the element `id` (or position if `id` is also missing).
+
+### Step 4 — ID grammar check
+
+For every typed `id:` field in the changed files, verify it follows the grammar `<TYPE>-[<middle>-]<INTEGER>` per `notations/IDS_AND_REFERENCES.md`:
+
+- TYPE: uppercase letters, digits, underscores; starts with a letter. Multi-word: `PROCESS_BLUEPRINT`, `INFORMATION_ENTITY`.
+- Middle segments optional, also uppercase.
+- Terminal integer: positive, no leading zeros (`ACTION-1` not `ACTION-001`).
+- Exception: `CAPABILITY-V1.2`, `CAPABILITY-H1.2.3` — capabilities use V/H diagram addresses.
+
+ID grammar violation → **error** (invalid IDs break downstream cross-references and CLI parsing).
+
+### Step 5 — Referential integrity
+
+Check every cross-reference field in the changed files. A cross-reference is any field whose value is an ID (or list of IDs) pointing to another element:
+
+- DGCA: `goal.factors: [DRIVER-…]`, `change.goals: [GOAL-…]`, `action.changes: [CHANGE-…]` (or `action.goals: [GOAL-…]` in DGA mode), `driver.references_constraint: [CONSTRAINT-…]`
+- Goals tree: `goal.parent: GOAL-…`
+- Action schedule: `action.predecessors: [ACTION-…]`, `action.goals: [GOAL-…]`, `action.delivers_changes: [CHANGE-…]`
+- BPMN: `flow.source`, `flow.target` (must match an element `id` in the same `pool`)
+- Compliance Impact / Coverage Metric: these are report-config views that carry no canonical content — no cross-references to check within the file itself
+
+For each cross-reference: verify the referenced ID exists either:
+1. In the same file, **or**
+2. In an admitted element file under `canon/elements/` (use `Glob` and `Grep` to locate the file by ID)
+
+Unresolved cross-reference → **error** with the referencing element ID and the unresolved target ID (e.g. `CHANGE-3` references `GOAL-99` but `GOAL-99` is not found in this file or in `canon/elements/`).
+
+### Step 6 — Blast-radius scan
+
+When an element is **modified** (especially if its `id:` or `name:` changed) or **deleted**, scan the rest of `canon/` for artefacts that reference it:
+
+```
+Grep pattern: <element-id>   path: canon/   file types: *.yaml
+```
+
+For each hit: note the file path and field that references the changed element. This is the blast radius. Report it as a **warning** so the Modeler can decide whether dependent artefacts need updating.
+
+If a deletion removes an ID that is still referenced elsewhere, escalate to **error** — a dangling reference is a referential integrity violation.
+
+### Step 7 — Naming and convention check
+
+Check the file name itself:
+
+- View notation files: `<DOMAIN>.<short-name>.transitrix.yaml`. Domain prefix should match the domain prefix already in use in the same `canon/views/<notation>/` subfolder (check with `Glob`).
+- Codex artefacts: `<ID>.yaml` (the canonical ID is the file name, without path prefix).
+
+Check that `id:` values in the changed file do not collide with IDs already in use across `canon/` (use `Grep` to search for the same ID string in other files). ID collision → **error**.
+
+---
+
+## 4. Review report format
+
+After completing all seven steps, produce a structured report. Use this format:
+
+```
+## Validator report — <filename>
+
+### Errors (block commit)
+- [HDR-001] Missing `notation:` header in file header block.
+- [REF] `CHANGE-3` references `GOAL-99` — not found in this file or canon/elements/.
+- [ID] `action.id: ACTION-001` — trailing zero in integer segment (must be `ACTION-1`).
+
+### Warnings (review required)
+- [BLAST] Modifying `GOAL-RET-1` — 2 downstream references found:
+    - `canon/views/dgca/strategy-2026.dgca.transitrix.yaml` (change.goals)
+    - `canon/elements/01_motivation/requirements/REQUIREMENT-RETENTION-1.yaml` (derived_from)
+- [FIELD] `CAPABILITY-V2.1.name` is present but `description:` is empty — consider adding one.
+
+### Passed
+- Structural validity: OK
+- ID grammar: OK
+- Admission record: OK
+- No ID collisions found.
+
+### Verdict
+❌ **Block** — 3 errors must be resolved before commit.
+```
+
+Or, when there are no errors:
+
+```
+### Verdict
+✅ **Clear to commit** — 0 errors. N warnings noted above; resolve or acknowledge before merging.
+```
+
+Always end with a **Verdict** line. Never leave the user guessing whether they can proceed.
+
+---
+
+## 5. Severity levels
+
+| Level | Symbol | Meaning | Action required |
+|---|---|---|---|
+| **Error** | ❌ | Structural violation, unresolved reference, ID collision, missing required field, invalid grammar | Must be fixed before commit. Do not merge a PR with open errors. |
+| **Warning** | ⚠ | Blast-radius hit on a downstream artefact, empty optional field, naming drift | Should be reviewed; commit only with explicit acknowledgement. |
+| **Pass** | ✅ | Check completed with no finding | No action. |
+
+The Validator reports findings only — it does not fix them. Surface each error with enough context for the Modeler to find and repair it without further investigation.
+
+---
+
+## 6. What the Validator does NOT do
+
+- **Does not write** to any file — not to `canon/`, `codex/`, `field/`, or any other location. Read-only.
+- **Does not decide** whether a failing check should be waived. That is the adopter's call. The Validator only reports.
+- **Does not merge** PRs or run `git commit`. It reviews; the Modeler (or the user) commits.
+- **Does not answer questions about the organisation** — redirect to the Analyst (`ANALYST.md`).
+- **Does not author or edit** model artefacts — redirect to the Modeler (`MODELER.md`).
+- **Does not check PlantUML or Mermaid files** — these are supplementary diagrams, not admitted canon artefacts. The CLI validator does not cover them; neither does the Validator role.
+- **Does not validate methodology files** in `transitrix/methodology` — those are governed by the methodology repo's own CI (`scripts/check-notations.mjs`), not by this role.
+
+---
+
+## 7. Fetching the notation spec
+
+When a check requires the full field list or validation rules for a specific notation, fetch the spec on demand:
+
+```
+WebFetch https://raw.githubusercontent.com/transitrix/methodology/main/notations/<NN>-<name>.md
+```
+
+Common notation spec files:
+- `02-dgca.md` — DGCA notation
+- `03-bpmn.md` — BPMN notation
+- `04-goals.md` — Goals tree notation
+- `05-capability-map.md` — Capability map notation
+- `06-process-map.md` — Process landscape map
+
+Do not embed the full spec text in your report unless the user asks for a notation explanation. Cite the relevant rule code and field name — the Modeler or user can fetch the full spec themselves.
+
+---
+
+## 8. Session start behaviour
+
+At the start of each Validator session:
+
+1. Ask: "Which files or PR should I review?" — do not assume scope.
+2. If the user says "everything changed", run `git diff --name-only HEAD` to detect changed files, filter to `canon/` and `codex/`, and confirm the list with the user before starting.
+3. Confirm: "I will review these N files for structural validity, required fields, ID grammar, referential integrity, and blast radius. I will not modify any files."


### PR DESCRIPTION
## Summary

- Adds `transitrix/skills/onboard/templates/VALIDATOR.md` — the third and final specialist role guide for Transitrix adopter repos, completing the Analyst / Modeler / Validator function-split set (epic #532 step 3).
- Updates `templates/AGENTS.md`: role-split table now has all three roles active (Validator row no longer marked *coming*).
- Updates `SKILL.md`: `VALIDATOR.md`, `MODELER.md`, and `ANALYST.md` added to the root-scaffolding drop-in list and the Templates table.

### What the Validator does

The Validator is a read-only reviewer invoked before any commit or PR that touches `canon/`. Seven-step protocol:

1. Identify the change set (`git diff` or user-specified)
2. Structural validity — notation header, root key shape, CLI validator output
3. Required-field completeness — per-notation checklist
4. ID grammar — `TYPE-[middle-]INTEGER` per `IDS_AND_REFERENCES.md`
5. Referential integrity — every cross-ref resolves within the file or `canon/elements/`
6. Blast-radius scan — `Grep canon/` for downstream references to modified/deleted IDs
7. Naming / collision check — file-name convention and ID uniqueness across canon

Produces a structured report with **Error** (block commit) / **Warning** (acknowledge before merge) / **Pass** severity, and ends with a clear Verdict line.

### Merge order

All three step PRs base on `main` and touch `AGENTS.md` / `SKILL.md`. Merge in order: #331 (Analyst) → #332 (Modeler) → this PR (Validator), resolving conflicts by accepting the latest version at each step.

## Test plan

- [ ] `VALIDATOR.md` exists at `transitrix/skills/onboard/templates/VALIDATOR.md`
- [ ] `AGENTS.md` role-split table lists all three roles with live links (no "coming" markers)
- [ ] `SKILL.md` root-scaffolding section lists all four role files (AGENTS, ANALYST, MODELER, VALIDATOR)
- [ ] `SKILL.md` Templates → Root scaffolding table includes ANALYST, MODELER, VALIDATOR rows
- [ ] `node scripts/check-notations.mjs` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)