### PR TITLE
feat(operations): add Feedback Record convention, wire escalate-methodology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ This adds a `Signed-off-by: Your Name <you@example.com>` trailer to the commit.
 - Pull requests and issues are the primary channels.
 - For broader strategic discussion, use Discussions on the GitHub repository (when enabled).
 - For other enquiries — [hello@transitrix.com](mailto:hello@transitrix.com).
+- An adopter running the Team Operations convention (`method/02-team-operations.md`) raises a methodology-directed finding in their own repo's `operations/feedback.md`, not as a GitHub issue here. Sending an entry on to the project is opt-in and manual — the same [hello@transitrix.com](mailto:hello@transitrix.com) address above.
 - Keep tone professional. The project is a working tool, not a debate club.
 
 ## Code of conduct

--- a/method/02-team-operations.md
+++ b/method/02-team-operations.md
@@ -1,10 +1,10 @@
 ---
 title: Team Operations — operational layer convention
 status: draft
-last_reviewed: 2026-06-03
+last_reviewed: 2026-07-27
 audience: public
 license: MIT
-tags: [transitrix, methodology, operations, adr, work-items]
+tags: [transitrix, methodology, operations, adr, work-items, feedback]
 ---
 
 # Team Operations — operational layer convention
@@ -17,7 +17,7 @@ The Transitrix model (`canon/`, `field/`, `codex/`) describes the **enterprise**
 
 A team applying Transitrix also accumulates a second, smaller body of artefacts that describe how **the team itself** is operating: the choices it has made about its own setup, and the units of work it currently has in flight. Those are statements *about the team*.
 
-This is the **Team Operations** convention. It defines a folder, its file shapes — two **record** shapes (ADR, WI) and a machine- or human-written **operational config/state** area — and one linking rule. Nothing more.
+This is the **Team Operations** convention. It defines a folder, its file shapes — three **record** shapes (ADR, WI, Feedback) and a machine- or human-written **operational config/state** area — and one linking rule. Nothing more.
 
 **Hard distinctions to preserve:**
 
@@ -35,6 +35,7 @@ The adopter instantiates the convention at:
 ```
 organizations/<org>/operations/
 ├── README.md                      # Local rules (~1 screen)
+├── feedback.md                    # Upstream feedback register (FB-… entries, one file; §3.3)
 ├── decisions/                     # Architecture decision records (ADR — human- or agent-authored; §3.1.1)
 │   ├── ADR-0001-<slug>.md
 │   ├── ADR-0002-<slug>.md
@@ -53,7 +54,7 @@ organizations/<org>/operations/
 
 ## 3. The file shapes
 
-The convention provides two **record** shapes (§3.1 ADR, §3.2 WI) and an operational **config/state** area (§3.3) for structured data a tool or process reads and writes.
+The convention provides three **record** shapes (§3.1 ADR, §3.2 WI, §3.3 Feedback) and an operational **config/state** area (§3.4) for structured data a tool or process reads and writes.
 
 ### 3.1 Architecture Decision Record (`ADR-…`)
 
@@ -127,32 +128,75 @@ relates_to:                  # optional — model IDs the work concerns
 
 Body — free-form Markdown. A short outcome statement and a checklist is usually enough; substantive discussion that leads to a course change is captured as an ADR, not as a long Work Item description.
 
-### 3.3 Operational config and state (`config/`, `state/`)
+### 3.3 Feedback Record (`FB-…`)
 
-A third area of `operations/`, distinct in *kind* from the ADR/WI records above: **structured operational data** a tool or process reads and writes, not human-authored prose. It has two halves — the **config/state split**:
+A short record of a **methodology-directed finding** raised from this repo — the landing place for `FINDINGS.md`'s `escalate-methodology` route (see the adopter role guides: `AGENTS.md`, `ANALYST.md`, `VALIDATOR.md`, `INGEST.md`). A finding here is about the notation or the spec itself (a gap, a friction, a suggestion), never about the modelled enterprise — a problem with the model is an `ASSESSMENT` in canon, per the hard distinction in §1.
+
+Deliberately **not** one-file-per-record like ADR/WI: a single file, `operations/feedback.md`, holds a checklist index at the top and one short block per entry below it. The checkbox means "closed" — same convention as the ADR/WI index would use, adapted to one file instead of a folder.
+
+```markdown
+## Register
+- [x] FB-0001 — no relation kind connects GOAL to CAPABILITY — closed (answered upstream)
+- [ ] FB-0002 — ID grammar rejects non-Latin element names — sent-upstream
+
+---
+### FB-0002
+type: notation-gap
+methodology_version: "2.0.0"
+raised_by: modeler
+date: "2026-07-27"
+status: sent-upstream
+upstream: sent 2026-07-27
+observation: <generic limitation, one paragraph>
+proposed: <what the team believes the fix would be — optional>
+```
+
+Fields:
+
+- `id` — `FB-NNNN`, carried by the entry's `###` heading (not repeated as a YAML key inside the block). Four-digit zero-padded, monotonically increasing within the single `operations/feedback.md` file — there is no per-record folder to enumerate, unlike ADR/WI (see §5).
+- `type` — `notation-gap` | `tooling-friction` | `doc-gap` | `model-suggestion` (§6.4).
+- `methodology_version` — **required**. A finding is always raised against a specific methodology version; record the one the repo's `transitrix.yaml` pins at the time.
+- `raised_by` — the role that raised it: `Ingest` | `Modeler` | `Analyst` | `Validator`, per `FINDINGS.md` §3.
+- `date` — ISO date the entry was written.
+- `status` — `open` | `triaged` | `resolved-locally` | `sent-upstream` | `answered` | `closed` | `wont-fix` (§6.5).
+- `upstream` — `not-sent` | `sent <date>` | `answered <date>` (§6.6).
+- `observation` — what was seen, in plain language, stripped of adopter specifics (see below).
+- `proposed` — what the team believes the fix would be. Optional.
+
+**Anonymised at authoring time, not at export.** An entry is written as a *generic limitation only* — no model content, no element IDs, no organisation-identifying detail — the same scrub discipline `FINDINGS.md` §2 step 3 already requires for methodology-directed findings, applied at the moment of writing rather than at the moment of sending. This is what makes the file safe to read, quote, or forward as-is; there is nothing left to redact later.
+
+**The record stays in the adopter's own repository.** Nothing in this convention writes to, opens an issue on, or transmits anything to `transitrix/methodology` or any other host. Submission upstream is opt-in and manual — the convention recommends `hello@transitrix.com` (see `CONTRIBUTING.md` §Communication) and stops there; a human decides whether an entry actually leaves this repo, and the `upstream:` field records that decision once made.
+
+An authoring skill, `/transitrix:feedback`, is the intended path for composing an entry, allocating the next `FB-NNNN`, running the scrub gate, and updating `status`/`upstream` on later invocations — same plugin as the `adr` skill (`transitrix/skills/adr`). Until it lands, an entry may be written by hand, following the field set and the scrub discipline above.
+
+### 3.4 Operational config and state (`config/`, `state/`)
+
+A fourth area of `operations/`, distinct in *kind* from the ADR/WI/Feedback records above: **structured operational data** a tool or process reads and writes, not human-authored prose. It has two halves — the **config/state split**:
 
 - **Config — `operations/config/<domain>/…` — human-authored operational *settings*.** Durable, intentional choices about how a tool or process the team runs is configured (cadences, toggles, the curated lists a team maintains to drive an operating activity). Hand-edited and reviewed like any other committed file. Format is the tool's own structured data (YAML / JSON).
 - **State — `operations/state/<domain>/…` — machine-written operational *state*.** The current operational data a tool maintains **across runs** — caches, cursors, last-seen change signals, run bookkeeping. Written by tooling, not hand-edited. It is **committed** (so it survives a fresh clone / CI checkout — the reason it cannot live in the transient `_intake/` workspace), **churny** (frequent, expected diffs), and **disposable / correctness-non-critical**: a consumer MUST tolerate it being absent or stale and regenerate or degrade gracefully. It is never a source of truth about the enterprise.
 
 `<domain>` is the tool or process that owns the data (e.g. `reg-intel`). *Worked example:* the reg-intel change-signal gate persists its last-seen `ETag` / `Last-Modified` / version values at `operations/state/reg-intel/signal-cache.json` — committed so a scheduled scan in a fresh checkout can cheaply tell whether a source moved, yet never part of the model and safe to delete (the gate then simply degrades to "always fetch").
 
-Like the rest of `operations/`, both areas sit **outside** the zone model and the canonical ID grammar, are **not** walked by the doc-lint (`scripts/check-notations.mjs`), and carry no admission gate. Unlike ADR/WI they carry no `id:` and no status vocabulary — they are addressed by **path**, and the *internal* shape of each file is owned by the tool that writes it, not by this convention. This convention fixes only **where** such data lives (`config/` vs `state/`) and the contract that `state/` is committed-but-disposable; a tool-specific config/state split conforms to this home rather than inventing its own location.
+Like the rest of `operations/`, both areas sit **outside** the zone model and the canonical ID grammar, are **not** walked by the doc-lint (`scripts/check-notations.mjs`), and carry no admission gate. Unlike ADR/WI/Feedback they carry no `id:` and no status vocabulary — they are addressed by **path**, and the *internal* shape of each file is owned by the tool that writes it, not by this convention. This convention fixes only **where** such data lives (`config/` vs `state/`) and the contract that `state/` is committed-but-disposable; a tool-specific config/state split conforms to this home rather than inventing its own location.
 
 ## 4. The linking rule — `relates_to:`
 
-Both file shapes carry an optional `relates_to:` list of **model entity IDs** the artefact concerns — Goals, Capabilities, Activities, Changes, Roles, and so on, drawn from the canonical TYPE registry in [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md) §3.
+ADR and WI carry an optional `relates_to:` list of **model entity IDs** the artefact concerns — Goals, Capabilities, Activities, Changes, Roles, and so on, drawn from the canonical TYPE registry in [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md) §3.
 
 `relates_to:` is the only link from operations into the model. The model does **not** link back: nothing inside `canon/` references an ADR or a Work Item, by design. The model describes the enterprise; the operations layer describes the team. The dependency is one-directional — operations → model.
 
 If a Work Item or ADR references a model ID that does not resolve (typo, deleted element, future plan), the convention treats it as a warning, not an error. The canonical doc-lint (`scripts/check-notations.mjs`) does not validate `operations/` — it is outside the linter's scope, on purpose.
 
+**Feedback Records (§3.3) do not carry `relates_to:`.** The whole point of the shape is that it contains no model-identifying detail — an entry citing an element ID is refused at authoring time (the scrub gate), not merely discouraged. A Feedback Record is about the notation or the spec, never about a specific model element, so there is nothing for it to link to.
+
 ## 5. IDs — distinct namespace from the model
 
-`ADR-` and `WI-` are deliberately **outside** the canonical ID grammar. The TYPE registry in [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md) governs model IDs only; `ADR-…` and `WI-…` carry zero-padded four-digit sequences (`ADR-0001`, `WI-0042`) and are unique within their own folder, not globally. They cannot be cross-referenced from inside the model.
+`ADR-`, `WI-`, and `FB-` are deliberately **outside** the canonical ID grammar. The TYPE registry in [`notations/IDS_AND_REFERENCES.md`](../notations/IDS_AND_REFERENCES.md) governs model IDs only; `ADR-…`, `WI-…`, and `FB-…` carry zero-padded four-digit sequences (`ADR-0001`, `WI-0042`, `FB-0002`) and are unique within their own folder (ADR/WI) or their own file (Feedback — see §3.3), not globally. They cannot be cross-referenced from inside the model.
 
-This is intentional: the team-operations namespace is a different *kind* of identifier than a model entity ID, and keeping them mechanically distinguishable (four-digit padded sequence with no domain segment) prevents accidental collisions. (When records from several repos are aggregated, the central Architecture Decision Log namespaces them as `<repo-slug>/ADR-NNNN` — the local id is unchanged; see [`method/03-architecture-decision-log.md`](03-architecture-decision-log.md) §4.)
+This is intentional: the team-operations namespace is a different *kind* of identifier than a model entity ID, and keeping them mechanically distinguishable (four-digit padded sequence with no domain segment) prevents accidental collisions. (When records from several repos are aggregated, the central Architecture Decision Log namespaces them as `<repo-slug>/ADR-NNNN` — the local id is unchanged; see [`method/03-architecture-decision-log.md`](03-architecture-decision-log.md) §4. Feedback Records are not aggregated across repos — each repo's register is independent, and there is no `FB-` equivalent of the central Architecture Decision Log.)
 
-Operational config/state files (§3.3) carry **no** identifier at all — they are addressed by **path** (`operations/state/<domain>/<name>`), not by a sequenced `ADR-`/`WI-` id and not by a model ID. They are never cross-referenced from inside the model.
+Operational config/state files (§3.4) carry **no** identifier at all — they are addressed by **path** (`operations/state/<domain>/<name>`), not by a sequenced `ADR-`/`WI-`/`FB-` id and not by a model ID. They are never cross-referenced from inside the model.
 
 ## 6. Status vocabularies
 
@@ -181,13 +225,43 @@ Operational config/state files (§3.3) carry **no** identifier at all — they a
 | `done` | The work is complete; outcome is recorded in the body. |
 | `closed` | No longer tracked — done-and-archived, withdrawn, or a "won't do". |
 
+### 6.4 Feedback `type:`
+
+| Value | Meaning |
+|---|---|
+| `notation-gap` | The notation or schema cannot express something the team needed to model. |
+| `tooling-friction` | The methodology's tooling (a skill, a validator, a CLI command) made the task harder than it should have been. |
+| `doc-gap` | A spec or guide is silent, ambiguous, or wrong about something the team needed to know. |
+| `model-suggestion` | Canon is valid and expressible as-is, but the methodology could guide adopters toward a better shape. |
+
+### 6.5 Feedback `status:`
+
+| Value | Meaning |
+|---|---|
+| `open` | Registered; not yet triaged. |
+| `triaged` | Reviewed locally; the team has decided how to route it. |
+| `resolved-locally` | Addressed within the adopter's own repo or practice; not going upstream. |
+| `sent-upstream` | Sent to the methodology maintainer. |
+| `answered` | The maintainer responded. |
+| `closed` | No longer tracked — the checkbox flips to `[x]` here or at `wont-fix`. |
+| `wont-fix` | Reviewed and deliberately not pursued. |
+
+### 6.6 Feedback `upstream:`
+
+| Value | Meaning |
+|---|---|
+| `not-sent` | Default — nothing has been sent yet. |
+| `sent <date>` | Sent to `hello@transitrix.com` on `<date>`. |
+| `answered <date>` | The maintainer replied on `<date>`. |
+
 ## 7. The 1-screen rules doc — `operations/README.md`
 
 Each adopter writes a short local README inside `operations/` covering:
 
-- The file shapes the convention provides (the ADR and WI records; the `config/`+`state/` operational-data area) — point at this canonical doc rather than restating the schema.
+- The file shapes the convention provides (the ADR, WI, and Feedback records; the `config/`+`state/` operational-data area) — point at this canonical doc rather than restating the schema.
 - The team's local **decision-making process** — when an ADR is required, who signs off, where supersedes are recorded.
 - The team's local **work-item flow** — how items are opened, who reviews, how items move through `proposed → in_progress → done`.
+- The team's local **feedback-routing process** — when a Feedback Record is written, whether the team reviews before marking `sent-upstream`, who owns actually sending it.
 
 The local README is the team's adaptation; this canonical doc is the convention.
 
@@ -202,6 +276,8 @@ Two starter templates live under `.templates/operations/` in the adopter reposit
 
 Copy a template into the matching subfolder, fill in the front-matter and body, commit.
 
+Feedback carries no separate per-record template — it is one growing file, not one file per entry. The onboarding skill (`transitrix/skills/onboard`) scaffolds `operations/feedback.md` with its empty header directly; an entry is appended to it (by hand, or by the `/transitrix:feedback` skill once it lands) following the shape in §3.3.
+
 ## 9. What this convention is not (extended)
 
 To keep the layer minimal and prevent it from drifting into a parallel process system:
@@ -209,16 +285,19 @@ To keep the layer minimal and prevent it from drifting into a parallel process s
 - **Not a ticket tracker.** Work Items are short, current, and few. A team that needs grooming, sprints, burn-down, and prioritisation has outgrown this convention and should use its existing tracker.
 - **Not a forum.** Long discussions belong in the PR that proposes the ADR, not in the ADR body.
 - **Not a versioned spec.** ADRs are decisions, not contracts; they do not carry `valid_from`/`valid_to` and they are not admitted to canon.
-- **Not a Transitrix Studio-rendered notation.** Operations files are plain Markdown — no rendering pipeline, no notation header, no extension convention. (The §3.3 config/state area is the one place `operations/` holds structured data rather than Markdown — but it is still un-rendered and un-linted.)
-- **Not a database of record.** `operations/state/` (§3.3) is a tool's committed working cache, not a source of truth. Anything correctness-critical belongs in the model or must be re-derivable; losing a state file must never lose model truth.
+- **Not a Transitrix Studio-rendered notation.** Operations files are plain Markdown — no rendering pipeline, no notation header, no extension convention. (The §3.4 config/state area is the one place `operations/` holds structured data rather than Markdown — but it is still un-rendered and un-linted.)
+- **Not a database of record.** `operations/state/` (§3.4) is a tool's committed working cache, not a source of truth. Anything correctness-critical belongs in the model or must be re-derivable; losing a state file must never lose model truth.
+- **Not a support channel.** A Feedback Record (§3.3) documents a generic limitation for the methodology maintainer, not adopter-specific troubleshooting or a request for help using the tool — that goes through the project's own support surfaces (`CONTRIBUTING.md`), same as any other user.
 
 ## 10. References
 
 - Multi-repo aggregation + agent-authorship: [`method/03-architecture-decision-log.md`](03-architecture-decision-log.md).
-- Worked example: [`operations/`](https://github.com/transitrix/acme-corp/tree/main/operations/) in the acme-corp reference repo.
+- Worked example: [`operations/`](https://github.com/transitrix/acme-corp/tree/main/operations/) in the acme-corp reference repo, including a filled [`operations/feedback.md`](https://github.com/transitrix/acme-corp/blob/main/operations/feedback.md).
 - Methodology overview: [`method/01-methodology.md`](01-methodology.md) §4 — repository structure.
 - Architectural findings about the enterprise are modelled as `ASSESSMENT` (the former model-side `issues` notation was retired, 2026-06-07).
 - Distinct from the canon zones: [`notations/CONTRACT.md`](../notations/CONTRACT.md) §5.
+- The propose → route → scrub protocol a Feedback Record's `observation` must satisfy before it is written: `FINDINGS.md` (adopter role-guide shared protocol, scaffolded by `transitrix/skills/onboard`) §2.
+- The opt-in upstream submission channel: [`CONTRIBUTING.md`](../CONTRIBUTING.md) §Communication.
 
 ---
 

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -133,9 +133,10 @@ After the directory tree exists, copy the canonical root files from the skill bu
 - `templates/FINDINGS.md` → `<repo-root>/FINDINGS.md` — the shared **raising a finding** protocol (propose → route → scrub) referenced by all four role guides above. Cross-cutting, not a role — always scaffolded alongside `AGENTS.md`; never activated on its own.
 - **Claude Code pointer — default, not optional.** Write `<repo-root>/CLAUDE.md` with a single line: *"Read `AGENTS.md` in the repo root and follow it."* Do this **unconditionally** when the current assistant is Claude Code — don't ask first, don't gate it behind a user request. `CLAUDE.md` at an adopter repo root is free (no collision) — unlike the methodology canon repo's own root, where the name is reserved for a private file.
 
-Additionally, write one generated file (no template — author it inline):
+Additionally, write these generated files inline (no template):
 
 - `<repo-root>/README.md` — a minimal org stub. Three sections: (1) one-paragraph intro naming the repo purpose and linking to `github.com/transitrix/methodology`; (2) "Getting started" pointing newcomers at `AGENTS.md` and the `/transitrix:onboard` skill; (3) "Tooling" recommending the two VS Code extensions — **Transitrix Studio** (`transitrix.transitrix-studio`, VS Code Marketplace) for live Transitrix notation preview (including `.puml` files — no separate PlantUML extension needed), and **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`, VS Code Marketplace and Open VSX) for Mermaid diagram preview in Markdown files. Leave `ADOPTER-FILL-ME` placeholders for org name, purpose, and team.
+- `<repo-root>/operations/feedback.md` — the empty upstream feedback register (`method/02-team-operations.md` §3.3), the landing place `FINDINGS.md`'s `escalate-methodology` route points at. A `# Feedback register` heading, a one-line pointer at `method/02-team-operations.md` §3.3 and the opt-in `hello@transitrix.com` submission route, and an empty `## Register` section — no entries; the first `FB-0001` is added the first time a finding is actually raised, not at scaffold time. Write this **unconditionally**, alongside the other root files, so the register exists before anyone needs it — same treatment as `FINDINGS.md` itself, not a lazily-created folder like `operations/decisions/` (which the `adr` skill scaffolds on first use instead).
 
 **Do not duplicate the agent guide itself outside `AGENTS.md`.** The canonical guide for every assistant is `AGENTS.md`; every per-tool file is a pointer, never a second copy of the guidance. Claude Code gets its `CLAUDE.md` pointer by default (bullet above, unconditional). For any other tool that doesn't read `AGENTS.md` natively (e.g. Cursor → `.cursor/rules/`), drop the equivalent one-line pointer file in that tool's location: *"Read `AGENTS.md` in the repo root and follow it."* See `AGENTS.md` §"Using this guide with your assistant".
 
@@ -379,6 +380,7 @@ Each notation template carries the canonical `notation:` and `spec_version:` hea
 | Shared protocol — raising a finding | `templates/FINDINGS.md` | `<repo-root>/FINDINGS.md` |
 | GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
 | VS Code extension recommendations | `templates/extensions.json` | `<repo-root>/.vscode/extensions.json` |
+| Upstream feedback register (empty) | *authored inline, no template* | `<repo-root>/operations/feedback.md` |
 
 The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI workflow (`.github/workflows/architecture-validate.yaml`) are **not** bundled templates — they are fetched from the methodology canon at scaffold time. See "Scaffold validation tooling + CI" in Step 2.
 

--- a/transitrix/skills/onboard/templates/FINDINGS.md
+++ b/transitrix/skills/onboard/templates/FINDINGS.md
@@ -25,8 +25,8 @@ Two outcomes, always:
 2. **Route.** The finding goes to a human, who decides:
    - **Apply the fix** — author or approve the change into `canon/`, through the same gating as any other change (`AGENTS.md` §11).
    - **Escalate to the data owner or architect** — when the fix needs organisational judgement the raising role can't supply.
-   - **Escalate upstream to the methodology** — when the finding is a notation or spec limitation, not a data problem (e.g. "there is no relation kind connecting X to Y").
-3. **Scrub (mandatory for methodology-directed findings).** A finding routed upstream to `transitrix/methodology` is stripped of adopter specifics before it leaves this repo — a generic limitation only, never client model content. Same discipline as "publish pattern, not client instance" and the real-names rule, applied to this feedback channel too.
+   - **Escalate upstream to the methodology** — when the finding is a notation or spec limitation, not a data problem (e.g. "there is no relation kind connecting X to Y"). This lands as an entry in `operations/feedback.md` (`method/02-team-operations.md` §3.3) — the repo's own register of methodology-directed findings. Sending it beyond this repo is a separate, opt-in step (§3 below); routing here only writes the local record.
+3. **Scrub (mandatory for methodology-directed findings).** An entry written into `operations/feedback.md` is stripped of adopter specifics at the moment of writing — a generic limitation only, never client model content. Same discipline as "publish pattern, not client instance" and the real-names rule, applied to this feedback channel too. This is what makes the register safe to read, quote, or forward as-is — there is nothing left to redact when the team later decides to send an entry to `hello@transitrix.com`.
 
 No role auto-applies its own proposed fill. Raising a finding is never itself a write to `canon/` — the human act of applying or escalating is what moves it.
 
@@ -46,7 +46,7 @@ routing: apply | escalate-owner | escalate-methodology
 
 - `type` — `data-error` (canon disagrees with itself or its source), `model-suggestion` (canon is valid but could model something better), `methodology-feedback` (a canon-confirmed gap in the notation itself, not fixable by editing data).
 - `confidence` — the two-tier signal from §2 step 1. Not a numeric score; a role either has structural certainty or it doesn't.
-- `routing` — the role's recommendation; the human makes the final call regardless.
+- `routing` — the role's recommendation; the human makes the final call regardless. `escalate-methodology` is written into `operations/feedback.md` as a Feedback Record (`method/02-team-operations.md` §3.3) — a different, fixed field set from this raise-time shape, suited to a standalone register entry rather than an in-flow finding.
 
 This shape generalises two things that already exist in the methodology: the Ingest skill's `review-queue.schema.json` (candidates carry `extraction_confidence` and land in a human-reviewed queue) and the Validator's structured severity report (`VALIDATOR.md` §5, error/warning/pass). A role with an existing structured output surfaces a finding inline in that output rather than in a separate file — see §4.
 


### PR DESCRIPTION
## Summary
- Adds `operations/feedback.md` as a third Team Operations record shape (alongside ADR/WI), documented in `method/02-team-operations.md` §3.3 — single-file checklist-index register, anonymised at authoring time, never transmitted automatically.
- Wires `FINDINGS.md`'s `escalate-methodology` route (skill template copy) at this destination.
- Onboarding scaffolds an empty, correctly-headered `operations/feedback.md` unconditionally alongside `FINDINGS.md`.
- `CONTRIBUTING.md` §Communication names the path and the opt-in `hello@transitrix.com` route.

The `/transitrix:feedback` authoring skill is a separate task under the same epic — out of scope here.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] `python transitrix/skills/onboard/tests/test_skill_integrity.py` — PASS
- [x] Manually re-read every edited file's tail for truncation