### PR TITLE
feat(templates): add RACI-on-Nested-Block-Diagram starter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ New to the ideas behind it? Read **[`method/01-methodology.md`](method/01-method
 - **[`method/01-methodology.md`](method/01-methodology.md)** — the methodology overview: model, principles, zones, change lifecycle.
 - **[`notations/README.md`](notations/README.md)** — the canonical notation index; [`notations/CONTRACT.md`](notations/CONTRACT.md) and the per-notation specs are the authoritative source for the model in detail.
 - **[`method/00-glossary.md`](method/00-glossary.md)** — standardised terminology.
+- **[`templates/`](templates/)** — forkable starter templates (recipes) for common artefacts — fork, rename, adapt.
 
 Process & releases:
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,33 @@
+# Templates
+
+Forkable starter artefacts — single-purpose recipes showing how to express
+one common thing in Transitrix notation. Copy a template into your own repo,
+rename it, adapt it.
+
+Templates are generic by construction: no client data, no adopter-specific
+content, pure method — "publish pattern, not instance," the same discipline
+this repository applies to every public-facing artefact (see e.g.
+[`transitrix/skills/onboard/templates/FINDINGS.md`](../transitrix/skills/onboard/templates/FINDINGS.md)).
+
+**How templates differ from the other worked material in this repo:**
+
+| | Purpose | Scope |
+|---|---|---|
+| [`notations/examples/`](../notations/examples/) | Minimal spec-conformance example per notation | One file, illustrates the schema |
+| **`templates/`** (this directory) | Adopter-facing starting point for a specific recipe | One file or a small set, ready to fork |
+| [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) | Full worked example of one adopter's whole model | A complete organisation, all notations together |
+
+## Available templates
+
+| Template | Notation | What it solves |
+|---|---|---|
+| [`raci-nested-blocks/`](raci-nested-blocks/) | [Nested Block Diagram](../notations/views/08-blocks.md) | Lay out a RACI (Responsible/Accountable/Consulted/Informed) matrix as nested blocks — no new notation needed. |
+
+## Using a template
+
+1. Open the template's own `README.md` — it explains the layout convention
+   and any modelling caveats specific to that recipe.
+2. Copy the `*.transitrix.yaml` file(s) into your own repository and rename
+   them for your content.
+3. Validate: `npx @transitrix/cli validate <your-file>` (Windows PowerShell:
+   `npx.cmd`).

--- a/templates/raci-nested-blocks/README.md
+++ b/templates/raci-nested-blocks/README.md
@@ -1,0 +1,80 @@
+# RACI matrix on a Nested Block Diagram
+
+A recommended layout for expressing a RACI matrix (who is **R**esponsible,
+**A**ccountable, **C**onsulted, **I**nformed per activity) using the
+[Nested Block Diagram](../../notations/views/08-blocks.md) notation — no new
+notation required.
+
+## What this is (and isn't)
+
+Nested Block Diagrams express **containment only** — "what is inside what"
+([`08-blocks.md`](../../notations/views/08-blocks.md) §1, §8). A RACI matrix
+is really a many-to-many cross-tab: one role is Accountable across many
+activities, one activity has several roles in different capacities. This
+template lays a RACI matrix out as a tree because that's what the notation
+draws — activities containing their role assignments.
+
+**This is a document-local visual convention, not a queryable RACI data
+model.** There is no first-class "assignment" relation between a role and an
+activity in the methodology today, so you cannot ask "what is the CFO
+accountable for across the whole organisation" and get an answer from this
+file — only "what does this one diagram say about this one process." If you
+need that kind of query, treat this template as a stopgap and raise the need
+for a dedicated, typed RACI notation with your Transitrix contact.
+
+## Layout convention
+
+- **Top-level blocks are activities** (or process steps), in the order they
+  occur.
+- **Child blocks are role assignments** — one child per role that has an R,
+  A, C, or I stake in that activity. Name each child `"<CODE> — <Role>"`
+  (e.g. `"A — CFO"`) so the code is visible directly in the rendered box.
+- Use the block `description` to say *why* the role has that stake — it
+  renders as a tooltip/detail panel and is what makes the diagram
+  self-explanatory without a separate legend.
+
+### ID convention
+
+Block IDs must be unique within the document (`BL-007`). Since the same role
+recurs across many activities, scope each child ID to its activity:
+
+```
+<ACTIVITY_ID>_<CODE>_<ROLE_ID>
+```
+
+e.g. `APPROVE_BUDGET_A_CFO`. Don't reuse a bare role ID (`CFO`) across
+multiple activities — it will collide.
+
+### Alternative: role-first orientation
+
+If your audience cares more about "what does this role do across the
+process" than "who's involved in this step," flip the tree: top-level blocks
+become roles, children become the activities they're assigned to, named the
+same `"<CODE> — <Activity>"` way. Pick one orientation per document — don't
+mix both in the same file.
+
+## Modelling reminders
+
+RACI convention (not enforced by the notation or its validator):
+
+- Exactly **one Accountable** per activity. Two accountables usually means
+  the decision owner hasn't actually been decided.
+- Keep **Responsible** to as few roles as practical — RACI works best when
+  "who does the work" is unambiguous.
+- Don't assign a code to every role on every activity. A role with no stake
+  in an activity simply isn't listed as a child there.
+
+## Using this template
+
+1. Copy [`raci-matrix.blocks.transitrix.yaml`](raci-matrix.blocks.transitrix.yaml)
+   into your own repo (e.g. `views/blocks/`).
+2. Rename `nested_blocks.id`, `name`, and `description` to your process.
+3. Replace the four sample activities with your own, and the four sample
+   roles with your own — add or remove child blocks per activity as needed.
+4. Validate: `npx @transitrix/cli validate <your-file>` (Windows PowerShell:
+   `npx.cmd`).
+5. Preview in Transitrix Studio, or render with any tool that consumes the
+   shared diagram engine.
+
+See [`08-blocks.md`](../../notations/views/08-blocks.md) for the full notation
+spec.

--- a/templates/raci-nested-blocks/raci-matrix.blocks.transitrix.yaml
+++ b/templates/raci-nested-blocks/raci-matrix.blocks.transitrix.yaml
@@ -1,0 +1,80 @@
+notation: blocks
+spec_version: "0.1"
+name: "RACI — Quarterly Budget Cycle (starter template)"
+generated_at: "2026-07-25"
+description: "Starter RACI matrix laid out as a Nested Block Diagram — top-level blocks are activities in a quarterly budget cycle, child blocks are role assignments (R/A/C/I) for each activity. Fork this file: rename the activities and roles, and adapt the RACI codes to your own process. See ../README.md for the layout convention this template follows."
+
+nested_blocks:
+  id: BLOCKS-RACI-STARTER-1
+  name: "RACI — Quarterly Budget Cycle"
+  description: "Who is Responsible, Accountable, Consulted, and Informed at each step of preparing, reviewing, approving, and communicating the quarterly budget."
+  version: "0.1"
+
+  blocks:
+    - id: PREPARE_BUDGET_DRAFT
+      name: "1. Prepare Budget Draft"
+      description: "Finance drafts next quarter's budget numbers from historical actuals and department input."
+      children:
+        - id: PREPARE_BUDGET_DRAFT_R_FINANCE_MANAGER
+          name: "R — Finance Manager"
+          description: "Responsible: owns drafting the numbers."
+        - id: PREPARE_BUDGET_DRAFT_A_CFO
+          name: "A — CFO"
+          description: "Accountable: signs off that the draft is fit to circulate."
+        - id: PREPARE_BUDGET_DRAFT_C_DEPARTMENT_HEADS
+          name: "C — Department Heads"
+          description: "Consulted: give input on their department's forecast before the draft is finalised."
+        - id: PREPARE_BUDGET_DRAFT_I_EMPLOYEES
+          name: "I — Employees"
+          description: "Informed: notified once a draft exists."
+
+    - id: REVIEW_BUDGET
+      name: "2. Review Budget"
+      description: "Department heads and Finance walk through the draft together and flag issues."
+      children:
+        - id: REVIEW_BUDGET_R_DEPARTMENT_HEADS
+          name: "R — Department Heads"
+          description: "Responsible: review their own department's lines and raise concerns."
+        - id: REVIEW_BUDGET_A_CFO
+          name: "A — CFO"
+          description: "Accountable: owns the outcome of the review round."
+        - id: REVIEW_BUDGET_C_FINANCE_MANAGER
+          name: "C — Finance Manager"
+          description: "Consulted: clarifies assumptions behind the draft numbers."
+        - id: REVIEW_BUDGET_I_EMPLOYEES
+          name: "I — Employees"
+          description: "Informed: no action needed at this stage."
+
+    - id: APPROVE_BUDGET
+      name: "3. Approve Budget"
+      description: "The reviewed budget is formally approved and locked for the quarter."
+      children:
+        - id: APPROVE_BUDGET_R_FINANCE_MANAGER
+          name: "R — Finance Manager"
+          description: "Responsible: assembles the final approval package."
+        - id: APPROVE_BUDGET_A_CFO
+          name: "A — CFO"
+          description: "Accountable: makes the approval decision."
+        - id: APPROVE_BUDGET_C_DEPARTMENT_HEADS
+          name: "C — Department Heads"
+          description: "Consulted: confirm they can commit to their final numbers."
+        - id: APPROVE_BUDGET_I_EMPLOYEES
+          name: "I — Employees"
+          description: "Informed: no action needed at this stage."
+
+    - id: COMMUNICATE_BUDGET
+      name: "4. Communicate Budget"
+      description: "The approved budget is published to the organisation."
+      children:
+        - id: COMMUNICATE_BUDGET_R_FINANCE_MANAGER
+          name: "R — Finance Manager"
+          description: "Responsible: publishes the approved numbers and the supporting notes."
+        - id: COMMUNICATE_BUDGET_A_CFO
+          name: "A — CFO"
+          description: "Accountable: owns the communication as final and binding."
+        - id: COMMUNICATE_BUDGET_C_DEPARTMENT_HEADS
+          name: "C — Department Heads"
+          description: "Consulted: sanity-check the summary before it goes out company-wide."
+        - id: COMMUNICATE_BUDGET_I_EMPLOYEES
+          name: "I — Employees"
+          description: "Informed: receive the published budget."


### PR DESCRIPTION
## Summary
- Adds a new `templates/` directory — forkable starter artefacts distinct from `notations/examples/` (spec-conformance examples) and the `acme-corp` full worked example.
- First template: a recommended RACI matrix layout on the existing Nested Block Diagram notation (`templates/raci-nested-blocks/`) — no new notation needed. Activities are top-level blocks, role assignments (R/A/C/I) are child blocks.
- Guide (`templates/raci-nested-blocks/README.md`) documents the layout convention, the ID-uniqueness scheme (BL-007), an alternative role-first orientation, and an explicit caveat: this is a document-local visual convention, not a queryable RACI data model — Nested Block Diagrams are containment-only.
- `templates/README.md` indexes the library and explains how it differs from `notations/examples/` and `acme-corp`.
- Root `README.md` gets one discoverability line under Documentation.

Note: the current Blocks spec (v0.5) uses structured YAML (`*.blocks.transitrix.yaml`); the legacy ASCII/Svgbob `*.blocks.transitrix.txt` form referenced when this idea first came up is retired. The template follows current canon.

## Test plan
- [x] `npx.cmd @transitrix/cli validate templates/raci-nested-blocks/raci-matrix.blocks.transitrix.yaml` — valid
- [x] `node scripts/check-notations.mjs` — clean
- [x] Re-read tail of every new/changed file for truncation