### PR TITLE
feat(notations): domain-package mechanism — two-dimensional coverage_profile

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -93,6 +93,8 @@ A modelled organisation accumulates three kinds of knowledge with different trus
 
 **Data is not migrated between zones.** Each zone has its own admission gate (§6); an artefact admitted to one zone is never moved to another. A Canon record MAY *cite* the Field material that informed it via `derived_from:` (§6) — that citation is the link, not a migration. Re-deriving Canon from Field yields a *new* Canon artefact; the Field artefact stays where it is.
 
+**Packages are not a fourth zone.** An optional domain package ([`PACKAGES.md`](PACKAGES.md)) is a top-level folder sitting alongside `canon/`, `field/`, `codex/`, but it carries none of the zone trust contracts above — it is self-contained, removable, and may only reference into a zone, never be referenced from one.
+
 ---
 
 ## 6. Admission record

--- a/notations/COVERAGE_PROFILES.md
+++ b/notations/COVERAGE_PROFILES.md
@@ -14,6 +14,8 @@ A repository without a profile defaults to **`full`** — the entire vocabulary 
 
 The shape of the profile, the closure rule, and the document-validation behaviour below were settled by methodology canon on 2026-05-31.
 
+This document bounds the **depth** of the *core* vocabulary only. A repository may separately opt into an **optional domain package** — a bounded, removable extension that sits alongside the core registry rather than inside it. That second, orthogonal axis is defined in [`PACKAGES.md`](PACKAGES.md); it does not change anything below.
+
 ---
 
 ## 1. Where the profile lives
@@ -327,6 +329,7 @@ The Coverage Profile is the canonical realisation of the *Coverage Variants* exp
 ## 12. References
 
 - [`MANIFEST.md`](MANIFEST.md) — the `transitrix.yaml` manifest envelope (where `coverage_profile:` lives).
+- [`PACKAGES.md`](PACKAGES.md) — the orthogonal breadth axis (optional domain packages), not bounded by this document.
 - [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §3 — TYPE registry the profile draws from.
 - [`ELEMENT_PRIMITIVES.md`](ELEMENT_PRIMITIVES.md) §6 — per-TYPE layer placement (which layer each TYPE belongs to).
 - [`elements/17-relations.md`](elements/17-relations.md) §3 — relation `type` enum the profile draws from.

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -33,6 +33,7 @@ methodology_version: "2.0.0"        # the methodology release this repo conforms
 notations: [dgca, goals, action, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md
+packages: [reqif]                   # optional — see PACKAGES.md
 confidence_decay:                   # optional — per-TYPE freshness decay; see CONTRACT.md §11.3
   defaults: { fresh_days: 180, stale_days: 730, floor: 0.3 }
 operating_parameters:               # optional — org-wide operating defaults
@@ -46,6 +47,7 @@ operating_parameters:               # optional — org-wide operating defaults
 | `notations` | yes | list | Short names of the notations the repository uses, from the catalogue in [README.md](README.md) — plus `codex` for the codex zone (see [14-codex.md](elements/14-codex.md)). |
 | `zones` | yes | list | Which zones the repository maintains — any subset of `canon`, `field`, `codex`. A repo MAY start canon-only and add `field` / `codex` later. |
 | `coverage_profile` | no | string \| map | Which slice of the methodology's vocabulary is in scope for this repo. Short form: a shipped preset name (`minimal` / `core` / `full`). Long form: a custom profile that extends a preset. Defaults to `full` when omitted. Full schema, presets, closure rule, and validation in [COVERAGE_PROFILES.md](COVERAGE_PROFILES.md). |
+| `packages` | no | list | Zero or more optional domain packages layered on top of the core vocabulary — orthogonal to `coverage_profile` (depth) and to each other. Absent or empty ⇒ no package active, with no warning. Full mechanism, reversibility contract, and validation in [PACKAGES.md](PACKAGES.md). |
 | `confidence_decay` | no | map | Per-element-TYPE freshness-decay parameters (`fresh_days`, `stale_days`, `floor`) used by confidence scoring. A `defaults` sub-map applies to any TYPE not listed under `by_type`. Defined in [CONTRACT.md](CONTRACT.md) §11.3. Omitted ⇒ the §11.3 defaults apply. |
 | `operating_parameters` | no | map | Org-wide defaults for automated operating activities. v1 carries `default_scan_frequency` (ISO 8601 duration) — the fallback scan cadence for `REGISTRY` rows that declare no `scan_frequency` and whose registry sets no `default_scan_frequency` ([ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §7.19). Additive — further operating defaults may be added here as automated activities are modelled. |
 
@@ -59,4 +61,5 @@ No validator enforces the manifest yet; it is declarative. Tooling MAY read it t
 - Notation catalogue (short names): [README.md](README.md).
 - Codex zone: [14-codex.md](elements/14-codex.md).
 - Coverage Profile (the `coverage_profile:` field): [COVERAGE_PROFILES.md](COVERAGE_PROFILES.md).
+- Domain Packages (the `packages:` field): [PACKAGES.md](PACKAGES.md).
 - Confidence and freshness (the `confidence_decay:` field): [CONTRACT.md](CONTRACT.md) §11.

--- a/notations/PACKAGES.md
+++ b/notations/PACKAGES.md
@@ -1,0 +1,137 @@
+---
+title: "Domain Packages — optional, removable vocabulary extensions"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-07-28"
+status: "draft"
+---
+
+# Domain Packages
+
+**Scope:** The mechanism an adopter uses to add an **optional, removable domain package** on top of the core vocabulary — a bounded extension shaped for one domain (e.g. a requirements-interchange layer, a compliance regime) that ships its own object types, its own validator, and its own removal procedure, without touching core.
+
+A repository that declares no packages is unaffected by this document: no additional TYPE is admitted, no additional validator rule runs, nothing renders. Packages are strictly additive to a repository that opts in.
+
+---
+
+## 1. Where a package is declared
+
+A package is declared at the repository root in `transitrix.yaml` under the `packages` key — a flat list, sibling to `coverage_profile`, not nested inside it.
+
+```yaml
+transitrix: 1
+methodology_version: "2.0.0"
+notations: [dgca, goals, activities, capability-map]
+zones: [canon, field]
+coverage_profile: core
+packages: [reqif]              # optional — zero or more shipped package names
+```
+
+`packages` absent, or an empty list, means no package is active — equivalent and interchangeable.
+
+---
+
+## 2. Two dimensions, not one
+
+`coverage_profile` (depth) and `packages` (breadth) bound the vocabulary along two independent axes:
+
+| Axis | Question it answers | Governed by |
+|---|---|---|
+| **Depth** — `coverage_profile` | How much of the *core* registry is in scope? | [`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) — unchanged by this document. |
+| **Breadth** — `packages` | Which *optional domain extensions*, if any, sit alongside the core? | This document. |
+
+The two axes are orthogonal. A repository on `coverage_profile: minimal` may still declare `packages: [reqif]` — a package does not require `core` or `full`, and does not widen or narrow the core coverage profile. Conversely, `coverage_profile: full` implies nothing about which packages are active; `full` bounds the core registry, not the package list.
+
+---
+
+## 3. What a package is
+
+A package is:
+
+- **A top-level folder** in the adopter repository, at the same level as `canon/`, `field/`, `codex/` — e.g. `reqif/` — named after the package's declared name in `packages:`.
+- **Not a zone.** [`CONTRACT.md`](CONTRACT.md) §5's zone model (`canon` / `field` / `codex`, each with its own trust contract) does not extend to packages. A package is a fourth kind of thing: optional, self-contained, and removable in a way no zone is (data is never migrated between zones, but a package folder can simply be deleted).
+- **Self-describing.** A package ships its own spec document (§6), its own object types, and its own validator/tooling. Core specs, core validators, and core tooling carry zero package-specific logic (§4.2).
+- **Shipped by the methodology**, the same way a coverage-profile preset is shipped ([`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) §3). An adopter cannot declare an arbitrary package name in `packages:` — only a name the pinned `methodology_version` ships (§7).
+
+---
+
+## 4. The reversibility contract
+
+A package must be removable — delete the folder, remove the name from `packages:`, and the repository is valid with zero trace of the package having existed. Three rules make this true.
+
+### 4.1 References point one way only
+
+A package object may reference a core element by ID (a ReqIF `SpecObject` citing a core `REQUIREMENT`, for instance). **No core element, view, admission record, or tool output may reference a package object.** The dependency graph is a DAG with a single direction: package → canon, never canon → package.
+
+This is not a new validation rule — it falls out of two things the core registry already guarantees:
+
+- The core TYPE registry ([`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §3.1) is closed. A package's own object types and ID grammar MUST be visibly disjoint from it — a package identifier must never be shaped so that it could be mistaken for a core `TYPE-NAME-<integer>` ID.
+- Existing referential-integrity checking already requires every cross-reference inside `canon/` to resolve to an admitted object of a known core TYPE. A reference to a package object cannot resolve (package objects are outside the core registry by construction), so it is already rejected by the checks a core validator runs today — no package-aware code is needed in core tooling to catch this.
+
+### 4.2 Package validator rules live in the package
+
+No package-specific check is ever wired into a core validator (`packages/ingest-cli`, `scripts/check-notations.mjs`, or Studio's validator registry). A package's own tooling runs only when the package is declared; when it is not, that tooling is simply never invoked — there is no flag to check, because there is no code path that knows the package exists.
+
+This is what makes absence silent (§5): a core validator that has never heard of a package cannot warn about it.
+
+### 4.3 Removal is tested, not just documented
+
+A package's own spec document (§6) states its removal procedure. The baseline procedure — delete the package folder, remove its name from `packages:` — is the same for every package; a package MAY add package-specific steps (e.g. clearing a generated cache) but MUST NOT require any change to a file outside its own folder plus the one line in `transitrix.yaml`. The procedure is demonstrated as a test against a worked instance of the package, not asserted in prose alone.
+
+---
+
+## 5. Absence is silence
+
+A repository whose `packages:` list omits a given package name behaves, for that package, exactly as if the package did not exist:
+
+- No object type the package defines is admitted anywhere in `canon/`, `field/`, or `codex/` (§4.1 — there is nowhere for such a reference to resolve).
+- No package validator rule runs (§4.2).
+- No view renders package content — a package's own views are defined and shipped inside the package; core view notations know nothing of them.
+- **No warning is emitted.** An undeclared package is not a gap to flag — it is the default. This mirrors how an out-of-profile core TYPE is a silent absence under `coverage_profile` ([`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) §6.1), with one difference: an out-of-profile core TYPE still gets a `CP-003` rejection if someone writes one anyway, because the core validator knows the full core registry. A package TYPE gets no equivalent rejection message from core tooling, because core tooling does not know the package's registry at all (§4.2) — the package's own validator is the only thing that could reject it, and that validator does not run unless the package is declared.
+
+---
+
+## 6. What a package's own spec must state
+
+Each shipped package ships a spec document (convention: `notations/packages/<name>.md`) that states, at minimum:
+
+| Element | Requirement |
+|---|---|
+| **Name and folder** | The `packages:` name and the top-level folder it governs. |
+| **Object types and ID grammar** | The package's own registry of object types and their identifier shape — visibly disjoint from the core `TYPE-NAME-<integer>` grammar (§4.1). |
+| **Validator** | What the package's own tooling checks, and where that tooling lives. |
+| **Removal procedure** | The baseline two-step procedure (§4.3) plus any package-specific addition. |
+| **Experimental status and review date** | Whether the package is experimental, and the date its status is next reviewed. **Required, not implied** — a package that says nothing about its status is not thereby stable; silence is not a valid value here. Core specs are never refactored to accommodate a package's experimental surface — an experimental package's rough edges stay contained inside the package. |
+
+---
+
+## 7. Version pinning
+
+Like a coverage-profile preset, the set of packages a methodology version ships is part of that version's registry. A `packages:` entry naming a package the pinned `methodology_version` does not ship is rejected (§8, `PKG-001`) — the same discipline [`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) §7 applies to preset names.
+
+---
+
+## 8. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `PKG-001` | error | `packages` is present and either not a list, or names an entry that is not a package shipped by the pinned `methodology_version`. |
+
+No other rule is defined here. A one-way-reference violation is caught by existing core referential-integrity checking (§4.1); a package's internal consistency is governed entirely by that package's own spec and tooling (§4.2), never by a core rule code.
+
+---
+
+## 9. Out of scope (v1)
+
+- **Cross-package references.** Two packages referencing each other's objects is undefined; each shipped package's own spec must say whether it permits this (default: no).
+- **Per-package coverage profiles.** A package either is or isn't declared; there is no partial/profiled adoption of a package's own vocabulary in v1.
+- **Package versioning independent of `methodology_version`.** A package's spec ships and versions together with the methodology release that carries it (§7); it does not carry its own independent SemVer line in v1.
+
+---
+
+## 10. References
+
+- [`MANIFEST.md`](MANIFEST.md) §2 — the `packages:` field on `transitrix.yaml`.
+- [`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) — the depth axis (§2 of this document draws the boundary between the two).
+- [`CONTRACT.md`](CONTRACT.md) §5 — the zone model packages sit outside of.
+- [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §3.1 — the closed core TYPE registry a package's ID grammar must stay disjoint from.

--- a/notations/README.md
+++ b/notations/README.md
@@ -56,6 +56,8 @@ The cross-cutting **element-primitive file schema** — the common envelope ever
 
 The cross-cutting **Coverage Profile** — the mechanism an adopter uses to declare which slice of the methodology's vocabulary (per-layer element TYPEs + relation TYPEs) is in scope for their repository — is defined in [`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md). Adopters declare a profile in [`transitrix.yaml`](MANIFEST.md); the default when omitted is `full`.
 
+The cross-cutting **Domain Packages** mechanism — the orthogonal `packages:` field an adopter uses to opt into a bounded, removable domain extension (e.g. a requirements-interchange layer) on top of the core vocabulary — is defined in [`PACKAGES.md`](PACKAGES.md). Absent ⇒ no package active, silently.
+
 The cross-cutting **Named view-config convention** — where saved view-configs live in an adopter repo, how they're named, listed, and re-run — is defined in [`views/REPORT_VIEW_CONFIG.md`](views/REPORT_VIEW_CONFIG.md). The convention applies uniformly across every view notation, and is the registry the report-config view specs ([`11-scenarios.md`](views/11-scenarios.md), [`21-compliance-impact.md`](views/21-compliance-impact.md), [`22-coverage-metric.md`](views/22-coverage-metric.md)) and the future report skill (per the *reports rendered from declarative view-configs* architecture decision) lean on.
 
 ## Status vocabulary


### PR DESCRIPTION
## Summary
- Adds `notations/PACKAGES.md` — the mechanism an adopter uses to declare an optional, removable **domain package** on top of the core vocabulary via a new `packages:` field on `transitrix.yaml`, orthogonal to `coverage_profile`'s depth axis (a package doesn't require `core`/`full`, and vice versa).
- Defines the **reversibility contract**: package objects may reference core elements but never the reverse; a package's validator rules live entirely inside the package (never wired into a core validator); removal is delete-folder-plus-one-manifest-line, demonstrated as a test once a package exists.
- Defines **absence is silence**: an undeclared package emits no warning — core tooling never has package-aware code to trigger one.
- Cross-references from `MANIFEST.md` (new `packages:` field), `COVERAGE_PROFILES.md` (orthogonality note), `CONTRACT.md` §5 (packages are not a fourth zone), and the notations catalogue (`README.md`).

**Scoped to the mechanism only.** The first package itself — ReqIF-shaped `SpecObject`/`SpecObjectType`/`SpecRelation`/`SpecHierarchy`, the YAML↔XML round-trip converter, workflow state, revisions, and suspect-link mechanics — is separate follow-up work; nothing in this PR builds it. No code changes: there is no package yet for a core validator to plug into, so `packages/ingest-cli` and `scripts/check-notations.mjs` are untouched by design (the whole point of the reversibility contract is that core tooling stays package-ignorant).

## Test plan
- [x] `node scripts/check-notations.mjs` — clean (16 view notations; examples, internal links, `methodology_version` pins, notation counts all consistent).
- [x] Manually re-read the tail of every edited/created file for truncation.