### PR TITLE
fix(goals,action): restore inline authoring — drop GOALS-008 and ACT-010

### DIFF
--- a/migrations/1.0-to-2.0/README.md
+++ b/migrations/1.0-to-2.0/README.md
@@ -9,20 +9,24 @@ version 1.0 to 2.0. Format per [`notations/CONTRACT.md`](../../notations/CONTRAC
 
 ## What this recipe covers
 
-2.0.0 completes the **view-purity migration** for the Goals Tree and Action
-Schedule notations: both now project over the canonical element catalogue rather
-than authoring elements inline. Adopters who have:
+**Inline authoring is the default.** As of the 2026-07-14 inline-authoring ADR
+(`architecture/cross-project/2026-07-14-inline-authoring-until-promotion.md`),
+`*.goals.transitrix.yaml` files with inline `goals[]` and
+`*.action.transitrix.yaml` files with inline `actions[]` are valid and do not
+need migration. Inline is the self-contained default; the projection form is for
+Full-tier adopters whose elements are shared across documents.
 
-- `*.goals.transitrix.yaml` files carrying an inline `goals[]` array, **or**
-- `*.action.transitrix.yaml` files carrying an inline `actions[]` array
+This recipe is therefore **optional** — run it when you want to promote elements
+from an inline view to standalone canonical files so they can be shared across
+multiple views or documents. The trigger for promotion is cross-document sharing,
+not a methodology version requirement.
 
-must apply the transforms below. Adopters who never used these notations (e.g.
-DGCA-only shops) have nothing to migrate.
-
-| Transform | Old (v1 inline) | Canonical (required at v2.0) |
+| Transform | Inline (valid v1 and v2) | Promoted (canonical elements) |
 |---|---|---|
-| **A** | `*.goals.transitrix.yaml` with `goals[]` inline | `view_config` + standalone `GOAL-*.yaml` element files |
-| **B** | `*.action.transitrix.yaml` with `actions[]` inline | `view_config` + standalone `ACTION-*.yaml` element files |
+| **A** | `*.goals.transitrix.yaml` with `goals[]` inline | standalone `GOAL-*.yaml` element files in `canon/elements/01_motivation/goals/` |
+| **B** | `*.action.transitrix.yaml` with `actions[]` inline | standalone `ACTION-*.yaml` element files in `canon/elements/05_implementation/actions/` |
+
+The codemod writes the element files but **does not strip inline data from the view** — after promotion the view file is still self-contained. Adopters who want a pure `view_config` projection may then manually remove the inline arrays from the view.
 
 ---
 
@@ -60,58 +64,14 @@ valid_to: null                        # from the inline entry's valid_to
 If an element file already exists for an ID in `goals[]`, the existing file is
 authoritative — do not overwrite it. The codemod skips existing files.
 
-### A.2 — Rewrite the view file to `view_config` format
+### A.2 — View file is not changed
 
-Remove `goal_types[]` and `goals[]` from the document root. Add `view_config`
-with the vocabulary and display settings. Remove `id` from the document root
-if it conflicts (it moves to the view_config context; see §4 of the spec).
-
-Before:
-```yaml
-notation: goals
-spec_version: "0.1"
-
-id: GOALS-STRAT-2026-1
-name: "Strategy 2026 — Goals Tree"
-generated_at: "2026-05-26"
-description: "..."
-period: "2026"
-author: Transitrix
-
-goal_types:
-  - { name: "Strategy",       level: 0 }
-  - { name: "Strategic Goal", level: 1 }
-
-goals:
-  - id: GOAL-REVENUE-1
-    name: "Triple revenue by 2028"
-    type: "Strategy"
-    level: 0
-    valid_from: "2026-05-26"
-    valid_to: null
-```
-
-After:
-```yaml
-notation: goals
-spec_version: "0.1"
-methodology_version: "2.0.0"
-
-id: GOALS-STRAT-2026-1
-name: "Strategy 2026 — Goals Tree"
-generated_at: "2026-05-26"
-description: "..."
-period: "2026"
-author: Transitrix
-
-view_config:
-  goal_types:
-    - { name: "Strategy",       level: 0 }
-    - { name: "Strategic Goal", level: 1 }
-  display:
-    depth: null
-    collapsed: []
-```
+The codemod does **not** rewrite the view file. After running, the view file
+still carries its inline `goals[]` and `goal_types[]` — it remains self-contained
+and valid. Adopters who want to convert the view to a pure `view_config` projection
+(no inline data) may do so manually by removing `goal_types[]` and `goals[]` from
+the document root and adding the `view_config` block as shown in §4 of
+`notations/views/04-goals.md`.
 
 ---
 
@@ -156,57 +116,14 @@ valid_to: null                        # from the inline entry's valid_to
 If an element file already exists for an ID in `actions[]`, skip it — the
 existing file is authoritative.
 
-### B.2 — Rewrite the view file to `view_config` format
+### B.2 — View file is not changed
 
-Remove `project:` and `actions[]` from the document root. Add `view_config`
-with scope (root_action + optional goal filter) and the schedule settings.
-Add `id` field (`ACTION_SCHED-…`).
-
-Before:
-```yaml
-notation: action
-spec_version: "0.1"
-
-title: "GDPR Remediation Programme 2026"
-description: |
-  ...
-version: "0.2"
-
-project:
-  start_date: "2026-03-01"
-
-actions:
-  - id: ACTION-EU-COMPLIANCE-1
-    name: "EU Data Protection Compliance Initiative"
-    type: Initiative
-    goals: [GOAL-EU-1]
-    valid_from: "2026-01-01"
-    valid_to: null
-```
-
-After:
-```yaml
-notation: action
-spec_version: "0.1"
-methodology_version: "2.0.0"
-
-id: ACTION_SCHED-GDPR-REMEDIATION-1
-name: "GDPR Remediation Programme 2026"
-description: |
-  ...
-
-view_config:
-  scope:
-    root_action: ACTION-EU-COMPLIANCE-1  # top-level action from the old inline list
-  schedule:
-    start_date: "2026-03-01"             # from the old project.start_date
-```
-
-**Choosing `root_action`.** The codemod uses the first action entry with no
-`parent` field (or `parent: null`) as `root_action`. For programmes and
-initiatives that nest multi-level hierarchies, this is the Initiative or
-Programme at the top of the tree. Review the generated `view_config` and
-adjust if the codemod chose the wrong root.
+The codemod does **not** rewrite the view file. After running, the view file
+still carries its inline `actions[]` and `project:` block — it remains
+self-contained and valid. Adopters who want to convert the view to a pure
+`view_config` projection (no inline data) may do so manually by removing
+`project:` and `actions[]` from the document root and adding a `view_config`
+block as shown in §4 of `notations/views/07-action.md`.
 
 ---
 
@@ -229,7 +146,7 @@ The codemod requires Node ≥ 20. No external dependencies.
 
 ---
 
-## Step 2 — Review generated element files
+## Step 2 — Review generated element files and bump `methodology_version`
 
 The codemod generates element files with `admitted_by: "migration-1.0-to-2.0"`.
 Review each generated file and:
@@ -237,9 +154,7 @@ Review each generated file and:
 2. Confirm the `admitted_at` and `valid_from` dates are accurate.
 3. Add any fields that were not captured in the inline entry (e.g. `link`, `tag`).
 
----
-
-## Step 3 — Bump `methodology_version`
+Then bump the manifest:
 
 ```yaml
 # transitrix.yaml
@@ -248,14 +163,15 @@ methodology_version: "2.0.0"
 
 ---
 
-## Step 4 — Re-run validation
+## Step 3 — Re-run validation
 
 ```bash
 transitrix-ingest validate <candidates-dir>
 node migrations/1.0-to-2.0/validate.mjs <adopter-root>
 ```
 
-A clean run shows no inline-element errors (no `GOALS-008` or `ACT-010`).
+A clean run confirms all promoted element files are well-formed and resolve
+their cross-references correctly.
 
 ---
 

--- a/migrations/1.0-to-2.0/codemod.mjs
+++ b/migrations/1.0-to-2.0/codemod.mjs
@@ -1,18 +1,28 @@
 #!/usr/bin/env node
 // Migration codemod — methodology 1.0 → 2.0.
 //
-// Applies two transforms to an adopter repo. Run with --dry-run first.
+// Run with --dry-run first; apply when ready.
+//
+// TRIGGER: run when inline goals[] or actions[] elements need to be promoted
+// to standalone canonical files so they can be shared across multiple views.
+// Inline authoring is the valid default — this codemod is optional, not a
+// mandatory migration step.
 //
 // TRANSFORMS (automated — idempotent):
-//   A. Goals Tree: extract inline goals[] → standalone GOAL-*.yaml element files
-//                  + rewrite view to view_config format
+//   A. Goals Tree: promote inline goals[] → standalone GOAL-*.yaml element files.
+//                  The view file is NOT changed — inline data is preserved.
 //
-//   B. Action Schedule: extract inline actions[] → standalone ACTION-*.yaml element files
-//                       + rewrite view to view_config format
+//   B. Action Schedule: promote inline actions[] → standalone ACTION-*.yaml element files.
+//                       The view file is NOT changed — inline data is preserved.
+//
+// After running, the view files are still self-contained (inline data intact).
+// Adopters who want a pure view_config projection may then manually remove the
+// inline arrays from the view (see notations/views/04-goals.md §4 and
+// notations/views/07-action.md §4 for the projection-form structure).
 //
 // Conventions:
 //   - Pure-Node, no native deps; Node ≥ 20.
-//   - Idempotent: a repo already on canonical v2.0 form is a no-op.
+//   - Idempotent: skips element files that already exist.
 //   - CLI: [--dry-run] [target-dir]. Default target = current working dir.
 
 import {
@@ -425,20 +435,16 @@ function findRootAction(entries) {
 function transformGoalsTree(file) {
   const yaml = readFileSync(file, 'utf8');
 
-  // Skip files that are already migrated (have view_config, no goals:)
-  if (yaml.includes('view_config:') && !yaml.match(/^goals:\s*\n/m)) {
-    return;
-  }
+  // Only process files that have inline goals[] at the root
   if (!yaml.match(/^goals:\s*\n/m)) return;
 
   const rel = relative(target, file);
   console.log(`A  ${rel}`);
 
-  const goalTypes = extractGoalTypes(yaml);
   const rawEntries = splitGoalsEntries(yaml);
   const goals = rawEntries.map(parseGoalEntry).filter(g => g.id);
 
-  // Write standalone element files
+  // Write standalone element files; view file is left unchanged (inline data preserved)
   for (const g of goals) {
     const elemDir = join(target, 'canon', 'elements', '01_motivation', 'goals');
     const elemFile = join(elemDir, `${g.id}.yaml`);
@@ -455,10 +461,7 @@ function transformGoalsTree(file) {
     }
   }
 
-  // Rewrite the view file
-  const newYaml = rewriteGoalsView(yaml, goalTypes);
-  console.log(`   ~ ${rel}`);
-  if (!dryRun) writeFileSync(file, newYaml, 'utf8');
+  console.log(`   (view ${rel} not changed — inline data preserved)`);
 }
 
 // ── Transform B — Action Schedule ────────────────────────────────────────────
@@ -466,8 +469,7 @@ function transformGoalsTree(file) {
 function transformActionSchedule(file) {
   const yaml = readFileSync(file, 'utf8');
 
-  // Skip files already migrated
-  if (yaml.includes('view_config:') && !yaml.match(/^actions:\s*\n/m)) return;
+  // Only process files that have inline actions[] at the root
   if (!yaml.match(/^actions:\s*\n/m)) return;
 
   const rel = relative(target, file);
@@ -475,10 +477,8 @@ function transformActionSchedule(file) {
 
   const rawEntries = splitActionsEntries(yaml);
   const actions = rawEntries.map(parseActionEntry).filter(a => a.id);
-  const startDate = extractProjectStartDate(yaml);
-  const rootActionId = findRootAction(rawEntries);
 
-  // Write standalone element files
+  // Write standalone element files; view file is left unchanged (inline data preserved)
   for (const a of actions) {
     const elemDir = join(target, 'canon', 'elements', '05_implementation', 'actions');
     const elemFile = join(elemDir, `${a.id}.yaml`);
@@ -495,10 +495,7 @@ function transformActionSchedule(file) {
     }
   }
 
-  // Rewrite the view file
-  const newYaml = rewriteActionView(yaml, rootActionId, startDate, null);
-  console.log(`   ~ ${rel}`);
-  if (!dryRun) writeFileSync(file, newYaml, 'utf8');
+  console.log(`   (view ${rel} not changed — inline data preserved)`);
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────

--- a/notations/views/04-goals.md
+++ b/notations/views/04-goals.md
@@ -1,8 +1,8 @@
 ---
 notation: "Goals Tree"
-version: "1.0"
+version: "1.1"
 author: "Valerii Korobeinikov"
-last_updated: "2026-07-06"
+last_updated: "2026-07-15"
 status: "documented"
 file_extension: "*.goals.transitrix.yaml"
 dsm_status: "implemented — Goals & Activities section, Visual Editor (G)"
@@ -10,10 +10,8 @@ dsm_status: "implemented — Goals & Activities section, Visual Editor (G)"
 
 # Goals Tree Notation — Reference
 
-**Scope:** Hierarchy of strategic and tactical goals; mono-type tree rendered from `GOAL` elements in `canon/elements/01_motivation/goals/`. The view document carries only a `view_config` (scope + display settings) — no element data is authored inline. The renderer assembles the tree from canonical elements at view time.
+**Scope:** Hierarchy of strategic and tactical goals. The view document has two valid authoring forms: inline (`goal_types[]` and `goals[]` authored directly in the file; default for self-contained documents) and projection (a `view_config` block that selects from `GOAL` elements in `canon/elements/01_motivation/goals/`; used after elements are shared across documents). Both forms use the same field schema.
 **Renderer:** Transitrix DSM — Visual Editor (G), Goals table; Transitrix Studio (planned)
-
-**Migration note (v2.0).** Documents authored in the v1 inline format (carrying `goals[]` at the root) must be migrated using the `migrations/1.0-to-2.0/` recipe. Inline `goals[]` is no longer accepted.
 
 ---
 
@@ -30,13 +28,16 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ## Source of truth
 
-**GOAL elements are standalone primitives in `canon/elements/01_motivation/goals/`** ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §4). The Goals Tree view document is a **projection** over those elements — it contains only a `view_config` that selects and filters the elements to render. No element data is authored inline in the view document.
+A Goals Tree document has two valid authoring forms — both use the same YAML field schema:
 
-The goal hierarchy (`parent` field) and the goal type vocabulary (`type` field) live on the element files themselves. The view derives the rendered tree by loading all GOAL elements in scope and resolving the `parent` references at render time.
+- **Inline form (default):** `goal_types[]` and `goals[]` are authored directly in the view file. The file is self-contained. This is the expected form for a new adopter and for any goals hierarchy where elements are not yet shared across documents.
+- **Projection form (Full tier — post-promotion):** the file carries only a `view_config` block that selects `GOAL` elements already admitted to `canon/elements/01_motivation/goals/`. No element data is in this file; the renderer loads the elements at view time. See [`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §4.
+
+The **promotion trigger** is cross-document sharing: a goal stays inline until a second document references it; at that point it is promoted to a standalone element file in `canon/elements/01_motivation/goals/` and both documents reference it by ID ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §1). Promotion is optional until it is forced by sharing — do not split elements into per-file form from day one.
 
 The reconstruction invariant applies: `render(Elements, view_config)` → Goals Tree diagram. Deleting `canon/views/goals/` loses no model knowledge. See [`CONTRACT.md`](../CONTRACT.md) §14 (view_config contract).
 
-**Where goals are authored.** New goals are authored as standalone element files in `canon/elements/01_motivation/goals/<GOAL-…>.yaml`, following the canonical element envelope ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §3 and §7.2). The Goals Tree view then projects over them. This is the same pattern as DGCA ([`02-dgca.md`](02-dgca.md)), the Actions Tree ([`23-actions-tree.md`](23-actions-tree.md)), and the Action Card ([`18-action-card.md`](18-action-card.md)).
+**Where goals are authored.** In the inline form, goals are authored directly in the view file under `goals[]`. In the projection form, new goals are authored as standalone element files in `canon/elements/01_motivation/goals/<GOAL-…>.yaml`, following the canonical element envelope ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §3 and §7.2). The Goals Tree view then projects over them. This is the same pattern as DGCA ([`02-dgca.md`](02-dgca.md)), the Actions Tree ([`23-actions-tree.md`](23-actions-tree.md)), and the Action Card ([`18-action-card.md`](18-action-card.md)).
 
 ---
 
@@ -75,6 +76,44 @@ Examples:
 
 ## 4. Document structure
 
+### Inline form (default — self-contained)
+
+Goals and their type vocabulary are authored directly in the view file. This is the standard form for a new adopter and for any tree where elements are not yet shared across documents.
+
+```yaml
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-STRATEGY-2026                # GOALS-[<middle>-]<INTEGER>
+name: "Strategy 2026 — Goals Tree"
+description: "Goal hierarchy for the 2026 plan."
+period: "2026"
+author: Transitrix
+
+goal_types:                            # display vocabulary
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
+  - { name: "Project Goal",   level: 2 }
+
+goals:
+  - id: GOAL-REVENUE-1
+    name: "Triple revenue in 3 years"
+    type: "Strategy"
+    level: 0
+
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+```
+
+A complete example: [`examples/goals/strategy-2026.goals.transitrix.yaml`](../examples/goals/strategy-2026.goals.transitrix.yaml).
+
+### Projection form (Full tier — post-promotion)
+
+After goals are promoted to `canon/elements/01_motivation/goals/`, the view becomes a `view_config` projection. No element data is in this file; the renderer loads elements at view time.
+
 ```yaml
 notation: goals
 spec_version: "0.1"
@@ -102,8 +141,6 @@ view_config:
     collapsed: []                      # GOAL-… IDs of collapsed nodes at load time
 ```
 
-A complete example: [`examples/goals/strategy-2026.goals.transitrix.yaml`](../examples/goals/strategy-2026.goals.transitrix.yaml).
-
 ---
 
 ## 5. Fields
@@ -121,7 +158,9 @@ A complete example: [`examples/goals/strategy-2026.goals.transitrix.yaml`](../ex
 | `description` | no | one-paragraph context |
 | `period` | no | time period the tree covers |
 | `author` | no | document author |
-| `view_config` | no | rendering configuration — see §5.1 |
+| `goal_types` | no | **Inline form only.** Display vocabulary at document root — same semantics as `view_config.goal_types` (see §5.2). Mutually exclusive with `view_config.goal_types`. |
+| `goals` | no | **Inline form only.** Array of goal entries authored directly in the view file. Each entry carries `id`, `name`, `type`, `level`, and optionally `parent`, `description`, `link`, `valid_from`, `valid_to`. Mutually exclusive with `view_config`. |
+| `view_config` | no | **Projection form only.** Rendering configuration for Full-tier projection over canonical element files — see §5.1. Mutually exclusive with `goals`. |
 
 ### 5.1 `view_config.scope`
 
@@ -163,11 +202,10 @@ If `goal_types` is absent, the renderer infers levels from the `parent` chain de
 | `GOALS-001` | error | `notation` missing or does not equal `goals`. |
 | `GOALS-002` | error | `id` missing or does not match `GOALS-[<middle>-]<INTEGER>`. |
 | `GOALS-003` | error | `name` missing or empty. |
-| `GOALS-004` | error | `view_config.goal_types` present but any entry lacks `name` or has a non-integer `level`. |
-| `GOALS-005` | error | `view_config.goal_types[].level` values are not contiguous integers starting at `0`. |
+| `GOALS-004` | error | `goal_types[]` or `view_config.goal_types[]` present but any entry lacks `name` or has a non-integer `level`. |
+| `GOALS-005` | error | `goal_types[].level` or `view_config.goal_types[].level` values are not contiguous integers starting at `0`. |
 | `GOALS-006` | error | `view_config.scope.root_goal` is set but the referenced `GOAL-…` ID does not resolve to an admitted GOAL element in canon. |
 | `GOALS-007` | error | `view_config.scope.type_filter` contains a value not present in `goal_types[].name`. |
-| `GOALS-008` | error | Inline `goals[]` field detected at document root — not accepted from v2.0. Run `migrations/1.0-to-2.0/codemod.mjs` to promote inline goals to standalone element files. |
 
 Element-level validation (parent cycles, type/level consistency, ID grammar) lives in the GOAL element rules applied when the canonical element files are validated, not here.
 

--- a/notations/views/07-action.md
+++ b/notations/views/07-action.md
@@ -1,8 +1,8 @@
 ---
 notation: "Action — Project Schedule"
-version: "2.0"
+version: "2.1"
 author: "Valerii Korobeinikov"
-last_updated: "2026-07-06"
+last_updated: "2026-07-15"
 status: "documented"
 file_extension: "*.action.transitrix.yaml"
 dsm_status: "partially implemented — Actions page; multi-value fields (predecessors, goals, tags) planned in 0.2.5; CPM analysis planned in 0.3.x; Gantt view planned in 0.4.x"
@@ -10,10 +10,8 @@ dsm_status: "partially implemented — Actions page; multi-value fields (predece
 
 # Action Notation — Project Schedule (Network and Timeline)
 
-**Scope:** Text-native form of a project schedule. The view document carries a `view_config` (scope + schedule anchor + display settings) that selects `ACTION` elements from `canon/elements/05_implementation/actions/` and renders them as a Project Schedule Network Diagram (PSND / AoN) for the dependency view and as a Gantt chart for the timeline view. No action data is authored inline in the view document — element data (name, type, duration, predecessors, goals, cost) lives on the standalone ACTION element files.
+**Scope:** Text-native form of a project schedule. The view document has two valid authoring forms: inline (`project:` schedule settings and `actions[]` authored directly in the file; default for self-contained documents) and projection (a `view_config` block that selects `ACTION` elements from `canon/elements/05_implementation/actions/`; used after elements are shared across documents). Both forms render as a Project Schedule Network Diagram (PSND / AoN) for the dependency view and as a Gantt chart for the timeline view.
 **Renderer:** Transitrix DSM — Actions page (graphical AoN today; Gantt view planned in 0.4.x); Transitrix Studio — preview planned in v0.5.0.
-
-**Migration note (v2.0).** Documents authored in the v1 inline format (carrying `actions[]` at the root) must be migrated using the `migrations/1.0-to-2.0/` recipe. Inline `actions[]` is no longer accepted.
 
 **Deprecated alias.** The former notation key `activities`, file extension `*.activities.transitrix.yaml`, root array field `activities:`, and per-entry field `activity_type` are deprecated as of 2026-06-25. Validators emit `ACT-020` warnings on old names; they remain accepted for backward compatibility until the 2.0 cut.
 
@@ -34,13 +32,16 @@ Header rules — required `notation:` field, `spec_version:` semantics, validato
 
 ## Source of truth
 
-**ACTION elements are standalone primitives in `canon/elements/05_implementation/actions/`** ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §4). The Action Schedule view document is a **projection** over those elements — it contains only a `view_config` (scope, schedule anchor, display settings) and does not inline element data.
+An Action Schedule document has two valid authoring forms — both use the same YAML field schema:
 
-The scheduling fields — `duration`, `predecessors`, `start_date`, `end_date` — live on the ACTION element files themselves (see [elements/24-action.md](../elements/24-action.md) §2). The renderer reads those fields from the elements when computing CPM or rendering the Gantt.
+- **Inline form (default):** `project:` (schedule anchor + calendar) and `actions[]` are authored directly in the view file. The file is self-contained. This is the expected form for a new adopter and for any schedule where elements are not yet shared across documents.
+- **Projection form (Full tier — post-promotion):** the file carries only a `view_config` block (scope, schedule anchor, display settings) that selects `ACTION` elements already admitted to `canon/elements/05_implementation/actions/`. No element data is in this file; the renderer reads scheduling fields (`duration`, `predecessors`, `start_date`, `end_date`) from the element files when computing CPM or rendering the Gantt. See [`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §4 and [elements/24-action.md](../elements/24-action.md) §2.
+
+The **promotion trigger** is cross-document sharing: an action stays inline until a second document references it; at that point it is promoted to a standalone element file in `canon/elements/05_implementation/actions/` and both documents reference it by ID ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §1). Promotion is optional until it is forced by sharing — do not split elements into per-file form from day one.
 
 The reconstruction invariant applies: `render(Elements, view_config)` → schedule diagram. Deleting `canon/views/action/` loses no model knowledge. See [`CONTRACT.md`](../CONTRACT.md) §14 (view_config contract).
 
-**Where actions are authored.** New actions are authored as standalone element files in `canon/elements/05_implementation/actions/<ACTION-…>.yaml`, following the canonical element envelope ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §3 and §7.4) and the ACTION schema ([elements/24-action.md](../elements/24-action.md)). The Action Schedule view then projects over them. This is the same pattern as DGCA ([`02-dgca.md`](02-dgca.md)), the Actions Tree ([`23-actions-tree.md`](23-actions-tree.md)), and the Action Card ([`18-action-card.md`](18-action-card.md)).
+**Where actions are authored.** In the inline form, actions are authored directly in the view file under `actions[]`. In the projection form, new actions are authored as standalone element files in `canon/elements/05_implementation/actions/<ACTION-…>.yaml`, following the canonical element envelope ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §3 and §7.4) and the ACTION schema ([elements/24-action.md](../elements/24-action.md)). The Action Schedule view then projects over them. This is the same pattern as DGCA ([`02-dgca.md`](02-dgca.md)), the Actions Tree ([`23-actions-tree.md`](23-actions-tree.md)), and the Action Card ([`18-action-card.md`](18-action-card.md)).
 
 ---
 
@@ -83,6 +84,46 @@ Examples:
 ---
 
 ## 4. Document structure
+
+### Inline form (default — self-contained)
+
+Actions and schedule settings are authored directly in the view file. This is the standard form for a new adopter and for any schedule where elements are not yet shared across documents.
+
+```yaml
+notation: action
+spec_version: "0.1"
+
+name: "Platform Launch 2026"
+description: |
+  Critical path through the customer-facing platform launch.
+  Used for Q3 2026 portfolio review.
+
+project:
+  start_date: "2026-06-01"            # project zero-time for computed Gantt
+  calendar:
+    working_days: [mon, tue, wed, thu, fri]
+    hours_per_day: 8
+
+actions:
+  - id: A-001
+    name: Requirements analysis
+    duration: 5
+    goals: [GOAL-CUST-001]
+    owner: ACTOR-PRODUCT-1
+
+  - id: A-002
+    name: Architecture design
+    duration: 8
+    predecessors: [A-001]
+    goals: [GOAL-CUST-001]
+    owner: ACTOR-ENGINEERING-1
+```
+
+Complete examples: [`examples/action/platform-launch.action.transitrix.yaml`](../examples/action/platform-launch.action.transitrix.yaml) and [`examples/action/office-relocation.action.transitrix.yaml`](../examples/action/office-relocation.action.transitrix.yaml).
+
+### Projection form (Full tier — post-promotion)
+
+After actions are promoted to `canon/elements/05_implementation/actions/`, the view becomes a `view_config` projection. No element data is in this file; the renderer loads elements at view time.
 
 ```yaml
 notation: action
@@ -131,7 +172,9 @@ view_config:
 | `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
 | `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
 | `description` | no | string | optional document-level description |
-| `view_config` | no | object | rendering configuration — see §5.1. When absent, all ACTION elements in canon are included with no schedule anchor. |
+| `project` | no | object | **Inline form only.** Schedule anchor and calendar settings at document root. Same semantics as `view_config.schedule` (see §5.2). Contains `start_date` (ISO 8601), and optionally `calendar` with `working_days`, `hours_per_day`, and `holidays`. Mutually exclusive with `view_config`. |
+| `actions` | no | array | **Inline form only.** Array of action entries authored directly in the view file. Each entry carries `id`, `name`, and optionally `duration`, `predecessors`, `start_date`, `end_date`, `goals`, `delivers_changes`, `owner`, `tags`, `type`, `parent`, `sort`, `description`, `valid_from`, `valid_to`. Mutually exclusive with `view_config`. Deprecated alias: `activities`. |
+| `view_config` | no | object | **Projection form only.** Rendering configuration for Full-tier projection over canonical element files — see §5.1. Mutually exclusive with `actions`. |
 
 ### 5.1 `view_config.scope`
 
@@ -179,7 +222,6 @@ The `schedule` block anchors the view on a calendar for Gantt rendering. Absent 
 | `ACT-007` | error | `view_config.schedule.calendar.working_days` values outside `{mon, tue, wed, thu, fri, sat, sun}` or duplicate |
 | `ACT-008` | error | `view_config.schedule.calendar.holidays` entries not valid ISO 8601 dates |
 | `ACT-009` | warn | `view_config.schedule.start_date` absent and no selected action has pinned dates → Gantt view will not render; the network view still does |
-| `ACT-010` | error | Inline `actions[]` or deprecated `activities[]` field detected at document root — not accepted from v2.0. Run `migrations/1.0-to-2.0/codemod.mjs` to promote inline actions to standalone element files. |
 | `ACT-020` | warn | Deprecated alias detected: `notation: activities`, `activities:` root array, or field `activity_type`. Migrate to `action` / `actions:` / `type`. |
 
 Element-level validation (predecessor cycles, duration non-negativity, date consistency, ID grammar) lives in the ACTION element rules applied when the canonical element files are validated; see [elements/24-action.md](../elements/24-action.md) §6.


### PR DESCRIPTION
## Summary

- **`notations/views/04-goals.md`** — drops `GOALS-008` (inline `goals[]` forbidden error); adds inline form as the default in §4 document structure and documents `goal_types`/`goals` fields at document root in §5; updates Source of truth section to describe both inline and projection forms with the cross-document-sharing promotion trigger (matching the DGCA model from PR #344)
- **`notations/views/07-action.md`** — drops `ACT-010` (inline `actions[]` forbidden error); adds inline form as the default in §4 document structure and documents `project`/`actions` fields at document root in §5; updates Source of truth section similarly
- **`migrations/1.0-to-2.0/README.md`** — reframed as an optional element-promotion recipe (cross-document sharing trigger), not a mandatory migration; removes Transform A.2/B.2 view-rewriting steps
- **`migrations/1.0-to-2.0/codemod.mjs`** — promotion writes standalone element files only; view files are no longer rewritten — inline data is preserved

## Why

The 2026-07-14 inline-authoring ADR (`architecture/cross-project/2026-07-14-inline-authoring-until-promotion.md`) ruled that every view notation must remain renderable from a single self-contained document with inline element data. Goals Tree and Action Schedule were the two notations PR #344 didn't cover. The three official examples (`strategy-2026.goals.transitrix.yaml`, `office-relocation.action.transitrix.yaml`, `platform-launch.action.transitrix.yaml`) were already in the correct inline form but failed validation because the specs still had the v2.0 inline-forbidden rules.

## Test plan

- [x] `node scripts/check-notations.mjs` passes (clean)
- [x] All three examples now conform to their updated specs (no GOALS-008/ACT-010 errors)
- [x] `04-goals.md` §4 shows inline form as primary, projection as additional demo
- [x] `07-action.md` §4 shows inline form as primary, projection as additional demo
- [x] `codemod.mjs` no longer rewrites view files (dry-run produces no `~` lines for view files)
- [x] Migration README correctly describes optional promotion, not mandatory migration

Do NOT merge — Valerii gates every merge.
