### PR TITLE
feat(onboard): wire jebbs.plantuml into scaffold and extension template

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -132,16 +132,17 @@ After the directory tree exists, copy the canonical root files from the skill bu
 
 Additionally, write one generated file (no template — author it inline):
 
-- `<repo-root>/README.md` — a minimal org stub. Three sections: (1) one-paragraph intro naming the repo purpose and linking to `github.com/transitrix/methodology`; (2) "Getting started" pointing newcomers at `AGENTS.md` and the `/transitrix:onboard` skill; (3) "Tooling" recommending both VS Code extensions — **Transitrix Studio** (`transitrix.transitrix-studio`, VS Code Marketplace) for live Transitrix notation preview, and **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`, VS Code Marketplace and Open VSX) for Mermaid diagram preview in Markdown files. Leave `ADOPTER-FILL-ME` placeholders for org name, purpose, and team.
+- `<repo-root>/README.md` — a minimal org stub. Three sections: (1) one-paragraph intro naming the repo purpose and linking to `github.com/transitrix/methodology`; (2) "Getting started" pointing newcomers at `AGENTS.md` and the `/transitrix:onboard` skill; (3) "Tooling" recommending the three VS Code extensions — **Transitrix Studio** (`transitrix.transitrix-studio`, VS Code Marketplace) for live Transitrix notation preview, **PlantUML** (`jebbs.plantuml`, VS Code Marketplace) for `.puml` diagram preview, and **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`, VS Code Marketplace and Open VSX) for Mermaid diagram preview in Markdown files. Leave `ADOPTER-FILL-ME` placeholders for org name, purpose, and team.
 
 **Do not scaffold a Claude-specific `CLAUDE.md` agent guide.** The canonical guide for every assistant is `AGENTS.md`. If the user is on a tool that doesn't read `AGENTS.md` natively (e.g. Claude Code looks for `CLAUDE.md`, Cursor looks for `.cursor/rules/`), drop a one-line pointer file in that tool's location that reads *"Read `AGENTS.md` in the repo root and follow it."* The guidance itself stays in `AGENTS.md` only — see `AGENTS.md` §"Using this guide with your assistant".
 
 ### Suggest editor tooling — right after scaffolding, don't wait for Step 5
 
-As soon as the root files exist, check what's already installed: `code --list-extensions` (swap `code` for `cursor` / `codium` if that's the detected editor; on Windows PowerShell with a restricted execution policy use `code.cmd` / `cursor.cmd`). If **Transitrix Studio** (`transitrix.transitrix-studio`) or **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) is missing, surface the install command(s) prominently now, before Step 3:
+As soon as the root files exist, also copy `templates/extensions.json` to `<repo-root>/.vscode/extensions.json` — this files the workspace extension recommendations so VS Code prompts the user to install the right tools immediately. Then check what's already installed: `code --list-extensions` (swap `code` for `cursor` / `codium` if that's the detected editor; on Windows PowerShell with a restricted execution policy use `code.cmd` / `cursor.cmd`). If **Transitrix Studio** (`transitrix.transitrix-studio`), **PlantUML** (`jebbs.plantuml`), or **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) is missing, surface the install command(s) prominently now, before Step 3:
 
 ```
 code --install-extension transitrix.transitrix-studio
+code --install-extension jebbs.plantuml
 code --install-extension bierner.markdown-mermaid
 ```
 
@@ -371,6 +372,7 @@ Each notation template carries the canonical `notation:` and `spec_version:` hea
 | MCP config — Analyst canon server | `templates/analyst-mcp.json` | `<repo-root>/.mcp.json` *(merge if file exists)* |
 | Agent guide — Validator (review before merge) | `templates/VALIDATOR.md` | `<repo-root>/VALIDATOR.md` |
 | GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
+| VS Code extension recommendations | `templates/extensions.json` | `<repo-root>/.vscode/extensions.json` |
 
 The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI workflow (`.github/workflows/architecture-validate.yaml`) are **not** bundled templates — they are fetched from the methodology canon at scaffold time. See "Scaffold validation tooling + CI" in Step 2.
 

--- a/transitrix/skills/onboard/templates/extensions.json
+++ b/transitrix/skills/onboard/templates/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "transitrix.transitrix-studio",
+    "jebbs.plantuml",
+    "bierner.markdown-mermaid"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `transitrix/skills/onboard/templates/extensions.json` — the VS Code workspace extension recommendations template; scaffolded to `.vscode/extensions.json` in every new adopter repo (pins `jebbs.plantuml`, `transitrix.transitrix-studio`, `bierner.markdown-mermaid`)
- Updates `SKILL.md` to add `jebbs.plantuml` to the "Suggest editor tooling" install step, the generated README "Tooling" section, and the root-scaffolding templates table

Tier 0 follow-up for the PlantUML adopter experience initiative. The primary Tier 0 delivery (theme file, DIAGRAMS.md, CI hook) is in the companion PR: transitrix/acme-corp#36.

## Test plan

- [ ] Run `/transitrix:onboard` on a new empty directory → `.vscode/extensions.json` is created with the three recommendations
- [ ] Verify VS Code surfaces the install prompt for `jebbs.plantuml` when the new repo is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)