### PR TITLE
docs(templates): update RACI implementation-status note for Studio grid validator

### DIFF
--- a/templates/raci/README.md
+++ b/templates/raci/README.md
@@ -7,7 +7,7 @@ A forkable RACI — who is **R**esponsible / **A**ccountable / **C**onsulted / *
 1. Copy [`raci.blocks.transitrix.yaml`](raci.blocks.transitrix.yaml) into your own repository (or fork this one).
 2. Edit `grid.columns` — one entry per role in your RACI (rename or add/remove roles).
 3. Edit `grid.rows` — one entry per activity, with an `assign:` map giving each involved role a letter (`R`, `A`, `C`, or `I`). Omit a role from `assign` if it has no involvement in that row.
-4. Validate: `npx @transitrix/cli validate raci.blocks.transitrix.yaml` (Windows PowerShell: `npx.cmd`).
+4. Validate: `npx @transitrix/cli validate raci.blocks.transitrix.yaml --template raci` (Windows PowerShell: `npx.cmd`). See "Implementation status" below — `--template raci` needs a CLI release newer than the one currently on npm.
 
 ## The layout convention
 
@@ -19,7 +19,7 @@ A forkable RACI — who is **R**esponsible / **A**ccountable / **C**onsulted / *
 
 **Exactly one `A` per row.** A RACI where an activity has zero Accountable owners has no one answerable for it; one with two has an ambiguous owner. This is a convention *this template* applies on top of the base `blocks` matrix subset — the base notation does not fix what `assign` values mean or constrain how many of a given value may appear in a row (see [08-blocks.md §6a](../../notations/views/08-blocks.md#6a-template-level-invariants-matrix-subset)). Other matrix templates (a coverage grid, a status board) would define their own rule, or none.
 
-**Implementation status.** As of this template's publication, `npx @transitrix/cli validate` validates the shared `blocks` header contract but does not yet recognise the `grid:` root form, and there is no shared mechanism yet for a template to plug in a custom per-row rule like the one above. Until Transitrix Studio's `blocks` validator gains matrix-subset support, treat the "exactly one `A` per row" rule as a documented convention to check by eye (or with your own lightweight script), not something the CLI enforces for you yet.
+**Implementation status.** Transitrix Studio's `blocks` validator now recognises the `grid:` root form (`BL-020`–`BL-025`) and can enforce this template's "exactly one `A` per row" rule via `npx @transitrix/cli validate raci.blocks.transitrix.yaml --template raci` — landed in [transitrix-studio#411](https://github.com/transitrix/transitrix-studio/pull/411) (merged 2026-07-26). **Not yet on the published npm package**, though: `@transitrix/cli`'s latest release predates that merge, so `npx @transitrix/cli` will not resolve `--template raci` until the next CLI release ships it. Until then, either build from a `transitrix-studio` clone (`npm install && npm run build`, then `npm run transitrix -- validate raci.blocks.transitrix.yaml --template raci`) or keep checking the rule by eye.
 
 ## Alternative: role-first orientation
 


### PR DESCRIPTION
## Summary
- transitrix-studio#411 (merged 2026-07-26) adds `grid:` root recognition (BL-020..BL-025) and `--template raci` enforcement to the `blocks` validator.
- That's merged to Studio's `main` but not yet published to npm — `@transitrix/cli`'s latest release predates the merge (Studio's `CHANGELOG.md` `## Unreleased` section is currently empty, and its release runbook requires a separate release PR + GitHub Release publish before npm picks anything up).
- Updates `templates/raci/README.md`'s fork-and-go step and "Implementation status" note to reflect that accurately: the command and behaviour that will work once the CLI release ships, plus a clone-build workaround for validating today.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] Verified via `npm view @transitrix/cli version` (2.1.0, published 2026-07-23) that the published CLI predates transitrix-studio#411 (merged 2026-07-26)
- [x] Confirmed `--template raci` flag and `npm run transitrix -- validate ... --template raci` invocation against transitrix-studio's `src/cli-parse.ts` / `docs/cli.md`