### PR TITLE
docs(onboard): wire the notation selection guide into agent prompts

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -412,6 +412,7 @@ When the user goes deeper than this cheat sheet covers, fetch the canonical spec
 - Adopter manifest schema (`transitrix.yaml`): `https://raw.githubusercontent.com/transitrix/methodology/main/notations/MANIFEST.md`
 - Notation index + family selection: `https://raw.githubusercontent.com/transitrix/methodology/main/notations/README.md`
 - Per-notation full specs: `https://raw.githubusercontent.com/transitrix/methodology/main/notations/<NN>-<short-name>.md` (including `14-codex.md` for the codex zone)
+- Notation selection guide (Mermaid / PlantUML / Transitrix side by side, with use-cases and a phrase-to-recommendation lookup table): `https://raw.githubusercontent.com/transitrix/methodology/main/notations/NOTATION_SELECTION_GUIDE.md` — fetch this when the user names a diagram/view but it's unclear which notation fits, or asks for something the family-selection table above doesn't resolve (e.g. a sequence diagram, a wireframe, a C4 diagram — things Mermaid/PlantUML cover and Transitrix doesn't, or vice versa). If the request is too vague to apply it (e.g. "make me a diagram"), ask a clarifying question first per the guide's §1.1 — don't guess.
 - Worked adopter example (the shape this skill scaffolds): `https://raw.githubusercontent.com/transitrix/acme-corp/main/AGENTS.md`
 
 Read sparingly — the cheat sheet above is enough for 80% of cases. Pull the full spec only when the user hits a validation rule they want to understand, or asks for a field's semantics that the summary doesn't cover.

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -56,6 +56,7 @@ The canonical Transitrix methodology lives at [github.com/transitrix/methodology
 - ID grammar and TYPE registry (`notations/IDS_AND_REFERENCES.md`).
 - Adopter manifest schema (`notations/MANIFEST.md`).
 - Notation index (`notations/README.md`).
+- Notation selection guide (`notations/NOTATION_SELECTION_GUIDE.md`) — use this when the user's request names a diagram/view but it's unclear which notation fits, or asks for something Mermaid/PlantUML could also draw; if the request itself is too vague to apply the guide (e.g. "make me a diagram"), ask a clarifying question first per its §1.1 before picking anything.
 
 **Resolution order when a local file and the canon disagree:**
 


### PR DESCRIPTION
## Summary
- `AGENTS.md` §2 ("Authority of the methodology") now lists `notations/NOTATION_SELECTION_GUIDE.md` alongside the other canonical references, with guidance on when to reach for it (a diagram/view request where the notation isn't obvious) and an explicit instruction to ask a clarifying question first when the request is too vague to apply it at all — per the guide's own §1.1.
- `SKILL.md`'s "Reference reads on demand" section gets the matching raw-GitHub-URL fetch entry, same pattern as the other on-demand spec reads (fetch when needed, don't inline).

Follow-up to `notations/NOTATION_SELECTION_GUIDE.md` (merged in #334) — agreed approach was link-and-fetch-on-demand rather than inlining the full 284-line guide into every agent prompt, consistent with this repo's existing "never copy methodology content inline" convention. Kept separate from #335 (Validator role) since it's an unrelated concern.

## Test plan
- [x] `node scripts/check-notations.mjs` — doc-lint clean
- [x] Verified tail integrity on both touched files
- [x] Diff scoped to exactly the two intended insertions (no incidental changes)