### PR TITLE
feat(notations): design-controls trace-matrix report-config view

### DIFF
--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -118,6 +118,7 @@ Each notation file carries its own ID using the same grammar; the TYPE names the
 | `ACTION_CARD` | `*.action-card.transitrix.yaml` (deprecated alias: `*.activity-card.transitrix.yaml`) |
 | `COMPLIANCE_IMPACT` | `*.compliance-impact.transitrix.yaml` |
 | `COVERAGE_METRIC` | `*.coverage-metric.transitrix.yaml` |
+| `DC_TRACE_MATRIX` | `*.design-controls-trace-matrix.transitrix.yaml` |
 
 BPMN diagrams use their `process.id` as the document identifier; that field is a free-form string defined by the spec, not by this appendix.
 

--- a/notations/README.md
+++ b/notations/README.md
@@ -4,7 +4,7 @@ Transitrix is a text-native methodology: every architecture artefact lives in a 
 
 ## Views
 
-The view notations live under [`views/`](views/) in two groups: **11 diagram views** that each render a visual diagram, and **4 report views** that produce a derived report or table. Studio also renders **PlantUML** (`.puml`/`.plantuml`) natively — no separate Transitrix notation is needed for it.
+The view notations live under [`views/`](views/) in two groups: **11 diagram views** that each render a visual diagram, and **5 report views** that produce a derived report or table. Studio also renders **PlantUML** (`.puml`/`.plantuml`) natively — no separate Transitrix notation is needed for it.
 
 | Spec | Short name | Purpose | File extension | Status |
 |---|---|---|---|---|
@@ -19,11 +19,12 @@ The view notations live under [`views/`](views/) in two groups: **11 diagram vie
 | [10-applications.md](views/10-applications.md) | `applications` | Inventory of applications and integrations — text-and-table catalogue, no diagram. | `*.applications.transitrix.yaml` | draft |
 | [13-process-blueprint.md](views/13-process-blueprint.md) | `process-blueprint` | Wide blueprint of a value chain — stages laid out left-to-right, each carrying its goal, result, and supporting systems / actors / equipment / information entities. | `*.process-blueprint.transitrix.yaml` | draft |
 | [18-action-card.md](views/18-action-card.md) | `action-card` | Single-project narrative view — DGCA chain, dates, milestones, gate decisions. | `*.action-card.transitrix.yaml` | draft |
-| — | **Report views (C = 4)** | | | |
+| — | **Report views (C = 5)** | | | |
 | [11-scenarios.md](views/11-scenarios.md) | `scenarios` | Report-config view over the `SCENARIO` element catalogue — rendering / ordering / filtering of alternative paths, each pointing at a `TARGET_STATE` and serving one or more `GOAL`s. | `*.scenarios.transitrix.yaml` | draft |
 | [21-compliance-impact.md](views/21-compliance-impact.md) | `compliance-impact` | Report-config view over the compliance overlay — derives the (obligation × subject) matrix from `ASSERTION` + process flow + `REQUIREMENT` status; distinguishes "No mapped obligation (current model)" from `n_a`. | `*.compliance-impact.transitrix.yaml` | draft |
 | [22-coverage-metric.md](views/22-coverage-metric.md) | `coverage-metric` | Report-config view over coverage of canon — counts subjects with zero admitted obligations from each regime, broken down per jurisdiction; distinguishes "Not yet modelled" (modelling gap) from "No obligation asserted (modelled fact)". | `*.coverage-metric.transitrix.yaml` | draft |
 | [23-actions-tree.md](views/23-actions-tree.md) | `actions-tree` | Report-config view over the `ACTION` element catalogue — renders the strategic portfolio as a top-down tree from Initiative through Programme, Project, to Task. | `*.actions-tree.transitrix.yaml` | draft |
+| [24-design-controls-trace-matrix.md](views/24-design-controls-trace-matrix.md) | `design-controls-trace-matrix` | Report-config view over the design-controls chain — renders `REQUIREMENT` → `VERIFICATION` and `HAZARD` → `RISK_CONTROL` → `REQUIREMENT` → `VERIFICATION` as a fixed audit table, annotating rows with the reverse-trace completeness gaps already defined on those elements. | `*.design-controls-trace-matrix.transitrix.yaml` | draft |
 
 Every view notation follows the convention `*.<short-name>.transitrix.yaml`. Every file begins with a `notation: <short-name>` header — see each spec's "File header" section and [CONTRACT.md](CONTRACT.md) §3 for the rule.
 

--- a/notations/elements/27-verification.md
+++ b/notations/elements/27-verification.md
@@ -161,10 +161,10 @@ A generic worked example exercising `VERIFICATION` alongside `REQUIREMENT`, `HAZ
 
 **Landed (v0.2, 2026-07-26):**
 - **Reverse-trace completeness** — `REQ-VERIF-COVERAGE-001` (no `VERIFICATION` targets this REQUIREMENT) and `REQ-VERIF-COVERAGE-002` (every `VERIFICATION` that does is stuck at `not_yet_run` / `inconclusive`), defined in [15-requirement.md](15-requirement.md) §4. Paired with the risk-control-side reverse-trace rules in [28-hazard-risk-control.md](28-hazard-risk-control.md) §6.
+- **SDS / trace-matrix rendering.** The design-controls trace matrix (`REQUIREMENT` → `VERIFICATION`, plus the risk chain) now renders as a report-config view: [`24-design-controls-trace-matrix.md`](../views/24-design-controls-trace-matrix.md). It renders the two chains canon actually supports today — see that spec §1.2 for the known limitation that Transitrix does not yet define standalone `USER_NEED` / `DESIGN` element TYPEs, so the literal FDA-terminology four-column matrix is not rendered as such.
 
 Out of scope for this schema:
 
-- **SDS / trace-matrix rendering.** A rendered design-controls trace matrix (User Need → Requirement → Design → Verification, plus the risk chain) is a separate report-config view, not yet implemented.
 - **Test execution management, 21 CFR Part 11 e-signatures, variant/configuration management.** Ceded to a dedicated ALM/QMS tool.
 
 ---

--- a/notations/elements/28-hazard-risk-control.md
+++ b/notations/elements/28-hazard-risk-control.md
@@ -196,11 +196,11 @@ The shared header (`HDR-001..004`, [CONTRACT.md](../CONTRACT.md) §2) and primit
 
 **Landed (v0.2, 2026-07-26):**
 - **Reverse-trace completeness** — `HAZ-RISKCTL-COVERAGE-001` / `-002` (orphan / inadequately-controlled hazard) and `RISKCTL-VERIF-COVERAGE-001` (risk-mitigating requirement lacking V&V closure), defined in §6. Paired with the REQUIREMENT-side rules in [27-verification.md](27-verification.md) §5 and [15-requirement.md](15-requirement.md) §4.
+- **SDS / trace-matrix rendering.** The design-controls trace matrix including the risk chain (Hazard → Risk-Control → Requirement → Verification) now renders as a report-config view: [`24-design-controls-trace-matrix.md`](../views/24-design-controls-trace-matrix.md).
 
 Out of scope for this schema:
 
 - **Numeric risk scoring.** No risk-priority-number formula or acceptability matrix is defined; an adopter's own risk-management procedure supplies it.
-- **SDS / trace-matrix rendering.** A rendered design-controls trace matrix including the risk chain (Hazard → Risk-Control → Verification) is a separate report-config view, not yet implemented.
 - **Post-market surveillance / risk-file maintenance workflow.** Ceded to a dedicated ALM/QMS tool.
 
 ---

--- a/notations/examples/design-controls-trace-matrix/README.md
+++ b/notations/examples/design-controls-trace-matrix/README.md
@@ -1,0 +1,49 @@
+# Design-Controls Trace Matrix — worked example
+
+A worked render of [`24-design-controls-trace-matrix.md`](../../views/24-design-controls-trace-matrix.md) over the union of the two existing design-controls element fixtures:
+
+- [`../design-controls/`](../design-controls/) — the happy-path chain (nothing seeded as incomplete).
+- [`../design-controls/reverse-trace-gaps/`](../design-controls/reverse-trace-gaps/) — the seeded-gap chain (each reverse-trace completeness rule trips exactly once).
+
+**Pattern, not adopter instance.** Same generic, invented scenario as the two source fixtures; no real product, organisation, or adopter is named.
+
+This folder does not duplicate the element files — [`full-chain.design-controls-trace-matrix.transitrix.yaml`](full-chain.design-controls-trace-matrix.transitrix.yaml) is the view-config that would render over them if both fixture trees were checked out under one `canon/` root (as they would be in an adopter repo). The table below is the render contract (§5 of the spec) applied **by hand** to the source elements, so it doubles as the expected-output fixture for a future CLI implementation — the same purpose the parent `reverse-trace-gaps/` folder serves for the validator rules themselves.
+
+## Requirement-chain section
+
+One row per `(REQUIREMENT, VERIFICATION)` pair, per §5.2. `REQUIREMENT-THERMAL-CUTOFF-1` has zero verifications, so it renders as a single gap row with no verification columns.
+
+| Requirement | Verification | Method | Outcome | Gap annotation |
+|---|---|---|---|---|
+| `REQUIREMENT-DEVICE-ALARM-1` | `VERIFICATION-DEVICE-ALARM-TEST-1` | test | pass | — (closed) |
+| `REQUIREMENT-THERMAL-CUTOFF-1` | — | — | — | **"No verification recorded"** — `REQ-VERIF-COVERAGE-001` |
+| `REQUIREMENT-ENCLOSURE-DROP-1` | `VERIFICATION-ENCLOSURE-DROP-TEST-1` | test | not_yet_run | **"Verification recorded but not yet closed"** — `REQ-VERIF-COVERAGE-002` |
+
+## Risk-chain section
+
+One row per `(HAZARD, RISK_CONTROL)` pair, per §5.2, with the Requirement/Verification columns resolved from the control's `satisfies` (or the fixed "Not yet decomposed to a requirement" state when absent — not seeded in this fixture, since every control here carries `satisfies`). `HAZARD-ENCLOSURE-CRACK-1` has zero controls, so it renders as a single gap row.
+
+| Hazard | Risk Control | Control type | Residual risk | Gap (hazard side) | Requirement | Verification | Gap (control side) |
+|---|---|---|---|---|---|---|---|
+| `HAZARD-BATTERY-DEPLETION-1` | `RISK_CONTROL-LOW-BATTERY-ALERT-1` | protective_measure | acceptable | — (closed) | `REQUIREMENT-DEVICE-ALARM-1` | `VERIFICATION-DEVICE-ALARM-TEST-1` (pass) | — (closed) |
+| `HAZARD-ENCLOSURE-CRACK-1` | — | — | — | **"No risk control recorded"** — `HAZ-RISKCTL-COVERAGE-001` | — | — | — |
+| `HAZARD-OVERHEAT-1` | `RISK_CONTROL-THERMAL-CUTOFF-1` | protective_measure | unacceptable | **"Control recorded but not shown adequate"** — `HAZ-RISKCTL-COVERAGE-002` | `REQUIREMENT-THERMAL-CUTOFF-1` | "No verification recorded" | **"Risk-mitigating requirement lacks V&V closure"** — `RISKCTL-VERIF-COVERAGE-001` |
+
+## Coverage of the render contract
+
+Every branch of §5.2 and every gap label in §5.3 is exercised at least once by this worked example:
+
+| Rule | Row it fires on |
+|---|---|
+| `REQ-VERIF-COVERAGE-001` | `REQUIREMENT-THERMAL-CUTOFF-1` (requirement-chain section), and reflected on the `HAZARD-OVERHEAT-1` row (risk-chain section) via `RISKCTL-VERIF-COVERAGE-001` |
+| `REQ-VERIF-COVERAGE-002` | `REQUIREMENT-ENCLOSURE-DROP-1` |
+| `HAZ-RISKCTL-COVERAGE-001` | `HAZARD-ENCLOSURE-CRACK-1` |
+| `HAZ-RISKCTL-COVERAGE-002` | `HAZARD-OVERHEAT-1` |
+| `RISKCTL-VERIF-COVERAGE-001` | `HAZARD-OVERHEAT-1` / `RISK_CONTROL-THERMAL-CUTOFF-1` |
+| No gap (fully closed) | `REQUIREMENT-DEVICE-ALARM-1` and `HAZARD-BATTERY-DEPLETION-1` — the happy path, present so the table isn't all-gaps |
+
+## References
+
+- [`24-design-controls-trace-matrix.md`](../../views/24-design-controls-trace-matrix.md) — the spec this example renders.
+- [`../design-controls/README.md`](../design-controls/README.md) — the happy-path source fixture.
+- [`../design-controls/reverse-trace-gaps/README.md`](../design-controls/reverse-trace-gaps/README.md) — the seeded-gap source fixture and the rule-by-rule breakdown its authoring already did.

--- a/notations/examples/design-controls-trace-matrix/full-chain.design-controls-trace-matrix.transitrix.yaml
+++ b/notations/examples/design-controls-trace-matrix/full-chain.design-controls-trace-matrix.transitrix.yaml
@@ -1,0 +1,32 @@
+notation: design-controls-trace-matrix
+spec_version: "0.1"
+name: "Worked example — full design-controls trace matrix"
+generated_at: "2026-07-26"
+methodology_version: "2.0.0"
+
+view:
+  id: DC_TRACE_MATRIX-WORKED-EXAMPLE-1
+  name: "Worked example — full design-controls trace matrix"
+  description: >
+    Renders both chains over the union of the design-controls example fixtures
+    (../design-controls/ happy path + ../design-controls/reverse-trace-gaps/
+    seeded gaps), so every reverse-trace completeness rule this view can
+    annotate fires at least once. See ../README.md for the by-hand-computed
+    output.
+  report_type: combined
+
+  subjects:
+    requirements:
+      - REQUIREMENT-DEVICE-ALARM-1
+      - REQUIREMENT-THERMAL-CUTOFF-1
+      - REQUIREMENT-ENCLOSURE-DROP-1
+    hazards:
+      - HAZARD-BATTERY-DEPLETION-1
+      - HAZARD-ENCLOSURE-CRACK-1
+      - HAZARD-OVERHEAT-1
+
+  status_display:
+    show_outcomes: ["pass", "fail", "inconclusive", "not_yet_run"]
+    show_residual_risk: ["acceptable", "alarp", "unacceptable", "not_recorded"]
+
+  order_rows_by: "id"

--- a/notations/views/24-design-controls-trace-matrix.md
+++ b/notations/views/24-design-controls-trace-matrix.md
@@ -1,0 +1,296 @@
+---
+notation: "Design-Controls Trace Matrix"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-07-26"
+status: "draft"
+file_extension: "*.design-controls-trace-matrix.transitrix.yaml"
+dsm_status: "not implemented — Studio compliance-views renderer planned (consumer-side, tracked separately)"
+---
+
+# Design-Controls Trace Matrix — Report-Configuration View — Reference
+
+**Version:** 0.1
+**Date:** 2026-07-26
+**Status:** Draft — first cut of the canonical report-config for the design-controls trace matrix. Sibling of [Compliance Impact](21-compliance-impact.md) and [Coverage Metric](22-coverage-metric.md); same "presentation surface over canon, nothing stored twice" posture, adapted to a fixed audit-table shape instead of a configurable pivot matrix (see §1.1).
+**File extension:** `*.design-controls-trace-matrix.transitrix.yaml`
+**Scope:** A **rendering / filtering configuration** for the design-controls trace matrix — the audit-facing table a QA / Regulatory-Affairs reader points at to confirm the engineering V&V chain (`REQUIREMENT` → `VERIFICATION`) and the ISO 14971 risk chain (`HAZARD` → `RISK_CONTROL` → `REQUIREMENT` → `VERIFICATION`) against the actual model, not a promise. The document is a presentation surface — it carries no canonical content of its own. Everything the view displays is **derived** from `HAZARD` / `RISK_CONTROL` ([28-hazard-risk-control.md](../elements/28-hazard-risk-control.md)), `REQUIREMENT` ([15-requirement.md](../elements/15-requirement.md)), and `VERIFICATION` ([27-verification.md](../elements/27-verification.md)).
+**Renderer:** Transitrix Studio — compliance views (planned); Transitrix DSM (planned).
+
+---
+
+## File header
+
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../CONTRACT.md). This notation's per-notation values:
+
+| Field | Value |
+|---|---|
+| `notation:` value | `design-controls-trace-matrix` |
+| File extension | `*.design-controls-trace-matrix.transitrix.yaml` |
+
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `design-controls-trace-matrix` (per [CONTRACT.md](../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../CONTRACT.md) §4. |
+| `view` | yes | object | the design-controls-trace-matrix view config — see §3 and §4 |
+
+Example header:
+
+```yaml
+notation: design-controls-trace-matrix
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+methodology_version: "2.0.0"
+view:
+  # ... see §3
+```
+
+---
+
+## 1. What this view is
+
+A design-controls trace matrix answers the question a design-controls audit always starts with: **for the requirements and hazards in scope, does the chain that is supposed to close them actually close — and where doesn't it?** It renders two chains, both already defined as first-class canon by their own element specs (not introduced here):
+
+```
+REQUIREMENT ──────────────── verified by ──────────────▶ VERIFICATION            (the "requirement" chain)
+
+HAZARD ── mitigated by ──▶ RISK_CONTROL ── satisfies ──▶ REQUIREMENT ── verified by ──▶ VERIFICATION   (the "risk" chain)
+```
+
+The renderer materialises both from canon. Nothing is stored twice:
+
+- The fact that *a control mitigates a hazard* is recorded once — on the `RISK_CONTROL.mitigates` field ([28-hazard-risk-control.md](../elements/28-hazard-risk-control.md) §3).
+- The fact that *a control is realised as a design requirement* is recorded once — on `RISK_CONTROL.satisfies` (same spec, §3).
+- The fact that *a protocol was run against a requirement, and what it found* is recorded once — on `VERIFICATION.verifies` / `.outcome` ([27-verification.md](../elements/27-verification.md) §2).
+- The judgement of whether a link in the chain is *missing* or *unclosed* is recorded nowhere new — it is exactly the reverse-trace completeness rules already defined on the referenced elements: `REQ-VERIF-COVERAGE-001`/`-002` ([15-requirement.md](../elements/15-requirement.md) §4), `HAZ-RISKCTL-COVERAGE-001`/`-002`, and `RISKCTL-VERIF-COVERAGE-001` ([28-hazard-risk-control.md](../elements/28-hazard-risk-control.md) §6). This view's row-level gap annotations are a **rendering of those rules**, not a new judgement.
+
+A design-controls-trace-matrix document declares **which slice of that chain to render** (which requirements, which hazards) and labelling overrides. It does not redeclare any of the four facts above, nor invent a sixth completeness rule. This obeys the reconstruction invariant ([ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1): the canon is reconstructible from the elements alone; the view document adds no fact.
+
+### 1.1 Why this view's columns are fixed, unlike Compliance Impact / Coverage Metric
+
+Compliance Impact and Coverage Metric are configurable pivot matrices — an adopter chooses the row axis, the column axis, and the grouping grain (§4 of each spec). This view does not offer that. A design-controls / DHF trace matrix has a conventionally fixed shape in every QMS and regulatory-audit context it serves (21 CFR 820.30, ISO 13485, ISO 14971): Hazard–Control–Requirement–Verification, or Requirement–Verification. Making the column set configurable would let two adopters render "the trace matrix" with different columns, undermining the audit-comparability the view exists to provide. `view.report_type` (§4) selects **which of the two fixed chains** to render — not their shape.
+
+### 1.2 Known limitation — no `USER_NEED` or `DESIGN` element TYPE
+
+Both source specs describe this view's aspiration using FDA 21 CFR 820.30 design-controls terminology — "User Need → Requirement → Design → Verification" ([27-verification.md](../elements/27-verification.md) §7, [28-hazard-risk-control.md](../elements/28-hazard-risk-control.md) §7, both prior to this spec). Transitrix does not define standalone `USER_NEED` or `DESIGN` element TYPEs today — only `REQUIREMENT` (the design-input analogue) and `VERIFICATION` exist on the plain chain; `RISK_CONTROL` (the design-output analogue on the risk chain, per ISO 14971) exists only where a hazard motivates it. This view therefore renders exactly the two chains canon supports (§1) — it does not render a literal four-column "User Need / Design" matrix, and it introduces no new element TYPE to backfill one. A report-config view carries no canonical content ([ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1) and is not the place to add a schema element; if an adopter needs `USER_NEED` / `DESIGN` as first-class canon, that is a separate, cross-notation schema proposal against [15-requirement.md](../elements/15-requirement.md) / [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md), not a change to this view.
+
+---
+
+## 2. When to use this view
+
+| Use case | Notation |
+|---|---|
+| Confirm every design requirement has closed V&V (`pass`/`fail`), for an audit or a design review. | Design-Controls Trace Matrix — `report_type: requirement` |
+| Confirm every identified hazard has an adequately-controlled, traced-through, verified mitigation, per ISO 14971. | Design-Controls Trace Matrix — `report_type: risk` |
+| A single audit-facing report covering both chains at once. | Design-Controls Trace Matrix — `report_type: combined` (default) |
+| Author the underlying requirement, hazard, control, or verification records. | The element primitives, not this view — see the table below. |
+
+For the canonical authoring of the chain this view reads, use the element primitives, not this view:
+
+| Concern | Authored as |
+|---|---|
+| The design requirement. | `REQUIREMENT` element ([15-requirement.md](../elements/15-requirement.md)) at `canon/elements/01_motivation/requirements/REQUIREMENT-<…>.yaml`. |
+| The potential source of harm. | `HAZARD` element ([28-hazard-risk-control.md](../elements/28-hazard-risk-control.md) §2) at `canon/elements/01_motivation/hazards/HAZARD-<…>.yaml`. |
+| The measure that mitigates a hazard, optionally realised as a requirement. | `RISK_CONTROL` element (same spec, §3) at `canon/elements/01_motivation/risk-controls/RISK_CONTROL-<…>.yaml`. |
+| The V&V protocol run against a requirement, with method and pass/fail outcome. | `VERIFICATION` element ([27-verification.md](../elements/27-verification.md)) at `canon/verifications/VERIFICATION-<…>.yaml`. |
+
+---
+
+## 3. Document structure
+
+A design-controls-trace-matrix view file is a short, declarative report config. It does not own any canonical content. Two top-level keys plus the shared header:
+
+```yaml
+notation: design-controls-trace-matrix
+spec_version: "0.1"
+name: "Device X — design-controls trace matrix"   # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"                        # optional per CONTRACT.md §4
+methodology_version: "2.0.0"
+
+view:
+  id: DC_TRACE_MATRIX-DEVICE-X-1
+  name: "Device X — design-controls trace matrix"
+  description: "Full requirement and risk trace for Device X ahead of the design review."
+  report_type: combined          # requirement | risk | combined — required; see §1.1 / §4
+
+  # What the view covers. Must match report_type:
+  #   requirement → subjects.requirements only (subjects.hazards MUST be absent)
+  #   risk        → subjects.hazards only (subjects.requirements MUST be absent)
+  #   combined    → both may be present; each renders its own section
+  subjects:
+    requirements: [REQUIREMENT-DEVICE-ALARM-1]
+    # hazards: [HAZARD-BATTERY-DEPLETION-1]     # use with report_type: risk or combined
+
+  # Which VERIFICATION outcomes and RISK_CONTROL residual_risk values to show.
+  status_display:
+    show_outcomes: ["pass", "fail", "inconclusive", "not_yet_run"]
+    show_residual_risk: ["acceptable", "alarp", "unacceptable", "not_recorded"]
+
+  # Gap labels — see §5.3 for the canonical strings and the rules they render.
+  gap_labels:
+    req_verif_coverage_001: "No verification recorded"
+
+  # Optional ordering knob.
+  order_rows_by: "id"            # id | name
+```
+
+The document carries the canonical envelope (`notation:` header, `spec_version:`, `methodology_version:` pin per [CONTRACT.md](../CONTRACT.md) §10), a `view` object, and presentation fields under it. Nothing under `view` is canonical content — it is all rendering configuration.
+
+---
+
+## 4. Fields
+
+Every field carries an explicit default, so a view with only the required envelope (`view.id`, `view.name`, `view.report_type`) renders deterministically — see §4.1.
+
+| Field | Required | Type | Default | Semantics |
+|---|---|---|---|---|
+| `view.id` | yes | string | — (required) | View identifier, canonical-grammar (`DC_TRACE_MATRIX-…`) per [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.2 (`DC_TRACE_MATRIX` document-level TYPE). |
+| `view.name` | yes | string | — (required) | Human-readable name shown in the renderer. |
+| `view.description` | no | string | empty | Short description of the purpose of this view (which requirements and/or hazards, why). |
+| `view.report_type` | yes | string | — (required) | `requirement` — renders only the requirement chain (§1); `subjects.hazards` MUST be absent. `risk` — renders only the risk chain; `subjects.requirements` MUST be absent. `combined` — renders both chains as two sections in one report; a REQUIREMENT named in `subjects.requirements` MAY also be reached via `subjects.hazards`' risk chain — the renderer MUST NOT deduplicate across sections (§5.2). Column shape is fixed per §1.1; this field selects which fixed chain(s), not their columns. |
+| `view.subjects.requirements` | no ¹ | list | **all `REQUIREMENT`s in canon**, sorted by id | Explicit list of `REQUIREMENT-…` IDs whose verification trace to render in the requirement-chain section. |
+| `view.subjects.hazards` | no ¹ | list | **all `HAZARD`s in canon**, sorted by id | Explicit list of `HAZARD-…` IDs whose risk-chain trace to render in the risk-chain section. |
+| `view.status_display.show_outcomes` | no | list | all four (`pass`, `fail`, `inconclusive`, `not_yet_run`) | Which `VERIFICATION.outcome` values to render in full; outcomes excluded from this list still count for gap classification (§5.2) but are shown collapsed as "(hidden by status_display)". |
+| `view.status_display.show_residual_risk` | no | list | all four (`acceptable`, `alarp`, `unacceptable`, `not_recorded`) | Which `RISK_CONTROL.residual_risk` values (plus the synthetic `not_recorded` for an absent field) to render in full, same collapsing behaviour as above. |
+| `view.gap_labels.req_verif_coverage_001` | no | string | `"No verification recorded"` (§5.3) | Label rendered when `REQ-VERIF-COVERAGE-001` fires for a row. |
+| `view.gap_labels.req_verif_coverage_002` | no | string | `"Verification recorded but not yet closed"` (§5.3) | Label rendered when `REQ-VERIF-COVERAGE-002` fires for a row. |
+| `view.gap_labels.haz_riskctl_coverage_001` | no | string | `"No risk control recorded"` (§5.3) | Label rendered when `HAZ-RISKCTL-COVERAGE-001` fires for a row. |
+| `view.gap_labels.haz_riskctl_coverage_002` | no | string | `"Control recorded but not shown adequate"` (§5.3) | Label rendered when `HAZ-RISKCTL-COVERAGE-002` fires for a row. |
+| `view.gap_labels.riskctl_verif_coverage_001` | no | string | `"Risk-mitigating requirement lacks V&V closure"` (§5.3) | Label rendered when `RISKCTL-VERIF-COVERAGE-001` fires for a row. |
+| `view.order_rows_by` | no | string | `id` | Row ordering key within each section: `id`, `name`. |
+
+¹ **`subjects`** — behaviour depends on `view.report_type`. `requirement`: `subjects.requirements` is optional (omit → all REQUIREMENTs in canon); `subjects.hazards` MUST be absent. `risk`: `subjects.hazards` is optional (omit → all HAZARDs in canon); `subjects.requirements` MUST be absent. `combined`: both keys are independently optional, each defaulting to its own full catalogue.
+
+All references in `view.subjects.*` resolve to canon primitives via the usual cross-reference rule ([IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §5).
+
+### 4.1 Zero-configuration default
+
+A view that carries only the required envelope —
+
+```yaml
+notation: design-controls-trace-matrix
+spec_version: "0.1"
+name: "Full design-controls trace matrix"   # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"                 # optional per CONTRACT.md §4
+methodology_version: "2.0.0"
+view:
+  id: DC_TRACE_MATRIX-ALL-1
+  name: "Full design-controls trace matrix"
+  report_type: combined                     # required; requirement | risk | combined
+```
+
+— renders **deterministically**: both sections, over every `REQUIREMENT` and every `HAZARD` in canon, all outcomes and residual-risk values shown in full, default gap labels, rows ordered by `id`. This is the fallback the report skill (per the *reports rendered from declarative view-configs* architecture decision, §4) states back to the user as "full trace, no filters". Each field a caller omits falls back to its §4 default; the result is reproducible from canon alone.
+
+Where a named, saved view-config of this notation lives in an adopter repo, and how a reader lists or re-runs it by name, is the registry convention in [REPORT_VIEW_CONFIG.md](REPORT_VIEW_CONFIG.md).
+
+---
+
+## 5. Render contract
+
+This section is the **render contract**: the deterministic algorithm any conformant renderer (Studio, DSM, a per-build script) MUST follow to reproduce the view from canon. The contract names its inputs, its derivation steps, and the canonical gap labels.
+
+### 5.1 Inputs
+
+A conformant renderer reads exactly these canonical inputs, each in **admitted** state (`admission_state: active` / `zone: canon` with a valid admission record):
+
+1. **`REQUIREMENT` catalogue** — every `REQUIREMENT-…` file under `canon/elements/01_motivation/requirements/`. Contributes `id`, `name`.
+2. **`VERIFICATION` catalogue** — every `VERIFICATION-…` file under `canon/verifications/`. Contributes `verifies` (the REQUIREMENT it targets), `method`, `outcome`, `result`.
+3. **`HAZARD` catalogue** — every `HAZARD-…` file under `canon/elements/01_motivation/hazards/`. Contributes `id`, `name`, `severity`.
+4. **`RISK_CONTROL` catalogue** — every `RISK_CONTROL-…` file under `canon/elements/01_motivation/risk-controls/`. Contributes `mitigates` (the HAZARD(s) it addresses), `control_type`, `satisfies` (the REQUIREMENT it realises, if any), `residual_risk`.
+
+The renderer reads **no other input**. In particular: the view document itself contributes only filter / labelling configuration — never a cell value or a gap judgement.
+
+### 5.2 Derivation
+
+**Requirement-chain section** (rendered when `view.report_type` is `requirement` or `combined`):
+
+1. Resolve the row set from `view.subjects.requirements` against the `REQUIREMENT` catalogue.
+2. For each `REQUIREMENT`, resolve every admitted `VERIFICATION` with `verifies` equal to that requirement's id.
+   - **Zero verifications** — render one row: Verification column carries the `req_verif_coverage_001` gap label (§5.3), reflecting `REQ-VERIF-COVERAGE-001`.
+   - **One or more verifications** — render one row per verification (fan-out; a REQUIREMENT with three verifications is three rows sharing the same Requirement cell), each showing `method` and `outcome` per `view.status_display.show_outcomes`. If **none** of the requirement's verifications reached `outcome: pass` or `outcome: fail`, additionally annotate the row group with the `req_verif_coverage_002` gap label, reflecting `REQ-VERIF-COVERAGE-002`.
+
+**Risk-chain section** (rendered when `view.report_type` is `risk` or `combined`):
+
+1. Resolve the row set from `view.subjects.hazards` against the `HAZARD` catalogue.
+2. For each `HAZARD`, resolve every admitted `RISK_CONTROL` whose `mitigates[]` contains that hazard's id.
+   - **Zero controls** — render one row: Risk Control column carries the `haz_riskctl_coverage_001` gap label, reflecting `HAZ-RISKCTL-COVERAGE-001`.
+   - **One or more controls** — render one row per control (fan-out), showing `control_type` and `residual_risk` per `view.status_display.show_residual_risk`. If **none** of the hazard's controls records `residual_risk: acceptable` or `residual_risk: alarp`, additionally annotate the row group with the `haz_riskctl_coverage_002` gap label, reflecting `HAZ-RISKCTL-COVERAGE-002`.
+3. For each `RISK_CONTROL` row from step 2, resolve `satisfies`:
+   - **Absent** — Requirement and Verification columns render `"Not yet decomposed to a requirement"`. This is **not** a gap — mirrors `RISKCTL-VERIF-COVERAGE-001`'s own precedent that an early-lifecycle control with no `satisfies` is not an orphan ([28-hazard-risk-control.md](../elements/28-hazard-risk-control.md) §6).
+   - **Present** — resolve the referenced `REQUIREMENT` and apply the same verification-resolution logic as the requirement-chain section (step 2 above) to render the Requirement and Verification columns for this row. If the referenced requirement is not verification-complete (per `REQ-VERIF-COVERAGE-001`/`-002`), additionally annotate the row with the `riskctl_verif_coverage_001` gap label, reflecting `RISKCTL-VERIF-COVERAGE-001`.
+
+**`combined` independence.** The two sections are derived independently from the same four catalogues. A `REQUIREMENT` reached via a `RISK_CONTROL.satisfies` link in the risk-chain section MAY also appear as its own row in the requirement-chain section if it is within `view.subjects.requirements` scope. The renderer MUST NOT deduplicate or cross-link rows between sections — each section is a complete, independent read, the same posture Compliance Impact's `combined` report type takes for its two column groups ([21-compliance-impact.md](21-compliance-impact.md) §7.1).
+
+The row-fan-out and gap-annotation order above is fixed so two renderers given the same canon produce identical output.
+
+### 5.3 Gap labels
+
+Every gap label rendered by this view is a direct rendering of an existing reverse-trace completeness rule — this view introduces no sixth rule and no new judgement. Adopters changing the label strings (via `view.gap_labels.*`) MUST preserve which underlying rule each label represents; a renderer MUST NOT merge two distinct rules under one label.
+
+| Condition | Canonical label | Underlying rule |
+|---|---|---|
+| A REQUIREMENT row has no admitted VERIFICATION at all. | **"No verification recorded"** (default) | [`REQ-VERIF-COVERAGE-001`](../elements/15-requirement.md) |
+| A REQUIREMENT row has VERIFICATION(s), but none reached `pass`/`fail`. | **"Verification recorded but not yet closed"** (default) | [`REQ-VERIF-COVERAGE-002`](../elements/15-requirement.md) |
+| A HAZARD row has no admitted RISK_CONTROL mitigating it. | **"No risk control recorded"** (default) | [`HAZ-RISKCTL-COVERAGE-001`](../elements/28-hazard-risk-control.md) |
+| A HAZARD row has RISK_CONTROL(s), but none records `residual_risk` in `{acceptable, alarp}`. | **"Control recorded but not shown adequate"** (default) | [`HAZ-RISKCTL-COVERAGE-002`](../elements/28-hazard-risk-control.md) |
+| A RISK_CONTROL row carries `satisfies`, but the referenced REQUIREMENT is not verification-complete. | **"Risk-mitigating requirement lacks V&V closure"** (default) | [`RISKCTL-VERIF-COVERAGE-001`](../elements/28-hazard-risk-control.md) |
+| A RISK_CONTROL row has no `satisfies`. | `"Not yet decomposed to a requirement"` (fixed; not overridable via `gap_labels`, because it is not a gap) | — (explicitly not a rule; see §5.2 step 3) |
+
+A conformant renderer MUST NOT collapse the "not yet decomposed" condition (a legitimate early-lifecycle state) into any of the five gap labels above — doing so would misreport a control that simply hasn't reached formal decomposition as an audit finding.
+
+---
+
+## 6. Relationship to other notations and elements
+
+```
+Design-Controls Trace Matrix view (this notation — report-config)
+  ├── reads   → REQUIREMENT elements       (15-requirement.md; admitted state only)
+  ├── reads   → VERIFICATION elements       (27-verification.md §2; admitted state only)
+  │     └── verifies    → REQUIREMENT
+  ├── reads   → HAZARD elements             (28-hazard-risk-control.md §2; admitted state only)
+  └── reads   → RISK_CONTROL elements       (28-hazard-risk-control.md §3; admitted state only)
+        ├── mitigates  → HAZARD
+        └── satisfies  → REQUIREMENT (optional)
+```
+
+Renders the reverse-trace completeness rules already defined on the referenced elements — `REQ-VERIF-COVERAGE-001`/`-002`, `HAZ-RISKCTL-COVERAGE-001`/`-002`, `RISKCTL-VERIF-COVERAGE-001` — rather than defining new ones (§1, §5.3).
+
+Pairs with **Compliance Impact** ([21-compliance-impact.md](21-compliance-impact.md)) and **Coverage Metric** ([22-coverage-metric.md](22-coverage-metric.md)) as the third report-config view over the compliance/design-controls domain — that pair covers regulatory-obligation compliance and coverage; this view covers engineering V&V and ISO 14971 risk-control completeness. The three are independent reads with no shared canonical input (ASSERTION/codex on one side, VERIFICATION/HAZARD/RISK_CONTROL on the other) — an adopter operating in a regulated-product domain (e.g. medical devices) is expected to use all three together.
+
+Pairs with **Transitrix Studio compliance views / export** (consumer side, tracked separately) — the in-Studio renderer that implements §5.
+
+---
+
+## 7. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `DCTM-001` | error | A required field from §4 is missing, or `id` does not match the canonical grammar `DC_TRACE_MATRIX-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §1). |
+| `DCTM-002` | error | `view.report_type` is absent or not one of `requirement`, `risk`, `combined`. |
+| `DCTM-003` | error | A reference in `view.subjects.requirements` does not resolve to an admitted `REQUIREMENT`, or a reference in `view.subjects.hazards` does not resolve to an admitted `HAZARD`. |
+| `DCTM-004` | error | `report_type: requirement` but `view.subjects.hazards` is present; or `report_type: risk` but `view.subjects.requirements` is present. Remove the cross-type subject entry, or change `report_type` to `combined`. |
+| `DCTM-005` | warning | The view selects zero rows for a rendered section after applying `subjects.*` — usually indicates a typo in an ID. |
+| `DCTM-006` | warning | `view.status_display.show_outcomes` contains a value outside `{pass, fail, inconclusive, not_yet_run}`, or `view.status_display.show_residual_risk` contains a value outside `{acceptable, alarp, unacceptable, not_recorded}`. |
+| `DCTM-007` | warning | A `view.gap_labels.*` override collapses the distinction between two of the five gap conditions in §5.3, or between a gap condition and the fixed "Not yet decomposed to a requirement" state (e.g. reusing the same string for two different keys). |
+
+The shared header rules `HDR-001..004` ([CONTRACT.md](../CONTRACT.md) §2) apply in addition.
+
+---
+
+## 8. References
+
+- `REQUIREMENT` element schema and `REQ-VERIF-COVERAGE-*` reverse-trace rules: [15-requirement.md](../elements/15-requirement.md) §4.
+- `VERIFICATION` element schema: [27-verification.md](../elements/27-verification.md).
+- `HAZARD` / `RISK_CONTROL` element schemas and `HAZ-RISKCTL-COVERAGE-*` / `RISKCTL-VERIF-COVERAGE-001` reverse-trace rules: [28-hazard-risk-control.md](../elements/28-hazard-risk-control.md) §6.
+- Worked example (happy-path chain + seeded reverse-trace gaps, rendered by hand against this contract): [`../examples/design-controls-trace-matrix/`](../examples/design-controls-trace-matrix/).
+- Compliance Impact — sibling report-config view (regulatory-obligation domain): [21-compliance-impact.md](21-compliance-impact.md).
+- Coverage Metric — sibling report-config view (regulatory-obligation domain): [22-coverage-metric.md](22-coverage-metric.md).
+- ID grammar and TYPE registry: [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) (`DC_TRACE_MATRIX` registered in §3.2).
+- Reconstruction invariant (why view documents are not content homes): [ELEMENT_PRIMITIVES.md](../ELEMENT_PRIMITIVES.md) §1.1.
+- Named view-config convention (where this view's saved configs live, how they're named, listed, and re-run): [REPORT_VIEW_CONFIG.md](REPORT_VIEW_CONFIG.md).
+- Architecture decision — reports are rendered from declarative view-configs, with a thin skill on top.

--- a/notations/views/REPORT_VIEW_CONFIG.md
+++ b/notations/views/REPORT_VIEW_CONFIG.md
@@ -8,7 +8,7 @@ status: "draft"
 
 # Named view-config convention
 
-**Scope:** Where saved, named view-configs live in an adopter repository, how they're named, how a reader lists them, and how a reader (or a tool, or the future report skill) re-runs one by name. This document **extends and codifies the existing report-config shape** declared by the three report-config view specs ([`11-scenarios.md`](11-scenarios.md), [`21-compliance-impact.md`](21-compliance-impact.md), [`22-coverage-metric.md`](22-coverage-metric.md)) — it does not introduce a new notation. Companion to the *reports rendered from declarative view-configs* architecture decision, Decision §1, §5, §7 (Step 1).
+**Scope:** Where saved, named view-configs live in an adopter repository, how they're named, how a reader lists them, and how a reader (or a tool, or the future report skill) re-runs one by name. This document **extends and codifies the existing report-config shape** declared by the four report-config view specs ([`11-scenarios.md`](11-scenarios.md), [`21-compliance-impact.md`](21-compliance-impact.md), [`22-coverage-metric.md`](22-coverage-metric.md), [`24-design-controls-trace-matrix.md`](24-design-controls-trace-matrix.md)) — it does not introduce a new notation. Companion to the *reports rendered from declarative view-configs* architecture decision, Decision §1, §5, §7 (Step 1).
 
 The convention is also the natural home for **any view document**, not only report-configs: every view notation in the catalogue ([README.md](../README.md) §Views) follows the same location and naming rule.
 
@@ -41,7 +41,7 @@ A view file that lives anywhere else — an inline example under [`../examples/`
 | `<basename>` | `kebab-case` slug uniquely identifying this saved config within its folder. Typically the slug-form of `view.id`'s middle segment (e.g. `view.id: SCENARIOS-2027-CUT-1` ⇒ basename `2027-cut`), or a `[DOMAIN]-[CONTEXT]` prefix (e.g. `retail-gdpr`, `eu-compliance`). |
 | `.<short-name>.transitrix.yaml` | The canonical file extension per [CONTRACT.md](../CONTRACT.md) §3 and the catalogue in [README.md](../README.md) §Views. The doc-lint [`scripts/check-notations.mjs`](../../scripts/check-notations.mjs) (E1) enforces extension + parent-folder match. |
 
-The convention is uniform across **every** view notation, not only the three report-config notations.
+The convention is uniform across **every** view notation, not only the four report-config notations.
 
 ---
 
@@ -106,7 +106,7 @@ The CLI surface above is the convention this document fixes. The CLI implementat
 
 ## 6. Zero-configuration default
 
-Every report-producing view spec ([`11-scenarios.md`](11-scenarios.md) §4, [`21-compliance-impact.md`](21-compliance-impact.md) §4 + §4.1, [`22-coverage-metric.md`](22-coverage-metric.md) §4 + §4.1) declares **explicit defaults** for every non-required field. A view-config that carries only the required envelope (`notation:`, `spec_version:`, `methodology_version:`, `view.id`, `view.name`) renders deterministically — each omitted field falls back to its spec default.
+Every report-producing view spec ([`11-scenarios.md`](11-scenarios.md) §4, [`21-compliance-impact.md`](21-compliance-impact.md) §4 + §4.1, [`22-coverage-metric.md`](22-coverage-metric.md) §4 + §4.1, [`24-design-controls-trace-matrix.md`](24-design-controls-trace-matrix.md) §4 + §4.1) declares **explicit defaults** for every non-required field. A view-config that carries only the required envelope (`notation:`, `spec_version:`, `methodology_version:`, `view.id`, `view.name`) renders deterministically — each omitted field falls back to its spec default.
 
 This is the surface the report skill leans on for its "what I assumed" message (per the *reports rendered from declarative view-configs* architecture decision, §4): given a free-text request without enough parameters, the skill materialises a minimal view-config under [§2](#2-location), renders it, and **states back** which defaults the spec applied ("full matrix, no jurisdiction filter — showing all"). The skill never invents defaults of its own; it never carries render logic.
 
@@ -116,7 +116,7 @@ Re-running a minimal view-config against a richer canon a quarter later picks up
 
 ## 7. What this document does not change
 
-- **No new notation.** This convention extends the three report-config view specs and the wider view-notation catalogue ([README.md](../README.md) §Views); no new `notation:` header, no new file extension, no new validation rule.
+- **No new notation.** This convention extends the four report-config view specs and the wider view-notation catalogue ([README.md](../README.md) §Views); no new `notation:` header, no new file extension, no new validation rule.
 - **No new validator gate.** The doc-lint [`scripts/check-notations.mjs`](../../scripts/check-notations.mjs) (E1, E2) already covers the extension + header + parent-folder rules this document leans on. The location convention in [§2](#2-location) is a **deployment** convention — the existing extension rule already lets the lint catch most filesystem drift.
 - **No render-logic homing.** The render contract for each view stays in its spec (e.g. [`21-compliance-impact.md`](21-compliance-impact.md) §5). This document is about the registry — where the parameter artefact lives and how it's named, listed, and re-run.
 
@@ -134,3 +134,4 @@ Re-running a minimal view-config against a richer canon a quarter later picks up
   - [`11-scenarios.md`](11-scenarios.md) — Scenarios.
   - [`21-compliance-impact.md`](21-compliance-impact.md) — Compliance Impact.
   - [`22-coverage-metric.md`](22-coverage-metric.md) — Coverage Metric.
+  - [`24-design-controls-trace-matrix.md`](24-design-controls-trace-matrix.md) — Design-Controls Trace Matrix.

--- a/transitrix/.claude-plugin/plugin.json
+++ b/transitrix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix",
-  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 11 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Products, Action Card) + PlantUML rendering, or one of the 4 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric), or a codex artefact.",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 11 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Products, Action Card) + PlantUML rendering, or one of the 5 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric, Design-Controls Trace Matrix), or a codex artefact.",
   "version": "0.1.0",
   "author": {
     "name": "Transitrix"

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -313,6 +313,7 @@ Use the matrix below to pick a notation. Full specs at `notations/<NN>-<name>.md
 | Single-project narrative view — goals served, dates, milestones, gate decisions | **Action Card** | `*.action-card.transitrix.yaml` |
 | Compliance overlay — which obligations hit which product / process stage / task, with each cell's status | **Compliance Impact** | `*.compliance-impact.transitrix.yaml` |
 | Coverage of canon — which subjects are dark for each regulatory regime, splitting modelling gaps from modelled exclusions | **Coverage Metric** | `*.coverage-metric.transitrix.yaml` |
+| Design-controls audit trace — requirement → verification, and hazard → risk control → requirement → verification, with reverse-trace gaps annotated | **Design-Controls Trace Matrix** | `*.design-controls-trace-matrix.transitrix.yaml` |
 
 **Family rule:** the strategy-chain notations split by shape. **DGCA** uses the **flat form** — top-level arrays at the document root (`factors[]` / `goals[]` / `changes[]` / `actions[]`), cross-references upstream inside the flat arrays. **Goals tree** and **Action schedule** (both since v2.0) are **pure projections** — the view document carries only `view_config`, and each `GOAL-…` / `ACTION-…` lives as a standalone element file under `canon/elements/…`; the parent link (Goals) and predecessor / duration / cross-refs (Action) live on the element files, not in the view. In all three, hierarchy uses `parent: <SAME-TYPE>-…` on the child; no nested wrapper keys.
 
@@ -400,6 +401,7 @@ The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI
 | Compliance Impact | `templates/compliance-impact.compliance-impact.transitrix.yaml` |
 | Coverage Metric | `templates/coverage-metric.coverage-metric.transitrix.yaml` |
 | Actions tree | `templates/actions-tree.actions-tree.transitrix.yaml` |
+| Design-Controls Trace Matrix | `templates/design-controls-trace-matrix.design-controls-trace-matrix.transitrix.yaml` |
 
 ### Codex zone primitives (drop into `codex/external/<jurisdiction>/` or `codex/internal/` in Step 3)
 

--- a/transitrix/skills/onboard/templates/design-controls-trace-matrix.design-controls-trace-matrix.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/design-controls-trace-matrix.design-controls-trace-matrix.transitrix.yaml
@@ -1,0 +1,39 @@
+notation: design-controls-trace-matrix
+spec_version: "0.1"
+methodology_version: "2.0.0"
+
+# Design-Controls Trace Matrix. Spec: notations/views/24-design-controls-trace-matrix.md
+# Report-config over the design-controls chain (sibling of Compliance Impact / Coverage Metric).
+# Carries no canonical content — every row is DERIVED from REQUIREMENT + VERIFICATION
+# + HAZARD + RISK_CONTROL. This file only declares which requirements and/or hazards
+# to render, and label overrides. Column shape is fixed by report_type (spec §1.1) —
+# unlike its two siblings, this view is not a configurable pivot matrix.
+
+name: "FILL-ME design-controls trace matrix"        # required per CONTRACT.md §1.1
+
+view:
+  id: DC_TRACE_MATRIX-FILL-ME-1
+  name: "FILL-ME — e.g. Device X — design-controls trace matrix"
+  description: "FILL-ME — which requirements and/or hazards, and why"
+  report_type: combined          # requirement | risk | combined — see spec §1.1 / §4
+
+  # What the view covers. Must match report_type:
+  #   requirement → subjects.requirements only (subjects.hazards MUST be absent)
+  #   risk        → subjects.hazards only (subjects.requirements MUST be absent)
+  #   combined    → both may be present; each renders its own section
+  subjects:
+    requirements: [REQUIREMENT-FILL-ME-1]
+    # hazards: [HAZARD-FILL-ME-1]   # use with report_type: risk or combined
+
+  # Which VERIFICATION outcomes and RISK_CONTROL residual_risk values to show in full
+  # (excluded values still count for gap classification — see spec §5.2).
+  status_display:
+    show_outcomes: ["pass", "fail", "inconclusive", "not_yet_run"]
+    show_residual_risk: ["acceptable", "alarp", "unacceptable", "not_recorded"]
+
+  # Gap labels — see spec §5.3 for the canonical strings and the rules they render.
+  # gap_labels:
+  #   req_verif_coverage_001: "No verification recorded"
+
+  # Optional ordering knob.
+  order_rows_by: "id"            # id | name


### PR DESCRIPTION
## Summary

- Adds `notations/views/24-design-controls-trace-matrix.md` — the SDS / design-controls trace-matrix report-config view, sibling of Compliance Impact and Coverage Metric. Renders `REQUIREMENT` → `VERIFICATION` and `HAZARD` → `RISK_CONTROL` → `REQUIREMENT` → `VERIFICATION` as a fixed audit table, annotating rows with the reverse-trace completeness gaps already defined on those elements (`REQ-VERIF-COVERAGE-*`, `HAZ-RISKCTL-COVERAGE-*`, `RISKCTL-VERIF-COVERAGE-001`) rather than inventing new judgement.
- **Scope note (spec §1.2):** canon has no `USER_NEED` or `DESIGN` element TYPE, even though the two source specs' "Evolution" sections used FDA 21 CFR 820.30 phrasing ("User Need → Requirement → Design → Verification") when flagging this view as future work. Adding those TYPEs is a schema change outside a report-config view's authority (a view carries no canonical content per the reconstruction invariant), so this view renders exactly the two chains canon supports today and documents the gap explicitly rather than inventing schema unilaterally.
- Registers the view (`notations/README.md`, 5 report views; `IDS_AND_REFERENCES.md` §3.2, `DC_TRACE_MATRIX`), bumps `plugin.json`'s report-view count/list, and updates the two now-stale "not yet implemented" guardrail notes in `27-verification.md` / `28-hazard-risk-control.md` §7.
- Adds a worked example under `notations/examples/design-controls-trace-matrix/`, hand-computed against the union of the existing `design-controls/` (happy path) and `design-controls/reverse-trace-gaps/` (seeded gaps) fixtures — exercises every branch of the render contract and every gap label at least once.

## Test plan

- [x] `node scripts/check-notations.mjs` passes clean (16 view notations; examples, links, version pins, notation counts all consistent).
- [x] Worked-example YAML parses (`python -c "import yaml; yaml.safe_load(...)"`).
- [ ] Valerii review — no CLI renderer exists yet for this notation (matches `compliance-impact` / `coverage-metric` precedent, both still `dsm_status: not implemented`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)