### PR TITLE
fix(onboard): remove repo-creation from Modeler role, name setup as one-time step

### DIFF
--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -13,11 +13,13 @@ This repository ships with a **recommended set of specialised roles**. An assist
 | Role | File | Use when… |
 |---|---|---|
 | **Ingest** | [`INGEST.md`](INGEST.md) | Turning raw material — interviews, policies, spreadsheets, notes — into `field` artefacts and canon candidates, at scale. Source in → candidate elements → through the human review gate; never writes admitted canon. |
-| **Modeler** | This file (`AGENTS.md`) | Authoring or editing model files — creating elements, views, relations; validating files; running the onboarding skill. |
+| **Modeler** | This file (`AGENTS.md`) | Authoring or editing model files *within this repo* — creating elements, views, relations; validating files. |
 | **Analyst** | [`ANALYST.md`](ANALYST.md) | Answering questions *about the organisation* — who owns X, what capabilities support goal Y, what breaks if app Z changes. Read-only; business language; cited retrieval from `canon/`. |
 | **Validator** | [`VALIDATOR.md`](VALIDATOR.md) | Reviewing a change before it lands — checking structure, relations, required fields, blast radius. Read-only; does not merge. |
 
 **Routing rule:** if the request is turning raw material into candidate elements → use Ingest. If it's a question about the organisation → use the Analyst. If it involves writing or changing any file → use the Modeler (this guide). If it's reviewing a change before it merges → use the Validator. When in doubt, start with the Analyst; it will redirect you if the task requires writing.
+
+**Repo setup is a one-time step, not a role.** Scaffolding a brand-new adopter repository runs once, via `/transitrix:onboard`, before any of the roles above apply. A client-side adopter typically joins a repo that already exists (Orient/Contribute mode); the Modeler authors *within* that repo and does not scaffold new ones. Turning raw material into candidate elements is its own role — see `INGEST.md` where scaffolded.
 
 The Analyst requires a one-time MCP setup — see `ANALYST.md` §6 and the `.mcp.json` file at the repo root. The Validator uses the same repo-wide file tools as the Modeler — no extra setup.
 


### PR DESCRIPTION
## Summary
- Modeler row in `templates/AGENTS.md` no longer claims "running the onboarding or ingest skill" — scaffolding a new repo is a one-time act, not day-to-day authoring, and ingest is its own role.
- Adds an explicit "Repo setup is a one-time step, not a role" note: `/transitrix:onboard` runs once, before any role applies; the Modeler authors within an existing repo.

Companion PR in the demo adopter repo: transitrix/acme-corp (branch `fix/modeler-role-no-repo-creation`).

## Note for review

Checked the epic's "stale MODELER.md reference" cleanup item — no live reference to a nonexistent `MODELER.md` exists in this repo's tracked docs (the one `SKILL.md` hit is just the word "Modeler", not a filename). However: **acme-corp's `AGENTS.md` genuinely points the Modeler row at a real `MODELER.md` file** (10KB, shipped in commit `40004b5`, "notation-selection ladder"), diverging from this template's design where Modeler = `AGENTS.md` with no separate file. That's a real structural divergence, not stray wording — out of scope for this task, flagging for a decision on whether acme-corp should keep its richer split or fold back to match the template.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] `python transitrix/skills/onboard/tests/test_skill_integrity.py` — all checks pass
- [x] Re-read tail of the changed file to confirm no truncation