### PR TITLE
chore(hygiene): close gitignore gaps; correct stale .templates/ note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,18 @@ htmlcov/
 dmypy.json
 
 # ============================================================================
+# NODE / JAVASCRIPT (packages/*/package.json — @transitrix/ingest-cli etc.)
+# ============================================================================
+
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.npm
+coverage/
+.nyc_output/
+
+# ============================================================================
 # IDE & EDITOR CONFIGURATION
 # ============================================================================
 
@@ -87,6 +99,9 @@ dmypy.json
 *.iml
 *.iws
 *.ipr
+
+# Visual Studio
+.vs/
 
 # Sublime Text
 *.sublime-project
@@ -102,6 +117,14 @@ dmypy.json
 *~
 \#*\#
 .\#*
+
+# Merge / patch artefacts
+*.orig
+*.rej
+
+# Windows Explorer
+desktop.ini
+$RECYCLE.BIN/
 
 # Others
 .DS_Store
@@ -157,6 +180,7 @@ Thumbs.db
 id_rsa*
 id_ed25519*
 *.key
+.netrc
 
 # Local configuration overrides
 local_config.yaml
@@ -204,7 +228,8 @@ docs/decisions/
 
 # Keep all .md files (documentation) EXCEPT internal-only files listed above
 # Keep all .yaml files in elements/, relations/, views/ (architecture)
-# Keep all templates in .templates/
+# Keep all forkable templates in templates/ (see templates/README.md) — these
+# ARE committed; not to be confused with the ignored AGENT RULES FILES above.
 # Archive old files in 0.archive/ instead of deleting them
 # Only files explicitly listed above are ignored
 


### PR DESCRIPTION
Full hygiene pass per strategy hub #772.

- Adds real .gitignore gaps: `node_modules/` + npm/yarn debug logs + coverage output (this repo ships Node CLIs under `packages/*`), Visual Studio `.vs/`, merge/patch artefacts (`*.orig`/`*.rej`), Windows Explorer cruft (`desktop.ini`, `$RECYCLE.BIN/`), and `.netrc` alongside the existing credentials block.
- Corrects the stale `NOTES` comment claiming a `.templates/` convention that was never implemented — the real, working convention is the committed top-level `templates/` (see `templates/README.md`).
- Cruft/stale/misplaced-file and structure/naming spot-checks (git ls-files vs. AGENTS.md's directory map, `git clean -ndx` dry run, merge-conflict-marker grep) found nothing to fix.
- A repeatable hygiene checklist was added to this repo's local `CLAUDE.md` (gitignored, not committed — per the convention this repo enforces, most recently in #370) covering gitignore audit, the CLAUDE.md/AGENTS.md convention, cruft sweep, the `templates/` convention, and structure/naming checks. Hygiene had previously only happened ad hoc.

Direct push to `main` is blocked by this repo's branch-protection ruleset (PR + 1 approving review required); opening as a PR instead.