### PR TITLE
feat(templates): add operating-model composite starter template

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -11,6 +11,7 @@ Forkable starter artefacts — generic patterns expressed in Transitrix notation
 | Template | Notation | Description |
 |---|---|---|
 | [`raci/`](raci/) | `blocks` (matrix subset, [08-blocks.md](../notations/views/08-blocks.md) §4a) | RACI matrix — who is Responsible / Accountable / Consulted / Informed across a set of activities. |
+| [`operating-model/`](operating-model/) | Composite — Goals, Capability Map, Process Blueprint, BPMN, Nested Block Diagram, Products, Applications | Starter kit showing "your operating model" is a composition of building blocks already expressible in Transitrix notation — one minimal, cross-referenced scenario running through all eight blocks. |
 
 ## Using a template
 
@@ -21,4 +22,9 @@ Forkable starter artefacts — generic patterns expressed in Transitrix notation
 
 ## Contributing a template
 
-A template must be a **generic pattern, not a client instance** — no real organisation's data, names, or figures. Keep it small (one notation, one clear purpose) and pair it with a short README explaining the layout convention and any modelling caveats.
+A template must be a **generic pattern, not a client instance** — no real organisation's data, names, or figures. Pair it with a short README explaining the layout convention and any modelling caveats.
+
+Two categories of template are welcome:
+
+- **Single-notation.** Keep it small — one notation, one clear purpose (e.g. `raci/`). This is still the default shape for most templates.
+- **Composite / starter-kit.** A template whose whole *purpose* is the composition of several building blocks across notations (e.g. `operating-model/`) — the point being made requires more than one notation, so it cannot be single-notation by construction. Keep it small a different way: exactly **one minimal instance per building block**, cross-referenced by real ID, not a full worked example. If you find yourself adding a second instance of any one building block "for realism," that's a sign the template has drifted from composite-proof into worked-example territory — stop and reconsider scope.

--- a/templates/operating-model/README.md
+++ b/templates/operating-model/README.md
@@ -1,0 +1,73 @@
+# Operating model — a composition, not a new artefact
+
+A forkable starter that demonstrates a claim, not just a pattern: **"your operating model" is not a separate artefact to author.** It is a view composed from building blocks you already express in Transitrix notation — motivation, capabilities, value streams, processes, organisation, information, products, and applications. This template runs **one** minimal, coherent scenario (a generic company's customer-onboarding operating slice) through all eight building blocks so the composition can be seen end to end, cross-referenced by real canonical IDs.
+
+No client or organisation data — every ID, name, and description below is generic and reusable. See [`../README.md`](../README.md) for how this differs from `notations/examples/` and from the `acme-corp` worked example.
+
+## Fork and go
+
+1. Copy [`canon/`](canon/) into your own repository (or fork this one and delete everything outside `templates/operating-model/`).
+2. Rename the `ONBOARDING` domain tag and the `1` sequence numbers to your own scenario's IDs — keep the `<TYPE>-<INTEGER>` grammar ([`../../notations/IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §1).
+3. Edit each element file under `canon/elements/` for your own goal, capability, process, roles, business object, product, and application. Edit the matching view under `canon/views/` to match — the view's inline fields should mirror the element's stable fields (see "The layout convention" below for which notations this applies to).
+4. Validate every file: `npx @transitrix/cli validate <file>` (Windows PowerShell: `npx.cmd`), and the whole set at once with `npx @transitrix/cli validate --scope=repo --root .` from inside `templates/operating-model/`.
+5. Grow from here: add more capabilities, a second process stage, a richer org tree — the composition scales the same way your real operating model does, one building block at a time.
+
+## The eight building blocks
+
+| # | Building block | Notation | File(s) |
+|---|---|---|---|
+| 1 | Motivation & goals | Goals tree | `canon/elements/01_motivation/goals/GOAL-ONBOARDING-1.yaml` + `canon/views/goals/onboarding.goals.transitrix.yaml` |
+| 2 | Capabilities | Capability Map | `canon/elements/02_business/capabilities/CAPABILITY-V1.yaml` + `canon/views/capabilities/onboarding.capability-map.transitrix.yaml` |
+| 3 | Value streams | Process Blueprint | `canon/views/process-blueprint/onboarding.process-blueprint.transitrix.yaml` |
+| 4 | Processes | BPMN | `canon/elements/02_business/processes/PROCESS-ONBOARDING-1.yaml` + `canon/views/bpmn/onboarding.bpmn.transitrix.yaml` |
+| 5 | Organisation | Nested Block Diagram | `canon/views/blocks/onboarding.blocks.transitrix.yaml` (tree form, §4 of [`08-blocks.md`](../../notations/views/08-blocks.md) — not the matrix subset the RACI template uses) |
+| 6 | Information | Business Object, shown in the Process Blueprint | `canon/elements/02_business/business-objects/BUSINESS_OBJECT-CUSTOMER-PROFILE-1.yaml`, referenced from the same process-blueprint file as row 3 |
+| 7 | Products & services | Products catalogue | `canon/elements/02_business/products/PRODUCT-ONBOARDING-1.yaml` + `canon/views/products/onboarding.products.transitrix.yaml` |
+| 8 | Applications | Applications catalogue | `canon/elements/03_application/applications/APPLICATION-ONBOARDING-1.yaml` + `canon/views/applications/onboarding.applications.transitrix.yaml` |
+
+Row 6 is deliberately not a separate file: the point of the composition is that "information" is not its own notation, it is a Business Object surfaced inside the Process Blueprint that already carries row 3.
+
+## The layout convention
+
+This template mirrors the real adopter file convention — the same one `transitrix/acme-corp` uses — rather than inlining everything into one file per notation:
+
+- **Standalone element files**, one per element, under `canon/elements/<NN>_<layer>/<plural-type>/<ID>.yaml`. Each carries the full envelope: header, admission record ([`CONTRACT.md`](../../notations/CONTRACT.md) §6), and primitive lifecycle (§7). This is the authoritative record for that element — the "elements are the complete and sufficient source of truth" invariant ([`ELEMENT_PRIMITIVES.md`](../../notations/ELEMENT_PRIMITIVES.md) §1.1).
+- **View files** under `canon/views/<notation>/`, each carrying only the presentation layer plus cross-references by ID.
+
+That second point splits into two shapes depending on the notation, because the notations themselves are at different points in the same migration:
+
+- **Goals** (row 1) is a **pure projection** (`view_config` only, no inline element data) — mandatory since methodology `2.0.0` (`CHANGELOG.md`, 2026-07-12): a `goals[]` array inline in the view is a validator error (`GOALS-008`). This is the shape every notation is expected to converge on.
+- **Capability Map, Products, Applications** (rows 2, 7, 8) are still **inline aggregator catalogues** in the current spec: the view's `capabilities[]` / `products[]` / `applications[]` entries duplicate the referenced element's stable fields rather than pointing at it by bare ID. This is the documented v1 shape (`05-capability-map.md` §12, `09-products.md` §4, `10-applications.md` §4) — not a shortcut this template took.
+- **Process Blueprint and Nested Blocks** (rows 3 and 5) were never element-backed catalogues to begin with — they are cross-cutting views whose stages/aspects/blocks are document-local, optionally cross-linking into element catalogues by canonical ID (`APPLICATION-…`, `ROLE-…`, `BUSINESS_OBJECT-…`) when the referenced element exists. This template's entries do carry those IDs, so a renderer can resolve them.
+- **BPMN** (row 4) is a **derived projection** of the `PROCESS` element's own `flow` field — the element is genuinely the only source of truth (`01-bpmn.md`, "Relationship to the PROCESS element"). This repository does not run the Studio generator that would derive `canon/views/bpmn/onboarding.bpmn.transitrix.yaml` automatically, so it is hand-authored here to mirror `PROCESS-ONBOARDING-1.yaml`'s `flow` — keep the two in sync if you edit either.
+
+## The modelling rule / relation vocabulary this template applies
+
+Every cross-reference in this template is a real field a notation spec already defines — no relation kind was invented to make the composition read cleanly:
+
+- `CAPABILITY.business_process` / `CAPABILITY.applications` (capability → process, capability → applications)
+- `PROCESS.capability` / `PROCESS.participants` (process → capability, process → roles)
+- `PRODUCT.capabilities` / `PRODUCT.processes` / `PRODUCT.supporting_apps` (product ← delivered by capability/process/application)
+- `APPLICATION.capabilities` / `APPLICATION.products` (application → capability, application → product)
+- Process Blueprint `systems[].id` / `actors[].id` / `business_objects[].id` (value stream → application/role/business object)
+- BPMN lane/element `performed_by_role` / `supported_by_application` (process step → role/application)
+- Nested block `id` matching a registered `TYPE-…` prefix (org block → role)
+
+**No `canon/relations/` folder.** The closed `REL` `type` enum ([`elements/17-relations.md`](../../notations/elements/17-relations.md) §3 — `parent`, `goal_parent`, `action_goal`, `unit_parent`, `employment`, `offers`, `realizes`, `hosts`, `uses`, …) only applies where two elements of the *same* kind need a time-aware link (a capability re-parented, a goal re-aimed, an org unit re-organised). This template keeps exactly one instance per building block, so none of that enum's kinds has a natural second element to link to. Fork this template and add a second capability, goal, or org unit, and the relevant `REL-…` file becomes the right home for that link — don't fabricate one here just to populate the folder.
+
+There is also no `GOAL → CAPABILITY` cross-reference field anywhere in this template. That is not an oversight: as of this writing, no notation spec defines one (`GOAL`'s fields are `type`, `level`, `parent`, `factors`; `CAPABILITY`'s fields carry `business_process` and `applications`, not `goals`). The motivation and capability building blocks here are tied together by the shared "customer onboarding" scenario and by prose, not by a schema-level link — an honest reflection of what the methodology currently expresses, not a gap this template silently patches over.
+
+## Implementation status — known CLI/spec gaps
+
+Run `npx @transitrix/cli validate <file>` (or `--scope=repo`) against every file in `canon/` before you extend this template; here is what to expect on the unmodified template itself (verified 2026-07-26):
+
+- **Standalone element files are not yet CLI-validated file-by-file.** `canon/elements/**/*.yaml` (notation values `goal`, `capability`, `process`, `product`, `application`, `role`, `business_object`) each print `notation "<x>" is not yet validated by the CLI` and exit `0` — informational, not a failure. Whole-canon checks do cover them: `npx @transitrix/cli validate --scope=repo --root .` from inside `templates/operating-model/` passes clean (`"valid": true`, zero findings) against this template as shipped.
+- **The goals projection view needs `--scope=repo`.** `canon/views/goals/onboarding.goals.transitrix.yaml` is a pure `view_config` projection; single-file validation has no `canon/elements/**` to resolve `GOAL-ONBOARDING-1` against, so it prints a notice rather than pass/fail. `--scope=repo` resolves it.
+- **Capability Map's `current_maturity` is required inline by the shipped validator, contradicting the spec.** `05-capability-map.md` §13–14 designates `current_maturity` time-varying (sidecar-only, `<id>.history.yaml`, per [`CONTRACT.md`](../../notations/CONTRACT.md) §9) — inlining it is documented as triggering `VERSIONED-004`. The shipped CLI validator (`packages/diagrams/src/capability-map/validate.ts` in `transitrix-studio`, rule `CMAP-003`) has not caught up: it requires `current_maturity` inline and does not know about sidecars or `VERSIONED-004` at all. `canon/views/capabilities/onboarding.capability-map.transitrix.yaml` inlines `current_maturity` so it validates against the CLI that actually ships today; the standalone element file `CAPABILITY-V1.yaml` omits it (per spec) since standalone `capability` elements are not yet CLI-validated (see above) — no VERSIONED-004 risk either way in the current CLI. Repro: delete `current_maturity` from the view's `capabilities[0]` entry and re-run `validate` — it fails with `CMAP-003`.
+- **Process Blueprint's shipped validator does not yet recognise `business_objects[]`.** The notation spec (`13-process-blueprint.md` §5.3) renamed `information_entities[]` to `business_objects[]`; the shipped validator (`packages/diagrams/src/process-blueprint/validate.ts`) still only checks `systems` / `actors` / `equipment` / `information_entities`. This is not a failure — an unrecognised category key is silently skipped, not rejected — but it means `business_objects[]` in `canon/views/process-blueprint/onboarding.process-blueprint.transitrix.yaml` gets no structural checking from the CLI today (ID-prefix and stage-reference checks that do run for `systems[]` / `actors[]` do not run for it). Confirm it by eye until the validator catches up.
+
+All six view files that the shipped CLI *does* validate at file scope — `applications`, `blocks`, `bpmn`, `capability-map`, `process-blueprint`, `products` — pass with zero errors and zero warnings as shipped.
+
+## What this is not
+
+This is **not** a full worked example like `transitrix/acme-corp`. `acme-corp` is a single, coherent, full-organisation model built for depth — many capabilities, many processes, a real maturity history, compliance chains. This template is a **minimal composition proof**: exactly one instance per building block, enough to show the eight rows are real, cross-referenced, and independently valid — not enough to run a transformation programme against. Extend it, don't read it as a reference architecture.

--- a/templates/operating-model/canon/elements/01_motivation/goals/GOAL-ONBOARDING-1.yaml
+++ b/templates/operating-model/canon/elements/01_motivation/goals/GOAL-ONBOARDING-1.yaml
@@ -1,0 +1,28 @@
+# Template element — one minimal GOAL, standalone per notations/views/04-goals.md
+# (v2.0, pure projection). Schema: notations/ELEMENT_PRIMITIVES.md §7.2 + envelope §3.
+# This is the motivation building block of the operating-model composition —
+# see templates/operating-model/README.md.
+
+notation: goal
+id: GOAL-ONBOARDING-1
+name: "Reduce time-to-value for new customers"
+type: "Strategic Goal"
+level: 0
+description: >
+  Shorten the interval between a customer signing up and reaching first
+  productive use of the offering. The driving intent behind the customer
+  onboarding capability, process, and supporting systems modelled in this
+  template.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-26"
+admitted_by: "template"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-26"
+valid_to: null

--- a/templates/operating-model/canon/elements/02_business/business-objects/BUSINESS_OBJECT-CUSTOMER-PROFILE-1.yaml
+++ b/templates/operating-model/canon/elements/02_business/business-objects/BUSINESS_OBJECT-CUSTOMER-PROFILE-1.yaml
@@ -1,0 +1,26 @@
+# Template element — one minimal BUSINESS_OBJECT, standalone per
+# notations/ELEMENT_PRIMITIVES.md §7.15 + envelope §3. Shown inside the
+# Process Blueprint view (canon/views/process-blueprint/) — the information
+# building block is not a separate notation, it is a Business Object
+# surfaced in the value-stream view (notations/views/13-process-blueprint.md).
+
+notation: business_object
+id: BUSINESS_OBJECT-CUSTOMER-PROFILE-1
+name: "Customer profile"
+type: record
+description: >
+  The record created when the onboarding agreement is confirmed, read to
+  verify identity, and updated when account access is provisioned.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-26"
+admitted_by: "template"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-26"
+valid_to: null

--- a/templates/operating-model/canon/elements/02_business/capabilities/CAPABILITY-V1.yaml
+++ b/templates/operating-model/canon/elements/02_business/capabilities/CAPABILITY-V1.yaml
@@ -1,0 +1,36 @@
+# Template element — one minimal CAPABILITY, standalone per
+# notations/views/05-capability-map.md §13 + envelope (ELEMENT_PRIMITIVES.md §3).
+# Time-varying fields (current_maturity, owner_role, target_date — CONTRACT.md §9)
+# are intentionally omitted here rather than sidecar-versioned, to keep this
+# template to one file per building block. See templates/operating-model/README.md.
+
+notation: capability
+id: CAPABILITY-V1
+name: "Customer Onboarding"
+type: domain
+description: >
+  The organisation's ability to bring a newly signed customer to first
+  productive use of the offering — identity verification, account
+  provisioning, and initial activation.
+
+# Stable forward-looking aspiration — not time-varying
+target_maturity: 3
+
+# Relations — stay inline in v1 (Wave 3 may promote to first-class
+# time-aware relation files); see 05-capability-map.md §13a.
+business_process: PROCESS-ONBOARDING-1
+applications:
+  - APPLICATION-ONBOARDING-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-26"
+admitted_by: "template"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-26"
+valid_to: null

--- a/templates/operating-model/canon/elements/02_business/processes/PROCESS-ONBOARDING-1.yaml
+++ b/templates/operating-model/canon/elements/02_business/processes/PROCESS-ONBOARDING-1.yaml
@@ -1,0 +1,62 @@
+# Template element — one minimal PROCESS, standalone per
+# notations/ELEMENT_PRIMITIVES.md §7.5 + envelope §3. This element is the
+# complete, self-sufficient definition of the process — participants and
+# flow — of which canon/views/bpmn/onboarding.bpmn.transitrix.yaml is a
+# rendered projection (notations/views/01-bpmn.md).
+
+notation: process
+id: PROCESS-ONBOARDING-1
+name: "Customer Onboarding"
+owner_role: ROLE-OPS-1
+capability: CAPABILITY-V1
+description: >
+  Bring a newly signed customer from confirmed agreement to first
+  productive use: confirm the agreement, verify identity, and provision
+  account access.
+
+# Participants — the process's lanes, in rendered top-to-bottom order.
+# Lane captions derive from each referenced element's `name`.
+participants:
+  - ROLE-CS-1
+  - ROLE-OPS-1
+
+# The canonical process graph — sufficient to regenerate the BPMN
+# projection at canon/views/bpmn/onboarding.bpmn.transitrix.yaml.
+flow:
+  steps:
+    - id: STEP-START-1
+      type: startEvent
+    - id: STEP-CONFIRM-1
+      type: task
+      name: "Confirm onboarding agreement"
+      performed_by: ROLE-CS-1
+    - id: STEP-VERIFY-1
+      type: task
+      name: "Verify identity"
+      performed_by: ROLE-OPS-1
+      supported_by_application: APPLICATION-ONBOARDING-1
+    - id: STEP-PROVISION-1
+      type: task
+      name: "Provision account access"
+      performed_by: ROLE-OPS-1
+      supported_by_application: APPLICATION-ONBOARDING-1
+    - id: STEP-END-1
+      type: endEvent
+  sequence:
+    - { from: STEP-START-1, to: STEP-CONFIRM-1 }
+    - { from: STEP-CONFIRM-1, to: STEP-VERIFY-1 }
+    - { from: STEP-VERIFY-1, to: STEP-PROVISION-1 }
+    - { from: STEP-PROVISION-1, to: STEP-END-1 }
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-26"
+admitted_by: "template"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-26"
+valid_to: null

--- a/templates/operating-model/canon/elements/02_business/products/PRODUCT-ONBOARDING-1.yaml
+++ b/templates/operating-model/canon/elements/02_business/products/PRODUCT-ONBOARDING-1.yaml
@@ -1,0 +1,31 @@
+# Template element — one minimal PRODUCT, standalone per
+# notations/ELEMENT_PRIMITIVES.md §7.6 + envelope §3.
+
+notation: product
+id: PRODUCT-ONBOARDING-1
+name: "Customer Onboarding Service"
+type: service
+domain: "Customer operations"
+description: >
+  The packaged onboarding experience offered to newly signed customers —
+  realised by the Customer Onboarding capability and process, supported
+  by the onboarding platform.
+capabilities:
+  - CAPABILITY-V1
+processes:
+  - PROCESS-ONBOARDING-1
+supporting_apps:
+  - APPLICATION-ONBOARDING-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-26"
+admitted_by: "template"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-26"
+valid_to: null

--- a/templates/operating-model/canon/elements/02_business/roles/ROLE-CS-1.yaml
+++ b/templates/operating-model/canon/elements/02_business/roles/ROLE-CS-1.yaml
@@ -1,0 +1,23 @@
+# Template element — one of two minimal ROLEs, standalone per
+# notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+
+notation: role
+id: ROLE-CS-1
+name: "Customer Success"
+description: >
+  Owns the first customer-facing step of onboarding — confirming the
+  onboarding agreement and acting as the customer's point of contact.
+responsibility_area: "Customer operations"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-26"
+admitted_by: "template"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-26"
+valid_to: null

--- a/templates/operating-model/canon/elements/02_business/roles/ROLE-OPS-1.yaml
+++ b/templates/operating-model/canon/elements/02_business/roles/ROLE-OPS-1.yaml
@@ -1,0 +1,23 @@
+# Template element — one of two minimal ROLEs, standalone per
+# notations/ELEMENT_PRIMITIVES.md §7.9 + envelope §3.
+
+notation: role
+id: ROLE-OPS-1
+name: "Onboarding Operations"
+description: >
+  Owns the operational steps of onboarding — verifying identity and
+  provisioning account access — supported by the onboarding platform.
+responsibility_area: "Customer operations"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-26"
+admitted_by: "template"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-26"
+valid_to: null

--- a/templates/operating-model/canon/elements/03_application/applications/APPLICATION-ONBOARDING-1.yaml
+++ b/templates/operating-model/canon/elements/03_application/applications/APPLICATION-ONBOARDING-1.yaml
@@ -1,0 +1,31 @@
+# Template element — one minimal APPLICATION, standalone per
+# notations/ELEMENT_PRIMITIVES.md §7.7 + envelope §3. Time-varying fields
+# (owner_role, vendor, lifecycle_stage, maturity — CONTRACT.md §9) are
+# intentionally omitted rather than sidecar-versioned, to keep this
+# template to one file per building block.
+
+notation: application
+id: APPLICATION-ONBOARDING-1
+name: "Onboarding Platform"
+type: application
+domain: "Customer operations"
+description: >
+  Supports identity verification and account provisioning during customer
+  onboarding.
+capabilities:
+  - CAPABILITY-V1
+products:
+  - PRODUCT-ONBOARDING-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-26"
+admitted_by: "template"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-26"
+valid_to: null

--- a/templates/operating-model/canon/views/applications/onboarding.applications.transitrix.yaml
+++ b/templates/operating-model/canon/views/applications/onboarding.applications.transitrix.yaml
@@ -1,0 +1,31 @@
+# Applications catalogue — one application, mirroring
+# APPLICATION-ONBOARDING-1's stable fields. Applications building block of
+# the operating-model composition. Notation spec: notations/views/10-applications.md.
+
+notation: applications
+spec_version: "0.1"
+name: "Customer onboarding — applications"
+generated_at: "2026-07-26"
+
+applications_catalogue:
+  id: APPLICATIONS_CAT-ONBOARDING-1
+  name: "Customer Onboarding Applications"
+  description: "The single application supporting the customer-onboarding operating slice."
+  version: "1.0"
+  updated_at: "2026-07-26"
+
+  applications:
+    - app_id: APPLICATION-ONBOARDING-1
+      name: "Onboarding Platform"
+      type: application
+      domain: "Customer operations"
+      status: "Active"
+      description: >
+        Supports identity verification and account provisioning during
+        customer onboarding.
+      capabilities:
+        - CAPABILITY-V1
+      products:
+        - PRODUCT-ONBOARDING-1
+      valid_from: "2026-07-26"
+      valid_to: null

--- a/templates/operating-model/canon/views/blocks/onboarding.blocks.transitrix.yaml
+++ b/templates/operating-model/canon/views/blocks/onboarding.blocks.transitrix.yaml
@@ -1,0 +1,27 @@
+# Nested block diagram — the organisation building block of the
+# operating-model composition: containment of the two roles that carry
+# out customer onboarding. Notation spec: notations/views/08-blocks.md
+# §4 (tree form — not the matrix subset used by templates/raci/).
+# The two leaf blocks cross-link into the roles catalogue (§5.2): their
+# ids match the registered ROLE- TYPE prefix.
+
+notation: blocks
+spec_version: "0.1"
+name: "Customer onboarding — organisation"
+generated_at: "2026-07-26"
+
+nested_blocks:
+  id: BLOCKS-ONBOARDING-ORG-1
+  name: "Customer onboarding — organisation"
+  description: "Who carries out the customer-onboarding process."
+  version: "0.1"
+  date: "2026-07-26"
+
+  blocks:
+    - id: ONBOARDING_TEAM
+      name: "Customer onboarding team"
+      children:
+        - id: ROLE-CS-1
+          name: "Customer Success"
+        - id: ROLE-OPS-1
+          name: "Onboarding Operations"

--- a/templates/operating-model/canon/views/bpmn/onboarding.bpmn.transitrix.yaml
+++ b/templates/operating-model/canon/views/bpmn/onboarding.bpmn.transitrix.yaml
@@ -1,0 +1,49 @@
+# BPMN process diagram — projection of PROCESS-ONBOARDING-1's flow
+# (notations/views/01-bpmn.md). Processes building block of the
+# operating-model composition. Node ids below are file-local labels
+# (IDS_AND_REFERENCES.md §3.3), not canonical ids — the canonical step
+# identity is PROCESS-ONBOARDING-1.flow.steps[].id.
+#
+# Hand-authored to mirror PROCESS-ONBOARDING-1.yaml's `flow`, since this
+# template repository does not run the Studio generator that would derive
+# it automatically. See templates/operating-model/README.md.
+
+notation: bpmn
+spec_version: "0.1"
+name: "Customer onboarding — process flow"
+generated_at: "2026-07-26"
+
+process:
+  id: customer-onboarding
+  name: "Customer Onboarding"
+  pools:
+    - id: onboarding
+      name: "Customer Onboarding"
+      lanes:
+        - id: cs
+          name: "Customer Success"
+          performed_by_role: ROLE-CS-1
+          elements:
+            - id: start
+              type: startEvent
+            - id: confirm-agreement
+              type: task
+              name: "Confirm onboarding agreement"
+        - id: ops
+          name: "Onboarding Operations"
+          performed_by_role: ROLE-OPS-1
+          supported_by_application: APPLICATION-ONBOARDING-1
+          elements:
+            - id: verify-identity
+              type: task
+              name: "Verify identity"
+            - id: provision-access
+              type: task
+              name: "Provision account access"
+            - id: end
+              type: endEvent
+  flows:
+    - { from: start, to: confirm-agreement }
+    - { from: confirm-agreement, to: verify-identity }
+    - { from: verify-identity, to: provision-access }
+    - { from: provision-access, to: end }

--- a/templates/operating-model/canon/views/capabilities/onboarding.capability-map.transitrix.yaml
+++ b/templates/operating-model/canon/views/capabilities/onboarding.capability-map.transitrix.yaml
@@ -1,0 +1,33 @@
+# Capability map — one capability, mirroring CAPABILITY-V1's stable fields.
+# Capabilities building block of the operating-model composition.
+# Notation spec: notations/views/05-capability-map.md.
+#
+# `current_maturity` is required inline by the shipped CLI validator
+# (packages/diagrams/src/capability-map/validate.ts, CMAP-003) even though
+# the spec (05-capability-map.md §13-14) designates it time-varying and
+# sidecar-only. Included here to pass validation — see the "Implementation
+# status" note in templates/operating-model/README.md.
+
+notation: capability-map
+spec_version: "0.1"
+name: "Customer onboarding — capability map"
+generated_at: "2026-07-26"
+
+capability_map:
+  id: CAPABILITY_MAP-ONBOARDING-1
+  name: "Customer Onboarding Capability Map"
+  description: "The single capability behind the customer-onboarding operating slice."
+  assessment_date: "2026-07-26"
+
+  capabilities:
+    - id: CAPABILITY-V1
+      name: "Customer Onboarding"
+      type: domain
+      current_maturity: 2
+      target_maturity: 3
+      owner_role: ROLE-OPS-1
+      business_process: PROCESS-ONBOARDING-1
+      applications:
+        - APPLICATION-ONBOARDING-1
+      valid_from: "2026-07-26"
+      valid_to: null

--- a/templates/operating-model/canon/views/goals/onboarding.goals.transitrix.yaml
+++ b/templates/operating-model/canon/views/goals/onboarding.goals.transitrix.yaml
@@ -1,0 +1,25 @@
+# Goals tree — projection form (v2.0, pure projection; notations/views/04-goals.md).
+# Motivation & goals building block of the operating-model composition.
+# No element data lives in this file — it selects GOAL-ONBOARDING-1 from
+# canon/elements/01_motivation/goals/. See templates/operating-model/README.md.
+
+notation: goals
+spec_version: "0.1"
+methodology_version: "2.0.0"
+
+id: GOALS-ONBOARDING-1
+name: "Customer onboarding — goals"
+generated_at: "2026-07-26"
+description: "Goal driving the customer-onboarding operating slice."
+
+view_config:
+  scope:
+    root_goal: null
+    period: null
+    type_filter: null
+    valid_at: null
+  goal_types:
+    - { name: "Strategic Goal", level: 0 }
+  display:
+    depth: null
+    collapsed: []

--- a/templates/operating-model/canon/views/process-blueprint/onboarding.process-blueprint.transitrix.yaml
+++ b/templates/operating-model/canon/views/process-blueprint/onboarding.process-blueprint.transitrix.yaml
@@ -1,0 +1,55 @@
+# Process blueprint — the customer-onboarding value stream, one stage per
+# BPMN task in canon/views/bpmn/onboarding.bpmn.transitrix.yaml, coarser
+# grained. Value streams (and, via business_objects[], the information)
+# building blocks of the operating-model composition.
+# Notation spec: notations/views/13-process-blueprint.md.
+
+notation: process-blueprint
+spec_version: "0.1"
+name: "Customer onboarding — value stream"
+generated_at: "2026-07-26"
+
+process_blueprint:
+  id: PROCESS_BLUEPRINT-ONBOARDING-1
+  name: "Customer onboarding — operational blueprint"
+  description: >
+    End-to-end customer-onboarding value chain: confirm the agreement,
+    verify identity, and provision account access.
+  period: "2026"
+  version: "0.1"
+  date: "2026-07-26"
+  process: PROCESS-ONBOARDING-1
+
+  stages:
+    - id: STAGE-1
+      name: "Confirm agreement"
+      goal: "Capture a confirmed onboarding agreement."
+      result: "Confirmed agreement recorded against the customer profile."
+    - id: STAGE-2
+      name: "Verify identity"
+      goal: "Confirm the customer's identity before granting access."
+      result: "Verified identity recorded against the customer profile."
+    - id: STAGE-3
+      name: "Provision access"
+      goal: "Grant the customer access to the offering."
+      result: "Active account, ready for first productive use."
+
+  systems:
+    - id: APPLICATION-ONBOARDING-1
+      name: "Onboarding Platform"
+      stages: [STAGE-1, STAGE-2, STAGE-3]
+
+  actors:
+    - id: ROLE-CS-1
+      name: "Customer Success"
+      stages: [STAGE-1]
+    - id: ROLE-OPS-1
+      name: "Onboarding Operations"
+      stages: [STAGE-2, STAGE-3]
+
+  business_objects:
+    - id: BUSINESS_OBJECT-CUSTOMER-PROFILE-1
+      name: "Customer profile"
+      stages: [STAGE-1, STAGE-2, STAGE-3]
+      valid_from: "2026-07-26"
+      valid_to: null

--- a/templates/operating-model/canon/views/products/onboarding.products.transitrix.yaml
+++ b/templates/operating-model/canon/views/products/onboarding.products.transitrix.yaml
@@ -1,0 +1,34 @@
+# Products catalogue — one product, mirroring PRODUCT-ONBOARDING-1's
+# stable fields. Products & services building block of the
+# operating-model composition. Notation spec: notations/views/09-products.md.
+
+notation: products
+spec_version: "0.1"
+name: "Customer onboarding — products"
+generated_at: "2026-07-26"
+
+products_catalogue:
+  id: PRODUCTS_CAT-ONBOARDING-1
+  name: "Customer Onboarding Products"
+  description: "The single product delivered by the customer-onboarding operating slice."
+  version: "1.0"
+  updated_at: "2026-07-26"
+
+  products:
+    - product_id: PRODUCT-ONBOARDING-1
+      name: "Customer Onboarding Service"
+      type: service
+      domain: "Customer operations"
+      owner_role: ROLE-OPS-1
+      status: "Active"
+      description: >
+        The packaged onboarding experience offered to newly signed
+        customers.
+      capabilities:
+        - CAPABILITY-V1
+      processes:
+        - PROCESS-ONBOARDING-1
+      supporting_apps:
+        - APPLICATION-ONBOARDING-1
+      valid_from: "2026-07-26"
+      valid_to: null


### PR DESCRIPTION
## Summary

- Adds `templates/operating-model/` — a second forkable template, this time composite/multi-notation: one minimal, coherent customer-onboarding scenario runs through all eight operating-model building blocks (Motivation & goals, Capabilities, Value streams, Processes, Organisation, Information, Products & services, Applications), each expressed in its real Transitrix notation and cross-referenced by canonical ID.
- Mirrors the real adopter file convention (`canon/elements/<layer>/<type>/`, `canon/views/<notation>/`), including the Goals notation's mandatory pure-projection form (methodology 2.0.0).
- Amends `templates/README.md`'s "Contributing a template" guidance to recognise composite/starter-kit templates as a second category, alongside the existing single-notation guidance — sized by "one minimal instance per building block" rather than "one notation."

## Test plan

- [x] `npx @transitrix/cli validate <file>` run against every file under `templates/operating-model/canon/` — 6 view files pass clean (zero errors/warnings); 8 element files + the goals projection view print an informational "not yet validated at file scope" notice (exit 0), documented in the template's README.
- [x] `npx @transitrix/cli validate --scope=repo --root .` from inside `templates/operating-model/` — passes clean, zero findings (covers the standalone elements and the goals projection that file-scope can't resolve).
- [x] `node scripts/check-notations.mjs` — clean.
- [x] Re-read every written file's tail after writing; none truncated, all parse (confirmed via the CLI's own YAML load, which surfaces parse errors).
- [x] Verified the one documented spec/CLI mismatch (Capability Map's `current_maturity` required inline by the shipped validator despite the spec designating it sidecar-only) with a concrete repro before writing it up.