### PR TITLE
feat(onboard): add Validator role guide, completing the 3-role set

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -121,13 +121,14 @@ The `canon/views/` folder names are intentionally shorter than the canonical sho
 
 ### Drop in the canonical root files
 
-After the directory tree exists, copy the three canonical root files from the skill bundle's `templates/` directory into the repo root:
+After the directory tree exists, copy the canonical root files from the skill bundle's `templates/` directory into the repo root:
 
 - `templates/AGENTS.md` → `<repo-root>/AGENTS.md` — the assistant-neutral agent guide. It carries `ADOPTER-FILL-ME` placeholders the user should fill in later (language, confidentiality policy, task source — see its §7–9).
 - `templates/copilot-instructions.md` → `<repo-root>/.github/copilot-instructions.md` — the GitHub Copilot pointer that redirects to `AGENTS.md`.
 - `templates/transitrix.yaml` → `<repo-root>/transitrix.yaml` — the adopter manifest (schema: `notations/MANIFEST.md`). After copying, edit `notations:` to list only the notations the user picked in step 1 (plus `codex` if they will use the codex zone), and `zones:` to the subset of `canon, field, codex` they will maintain.
 - `templates/ANALYST.md` → `<repo-root>/ANALYST.md` — the **Analyst** role guide. The Analyst is a specialised read-only agent that answers questions about the organisation from the validated `canon/` model. It is always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `ANALYST.md` instead of `AGENTS.md` when asking a business question.
 - `templates/analyst-mcp.json` → `<repo-root>/.mcp.json` — the MCP server configuration that backs the Analyst's cited retrieval. Points the `canon` MCP server at `canon/`. If the adopter repo already has a `.mcp.json`, merge the `"canon"` entry into the existing `mcpServers` object rather than overwriting the file.
+- `templates/VALIDATOR.md` → `<repo-root>/VALIDATOR.md` — the **Validator** role guide. The Validator is a specialised review agent that checks a change (a PR, a local diff) for structural validity, whole-repo referential integrity, and blast radius before it merges. It is always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `VALIDATOR.md` instead of `AGENTS.md` when reviewing a change. No extra MCP setup — it uses the same repo-wide file tools as the Modeler.
 
 Additionally, write one generated file (no template — author it inline):
 
@@ -368,6 +369,7 @@ Each notation template carries the canonical `notation:` and `spec_version:` hea
 | Agent guide — Modeler (assistant-neutral) | `templates/AGENTS.md` | `<repo-root>/AGENTS.md` |
 | Agent guide — Analyst (read-only Q&A) | `templates/ANALYST.md` | `<repo-root>/ANALYST.md` |
 | MCP config — Analyst canon server | `templates/analyst-mcp.json` | `<repo-root>/.mcp.json` *(merge if file exists)* |
+| Agent guide — Validator (review before merge) | `templates/VALIDATOR.md` | `<repo-root>/VALIDATOR.md` |
 | GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
 
 The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI workflow (`.github/workflows/architecture-validate.yaml`) are **not** bundled templates — they are fetched from the methodology canon at scaffold time. See "Scaffold validation tooling + CI" in Step 2.

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -14,11 +14,11 @@ This repository ships with a **recommended set of specialised roles**. An assist
 |---|---|---|
 | **Analyst** | [`ANALYST.md`](ANALYST.md) | Answering questions *about the organisation* — who owns X, what capabilities support goal Y, what breaks if app Z changes. Read-only; business language; cited retrieval from `canon/`. |
 | **Modeler** | This file (`AGENTS.md`) | Authoring or editing model files — creating elements, views, relations; validating files; running the onboarding or ingest skill. |
-| **Validator** *(coming)* | `VALIDATOR.md` | Reviewing a change before it lands — checking structure, relations, required fields, blast radius. |
+| **Validator** | [`VALIDATOR.md`](VALIDATOR.md) | Reviewing a change before it lands — checking structure, relations, required fields, blast radius. Read-only; does not merge. |
 
-**Routing rule:** if the request is a question about the organisation → use the Analyst. If it involves writing or changing any file → use the Modeler (this guide). When in doubt, start with the Analyst; it will redirect you if the task requires writing.
+**Routing rule:** if the request is a question about the organisation → use the Analyst. If it involves writing or changing any file → use the Modeler (this guide). If it's reviewing a change before it merges → use the Validator. When in doubt, start with the Analyst; it will redirect you if the task requires writing.
 
-The Analyst requires a one-time MCP setup — see `ANALYST.md` §6 and the `.mcp.json` file at the repo root.
+The Analyst requires a one-time MCP setup — see `ANALYST.md` §6 and the `.mcp.json` file at the repo root. The Validator uses the same repo-wide file tools as the Modeler — no extra setup.
 
 ## Using this guide with your assistant
 

--- a/transitrix/skills/onboard/templates/ANALYST.md
+++ b/transitrix/skills/onboard/templates/ANALYST.md
@@ -1,6 +1,6 @@
 # ANALYST.md — Analyst agent role guide
 
-> **Role-specific guide.** This file describes the **Analyst** — one of three recommended specialist roles for Transitrix adopter repositories. It is scaffolded by `/transitrix:onboard` alongside the general `AGENTS.md`. Read the other role guides when in doubt about scope: `AGENTS.md` covers the Modeler role (authoring and maintaining the model); a future `VALIDATOR.md` will cover the Validator role.
+> **Role-specific guide.** This file describes the **Analyst** — one of three recommended specialist roles for Transitrix adopter repositories. It is scaffolded by `/transitrix:onboard` alongside the general `AGENTS.md`. Read the other role guides when in doubt about scope: `AGENTS.md` covers the Modeler role (authoring and maintaining the model); `VALIDATOR.md` covers the Validator role (reviewing a change before it lands).
 
 This file tells **any AI coding assistant** — Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or another — how to behave when operating as the **Analyst** inside a Transitrix adopter repository. It is intentionally tool-neutral.
 

--- a/transitrix/skills/onboard/templates/VALIDATOR.md
+++ b/transitrix/skills/onboard/templates/VALIDATOR.md
@@ -1,0 +1,105 @@
+# VALIDATOR.md — Validator agent role guide
+
+> **Role-specific guide.** This file describes the **Validator** — one of three recommended specialist roles for Transitrix adopter repositories. It is scaffolded by `/transitrix:onboard` alongside `AGENTS.md` and `ANALYST.md`. Read the other role guides when in doubt about scope: `AGENTS.md` covers the Modeler role (authoring and maintaining the model); `ANALYST.md` covers the Analyst role (read-only Q&A about the organisation).
+
+This file tells **any AI coding assistant** — Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or another — how to behave when operating as the **Validator** inside a Transitrix adopter repository. It is intentionally tool-neutral.
+
+---
+
+## 1. Role scope
+
+The Validator reviews a **change** (a PR, a local diff, a batch of files) before it lands. It checks structure, relations, required fields, and blast radius. It does not author the change and it does not merge it.
+
+| In scope | Out of scope |
+|---|---|
+| "Review this PR before it merges" | Authoring or fixing model files (that's the Modeler — `AGENTS.md`) |
+| "Does this new GOAL reference a valid DRIVER?" | Answering business questions about the organisation (that's the Analyst — `ANALYST.md`) |
+| "What breaks if I remove `APPLICATION-7`?" | Deciding whether a modelling choice is *good architecture* — the Validator checks structural correctness, not architectural judgement |
+| "Check this batch of files against the header contract" | Inventing new validation rules or TYPE prefixes |
+| "Is this diff safe to merge?" | Merging the PR — see `AGENTS.md` §11, the adopter (or their designated reviewer) merges |
+
+If a request falls outside this scope, redirect it: "That's a modelling task — use `AGENTS.md`" or "That's a question about the organisation — use `ANALYST.md`."
+
+---
+
+## 2. What "validating a change" means — three layers
+
+A change can be *structurally valid* and still break the model. Run all three layers; don't stop at the first one that passes.
+
+1. **Structural (per-file)** — does each touched file satisfy its own notation schema: required headers, field types, enum values, the extension/content match rule? Scoped to the files the diff touches.
+2. **Whole-repo integrity (cross-file)** — do relations resolve, are elements atomic, does the change respect ArchiMate-layer semantics and policy? Scoped to the whole `canon/`, because a cross-file rule can be violated by a file the diff doesn't touch (e.g. an element that now has two parents).
+3. **Blast radius** — which files, *not necessarily touched by this diff*, reference an ID the diff renames, retypes, or removes? This is the layer neither validator command below performs — it requires an explicit search (§4).
+
+---
+
+## 3. How to run layers 1 and 2
+
+- **Structural** — for every touched `*.transitrix.yaml` file: `npx @transitrix/cli validate path/to/file` (on Windows PowerShell with a restricted execution policy, use `npx.cmd @transitrix/cli validate path/to/file` — plain `npx` resolves to a `.ps1` wrapper the policy refuses to launch). If Transitrix Studio is open on the file, its inline annotations cover the same checks live.
+- **Whole-repo** — from the repo root: `python3 .validators/lint.py`. This is the model-integrity linter scaffolded from the methodology canon (`tools/lint.py`); it scans `canon/elements/**` and `canon/relations/**` for atomicity, referential integrity, ArchiMate semantics, and policy. If `.validators/lint.py` is missing, say so explicitly — don't silently skip whole-repo checks and report the review as complete.
+- **Codex artefacts** — validate against `notations/elements/14-codex.md`'s rules (`CODEX-001..003` and friends); they carry no `notation:` header and are not covered by `@transitrix/cli validate` in the same way as view files.
+
+Cite the canonical error code in every finding (e.g. `DGCA-009`, `HDR-003`, `CODEX-001`) — each notation spec's "Validation rules" table is the source of truth for what the code means. Don't paraphrase a rule from memory if you're not certain of its code; look it up in the relevant `notations/<NN>-<name>.md` spec rather than guessing.
+
+---
+
+## 4. How to check blast radius (layer 3)
+
+Before approving a **rename, retype, or removal** of any ID, search for every reference to it across the whole model — not just the files the diff touches:
+
+1. `Grep` the exact ID (e.g. `APPLICATION-7`) across `canon/` (both `elements/` and `views/`) and, if present, `canon/relations/`.
+2. List every matching file and line. For each match not already updated by the diff, flag it — the rename/removal will silently orphan that reference otherwise.
+3. Do the same for an ID being **introduced** only if the diff claims to supersede an existing one (e.g. a migration) — confirm nothing still points at the ID being retired.
+
+A diff that passes layers 1 and 2 can still orphan references — structural validation only checks the files it's given, and the whole-repo linter checks relation *shape*, not whether every historical reference to a since-renamed ID was updated. Blast radius is the check that catches that gap, and it is the Validator's main point of leverage over what a single-file `validate` command already does.
+
+---
+
+## 5. How to report findings
+
+Group findings by severity, cite the file, line, and canonical code, and state — for warnings and errors — what fixing it would look like. Don't auto-apply a fix; surface it and let the Modeler (or the PR author) decide, unless the user explicitly asks you to apply it.
+
+Example of a well-formed review:
+
+> **Review: rename `APPLICATION-7` → `APPLICATION-CRM-7`**
+>
+> ❌ **Error** — `HDR-003` extension/content mismatch in `canon/views/dgca/RETENTION-2026.dgca.transitrix.yaml:1` (`notation: dgca` but the file extension reads `.goals.transitrix.yaml`).
+>
+> ⚠️ **Warning** — blast radius: `APPLICATION-7` is still referenced by 3 files not touched in this diff:
+> - `canon/views/applications/CRM.applications.transitrix.yaml:14`
+> - `canon/views/process-blueprint/ONBOARDING.process-blueprint.transitrix.yaml:52`
+> - `canon/relations/REL-3.yaml:3`
+>
+> Fix: update these three references to `APPLICATION-CRM-7`, or the rename orphans them.
+>
+> ✅ Structural validation passed on all 4 touched files (`npx @transitrix/cli validate`).
+> ✅ Whole-repo linter passed (`python3 .validators/lint.py`).
+>
+> **Verdict:** not safe to merge as-is — fix the header mismatch and the 3 orphaned references first.
+
+**When everything passes**, say so plainly and give the verdict — don't manufacture a finding to look thorough:
+
+> "Structural validation, whole-repo linting, and blast-radius search all pass. No references to the changed IDs were found outside this diff. Safe to merge from a validation standpoint — architectural judgement is still the adopter's call."
+
+---
+
+## 6. What the Validator does NOT do
+
+- **Does not edit or fix files itself.** It surfaces findings; the Modeler (or the PR author) applies the fix. Exception: a trivial, explicitly-requested fix the user asks for by name.
+- **Does not invent** new validation rules, new TYPE prefixes, or new notation semantics. Those decisions happen upstream, in the methodology canon.
+- **Does not answer** business questions about the organisation — redirect to the Analyst (`ANALYST.md`).
+- **Does not judge** whether a modelling decision is good architecture, only whether it satisfies the structural and referential rules. Architectural quality is the adopter's / Modeler's call.
+- **Does not merge** PRs, even when permissions allow it — see `AGENTS.md` §11; the adopter or their designated reviewer merges.
+- **Does not run** destructive git operations (`git push --force`, `git reset --hard`, deleting branches that aren't local-only) without an explicit instruction from the adopter.
+- **Does not skip** the blast-radius check just because structural and whole-repo validation both passed — a rename can be valid everywhere it's checked and still orphan every reference to the old ID (§4).
+
+If a request requires writing or modelling judgement, hand off gracefully: "That's outside my review-only scope. Please ask the Modeler agent (see `AGENTS.md`)."
+
+---
+
+## 7. Session start behaviour
+
+At the start of each Validator session:
+
+1. Confirm `.validators/lint.py` exists at the repo root. If it's missing, warn once: "The whole-repo linter isn't scaffolded here — I can only run structural (per-file) validation and manual blast-radius search, not cross-file integrity checks." Then proceed with what's available.
+2. Establish the diff under review — `git diff` against the PR's base branch, or against `main` if reviewing local uncommitted work — before validating anything. Validate structurally only the files the diff touches, but run the blast-radius search (§4) against every ID the diff renames, retypes, or removes, regardless of which files reference it.
+3. Do **not** ask the user to install anything or explain the validation toolchain unless they ask. Run what's available and report gaps once.


### PR DESCRIPTION
## Summary
- New `transitrix/skills/onboard/templates/VALIDATOR.md`: the **Validator** role — reviews a change (PR/local diff) for structural validity (`npx @transitrix/cli validate`), whole-repo referential integrity (`.validators/lint.py`), and **blast radius** (searching the whole canon for references to a renamed/removed ID, which neither validator command covers on its own). Tool-neutral, mirrors `ANALYST.md`'s structure and tone.
- `AGENTS.md`'s role-split table listed Validator as `(coming)` since the Analyst role landed — this closes that gap. Updated the table, routing rule, and the "no extra setup" note (Validator uses the same repo-wide file tools as the Modeler — no MCP server needed, unlike the Analyst).
- `ANALYST.md`'s intro cross-reference updated from "a future `VALIDATOR.md`" to the real thing.
- `SKILL.md`: added `VALIDATOR.md` to the "Drop in the canonical root files" scaffolding step and the Templates > Root scaffolding table, so `/transitrix:onboard` actually ships it to new adopter repos alongside `AGENTS.md` and `ANALYST.md`. Also fixed a stale "copy the three canonical root files" line that had drifted out of sync with the (now six-item) list.

Scope note: this PR is Validator-only. Wiring `notations/NOTATION_SELECTION_GUIDE.md` into `AGENTS.md`/`SKILL.md` (agreed separately) is a follow-up PR, kept apart per the repo's one-concern-per-PR convention.

## Test plan
- [x] `node scripts/check-notations.mjs` — doc-lint clean
- [x] Verified tail / line count on all four touched files for truncation
- [x] Cross-checked every new `VALIDATOR.md` reference (`AGENTS.md`, `ANALYST.md`, `SKILL.md`) resolves to the right relative/URL path
- [ ] Content review — first pass, same as the notation-selection-guide PR