### PR TITLE
feat(onboard): cross-cutting raise-a-finding protocol for adopter roles

### DIFF
--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -130,6 +130,7 @@ After the directory tree exists, copy the canonical root files from the skill bu
 - `templates/analyst-mcp.json` → `<repo-root>/.mcp.json` — the MCP server configuration that backs the Analyst's cited retrieval. Points the `canon` MCP server at `canon/`. If the adopter repo already has a `.mcp.json`, merge the `"canon"` entry into the existing `mcpServers` object rather than overwriting the file.
 - `templates/VALIDATOR.md` → `<repo-root>/VALIDATOR.md` — the **Validator** role guide. The Validator is a specialised review agent that checks a change (a PR, a local diff) for structural validity, whole-repo referential integrity, and blast radius before it merges. It is always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `VALIDATOR.md` instead of `AGENTS.md` when reviewing a change. No extra MCP setup — it uses the same repo-wide file tools as the Modeler.
 - `templates/INGEST.md` → `<repo-root>/INGEST.md` — the **Ingest** role guide. Ingest is the front-door agent that turns raw material (interviews, policies, spreadsheets, notes) into `field` artefacts and canon candidates via the `/transitrix:ingest` skill, never writing admitted canon directly. It is always scaffolded alongside `AGENTS.md`; the user activates it by pointing their assistant at `INGEST.md` instead of `AGENTS.md` when loading raw material into the repo.
+- `templates/FINDINGS.md` → `<repo-root>/FINDINGS.md` — the shared **raising a finding** protocol (propose → route → scrub) referenced by all four role guides above. Cross-cutting, not a role — always scaffolded alongside `AGENTS.md`; never activated on its own.
 
 Additionally, write one generated file (no template — author it inline):
 
@@ -373,6 +374,7 @@ Each notation template carries the canonical `notation:` and `spec_version:` hea
 | MCP config — Analyst canon server | `templates/analyst-mcp.json` | `<repo-root>/.mcp.json` *(merge if file exists)* |
 | Agent guide — Validator (review before merge) | `templates/VALIDATOR.md` | `<repo-root>/VALIDATOR.md` |
 | Agent guide — Ingest (raw material → candidates) | `templates/INGEST.md` | `<repo-root>/INGEST.md` |
+| Shared protocol — raising a finding | `templates/FINDINGS.md` | `<repo-root>/FINDINGS.md` |
 | GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
 | VS Code extension recommendations | `templates/extensions.json` | `<repo-root>/.vscode/extensions.json` |
 

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -23,6 +23,8 @@ This repository ships with a **recommended set of specialised roles**. An assist
 
 The Analyst requires a one-time MCP setup — see `ANALYST.md` §6 and the `.mcp.json` file at the repo root. The Validator uses the same repo-wide file tools as the Modeler — no extra setup.
 
+**Cross-cutting, not a fifth role:** every role above can hit something outside its own lane while doing its actual job. [`FINDINGS.md`](FINDINGS.md) is the shared propose → route → scrub protocol for raising that as a finding instead of silently fixing or dropping it — see §14 below and the matching section in each other role guide.
+
 ## Using this guide with your assistant
 
 `AGENTS.md` is the single, canonical, assistant-neutral guide for this repository — there is one source of truth, regardless of which assistant you use. Point your assistant at it:
@@ -281,3 +283,9 @@ When the adopter (or anyone else) asks a question *about the organization itself
 **Do not** answer by grepping arbitrary top-level folders (scratch notes, an adopter's personal `docs/`, `_intake/`, chat logs) as if they were canon — those are not zoned sources and carry no admission record. If the question genuinely isn't covered by `canon/` or `codex/`, say so explicitly ("not modelled yet" / "no admitted artefact answers this") rather than synthesizing an answer from whatever files happen to be nearby.
 
 If a broader repo search is genuinely needed (e.g. "where is X mentioned anywhere in this repo"), that's fine as an explicit, separate action — just don't let it substitute for checking canon/codex first, and don't present unzoned matches with the same confidence as an admitted canon fact.
+
+---
+
+## 14. Raising a finding
+
+If, while authoring or editing, the Modeler notices something outside the requested change — a neighbouring element with a wrong attribute or relation it wasn't asked to touch, or a gap in the notation itself — it does not silently fix it and does not drop it. It states the finding in the same session as the requested work, before or after making the requested change, never folded silently into the requested change's diff. Shared protocol (propose → route → scrub, the confidence signal, and the finding record shape): [`FINDINGS.md`](FINDINGS.md).

--- a/transitrix/skills/onboard/templates/ANALYST.md
+++ b/transitrix/skills/onboard/templates/ANALYST.md
@@ -148,3 +148,9 @@ At the start of each Analyst session:
 3. Do **not** ask the user to install anything or explain MCP setup unless they ask. Surface the single warning and proceed.
 
 Always confirm which `canon/` sub-folders are non-empty before answering, so the answer reflects what is actually modelled (not what might be modelled eventually).
+
+---
+
+## 8. Raising a finding
+
+If, while answering a question, the Analyst notices something outside the question asked — a stale relation, an owner that looks wrong, a gap in the notation itself — it does not silently note it and move on, and it does not fix it (out of scope for a read-only role). It states the finding as a caveat alongside the cited answer to the question actually asked — never in place of answering the question. Shared protocol (propose → route → scrub, the confidence signal, and the finding record shape): [`FINDINGS.md`](FINDINGS.md).

--- a/transitrix/skills/onboard/templates/FINDINGS.md
+++ b/transitrix/skills/onboard/templates/FINDINGS.md
@@ -1,0 +1,69 @@
+# FINDINGS.md — raising a finding (shared protocol)
+
+> **Shared across all four adopter role guides** — [`AGENTS.md`](AGENTS.md) (Modeler), [`ANALYST.md`](ANALYST.md), [`VALIDATOR.md`](VALIDATOR.md), [`INGEST.md`](INGEST.md). This is the single source for the propose → route → scrub rule; each role guide references this file rather than repeating it, and adds only its own one-line note on how a finding surfaces from that role's normal output (§4 below).
+
+This file tells **any AI coding assistant** operating inside a Transitrix adopter repository, in any of the four roles, what to do when it notices something outside the task it was actually asked to do.
+
+---
+
+## 1. When this applies
+
+Every role has strict guardrails — the Analyst is read-only, the Modeler doesn't decide waivers, the Validator doesn't merge, the Ingest role never writes admitted canon. Those guardrails hold even when a role notices something outside its own lane while doing its actual job: the Modeler authoring one element spots that a neighbouring element has the wrong owner; the Analyst answering a question about a capability notices a stale relation; the Validator reviewing a diff spots an unrelated structural problem; the Ingest role extracting candidates hits raw material that implies a gap in the notation itself.
+
+Two outcomes, always:
+
+- **Requested work** → the role does it, within its own lane, per its own guide.
+- **Incidental finding** → the role does not silently fix it (that may be outside its role's write permission entirely, or simply outside what was asked) and does not drop it (the observation is real and would otherwise be lost). It raises a finding instead.
+
+---
+
+## 2. The rule — propose → route → scrub
+
+1. **Propose.** State the correct fill — what the role believes the fix should be — alongside a **confidence signal**:
+   - **Structural** wrongness (a missing required field, a dangling reference, an ArchiMate-layer violation, an ID-grammar violation) → **high confidence**. This is a fact about the model's shape, checkable the same way any validator checks it.
+   - **Business-value** wrongness (which attribute is correct, who the real owner is, which of two plausible relations is right) → **flagged as the human's call**. The role states what it observed and why it looks wrong, but does not assert the "correct" answer with the same certainty as a structural finding.
+2. **Route.** The finding goes to a human, who decides:
+   - **Apply the fix** — author or approve the change into `canon/`, through the same gating as any other change (`AGENTS.md` §11).
+   - **Escalate to the data owner or architect** — when the fix needs organisational judgement the raising role can't supply.
+   - **Escalate upstream to the methodology** — when the finding is a notation or spec limitation, not a data problem (e.g. "there is no relation kind connecting X to Y").
+3. **Scrub (mandatory for methodology-directed findings).** A finding routed upstream to `transitrix/methodology` is stripped of adopter specifics before it leaves this repo — a generic limitation only, never client model content. Same discipline as "publish pattern, not client instance" and the real-names rule, applied to this feedback channel too.
+
+No role auto-applies its own proposed fill. Raising a finding is never itself a write to `canon/` — the human act of applying or escalating is what moves it.
+
+---
+
+## 3. Finding record shape
+
+```yaml
+type: data-error | model-suggestion | methodology-feedback
+raised_by: <role>              # Ingest | Modeler | Analyst | Validator
+subject: <element/artefact ID or area, e.g. CAPABILITY-V2 or "GOAL relation kinds">
+confidence: structural | business-judgement
+observation: <what was seen, in plain language>
+proposed_fill: <the role's proposed correct value, if any — omit if none>
+routing: apply | escalate-owner | escalate-methodology
+```
+
+- `type` — `data-error` (canon disagrees with itself or its source), `model-suggestion` (canon is valid but could model something better), `methodology-feedback` (a canon-confirmed gap in the notation itself, not fixable by editing data).
+- `confidence` — the two-tier signal from §2 step 1. Not a numeric score; a role either has structural certainty or it doesn't.
+- `routing` — the role's recommendation; the human makes the final call regardless.
+
+This shape generalises two things that already exist in the methodology: the Ingest skill's `review-queue.schema.json` (candidates carry `extraction_confidence` and land in a human-reviewed queue) and the Validator's structured severity report (`VALIDATOR.md` §5, error/warning/pass). A role with an existing structured output surfaces a finding inline in that output rather than in a separate file — see §4.
+
+---
+
+## 4. How each role surfaces a finding
+
+- **Ingest** — an incidental finding rides in the existing `review-queue` output alongside candidates and relation suggestions (`INGEST.md` §3); no new file.
+- **Validator** — an incidental finding (something outside the diff under review) is reported alongside the diff's own findings, in the same severity-graded report (`VALIDATOR.md` §4-5), clearly marked as out-of-diff.
+- **Modeler** — states the finding in the same session as the requested work, before or after making the requested change — never folded silently into the requested change's diff.
+- **Analyst** — states the finding as a caveat alongside the cited answer to the question actually asked — never in place of answering the question.
+
+---
+
+## 5. What this protocol does NOT do
+
+- Does **not** let a role write outside the zone or file types its own guide permits — a finding is a proposal, not a write.
+- Does **not** replace the requested task — raise the finding in addition to doing the actual work, never instead of it.
+- Does **not** apply to structural findings a role's own guide already requires it to check and report as part of its normal output (e.g. the Validator's three layers, `VALIDATOR.md` §2) — those are the role's job, not an "incidental" finding.
+- Does **not** bypass human review — routing is a recommendation; a human decides apply vs. escalate vs. discard.

--- a/transitrix/skills/onboard/templates/INGEST.md
+++ b/transitrix/skills/onboard/templates/INGEST.md
@@ -79,3 +79,9 @@ At the start of each Ingest session:
 4. Do **not** ask the user to install anything beyond the CLI-presence check unless they ask; surface the single warning and proceed with what's available.
 
 `ADOPTER-FILL-ME` — if this adopter uses the BA-facing shortcut (motivation-layer-only extraction via `prompts/01_motivation.md`), record it here so sessions default to that narrower scope without re-asking each time.
+
+---
+
+## 7. Raising a finding
+
+If, while extracting candidates, the Ingest role hits raw material that implies a gap in the notation itself — a concept with no TYPE to extract into, a relation the schema can't express — that is a finding, not a reason to force-fit or silently drop the material (§4 already covers the force-fit/drop guardrail for candidates themselves; this is the escalation half). It rides in the existing `review-queue` output alongside candidates and relation suggestions (§3); no new file. Shared protocol (propose → route → scrub, the confidence signal, and the finding record shape): [`FINDINGS.md`](FINDINGS.md).

--- a/transitrix/skills/onboard/templates/VALIDATOR.md
+++ b/transitrix/skills/onboard/templates/VALIDATOR.md
@@ -103,3 +103,9 @@ At the start of each Validator session:
 1. Confirm `.validators/lint.py` exists at the repo root. If it's missing, warn once: "The whole-repo linter isn't scaffolded here — I can only run structural (per-file) validation and manual blast-radius search, not cross-file integrity checks." Then proceed with what's available.
 2. Establish the diff under review — `git diff` against the PR's base branch, or against `main` if reviewing local uncommitted work — before validating anything. Validate structurally only the files the diff touches, but run the blast-radius search (§4) against every ID the diff renames, retypes, or removes, regardless of which files reference it.
 3. Do **not** ask the user to install anything or explain the validation toolchain unless they ask. Run what's available and report gaps once.
+
+---
+
+## 8. Raising a finding
+
+If, while reviewing a diff, the Validator notices a structural problem outside the diff under review — something the diff didn't touch but that's still wrong — it does not silently note it in passing and it does not attempt to fix it (the Validator never writes). It reports the finding alongside the diff's own findings, in the same severity-graded report (§4-5), clearly marked as out-of-diff. Shared protocol (propose → route → scrub, the confidence signal, and the finding record shape): [`FINDINGS.md`](FINDINGS.md).


### PR DESCRIPTION
## Summary
- Adds `templates/FINDINGS.md` as the single shared source for the propose -> route -> scrub rule, generalising the ingest review-queue and the Validator's severity report.
- `AGENTS.md`, `ANALYST.md`, `VALIDATOR.md`, `INGEST.md` each gain a short reference section (not a copy-pasted rule) plus a role-specific one-liner on how a finding surfaces from that role's normal output.
- `SKILL.md` scaffolds `FINDINGS.md` alongside the other role guides for new adopter repos.

## Test plan
- [x] `node scripts/check-notations.mjs` passes clean
- [x] Re-read the tail of every changed/created file to confirm no truncation
- [x] Diff scoped to exactly this concern (6 files, all onboarding templates/skill)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>