### PR TITLE
fix(onboard): drop jebbs.plantuml — Studio 3.0.6 renders .puml natively

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -132,17 +132,16 @@ After the directory tree exists, copy the canonical root files from the skill bu
 
 Additionally, write one generated file (no template — author it inline):
 
-- `<repo-root>/README.md` — a minimal org stub. Three sections: (1) one-paragraph intro naming the repo purpose and linking to `github.com/transitrix/methodology`; (2) "Getting started" pointing newcomers at `AGENTS.md` and the `/transitrix:onboard` skill; (3) "Tooling" recommending the three VS Code extensions — **Transitrix Studio** (`transitrix.transitrix-studio`, VS Code Marketplace) for live Transitrix notation preview, **PlantUML** (`jebbs.plantuml`, VS Code Marketplace) for `.puml` diagram preview, and **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`, VS Code Marketplace and Open VSX) for Mermaid diagram preview in Markdown files. Leave `ADOPTER-FILL-ME` placeholders for org name, purpose, and team.
+- `<repo-root>/README.md` — a minimal org stub. Three sections: (1) one-paragraph intro naming the repo purpose and linking to `github.com/transitrix/methodology`; (2) "Getting started" pointing newcomers at `AGENTS.md` and the `/transitrix:onboard` skill; (3) "Tooling" recommending the two VS Code extensions — **Transitrix Studio** (`transitrix.transitrix-studio`, VS Code Marketplace) for live Transitrix notation preview (including `.puml` files — no separate PlantUML extension needed), and **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`, VS Code Marketplace and Open VSX) for Mermaid diagram preview in Markdown files. Leave `ADOPTER-FILL-ME` placeholders for org name, purpose, and team.
 
 **Do not scaffold a Claude-specific `CLAUDE.md` agent guide.** The canonical guide for every assistant is `AGENTS.md`. If the user is on a tool that doesn't read `AGENTS.md` natively (e.g. Claude Code looks for `CLAUDE.md`, Cursor looks for `.cursor/rules/`), drop a one-line pointer file in that tool's location that reads *"Read `AGENTS.md` in the repo root and follow it."* The guidance itself stays in `AGENTS.md` only — see `AGENTS.md` §"Using this guide with your assistant".
 
 ### Suggest editor tooling — right after scaffolding, don't wait for Step 5
 
-As soon as the root files exist, also copy `templates/extensions.json` to `<repo-root>/.vscode/extensions.json` — this files the workspace extension recommendations so VS Code prompts the user to install the right tools immediately. Then check what's already installed: `code --list-extensions` (swap `code` for `cursor` / `codium` if that's the detected editor; on Windows PowerShell with a restricted execution policy use `code.cmd` / `cursor.cmd`). If **Transitrix Studio** (`transitrix.transitrix-studio`), **PlantUML** (`jebbs.plantuml`), or **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) is missing, surface the install command(s) prominently now, before Step 3:
+As soon as the root files exist, also copy `templates/extensions.json` to `<repo-root>/.vscode/extensions.json` — this files the workspace extension recommendations so VS Code prompts the user to install the right tools immediately. Then check what's already installed: `code --list-extensions` (swap `code` for `cursor` / `codium` if that's the detected editor; on Windows PowerShell with a restricted execution policy use `code.cmd` / `cursor.cmd`). If **Transitrix Studio** (`transitrix.transitrix-studio`) or **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`) is missing, surface the install command(s) prominently now, before Step 3:
 
 ```
 code --install-extension transitrix.transitrix-studio
-code --install-extension jebbs.plantuml
 code --install-extension bierner.markdown-mermaid
 ```
 

--- a/transitrix/skills/onboard/templates/extensions.json
+++ b/transitrix/skills/onboard/templates/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "transitrix.transitrix-studio",
-    "jebbs.plantuml",
     "bierner.markdown-mermaid"
   ]
 }


### PR DESCRIPTION
## Summary

- Removes `jebbs.plantuml` from `transitrix/skills/onboard/templates/extensions.json`
- Updates `SKILL.md` to remove all three references to `jebbs.plantuml` (README Tooling section description, extension check list, and install command block)
- `templates/extensions.json` now matches `acme-corp/.vscode/extensions.json` exactly

## Why

Studio 3.0.6 (2026-07-13) renders `.puml`/`.plantuml` natively via `@plantuml/core` — no Java, no Graphviz. Recommending `jebbs.plantuml` alongside it installs a conflicting renderer with no way to tell which preview opens; it also won't apply the Transitrix theme. `bierner.markdown-mermaid` stays — Mermaid is genuinely not rendered by Studio.

## Test plan

- [x] `templates/extensions.json` contains only `transitrix.transitrix-studio` and `bierner.markdown-mermaid`
- [x] `SKILL.md` has no remaining `jebbs.plantuml` mentions
- [x] Both match `acme-corp/.vscode/extensions.json`
- [x] `node scripts/check-notations.mjs` passes

Do NOT merge — Valerii gates every merge.
