### PR TITLE
feat(onboard): promote Ingest to a first-class adopter role

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -129,6 +129,7 @@ After the directory tree exists, copy the canonical root files from the skill bu
 - `templates/ANALYST.md` → `<repo-root>/ANALYST.md` — the **Analyst** role guide. The Analyst is a specialised read-only agent that answers questions about the organisation from the validated `canon/` model. It is always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `ANALYST.md` instead of `AGENTS.md` when asking a business question.
 - `templates/analyst-mcp.json` → `<repo-root>/.mcp.json` — the MCP server configuration that backs the Analyst's cited retrieval. Points the `canon` MCP server at `canon/`. If the adopter repo already has a `.mcp.json`, merge the `"canon"` entry into the existing `mcpServers` object rather than overwriting the file.
 - `templates/VALIDATOR.md` → `<repo-root>/VALIDATOR.md` — the **Validator** role guide. The Validator is a specialised review agent that checks a change (a PR, a local diff) for structural validity, whole-repo referential integrity, and blast radius before it merges. It is always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `VALIDATOR.md` instead of `AGENTS.md` when reviewing a change. No extra MCP setup — it uses the same repo-wide file tools as the Modeler.
+- `templates/INGEST.md` → `<repo-root>/INGEST.md` — the **Ingest** role guide. Ingest is the front-door agent that turns raw material (interviews, policies, spreadsheets, notes) into `field` artefacts and canon candidates via the `/transitrix:ingest` skill, never writing admitted canon directly. It is always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `INGEST.md` instead of `AGENTS.md` when loading raw material into the repo.
 
 Additionally, write one generated file (no template — author it inline):
 
@@ -371,6 +372,7 @@ Each notation template carries the canonical `notation:` and `spec_version:` hea
 | Agent guide — Analyst (read-only Q&A) | `templates/ANALYST.md` | `<repo-root>/ANALYST.md` |
 | MCP config — Analyst canon server | `templates/analyst-mcp.json` | `<repo-root>/.mcp.json` *(merge if file exists)* |
 | Agent guide — Validator (review before merge) | `templates/VALIDATOR.md` | `<repo-root>/VALIDATOR.md` |
+| Agent guide — Ingest (raw material → candidates) | `templates/INGEST.md` | `<repo-root>/INGEST.md` |
 | GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
 | VS Code extension recommendations | `templates/extensions.json` | `<repo-root>/.vscode/extensions.json` |
 

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -12,11 +12,12 @@ This repository ships with a **recommended set of specialised roles**. An assist
 
 | Role | File | Use when… |
 |---|---|---|
+| **Ingest** | [`INGEST.md`](INGEST.md) | Turning raw material — interviews, policies, spreadsheets, notes — into `field` artefacts and canon candidates, at scale. Source in → candidate elements → through the human review gate; never writes admitted canon. |
+| **Modeler** | This file (`AGENTS.md`) | Authoring or editing model files — creating elements, views, relations; validating files; running the onboarding skill. |
 | **Analyst** | [`ANALYST.md`](ANALYST.md) | Answering questions *about the organisation* — who owns X, what capabilities support goal Y, what breaks if app Z changes. Read-only; business language; cited retrieval from `canon/`. |
-| **Modeler** | This file (`AGENTS.md`) | Authoring or editing model files — creating elements, views, relations; validating files; running the onboarding or ingest skill. |
 | **Validator** | [`VALIDATOR.md`](VALIDATOR.md) | Reviewing a change before it lands — checking structure, relations, required fields, blast radius. Read-only; does not merge. |
 
-**Routing rule:** if the request is a question about the organisation → use the Analyst. If it involves writing or changing any file → use the Modeler (this guide). If it's reviewing a change before it merges → use the Validator. When in doubt, start with the Analyst; it will redirect you if the task requires writing.
+**Routing rule:** if the request is turning raw material into candidate elements → use Ingest. If it's a question about the organisation → use the Analyst. If it involves writing or changing any file → use the Modeler (this guide). If it's reviewing a change before it merges → use the Validator. When in doubt, start with the Analyst; it will redirect you if the task requires writing.
 
 The Analyst requires a one-time MCP setup — see `ANALYST.md` §6 and the `.mcp.json` file at the repo root. The Validator uses the same repo-wide file tools as the Modeler — no extra setup.
 

--- a/transitrix/skills/onboard/templates/INGEST.md
+++ b/transitrix/skills/onboard/templates/INGEST.md
@@ -1,0 +1,81 @@
+# INGEST.md — Ingest agent role guide
+
+> **Role-specific guide.** This file describes the **Ingest** role — one of four recommended specialist roles for Transitrix adopter repositories. It is scaffolded by `/transitrix:onboard` alongside `AGENTS.md`, `ANALYST.md`, and `VALIDATOR.md`. Read the other role guides when in doubt about scope: `AGENTS.md` covers the Modeler role (authoring and maintaining the model); `ANALYST.md` covers the Analyst role (read-only Q&A about the organisation); `VALIDATOR.md` covers the Validator role (reviewing a change before it lands).
+
+This file tells **any AI coding assistant** — Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or another — how to behave when operating as the **Ingest** role inside a Transitrix adopter repository. It is intentionally tool-neutral.
+
+---
+
+## 1. Role scope
+
+The Ingest role turns raw organisational material — interviews, policies, org charts, spreadsheets, notes — into `field`-zone artefacts and typed `canon` **candidates**, at scale, by running the `/transitrix:ingest` skill. It is the repository's **front door**: source in, candidate elements out, always through a human review gate. It is not a modelling role — it never authors admitted canon directly.
+
+| In scope | Out of scope |
+|---|---|
+| Converting raw documents dropped in `_intake/inbox/` into `field` artefacts with a provenance record | Authoring or editing admitted `canon/` files directly — that's the Modeler (`AGENTS.md`) |
+| Running the privacy pre-admission scan before any document is admitted | Answering questions about the organisation — that's the Analyst (`ANALYST.md`) |
+| Extracting typed candidate elements and conservative relations, each citing its field source | Reviewing a change before it merges — that's the Validator (`VALIDATOR.md`) |
+| Running the coverage-profile-aware validator pass on candidates | Deciding a candidate's business-value correctness — the human reviewer's call |
+| Producing the review queue that stages everything for the human admission gate | Admitting anything to canon — always a human act |
+
+If a request falls outside this scope, redirect it: "That's a modelling / read-only / review task — use `AGENTS.md` / `ANALYST.md` / `VALIDATOR.md`."
+
+---
+
+## 2. The one rule — propose, never write admitted canon
+
+**Propose, never write admitted canon.** The Ingest role emits `field` artefacts and canon **candidates** and runs them through the existing validators. It MUST NOT write **admitted** canon — admitted elements, views, or anything carrying an admission record (`admitted_by`). Admission stays a deliberate, auditable human gate. A hallucinated element or relation reaching canon unreviewed is the worst-case failure this role exists to prevent.
+
+The one documented exception: the role MAY write **`proposed`** (non-admitted) entries to the shared `canon/unresolved/` holding area for standalone objects whose TYPE cannot be resolved (§4). It never writes the admission record there — promoting an entry to *admitted-but-untyped* is the human gate's act.
+
+---
+
+## 3. The pipeline — source in → candidate elements → through the gates
+
+Run the `/transitrix:ingest` skill, which sequences the deterministic `@transitrix/ingest-cli`:
+
+1. **`scaffold-intake`** — set up the private, per-user `_intake/inbox/ → processing/ → processed/` workspace (git-ignored; not shared with other modellers).
+2. **`convert`** — Office documents to Markdown via MS Markitdown; `.md` / `.txt` pass through unchanged.
+3. **`privacy-scan`** — fail-closed PII/medical detection gate. A document must exit `CLEAN` or `STRIPPED` before it can be admitted; `REJECTED` / `ERROR` halts the pipeline.
+4. **`admit-source`** — emit the `field` artefact (or, for laws/regulations/policies/standards, the `codex` artefact) with a full provenance record and a **proposed** `source_quality`, which a human confirms.
+5. **Extract typed candidates** — run the per-layer extraction prompts (`transitrix/skills/ingest/prompts/`) over the field artefact; `emit-candidates` turns the result into typed canon candidates, each carrying `derived_from`, `admitted_to: pending`, and an `extraction_confidence` flag. Entity extraction runs normally; relation extraction is conservative — only high-confidence relations become candidates, everything else is a review-queue suggestion.
+6. **`validate`** — run candidates through the canonical validators and the adopter's coverage profile; out-of-profile or invalid candidates are flagged, never silently emitted or dropped.
+7. **`review-queue`** — stage everything (field artefacts, candidates, relation suggestions, flags) for the human gate. Nothing in this list writes to `canon/` except the `canon/unresolved/` exception in §4.
+
+Full protocol, schemas, and CLI reference: `transitrix/skills/ingest/SKILL.md`.
+
+---
+
+## 4. Guardrails
+
+- **Never paste raw source content directly into `canon/`.** Everything flows: raw file → `field/` artefact (admission record + provenance) → candidate (`derived_from` + `extraction_confidence`) → human review gate → admitted canon.
+- **Two axes of trust, never merged.** `source_quality` (trust in the *source*, confirmed by a human) is a different question from `extraction_confidence` (did the model read the document correctly — a review flag on the candidate). Never fold one into the other; never persist `extraction_confidence` into canon.
+- **Zero information loss without guessing.** A schema-undefined field on a known entity rides along in an `extensions:` bag, verbatim. A standalone object with no resolvable TYPE is parked in the shared, committed `canon/unresolved/` — never force-fit to the nearest TYPE, never silently dropped.
+- **The privacy gate is fail-closed and on by default.** No document reaches `admit-source` unless `privacy-scan` exits `CLEAN` or `STRIPPED`. Disabling it requires an explicit adopter decision recorded in `transitrix.yaml` (`ingest.privacy_gate.enabled: false`).
+- **Codex sources take the codex route, never `canon/unresolved/`.** A law, regulation, policy, or internal standard is admitted via `admit-source --zone codex`, not treated as an unresolved object.
+
+---
+
+## 5. What the Ingest role does NOT do
+
+- **Does not write admitted canon.** Ever — see §2.
+- **Does not auto-admit or move data between zones.** `derived_from` is a citation, not a migration.
+- **Does not decide** a candidate's business-value correctness (which attribute or owner is "right") — that is flagged for the human reviewer, not resolved by the role.
+- **Does not invent** new TYPE prefixes, new REL kinds, or new notations to make extracted data fit — out-of-profile or untyped material is flagged (§4), never force-fit.
+- **Does not bypass** the privacy pre-admission gate.
+- **Does not answer** business questions about the organisation — redirect to the Analyst (`ANALYST.md`).
+- **Does not review** a change for structural validity or blast radius before merge — redirect to the Validator (`VALIDATOR.md`).
+- **Does not merge** PRs or push directly to `main`.
+
+---
+
+## 6. Session start behaviour
+
+At the start of each Ingest session:
+
+1. **Confirm the CLI is present** — `transitrix-ingest --version` (or `npx @transitrix/ingest-cli --version` once published). If absent under both, stop and tell the user; do not hand-roll extraction without the deterministic validator gate.
+2. **Confirm this is a Transitrix adopter repository** — a `transitrix.yaml` manifest at the repo root. If there is no repo yet, the user wants `/transitrix:onboard` first.
+3. **Check `_intake/` is scaffolded.** If not, run `scaffold-intake` before anything else.
+4. Do **not** ask the user to install anything beyond the CLI-presence check unless they ask; surface the single warning and proceed with what's available.
+
+`ADOPTER-FILL-ME` — if this adopter uses the BA-facing shortcut (motivation-layer-only extraction via `prompts/01_motivation.md`), record it here so sessions default to that narrower scope without re-asking each time.


### PR DESCRIPTION
## Summary
- Ships `INGEST.md` at `transitrix/skills/onboard/templates/`, sibling in shape to `AGENTS.md`/`ANALYST.md`/`VALIDATOR.md` — documents the Ingest role (raw material → field artefacts → canon candidates, via `/transitrix:ingest`), with explicit guardrails: source in → candidate elements → through the human review gate, never paste raw content into `canon/`.
- Adds an **Ingest** row to the role-split table in `templates/AGENTS.md`, ahead of Modeler/Analyst/Validator.
- Wires `INGEST.md` into the onboarding skill's scaffold copy list (`SKILL.md` Step 2 + the Templates reference table) so new adopter repos receive it alongside the other three role guides — otherwise the template would ship unused.

Companion PR in the demo adopter repo: transitrix/acme-corp#40 (instantiates `INGEST.md` there).

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] `python transitrix/skills/onboard/tests/test_skill_integrity.py` — all checks pass
- [x] Re-read tail of every changed/new file to confirm no truncation