### PR TITLE
chore(onboard): stop scaffolding methodology_version: "0.4.x"

### DIFF
--- a/transitrix/skills/onboard/templates/transitrix.yaml
+++ b/transitrix/skills/onboard/templates/transitrix.yaml
@@ -4,7 +4,7 @@
 # at the pinned methodology_version.
 
 transitrix: 1                       # manifest schema version (integer; 1 today)
-methodology_version: "0.4.x"        # pin a real release once the adopter chooses one
+methodology_version: "2.0.0"        # pin the release you're onboarding against — update if newer
 notations:                          # short names from notations/README.md (+ codex)
   - dgca
   - goals


### PR DESCRIPTION
## Summary

- `transitrix/skills/onboard/templates/transitrix.yaml` still pinned `methodology_version: "0.4.x"` as its placeholder example — pre-1.0, five majors behind current. Found while testing the fetch-and-follow onboarding prompt end-to-end against a scratch repo.
- Bumped the example to `2.0.0`, the actual current release.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean