### PR TITLE
feat(ingest-cli): implement fail-closed privacy-scan pre-admission gate

### DIFF
--- a/packages/ingest-cli/README.md
+++ b/packages/ingest-cli/README.md
@@ -37,7 +37,8 @@ transitrix-ingest <command> [args]
 | `--version` / `--help` | ✅ | Version (the skill's Step-0 pre-check) and usage. |
 | `scaffold-intake <org-root>` | ✅ | Create `_intake/{inbox,processing,processed}` (idempotent). |
 | `convert <inbox-file>` | ✅ | Convert a document to Markdown in `_intake/processing/` (Markitdown; `.md`/`.txt` passthrough). |
-| `field-artefact <md> --type --role --date` | ✅ | Emit a field artefact with provenance + proposed `source_quality`; retain the raw source in `_intake/processed/`. |
+| `privacy-scan <processing/file.md>` | ✅ | Fail-closed PII/medical pre-admission gate; `CLEAN`/`STRIPPED`/`REJECTED`/`ERROR`, a `STRIPPED` run writes `<file>.redacted.md`. `admit-source --zone field` refuses without a passing, content-matching scan record. |
+| `admit-source <md> --zone field\|codex` (`field-artefact` / `codex-artefact` deprecated aliases) | ✅ | Emit a field or codex artefact with provenance + (field only) proposed `source_quality`; retain the raw source in `_intake/processed/`. |
 | `emit-candidates <field-artefact> --from <result.json>` | ✅ | Shape the agent's extraction result into candidates (entity-strong, relation-conservative; non-`high` relations become suggestions). |
 | `validate <candidates-dir>` | ✅ | Validate candidate `*.json` against the contract (in code) + coverage profile; flags, never drops. |
 | `review-queue <candidates-dir>` | ✅ | Stage the human review queue (`review-queue.yaml`); `gate.admits_to_canon: false`; annotates each element candidate with its §4 `placement`. |
@@ -58,6 +59,7 @@ packages/ingest-cli/
     intake.mjs         # _intake/ scaffolding + stage moves
     convert.mjs        # document -> Markdown (Markitdown shell-out)
     yaml.mjs           # zero-dep YAML emitter + manifest scalar reader
+    privacy-scan.mjs   # fail-closed PII pre-admission gate (detectors, sidecar records, privacy-report.yaml)
     field-artefact.mjs # emit a field artefact + proposed source_quality
     coverage.mjs       # resolve coverage_profile (preset/custom) + classify in/out
     coverage-presets.mjs # shipped preset membership (COVERAGE_PROFILES §3/§3.1)

--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -11,9 +11,9 @@
 //
 // Exit codes:  0 = ok  ·  1 = usage / findings that need review  ·  2 = error
 //
-// Implemented: --version, scaffold-intake, convert, admit-source (field + codex;
-// field-artefact / codex-artefact remain as deprecated aliases), emit-candidates,
-// validate, review-queue.
+// Implemented: --version, scaffold-intake, convert, privacy-scan, admit-source (field
+// + codex; field-artefact / codex-artefact remain as deprecated aliases),
+// emit-candidates, validate, review-queue.
 
 import { readFile, access } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -32,6 +32,8 @@ import { resolvePlacement, checkCanonPlacement } from './src/placement.mjs';
 import { repoCheck } from './src/repo-check.mjs';
 import { checkStale } from './src/check-stale.mjs';
 import { dump } from './src/yaml.mjs';
+import { runPrivacyScan, parsePrivacyGateConfig } from './src/privacy-scan.mjs';
+import { randomUUID } from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -65,6 +67,8 @@ function usage() {
     'Commands:',
     '  scaffold-intake <org-root>     Create _intake/{inbox,processing,processed} (idempotent)',
     '  convert <inbox-file>           Convert a document to Markdown in _intake/processing/',
+    '  privacy-scan <processing/file.md>   Fail-closed PII/medical pre-admission gate (SKILL.md Step 2b)',
+    '                                 CLEAN|STRIPPED proceed to admit-source; REJECTED|ERROR halt the pipeline',
     '  admit-source <md> --zone field|codex   Admit a converted source to the field or codex zone',
     '                 field: --type INTERVIEW|SURVEY|OBSERVATION|DRAFT --role R --date YYYY-MM-DD',
     '                        [--captured-by X] [--source-quality Q] [--slug SL] [--admitted-at A]',
@@ -121,6 +125,37 @@ async function cmdConvert(args) {
   }
 }
 
+async function cmdPrivacyScan(args) {
+  const { _ } = parseArgs(args);
+  const md = _[0];
+  if (!md) { console.error('privacy-scan: missing <processing/file.md>'); return 1; }
+  const mdPath = resolve(md);
+  try { await access(mdPath); } catch { console.error(`privacy-scan: file not found: ${md}`); return 2; }
+  const orgRoot = await findOrgRoot(mdPath);
+  if (!orgRoot) { console.error(`privacy-scan: "${md}" is not inside an _intake/ workspace.`); return 2; }
+
+  const config = parsePrivacyGateConfig(await readManifestText(orgRoot));
+  const processingDir = stageDir(orgRoot, 'processing');
+  const res = await runPrivacyScan({ mdPath, processingDir, config, runId: randomUUID() });
+
+  console.log(`privacy-scan  ${md}  ->  ${res.outcome}`);
+  if (res.outcome === 'STRIPPED') {
+    console.log(`  ${res.blockedFragments.filter((f) => !f.allowlist_cleared).length} fragment(s) redacted -> ${res.redactedFile}`);
+    console.log('  admit-source must be run on the redacted copy, not the original.');
+  }
+  if (res.outcome === 'REJECTED') {
+    console.error(`  ${res.blockedFragments.length} fragment(s) blocked — document not admissible; see privacy-report.yaml`);
+  }
+  if (res.outcome === 'ERROR') {
+    console.error(`  ${res.errorDetail}`);
+  }
+  console.log(`  privacy-report.yaml  ->  ${join(processingDir, 'privacy-report.yaml')}`);
+
+  if (res.outcome === 'CLEAN' || res.outcome === 'STRIPPED') return 0;
+  if (res.outcome === 'REJECTED') return 1;
+  return 2;
+}
+
 async function cmdFieldArtefact(args) {
   const { _, flags } = parseArgs(args);
   const md = _[0];
@@ -159,7 +194,7 @@ async function cmdFieldArtefact(args) {
       return 0;
     }
     console.error(`field-artefact: ${err.message}`);
-    return 2;
+    return err.privacyGate ? 1 : 2;
   }
 }
 
@@ -398,6 +433,7 @@ async function main(argv) {
   switch (cmd) {
     case 'scaffold-intake': return cmdScaffoldIntake(args);
     case 'convert':         return cmdConvert(args);
+    case 'privacy-scan':    return cmdPrivacyScan(args);
     case 'admit-source':    return cmdAdmitSource(args);
     case 'field-artefact':  return cmdFieldArtefact(args);
     case 'codex-artefact':  return cmdCodexArtefact(args);

--- a/packages/ingest-cli/src/field-artefact.mjs
+++ b/packages/ingest-cli/src/field-artefact.mjs
@@ -4,14 +4,16 @@
 // source is moved to _intake/processed/ for traceability; the artefact cites it.
 //
 // The skill PROPOSES source_quality; a human confirms at admission. This command
-// never touches canon/.
+// never touches canon/. Admission is fail-closed on the privacy pre-admission gate
+// (SKILL.md Step 2b, privacy-scan.mjs) unless the adopter has explicitly disabled it.
 
 import { readFile, writeFile, mkdir, readdir, rename, access } from 'node:fs/promises';
 import { join, resolve, basename, extname } from 'node:path';
 import { isValidId, makeId, slugSegment, parseId } from './ids.mjs';
 import { dump } from './yaml.mjs';
-import { INTAKE, stageDir } from './intake.mjs';
+import { INTAKE, stageDir, readManifestText } from './intake.mjs';
 import { hashFile, shortHash, findDuplicateSource, DuplicateSourceError } from './source-hash.mjs';
+import { checkPrivacyGate, parsePrivacyGateConfig } from './privacy-scan.mjs';
 
 // Field TYPE → field/ subfolder and body-block key.
 const TYPE_INFO = {
@@ -69,6 +71,12 @@ export async function emitFieldArtefact(opts) {
   if (sourceQuality && !SOURCE_QUALITY.has(sourceQuality)) {
     throw new Error(`--source-quality must be one of ${[...SOURCE_QUALITY].join(', ')}`);
   }
+
+  // Fail-closed privacy pre-admission gate (SKILL.md Step 2b): refuse to admit a
+  // document with no passing, content-matching privacy-scan record. Skipped only when
+  // an adopter has explicitly disabled the gate (`ingest.privacy_gate.enabled: false`).
+  const gateConfig = parsePrivacyGateConfig(await readManifestText(orgRoot));
+  if (gateConfig.enabled !== false) await checkPrivacyGate(mdPath);
 
   // Fingerprint the raw bytes up front and refuse a duplicate re-ingest (same content
   // already admitted to field/) unless --force — before minting an id or moving anything.

--- a/packages/ingest-cli/src/privacy-scan.mjs
+++ b/packages/ingest-cli/src/privacy-scan.mjs
@@ -1,0 +1,378 @@
+// `privacy-scan` — the fail-closed pre-admission gate (SKILL.md Step 2b). Runs a
+// closed set of deterministic pattern + dictionary detectors over a converted
+// document and produces one of CLEAN / STRIPPED / REJECTED / ERROR. A STRIPPED run
+// writes a redacted copy; admit-source (field zone only — codex sources are
+// laws/regulations, not personal data) refuses to proceed without a passing,
+// content-matching scan record for the exact file it is given.
+//
+// Honesty about limits: this is a regex/dictionary-class detector, not a guarantee.
+// It catches shaped tokens (SSN/NI-number patterns, emails, phone numbers, card
+// numbers, passport-shaped codes) and a fixed medical-vocabulary list — it does not
+// understand context, cannot catch PII that doesn't match a known shape, and can
+// both over-flag (a false positive) and miss real PII (a false negative). The
+// per-run privacy-report.yaml exists precisely so a human can audit both directions.
+
+import { readFile, writeFile, access } from 'node:fs/promises';
+import { basename, dirname, extname, join } from 'node:path';
+import { hashBytes } from './source-hash.mjs';
+import { dump } from './yaml.mjs';
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+export const DETECTION_CATEGORIES = [
+  { code: 'PII-001', category: 'National identifier', examples: 'SSN, NI number, national-ID-shaped tokens' },
+  { code: 'PII-002', category: 'Date of birth', examples: 'DOB phrases combined with date-shaped tokens in a personal context' },
+  { code: 'PII-003', category: 'Medical / health terms', examples: 'Diagnosis codes, medication names, clinical and diagnostic vocabulary' },
+  { code: 'PII-004', category: 'Contact PII beyond allowlist', examples: 'Personal email, personal phone (non-work)' },
+  { code: 'PII-005', category: 'Financial personal', examples: 'Credit / debit card numbers, personal bank account numbers' },
+  { code: 'PII-006', category: 'Biometric / government identifier', examples: 'Passport numbers, biometric descriptors' },
+];
+
+export const DEFAULT_ALLOWLIST = [
+  { field: 'first_name', on: ['ACTOR', 'ORG'] },
+  { field: 'last_name', on: ['ACTOR', 'ORG'] },
+  { field: 'work_phone', on: ['ACTOR', 'ORG'] },
+  { field: 'work_email', on: ['ACTOR', 'ORG'] },
+];
+
+// ── transitrix.yaml `ingest.privacy_gate` config (hand-rolled, zero-dep — same
+// discipline as coverage.mjs's custom coverage_profile block reader) ──────────
+
+function indentOf(line) { return line.match(/^\s*/)[0].length; }
+
+// Find a `key:` header line (block form, no inline value) at/after fromIdx and
+// return its body lines up to the first line at or below its own indentation.
+function blockUnder(lines, headerRe, fromIdx = 0) {
+  for (let i = fromIdx; i < lines.length; i++) {
+    const raw = lines[i];
+    if (raw.trim() === '' || raw.trim().startsWith('#')) continue;
+    if (!headerRe.test(raw.trim())) continue;
+    const indent = indentOf(raw);
+    const body = [];
+    let j = i + 1;
+    for (; j < lines.length; j++) {
+      const ln = lines[j];
+      if (ln.trim() === '' || ln.trim().startsWith('#')) { body.push(ln); continue; }
+      if (indentOf(ln) <= indent) break;
+      body.push(ln);
+    }
+    return { idx: i, indent, body, endIdx: j };
+  }
+  return null;
+}
+
+export function parsePrivacyGateConfig(manifestText) {
+  const defaults = () => ({ enabled: true, onDetection: 'strip', allowlist: DEFAULT_ALLOWLIST.map((a) => ({ ...a })) });
+  if (typeof manifestText !== 'string') return defaults();
+
+  const lines = manifestText.replace(/\r\n/g, '\n').split('\n');
+  const ingest = blockUnder(lines, /^ingest:\s*$/);
+  if (!ingest) return defaults();
+  const pg = blockUnder(ingest.body, /^privacy_gate:\s*$/);
+  if (!pg) return defaults();
+
+  const cfg = defaults();
+  for (let i = 0; i < pg.body.length; i++) {
+    const ln = pg.body[i];
+    const t = ln.trim();
+    if (t === '' || t.startsWith('#')) continue;
+    let m;
+    if ((m = t.match(/^enabled:\s*(true|false)\b/))) { cfg.enabled = m[1] === 'true'; continue; }
+    if ((m = t.match(/^on_detection:\s*(strip|reject)\b/))) { cfg.onDetection = m[1]; continue; }
+    if (/^allowlist:\s*$/.test(t)) {
+      const allow = blockUnder(pg.body, /^allowlist:\s*$/, i);
+      const entries = [];
+      let cur = null;
+      for (const l2 of allow.body) {
+        const t2 = l2.trim();
+        let mm;
+        if ((mm = t2.match(/^-\s*field:\s*(\S+)\s*$/))) { cur = { field: mm[1], on: [] }; entries.push(cur); continue; }
+        if ((mm = t2.match(/^on:\s*\[([^\]]*)\]\s*$/)) && cur) {
+          cur.on = mm[1].split(',').map((s) => s.trim()).filter(Boolean);
+        }
+      }
+      if (entries.length) cfg.allowlist = entries;
+      i = allow.endIdx - pg.idx - 1; // skip the consumed sub-block
+      continue;
+    }
+  }
+  return cfg;
+}
+
+// ── Detectors — deterministic pattern + dictionary matching ─────────────────
+
+function luhnValid(digits) {
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = Number(digits[i]);
+    if (alt) { d *= 2; if (d > 9) d -= 9; }
+    sum += d;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+
+const MEDICAL_TERMS = [
+  'diagnosis', 'diagnosed with', 'prescribed', 'prescription', 'medication',
+  'chronic condition', 'psychiatric', 'mental health', 'therapy session',
+  'clinical history', 'medical history', 'treatment plan', 'insulin', 'chemotherapy',
+];
+
+const DETECTORS = [
+  {
+    code: 'PII-001',
+    reason: 'national-ID-shaped token matched (SSN or NI-number pattern)',
+    regex: /\b\d{3}-\d{2}-\d{4}\b|\b[A-CEGHJ-PR-TW-Z]{2}\s?\d{6}\s?[A-D]\b/g,
+  },
+  {
+    code: 'PII-002',
+    reason: 'date-of-birth phrase combined with a date-shaped token',
+    regex: /\b(?:date of birth|d\.?o\.?b\.?|born on)\s*[:\-]?\s*(?:\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4}|\d{1,2}\s+[A-Za-z]+\s+\d{4})/gi,
+  },
+  {
+    code: 'PII-003',
+    reason: 'medical/health vocabulary matched',
+    regex: new RegExp(`\\b(?:${MEDICAL_TERMS.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})\\b`, 'gi'),
+  },
+  {
+    code: 'PII-005',
+    reason: 'financial card/account-shaped digit sequence (Luhn-valid)',
+    regex: /\b(?:\d[ -]?){13,19}\b/g,
+    validate: (m) => luhnValid(m.replace(/[ -]/g, '')),
+  },
+  {
+    code: 'PII-006',
+    reason: 'passport-number-shaped token matched',
+    regex: /\bpassport\s*(?:no\.?|number)?\s*[:\-]?\s*[A-Z0-9]{6,9}\b/gi,
+  },
+  {
+    code: 'PII-004',
+    reason: 'personal contact detail (email or phone) not covered by the allowlist',
+    regex: /\b[\w.+-]+@[\w-]+\.[\w.-]+\b|\b\+?\d[\d\- ]{7,14}\d\b/g,
+    allowlistable: true,
+  },
+];
+
+function preview(fragment) {
+  return `${fragment.slice(0, 20)}***`;
+}
+
+function lineOf(text, index) {
+  const start = text.lastIndexOf('\n', index) + 1;
+  const end = text.indexOf('\n', index);
+  return text.slice(start, end === -1 ? text.length : end);
+}
+
+function isAllowlistedContext(text, index, allowlist) {
+  const line = lineOf(text, index).toLowerCase();
+  return allowlist.some((entry) => {
+    const label = String(entry.field).toLowerCase();
+    return line.includes(label) || line.includes(label.replace(/_/g, ' '));
+  });
+}
+
+function findMatches(text, def) {
+  const out = [];
+  const re = new RegExp(def.regex.source, def.regex.flags);
+  let m;
+  while ((m = re.exec(text))) {
+    const val = m[0];
+    if (val.length === 0) { re.lastIndex++; continue; }
+    if (def.validate && !def.validate(val)) continue;
+    out.push({ code: def.code, index: m.index, length: val.length, text: val, reason: def.reason, allowlistable: !!def.allowlistable });
+  }
+  return out;
+}
+
+// Scan `text` against the detector set. Returns { outcome, blockedFragments, redactedText }.
+// `config.onDetection`: 'strip' (default) redacts and admits the clean copy; 'reject'
+// blocks the whole document. Overlapping matches keep the earliest, highest-priority
+// detector (DETECTORS order — PII-004 contact detection runs last so a token already
+// claimed by a more specific category, e.g. a card number, is not double-reported).
+export function scanText(text, config = {}) {
+  const allowlist = config.allowlist || DEFAULT_ALLOWLIST;
+  const onDetection = config.onDetection || 'strip';
+
+  const all = [];
+  for (const def of DETECTORS) all.push(...findMatches(text, def));
+  all.sort((a, b) => a.index - b.index || DETECTORS.findIndex((d) => d.code === a.code) - DETECTORS.findIndex((d) => d.code === b.code));
+
+  const kept = [];
+  let lastEnd = -1;
+  for (const m of all) {
+    if (m.index < lastEnd) continue;
+    kept.push(m);
+    lastEnd = m.index + m.length;
+  }
+
+  const blockedFragments = [];
+  const toRedact = [];
+  for (const m of kept) {
+    const cleared = m.allowlistable && isAllowlistedContext(text, m.index, allowlist);
+    const entry = { code: m.code, reason: m.reason, fragment_preview: preview(m.text) };
+    if (cleared) { entry.allowlist_cleared = true; blockedFragments.push(entry); continue; }
+    blockedFragments.push(entry);
+    toRedact.push(m);
+  }
+
+  let outcome = 'CLEAN';
+  if (toRedact.length > 0) outcome = onDetection === 'reject' ? 'REJECTED' : 'STRIPPED';
+
+  let redactedText = null;
+  if (outcome === 'STRIPPED') {
+    let out = text;
+    for (const m of [...toRedact].sort((a, b) => b.index - a.index)) {
+      out = `${out.slice(0, m.index)}[REDACTED:${m.code}]${out.slice(m.index + m.length)}`;
+    }
+    redactedText = out;
+  }
+
+  return { outcome, blockedFragments, redactedText };
+}
+
+// ── Sidecar scan records + admit-source's fail-closed check ─────────────────
+
+function sidecarPath(mdPath) { return `${mdPath}.privacy-scan.json`; }
+
+async function readSidecar(mdPath) {
+  const p = sidecarPath(mdPath);
+  if (!(await exists(p))) return null;
+  try { return JSON.parse(await readFile(p, 'utf8')); } catch { return null; }
+}
+
+async function writeSidecar(mdPath, record) {
+  await writeFile(sidecarPath(mdPath), JSON.stringify(record, null, 2) + '\n', 'utf8');
+}
+
+export class PrivacyGateError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'PrivacyGateError';
+    this.privacyGate = true;
+  }
+}
+
+// Fail-closed check called by admit-source (field zone). Throws PrivacyGateError
+// unless `mdPath` carries a passing, content-matching privacy-scan record.
+export async function checkPrivacyGate(mdPath) {
+  const sidecar = await readSidecar(mdPath);
+  if (!sidecar) {
+    throw new PrivacyGateError(
+      `no privacy-scan record for ${mdPath} — run \`transitrix-ingest privacy-scan ${mdPath}\` first ` +
+      '(fail-closed pre-admission gate, SKILL.md Step 2b).'
+    );
+  }
+  const currentHash = hashBytes(await readFile(mdPath));
+  if (sidecar.source_sha256 !== currentHash) {
+    throw new PrivacyGateError(
+      `privacy-scan record for ${mdPath} is stale (content changed since the scan) — re-run privacy-scan.`
+    );
+  }
+  if (sidecar.outcome === 'REJECTED') {
+    throw new PrivacyGateError(`${mdPath} was REJECTED by the privacy gate — see privacy-report.yaml; do not admit.`);
+  }
+  if (sidecar.outcome === 'ERROR') {
+    throw new PrivacyGateError(`privacy-scan did not complete for ${mdPath} (${sidecar.error_detail || 'unknown error'}) — fix and re-scan.`);
+  }
+  if (sidecar.outcome === 'STRIPPED' && sidecar.redacted_file) {
+    throw new PrivacyGateError(
+      `the privacy gate stripped blocked content from ${mdPath} — admit the redacted copy instead: ${sidecar.redacted_file}.`
+    );
+  }
+  if (sidecar.outcome !== 'CLEAN' && sidecar.outcome !== 'STRIPPED') {
+    throw new PrivacyGateError(`privacy-scan record for ${mdPath} carries an unrecognised outcome (${sidecar.outcome}) — re-run privacy-scan.`);
+  }
+  return sidecar;
+}
+
+// ── privacy-report.yaml — per-run aggregate, alongside review-queue.yaml ────
+
+// The human-facing artefact is YAML (privacy-report.yaml, per SKILL.md). To merge
+// entries across multiple privacy-scan invocations in one run without a general YAML
+// parser, the CLI keeps a parallel JSON run-state file and regenerates the YAML from
+// it on every call — the JSON file is an implementation detail, not part of the contract.
+function runStatePath(processingDir) { return join(processingDir, '.privacy-report-state.json'); }
+
+async function loadRunState(processingDir) {
+  const p = runStatePath(processingDir);
+  if (!(await exists(p))) return { run_id: null, scanned: [] };
+  try { return JSON.parse(await readFile(p, 'utf8')); } catch { return { run_id: null, scanned: [] }; }
+}
+
+async function saveRunState(processingDir, state) {
+  await writeFile(runStatePath(processingDir), JSON.stringify(state), 'utf8');
+}
+
+function summarize(scanned) {
+  const summary = { total: scanned.length, clean: 0, stripped: 0, rejected: 0, error: 0 };
+  for (const s of scanned) {
+    if (s.outcome === 'CLEAN') summary.clean++;
+    else if (s.outcome === 'STRIPPED') summary.stripped++;
+    else if (s.outcome === 'REJECTED') summary.rejected++;
+    else if (s.outcome === 'ERROR') summary.error++;
+  }
+  return summary;
+}
+
+async function updatePrivacyReport(processingDir, entry, config, runId) {
+  const state = await loadRunState(processingDir);
+  if (!state.run_id) state.run_id = runId;
+  const i = state.scanned.findIndex((s) => s.source_file === entry.source_file);
+  if (i >= 0) state.scanned[i] = entry; else state.scanned.push(entry);
+  await saveRunState(processingDir, state);
+
+  const report = {
+    generated_by: 'transitrix-ingest',
+    run_id: state.run_id,
+    config_snapshot: { enabled: true, on_detection: config.onDetection, allowlist: config.allowlist },
+    scanned: state.scanned,
+    summary: summarize(state.scanned),
+  };
+  await writeFile(join(processingDir, 'privacy-report.yaml'), dump(report), 'utf8');
+  return report;
+}
+
+// ── The `privacy-scan <file>` command's business logic ───────────────────────
+
+export async function runPrivacyScan({ mdPath, processingDir, config, runId }) {
+  let content;
+  try {
+    content = await readFile(mdPath, 'utf8');
+  } catch (err) {
+    const entry = { source_file: basename(mdPath), outcome: 'ERROR', error_detail: `could not read file: ${err.message}` };
+    await writeSidecar(mdPath, { outcome: 'ERROR', scanned_at: new Date().toISOString(), error_detail: entry.error_detail });
+    await updatePrivacyReport(processingDir, entry, config, runId);
+    return { outcome: 'ERROR', errorDetail: entry.error_detail };
+  }
+
+  const { outcome, blockedFragments, redactedText } = scanText(content, config);
+  const scannedAt = new Date().toISOString();
+  const entry = { source_file: basename(mdPath), outcome };
+
+  if (outcome === 'CLEAN') {
+    await writeSidecar(mdPath, { outcome, scanned_at: scannedAt, source_sha256: hashBytes(Buffer.from(content, 'utf8')) });
+  } else if (outcome === 'STRIPPED') {
+    const redactedPath = join(dirname(mdPath), `${basename(mdPath, extname(mdPath))}.redacted${extname(mdPath) || '.md'}`);
+    await writeFile(redactedPath, redactedText, 'utf8');
+    const redactedBuf = Buffer.from(redactedText, 'utf8');
+    await writeSidecar(mdPath, {
+      outcome, scanned_at: scannedAt,
+      source_sha256: hashBytes(Buffer.from(content, 'utf8')),
+      redacted_file: redactedPath,
+    });
+    await writeSidecar(redactedPath, {
+      outcome, scanned_at: scannedAt,
+      source_sha256: hashBytes(redactedBuf),
+      derived_from: mdPath,
+    });
+    entry.redacted_file = redactedPath;
+    entry.blocked_fragments = blockedFragments;
+  } else if (outcome === 'REJECTED') {
+    await writeSidecar(mdPath, { outcome, scanned_at: scannedAt, source_sha256: hashBytes(Buffer.from(content, 'utf8')) });
+    entry.blocked_fragments = blockedFragments;
+  }
+
+  await updatePrivacyReport(processingDir, entry, config, runId);
+  return { outcome, blockedFragments, redactedFile: entry.redacted_file || null };
+}

--- a/transitrix/skills/ingest/README.md
+++ b/transitrix/skills/ingest/README.md
@@ -70,7 +70,7 @@ In v0 this convention is **skill-local** — documented here and in [`templates/
 | **CLI** ✓ landed | `@transitrix/ingest-cli` — the deterministic subcommands (`scaffold-intake`, `convert`, `admit-source`/`field-artefact`/`codex-artefact`, `emit-candidates`, `validate`, `review-queue`) + the forked extraction prompts in `prompts/`. |
 | **Tests + CI** ✓ landed | A no-API-key integrity test (bundle + dry CLI run on a fixture) and a weekly LLM-drive, plus a workflow — mirroring the onboarding skill's test harness. |
 | **Zero information loss** ✓ landed | `extensions:` carry-through + `canon/unresolved/` emission (CONTRACT §12/§13). `emit-candidates` carries `extensions:` onto candidates and parks untyped objects in `canon/unresolved/`; `validate` enforces `EXT-002`; `repo-check` reports the holding count; typed canon walkers skip the holding area (`UNRES-004`). Covered by Part O of the integrity test. |
-| **Privacy gate spec** ✓ landed | Step 2b `privacy-scan`: rule-based fail-closed pre-admission gate with six PII/medical detection categories, a narrow business-contact allowlist, `CLEAN`/`STRIPPED`/`REJECTED`/`ERROR` outcomes, and a per-run `privacy-report.yaml`. CLI implementation (`@transitrix/ingest-cli privacy-scan`) is the downstream delivery. |
+| **Privacy gate** ✓ landed | Step 2b `privacy-scan`: rule-based fail-closed pre-admission gate with six PII/medical detection categories, a narrow business-contact allowlist, `CLEAN`/`STRIPPED`/`REJECTED`/`ERROR` outcomes, and a per-run `privacy-report.yaml`. `@transitrix/ingest-cli privacy-scan` is implemented; `admit-source --zone field` refuses to proceed without a passing, content-matching scan record. |
 
 ---
 

--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 The **front door** to a Transitrix repository: it turns raw material into `field`-zone artefacts and typed `canon` *candidates*, at scale, and routes everything through a human review gate. It is the operational counterpart to the per-layer extraction prompts — the part that converts documents, scores source trust, runs the validators, and stages a review queue.
 
-> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`, see [§ The CLI](#the-cli)) implements every subcommand below — `scaffold-intake`, `convert`, `admit-source` (field + codex routes), `emit-candidates`, `validate`, `review-queue`, `suggest-profile`, `check-placement`, `resolve-placement` — and is exercised end-to-end by the bundle's integrity test. Run the **CLI-presence pre-check** (Step 0) first; if the CLI is not on PATH in this install, install it before proceeding.
+> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`, see [§ The CLI](#the-cli)) implements every subcommand below — `scaffold-intake`, `convert`, `privacy-scan`, `admit-source` (field + codex routes), `emit-candidates`, `validate`, `review-queue`, `suggest-profile`, `check-placement`, `resolve-placement` — and is exercised end-to-end by the bundle's integrity test. Run the **CLI-presence pre-check** (Step 0) first; if the CLI is not on PATH in this install, install it before proceeding.
 
 The methodology is canon at `github.com/transitrix/methodology`; this skill is the agent-facing protocol for operating the field→canon pipeline against it. It runs **agent-neutrally** under Claude and GitHub Copilot — all heavy logic is in the CLI, and this `SKILL.md` only sequences it.
 

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -3,11 +3,11 @@
 
 Deterministic, no-API-key guard. Nine parts:
 
-  A. Bundle integrity — SKILL.md frontmatter, the three JSON schemas parse, the
+  A. Bundle integrity — SKILL.md frontmatter, the four JSON schemas parse, the
      four layer prompts + READMEs exist, the _intake template is present.
   B. CLI pipeline drive — runs the real CLI end-to-end on a fixture
-     (scaffold-intake -> convert -> field-artefact -> emit-candidates -> validate
-     -> review-queue) and asserts the outputs: a conformant field artefact with a
+     (scaffold-intake -> convert -> privacy-scan -> field-artefact -> emit-candidates
+     -> validate -> review-queue) and asserts the outputs: a conformant field artefact with a
      proposed source_quality, candidate files, a review queue with the gate closed,
      the two-axes rule (a candidate carrying source_quality is flagged), and THE ONE
      RULE — canon/ is never written.
@@ -38,6 +38,11 @@ Deterministic, no-API-key guard. Nine parts:
   Q. origin pass-through + REQ-004 — emit-candidates carries origin through for all three
      valid values (legislative/process-product/project-product); validate enforces REQ-004
      (closed vocabulary) on the candidate origin field.
+  R. #807 privacy gate — privacy-scan CLEAN/STRIPPED/REJECTED outcomes; admit-source
+     (field zone) refuses with no scan record, refuses a stale record, and refuses the
+     original after STRIPPED (must admit the redacted copy); the epic's name+email+phone
+     reproduction is not admitted verbatim; privacy-report.yaml never leaks a fragment
+     verbatim; `enabled: false` is an explicit adopter opt-out.
 
 This is the PR-CI guard. The LLM-driven walk-through lives in drive_ingest_e2e.py,
 gated to the weekly cron. See tests/README.md.
@@ -95,7 +100,7 @@ def part_a_bundle():
             for key in ("name", "description", "when_to_use", "allowed-tools"):
                 check(key in fm, f"SKILL.md frontmatter missing required key: {key}")
 
-    for short in ("field-artefact", "candidate", "review-queue"):
+    for short in ("field-artefact", "candidate", "review-queue", "privacy-report"):
         p = os.path.join(SKILL_DIR, "schemas", f"{short}.schema.json")
         if check(os.path.isfile(p), f"schema missing: schemas/{short}.schema.json"):
             try:
@@ -145,6 +150,10 @@ def part_b_pipeline():
         check(r.returncode == 0, f"convert failed: {r.stderr.strip()}")
         md = os.path.join(org, "_intake", "processing", "INTERVIEW-sample.md")
         check(os.path.isfile(md), "convert did not produce processing/INTERVIEW-sample.md")
+
+        r = run_cli("privacy-scan", md)
+        check(r.returncode == 0 and "CLEAN" in r.stdout,
+              f"privacy-scan should report CLEAN for the clean fixture: {r.stdout}{r.stderr}")
 
         r = run_cli("field-artefact", md, "--type", "INTERVIEW", "--role", "Head of Operations",
                     "--date", "2026-04-15", "--slug", "ops", "--admitted-at", "2026-04-16",
@@ -444,6 +453,7 @@ def part_f_ig3():
                 fh.write("# " + stem + "\n" + body + "\n")
 
         drop("INT", "note")
+        run_cli("privacy-scan", os.path.join(proc, "INT.md"))
         r = run_cli("admit-source", "--zone", "field", os.path.join(proc, "INT.md"),
                     "--type", "INTERVIEW", "--role", "Ops", "--date", "2026-01-01",
                     "--slug", "ops", "--admitted-at", "2026-01-02")
@@ -460,6 +470,7 @@ def part_f_ig3():
               "IG-3: admit-source --zone codex did not write a codex artefact")
 
         drop("INT2", "note2")
+        run_cli("privacy-scan", os.path.join(proc, "INT2.md"))
         r = run_cli("field-artefact", os.path.join(proc, "INT2.md"),
                     "--type", "INTERVIEW", "--role", "Ops2", "--date", "2026-01-01",
                     "--slug", "ops2", "--admitted-at", "2026-01-02")
@@ -755,6 +766,7 @@ def part_j_duplicate_source():
                 fh.write(content)
             run_cli("convert", os.path.join(inbox, "src.md"))
             md = os.path.join(org, "_intake", "processing", "src.md")
+            run_cli("privacy-scan", md)
             return run_cli("admit-source", md, "--zone", "field", "--type", "INTERVIEW",
                            "--role", "ops", "--date", "2026-01-01", "--slug", "ops",
                            "--admitted-at", "2026-01-02", *extra)
@@ -1262,6 +1274,140 @@ def part_q_origin_classification():
         shutil.rmtree(work, ignore_errors=True)
 
 
+# ── Part R — #807 privacy pre-admission gate ──────────────────────
+
+def part_r_privacy_gate():
+    """privacy-scan CLEAN/STRIPPED/REJECTED; admit-source (field) refuses with no scan
+    record, a stale record, or the un-redacted original after STRIPPED; the epic's
+    name+email+phone reproduction is not admitted verbatim; enabled:false opts out."""
+    if not shutil.which("node"):
+        print("SKIP Part R: `node` not found.")
+        return
+    work = tempfile.mkdtemp(prefix="ingest-privacy-")
+    try:
+        org = os.path.join(work, "org")
+        os.makedirs(org)
+        run_cli("scaffold-intake", org)
+        with open(os.path.join(org, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n')
+        inbox = os.path.join(org, "_intake", "inbox")
+        proc = os.path.join(org, "_intake", "processing")
+
+        # R1 — a clean document scans CLEAN.
+        with open(os.path.join(inbox, "clean.md"), "w", encoding="utf-8") as fh:
+            fh.write("The Head of Operations described rising churn over two quarters.\n")
+        run_cli("convert", os.path.join(inbox, "clean.md"))
+        clean_md = os.path.join(proc, "clean.md")
+        r = run_cli("privacy-scan", clean_md)
+        check(r.returncode == 0 and "CLEAN" in r.stdout, f"R1: clean fixture should scan CLEAN: {r.stdout}{r.stderr}")
+
+        # R2 — admit-source refuses a document with NO privacy-scan record.
+        with open(os.path.join(inbox, "unscanned.md"), "w", encoding="utf-8") as fh:
+            fh.write("Unscanned note.\n")
+        run_cli("convert", os.path.join(inbox, "unscanned.md"))
+        unscanned_md = os.path.join(proc, "unscanned.md")
+        r = run_cli("admit-source", "--zone", "field", unscanned_md,
+                    "--type", "OBSERVATION", "--role", "ROLE-OPS-1", "--date", "2026-07-14")
+        check(r.returncode == 1 and "no privacy-scan record" in (r.stdout + r.stderr),
+              f"R2: admit-source must refuse a document with no privacy-scan record: {r.stdout}{r.stderr}")
+        check(not os.path.isdir(os.path.join(org, "field", "observations")),
+              "R2: a refused document must not be admitted")
+
+        # R3 — the epic's reproduction: full name + personal email + personal phone.
+        repro = ("Contact: Jane Doe\nEmail: jane.doe@personalmail.example\n"
+                 "Phone: +1 555-123-4567\n")
+        with open(os.path.join(inbox, "repro.md"), "w", encoding="utf-8") as fh:
+            fh.write(repro)
+        run_cli("convert", os.path.join(inbox, "repro.md"))
+        repro_md = os.path.join(proc, "repro.md")
+        r = run_cli("privacy-scan", repro_md)
+        check(r.returncode == 0 and "STRIPPED" in r.stdout,
+              f"R3: name+email+phone fixture should be STRIPPED (default on_detection: strip): {r.stdout}{r.stderr}")
+        redacted = os.path.join(proc, "repro.redacted.md")
+        check(os.path.isfile(redacted), "R3: STRIPPED must write a redacted copy")
+        redacted_text = open(redacted, encoding="utf-8").read()
+        check("jane.doe@personalmail.example" not in redacted_text and "555-123-4567" not in redacted_text,
+              "R3: the redacted copy must not carry the blocked email/phone verbatim")
+
+        # admit-source on the ORIGINAL (still carrying the blocked fragments) is refused...
+        r = run_cli("admit-source", "--zone", "field", repro_md,
+                    "--type", "OBSERVATION", "--role", "ROLE-OPS-1", "--date", "2026-07-14")
+        check(r.returncode == 1 and "admit the redacted copy instead" in (r.stdout + r.stderr),
+              f"R3: admit-source on the original after STRIPPED must be refused: {r.stdout}{r.stderr}")
+
+        # ...but succeeds on the redacted copy, and the admitted artefact carries no PII verbatim.
+        r = run_cli("admit-source", "--zone", "field", redacted,
+                    "--type", "OBSERVATION", "--role", "ROLE-OPS-1", "--date", "2026-07-14",
+                    "--slug", "repro")
+        check(r.returncode == 0, f"R3: admit-source on the redacted copy should succeed: {r.stdout}{r.stderr}")
+        art = os.path.join(org, "field", "observations", "OBSERVATION-repro-20260714-1.yaml")
+        if check(os.path.isfile(art), "R3: the redacted-copy admission did not write a field artefact"):
+            body = open(art, encoding="utf-8").read()
+            check("jane.doe@personalmail.example" not in body and "555-123-4567" not in body,
+                  "R3: the admitted field artefact must not carry the blocked PII verbatim")
+
+        # R4 — a stale scan (content changed after scanning) is refused, not silently trusted.
+        with open(os.path.join(inbox, "stale.md"), "w", encoding="utf-8") as fh:
+            fh.write("Original content.\n")
+        run_cli("convert", os.path.join(inbox, "stale.md"))
+        stale_md = os.path.join(proc, "stale.md")
+        run_cli("privacy-scan", stale_md)
+        with open(stale_md, "a", encoding="utf-8") as fh:
+            fh.write("Changed after scanning.\n")
+        r = run_cli("admit-source", "--zone", "field", stale_md,
+                    "--type", "OBSERVATION", "--role", "ROLE-OPS-1", "--date", "2026-07-14")
+        check(r.returncode == 1 and "stale" in (r.stdout + r.stderr),
+              f"R4: a stale privacy-scan record must be refused, not trusted: {r.stdout}{r.stderr}")
+
+        # R5 — on_detection: reject blocks the whole document (REJECTED, no redacted copy);
+        # privacy-report.yaml records it and never leaks a fragment verbatim.
+        org2 = os.path.join(work, "org2")
+        os.makedirs(org2)
+        run_cli("scaffold-intake", org2)
+        with open(os.path.join(org2, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n'
+                     'ingest:\n  privacy_gate:\n    enabled: true\n    on_detection: reject\n')
+        with open(os.path.join(org2, "_intake", "inbox", "bad.md"), "w", encoding="utf-8") as fh:
+            fh.write(repro)
+        run_cli("convert", os.path.join(org2, "_intake", "inbox", "bad.md"))
+        bad_md = os.path.join(org2, "_intake", "processing", "bad.md")
+        r = run_cli("privacy-scan", bad_md)
+        check(r.returncode == 1 and "REJECTED" in r.stdout,
+              f"R5: on_detection: reject should produce REJECTED, not STRIPPED: {r.stdout}{r.stderr}")
+        check(not os.path.isfile(os.path.join(org2, "_intake", "processing", "bad.redacted.md")),
+              "R5: REJECTED must not write a redacted copy")
+        report_path = os.path.join(org2, "_intake", "processing", "privacy-report.yaml")
+        if check(os.path.isfile(report_path), "R5: privacy-report.yaml was not written"):
+            rep = yaml.safe_load(open(report_path, encoding="utf-8"))
+            check(rep.get("summary", {}).get("rejected") == 1,
+                  f"R5: privacy-report summary.rejected should be 1: {rep.get('summary')}")
+            scanned = rep.get("scanned", [])
+            check(any(s.get("outcome") == "REJECTED" for s in scanned), "R5: privacy-report did not record the REJECTED scan")
+            for s in scanned:
+                for frag in (s.get("blocked_fragments") or []):
+                    check("jane.doe@personalmail.example" not in frag.get("fragment_preview", ""),
+                          "R5: privacy-report fragment_preview must never carry verbatim PII")
+
+        # R6 — enabled: false is an explicit adopter opt-out: admit-source proceeds
+        # with NO privacy-scan record at all.
+        org3 = os.path.join(work, "org3")
+        os.makedirs(org3)
+        run_cli("scaffold-intake", org3)
+        with open(os.path.join(org3, "transitrix.yaml"), "w", encoding="utf-8") as fh:
+            fh.write('transitrix: 1\nmethodology_version: "0.5.0"\ncoverage_profile: full\n'
+                     'ingest:\n  privacy_gate:\n    enabled: false\n')
+        with open(os.path.join(org3, "_intake", "inbox", "off.md"), "w", encoding="utf-8") as fh:
+            fh.write("Note.\n")
+        run_cli("convert", os.path.join(org3, "_intake", "inbox", "off.md"))
+        off_md = os.path.join(org3, "_intake", "processing", "off.md")
+        r = run_cli("admit-source", "--zone", "field", off_md,
+                    "--type", "OBSERVATION", "--role", "ROLE-OPS-1", "--date", "2026-07-14")
+        check(r.returncode == 0,
+              f"R6: enabled:false must let admit-source proceed without a privacy-scan record: {r.stdout}{r.stderr}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
 part_a_bundle()
 part_b_pipeline()
 part_c_ig5()
@@ -1279,6 +1425,7 @@ part_n_entity_resolution()
 part_o_unresolved_extensions()
 part_p_preset_version_currency()
 part_q_origin_classification()
+part_r_privacy_gate()
 
 if _failures:
     print("FAIL - Transitrix Ingest skill integrity:")


### PR DESCRIPTION
## Summary
- The ingest skill's `SKILL.md` and the adopter role-guide already documented a fail-closed `privacy-scan` gate ahead of `admit-source`, but the CLI had no such subcommand — `admit-source` admitted personal data verbatim, unchecked.
- Adds `privacy-scan <processing/file.md>` to `@transitrix/ingest-cli`: six deterministic PII/medical detectors (national ID, DOB, medical vocabulary, contact PII beyond a narrow work-contact allowlist, financial/card numbers, passport-shaped tokens), `CLEAN`/`STRIPPED`/`REJECTED`/`ERROR` outcomes, a `STRIPPED` run writes a redacted copy, and a per-run `privacy-report.yaml` (fragment previews only, never verbatim PII).
- `admit-source --zone field` now refuses to admit a document with no passing, content-matching privacy-scan record — refusal is the default (fail-closed), controllable only via an explicit `ingest.privacy_gate.enabled: false` in `transitrix.yaml`. The codex zone (laws/regulations) is unaffected — it was never in scope for this gate.
- Updates the CLI README and skill README "status" banners, which previously omitted `privacy-scan` from the list of implemented commands.

## Test plan
- [x] `python transitrix/skills/ingest/tests/test_ingest_integrity.py` — all parts pass, including new Part R covering CLEAN/STRIPPED/REJECTED outcomes, admit-source refusing an unscanned/stale/un-redacted document, the reproduction scenario (name + email + phone caught, not admitted verbatim), and the `enabled: false` opt-out.
- [x] `node scripts/check-notations.mjs` — clean.
- [x] Manually reproduced the original repro steps end-to-end (scaffold-intake → convert → privacy-scan → admit-source) and confirmed the document is no longer admitted verbatim.