### PR TITLE
feat(notations): composite notation count + mechanical count lint (C1)

### DIFF
--- a/notations/README.md
+++ b/notations/README.md
@@ -4,7 +4,7 @@ Transitrix is a text-native methodology: every architecture artefact lives in a 
 
 ## Views
 
-The 15 view notations live under [`views/`](views/) — each describes a render-able artefact with its own YAML schema and file extension.
+The view notations live under [`views/`](views/) in two groups: **11 diagram views** that each render a visual diagram, and **4 report views** that produce a derived report or table. Studio also renders **PlantUML** (`.puml`/`.plantuml`) natively — no separate Transitrix notation is needed for it.
 
 | Spec | Short name | Purpose | File extension | Status |
 |---|---|---|---|---|
@@ -17,9 +17,10 @@ The 15 view notations live under [`views/`](views/) — each describes a render-
 | [08-blocks.md](views/08-blocks.md) | `blocks` | Multi-level container layouts for deep architectural overviews — recursive `block` tree rendered as nested boxes. | `*.blocks.transitrix.yaml` | documented |
 | [09-products.md](views/09-products.md) | `products` | Inventory of products and services — text-and-table catalogue, no diagram. | `*.products.transitrix.yaml` | draft |
 | [10-applications.md](views/10-applications.md) | `applications` | Inventory of applications and integrations — text-and-table catalogue, no diagram. | `*.applications.transitrix.yaml` | draft |
-| [11-scenarios.md](views/11-scenarios.md) | `scenarios` | Report-config view over the `SCENARIO` element catalogue — rendering / ordering / filtering of alternative paths, each pointing at a `TARGET_STATE` and serving one or more `GOAL`s. | `*.scenarios.transitrix.yaml` | draft |
 | [13-process-blueprint.md](views/13-process-blueprint.md) | `process-blueprint` | Wide blueprint of a value chain — stages laid out left-to-right, each carrying its goal, result, and supporting systems / actors / equipment / information entities. | `*.process-blueprint.transitrix.yaml` | draft |
 | [18-action-card.md](views/18-action-card.md) | `action-card` | Single-project narrative view — DGCA chain, dates, milestones, gate decisions. | `*.action-card.transitrix.yaml` | draft |
+| — | **Report views (C = 4)** | | | |
+| [11-scenarios.md](views/11-scenarios.md) | `scenarios` | Report-config view over the `SCENARIO` element catalogue — rendering / ordering / filtering of alternative paths, each pointing at a `TARGET_STATE` and serving one or more `GOAL`s. | `*.scenarios.transitrix.yaml` | draft |
 | [21-compliance-impact.md](views/21-compliance-impact.md) | `compliance-impact` | Report-config view over the compliance overlay — derives the (obligation × subject) matrix from `ASSERTION` + process flow + `REQUIREMENT` status; distinguishes "No mapped obligation (current model)" from `n_a`. | `*.compliance-impact.transitrix.yaml` | draft |
 | [22-coverage-metric.md](views/22-coverage-metric.md) | `coverage-metric` | Report-config view over coverage of canon — counts subjects with zero admitted obligations from each regime, broken down per jurisdiction; distinguishes "Not yet modelled" (modelling gap) from "No obligation asserted (modelled fact)". | `*.coverage-metric.transitrix.yaml` | draft |
 | [23-actions-tree.md](views/23-actions-tree.md) | `actions-tree` | Report-config view over the `ACTION` element catalogue — renders the strategic portfolio as a top-down tree from Initiative through Programme, Project, to Task. | `*.actions-tree.transitrix.yaml` | draft |
@@ -28,7 +29,7 @@ Every view notation follows the convention `*.<short-name>.transitrix.yaml`. Eve
 
 ## Elements
 
-The 13 element notations live under [`elements/`](elements/) — each defines a zone primitive: standalone YAML files admitted to a zone and referenced (by ID) from views and other elements. Canon and codex element primitives carry their own admission record + primitive lifecycle per [`CONTRACT.md`](CONTRACT.md) §6–7; field-zone primitives carry the admission record without a primitive lifecycle (a field artefact records an event, not a temporal element of the organisation).
+The **13** element notations live under [`elements/`](elements/) — each defines a zone primitive: standalone YAML files admitted to a zone and referenced (by ID) from views and other elements. Canon and codex element primitives carry their own admission record + primitive lifecycle per [`CONTRACT.md`](CONTRACT.md) §6–7; field-zone primitives carry the admission record without a primitive lifecycle (a field artefact records an event, not a temporal element of the organisation).
 
 | Spec | Short name | Purpose | File location | Status |
 |---|---|---|---|---|

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -234,6 +234,99 @@ async function checkVersion(failures) {
   }
 }
 
+// --- C1: notation count lint -----------------------------------------------
+//
+// Derives A (diagram views), C (report-config views), and E (element notations)
+// from the filesystem + spec front-matter, then verifies that every stated count
+// in notations/README.md and transitrix/.claude-plugin/plugin.json matches.
+//
+// Classification rules:
+//   deprecated  — spec front-matter status: deprecated → excluded from A and C.
+//   report-config — short name appears in the README table after the
+//                   "| — | **Report views …" separator row → counted as C.
+//   diagram     — all other non-deprecated view specs → counted as A.
+//
+// Why the README table is used for classification (not spec front-matter alone):
+//   The separator row is a deliberate structural marker, not prose; the count
+//   in the prose header is what we're verifying against. Adding a `kind:` field
+//   to every spec would be redundant with the table that already separates them.
+
+const VIEWS_DIR    = join(REPO_ROOT, 'notations', 'views');
+const ELEMENTS_DIR = join(REPO_ROOT, 'notations', 'elements');
+const PLUGIN_JSON  = join(REPO_ROOT, 'transitrix', '.claude-plugin', 'plugin.json');
+const NON_SPEC_VIEW_FILES = new Set(['REPORT_VIEW_CONFIG.md']);
+
+// Returns the Set of short names that appear in the "Report views" block of the
+// README table (i.e., after the separator row).
+async function parseReportConfigShorts() {
+  const text = await readFile(CATALOGUE_PATH, 'utf8');
+  const lines = text.split('\n');
+  const viewsIdx = lines.findIndex(l => /^##\s+Views\s*$/.test(l));
+  if (viewsIdx < 0) throw new Error('notations/README.md: "## Views" section not found');
+  const nextSectionIdx = lines.findIndex((l, i) => i > viewsIdx && /^##\s/.test(l));
+  const end = nextSectionIdx < 0 ? lines.length : nextSectionIdx;
+
+  const out = new Set();
+  let pastSeparator = false;
+  for (let i = viewsIdx + 1; i < end; i++) {
+    const line = lines[i];
+    if (/^\|\s+—\s+\|.*Report views/.test(line)) { pastSeparator = true; continue; }
+    if (!pastSeparator || !line.startsWith('| [')) continue;
+    const shorts = [...line.matchAll(/`([a-z][a-z0-9-]*)`/g)].map(m => m[1]);
+    if (shorts[0]) out.add(shorts[0]);
+  }
+  return out;
+}
+
+async function checkNotationCounts(failures) {
+  // Derive counts from filesystem + spec front-matter.
+  const reportConfigShorts = await parseReportConfigShorts();
+
+  let diagCount = 0, reportCount = 0;
+  for (const e of await readdir(VIEWS_DIR, { withFileTypes: true })) {
+    if (!e.isFile() || !e.name.endsWith('.md') || NON_SPEC_VIEW_FILES.has(e.name)) continue;
+    const text = await readFile(join(VIEWS_DIR, e.name), 'utf8');
+    const statusM = text.match(/^status:\s*"?(\w+)"?/m);
+    if (statusM && statusM[1] === 'deprecated') continue;
+    const extM = text.match(/^file_extension:\s*"?\*\.([a-z0-9-]+)\.transitrix\.yaml"?/m);
+    const short = extM ? extM[1] : null;
+    if (short && reportConfigShorts.has(short)) { reportCount++; } else { diagCount++; }
+  }
+
+  const elemCount = (await readdir(ELEMENTS_DIR, { withFileTypes: true }))
+    .filter(e => e.isFile() && e.name.endsWith('.md')).length;
+
+  // Verify stated counts. `null` means the pattern wasn't found in the file.
+  function check(stated, actual, file, pattern) {
+    if (stated === null) {
+      failures.push({ check: 'C1', message: `${file}: ${pattern} not found — add it so the lint can guard this count.` });
+    } else if (stated !== actual) {
+      failures.push({ check: 'C1', message: `${file}: ${pattern} states ${stated} but filesystem has ${actual}.` });
+    }
+  }
+
+  const readmeText = await readFile(CATALOGUE_PATH, 'utf8');
+  const dm = readmeText.match(/\*\*(\d+)\s+diagram\s+views\*\*/);
+  check(dm ? parseInt(dm[1], 10) : null, diagCount, 'notations/README.md', '"**N diagram views**"');
+  const rm = readmeText.match(/\*\*(\d+)\s+report\s+views\*\*/);
+  check(rm ? parseInt(rm[1], 10) : null, reportCount, 'notations/README.md', '"**N report views**"');
+  const em = readmeText.match(/The\s+\*\*(\d+)\*\*\s+element\s+notations/);
+  check(em ? parseInt(em[1], 10) : null, elemCount, 'notations/README.md', '"The **N** element notations"');
+
+  // plugin.json — only verify counts that are actually stated there.
+  let pluginText;
+  try { pluginText = await readFile(PLUGIN_JSON, 'utf8'); } catch { return; }
+  const desc = JSON.parse(pluginText).description || '';
+  const pdm = desc.match(/(\d+)\s+diagram\s+view/);
+  if (pdm && parseInt(pdm[1], 10) !== diagCount) {
+    failures.push({ check: 'C1', message: `transitrix/.claude-plugin/plugin.json: description states ${pdm[1]} diagram views but filesystem has ${diagCount}.` });
+  }
+  const prm = desc.match(/(\d+)\s+report\s+view/);
+  if (prm && parseInt(prm[1], 10) !== reportCount) {
+    failures.push({ check: 'C1', message: `transitrix/.claude-plugin/plugin.json: description states ${prm[1]} report views but filesystem has ${reportCount}.` });
+  }
+}
+
 // --- main ------------------------------------------------------------------
 
 async function main() {
@@ -244,6 +337,7 @@ async function main() {
     await checkExamples(catalogue, failures);
     await checkLinks(failures);
     await checkVersion(failures);
+    await checkNotationCounts(failures);
   } catch (e) {
     console.error(`error: ${e.message}`);
     process.exit(2);
@@ -263,7 +357,7 @@ async function main() {
 
   console.log(
     `Notations doc-lint clean — ${catalogue.size} view notations; examples, ` +
-    `internal links, and methodology_version pins all consistent.`
+    `internal links, methodology_version pins, and notation counts all consistent.`
   );
   process.exit(0);
 }

--- a/scripts/check-skill-cheatsheet.mjs
+++ b/scripts/check-skill-cheatsheet.mjs
@@ -71,6 +71,9 @@ async function parseCatalogue() {
   for (let i = headerIdx + 2; i < lines.length; i++) {
     const line = lines[i];
     if (!line.startsWith('|')) break;
+    // Structural separator row marking the report-config block (e.g.
+    // "| — | **Report views (C = 4)** | | | |") — not a notation entry.
+    if (/^\|\s+—\s+\|/.test(line)) continue;
     const cells = line.split('|').map(c => c.trim());
     // cells: ['', Spec, ShortName, Purpose, FileExtension, Status, '']
     if (cells.length < 7) continue;

--- a/transitrix/.claude-plugin/plugin.json
+++ b/transitrix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix",
-  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 15 view notations (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Actions tree, Nested blocks, Scenarios, Applications, Products, Action Card, Compliance Impact, Coverage Metric) or a codex artefact.",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 11 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Products, Action Card) + PlantUML rendering, or one of the 4 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric), or a codex artefact.",
   "version": "0.1.0",
   "author": {
     "name": "Transitrix"


### PR DESCRIPTION
## Summary

Composite notation count (A = 11 diagram views / + PlantUML / C = 4 report views) plus a mechanical lint that keeps prose counts in sync with the filesystem, so count drift can't recur unnoticed.

**Composite notation count**

- `notations/README.md` Views header replaced: "The 15 view notations…" → "**11 diagram views** … **4 report views** … Studio also renders **PlantUML**". Table reorganised with a separator row marking the report-config block.
- `notations/README.md` Elements header: bolded "The **13** element notations" — machine-parseable so the new lint can guard it.
- `transitrix/.claude-plugin/plugin.json` description: composite form "one of the 11 diagram views … + PlantUML … or one of the 4 report views" replaces the former flat list.

**Mechanical count lint (C1 check)**

New `C1` check added to `scripts/check-notations.mjs` (already in CI as `notations-doc-lint.yml`):
- Derives the diagram-view count, report-view count, and element-notation count from the filesystem and each spec's `status:` front-matter.
- Classification: `status: deprecated` → excluded; short name after the README table separator → report view; all others → diagram view.
- Fails when any stated count in `notations/README.md` or `plugin.json`'s description disagrees with the derived value.

**Fix included:** `scripts/check-skill-cheatsheet.mjs`'s catalogue-table parser threw on the new separator row (it expected every row to be a real notation entry). Taught it to skip structural separator rows the same way the new C1 check does.

## Test plan

- [x] `node scripts/check-notations.mjs` passes clean
- [x] `node scripts/check-skill-cheatsheet.mjs` passes clean
- [x] CI green on this PR
- [x] `notations/README.md` renders correctly (table separator row, bolded counts)
- [x] `plugin.json` description is coherent

Do NOT merge — Valerii gates every merge.
