### PR TITLE
fix(tools): reconfigure lint.py/render_trace_matrix.py stdio to UTF-8

### DIFF
--- a/.github/workflows/lint-encoding-test.yml
+++ b/.github/workflows/lint-encoding-test.yml
@@ -1,0 +1,38 @@
+name: lint.py encoding regression test
+
+# Regression test for the Windows UnicodeEncodeError crash in tools/lint.py
+# (and the same-root-cause instance in tools/render_trace_matrix.py): a
+# legacy, non-UTF-8 console code page must not crash either script mid-report.
+# Runs on windows-latest since the bug is Windows-console-specific.
+
+on:
+  pull_request:
+    paths:
+      - 'tools/lint.py'
+      - 'tools/render_trace_matrix.py'
+      - 'tools/tests/test_lint_encoding.py'
+      - '.github/workflows/lint-encoding-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'tools/lint.py'
+      - 'tools/render_trace_matrix.py'
+  workflow_dispatch:
+
+jobs:
+  windows-encoding:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Run encoding regression test
+        run: python tools/tests/test_lint_encoding.py

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ For every release, in order:
 
 The conceptual companion to this section — the **propagation mechanism**: transport, the named operation, the ratification gate on autonomous agents, and what makes the upgrade *bounded / traceable / reproducible* — lives in [`method/04-methodology-update-propagation.md`](method/04-methodology-update-propagation.md). This section is the operational checklist; that document is the contract the checklist satisfies.
 
-When an adopter repo moves from one methodology version to another, **three artefacts must move together** — specs, skill bundle, and CLI — in this order:
+When an adopter repo moves from one methodology version to another, **four artefacts must move together** — specs, skill bundle, CLI, and the vendored whole-repo validator — in this order:
 
 1. **Bump `methodology_version`** in the adopter's `transitrix.yaml` to the new version string.
 2. **Run the migration recipe** (MAJOR bump only) from `migrations/<prev>-to-<this>/` in this repo:
@@ -56,14 +56,18 @@ When an adopter repo moves from one methodology version to another, **three arte
    transitrix-ingest --version
    ```
    Once the CLI is extracted to its own tooling repo and published, `npm install -g @transitrix/ingest-cli` (or `npx @transitrix/ingest-cli --version`) becomes the equivalent shorthand.
-5. **Run `repo-check`** to confirm version currency:
+5. **Re-fetch `.validators/lint.py`** if `tools/lint.py` changed in this release (check the release notes) — this is a vendored copy, fetched once at scaffold time ([`transitrix/skills/onboard/SKILL.md`](transitrix/skills/onboard/SKILL.md) Step 2), and it does not auto-update either:
+   ```
+   curl -fsSL https://raw.githubusercontent.com/transitrix/methodology/vX.Y.Z/tools/lint.py -o .validators/lint.py
+   ```
+6. **Run `repo-check`** to confirm version currency:
    ```
    transitrix-ingest repo-check [org-root]
    ```
    A clean run shows `tooling.ok: true` and no version-mismatch red flag. If `tooling.ok: false` still appears, the installed binary is still the old version — repeat step 4.
-6. **Re-resolve the coverage profile** (if the new release changed the preset vocabulary — see `COVERAGE_PROFILES.md` §7 for what changes between versions). Fix `transitrix.yaml` if needed, then re-run `repo-check` to clear any `coverage_warning`.
+7. **Re-resolve the coverage profile** (if the new release changed the preset vocabulary — see `COVERAGE_PROFILES.md` §7 for what changes between versions). Fix `transitrix.yaml` if needed, then re-run `repo-check` to clear any `coverage_warning`.
 
-Steps 1–3 handle the **spec and canon**; step 4 handles the **CLI**; steps 5–6 confirm the three artefacts are in sync. Skipping step 4 leaves the CLI binary stale — it will run against new artefacts with old validators and a mismatched coverage-preset vocabulary.
+Steps 1–3 handle the **spec and canon**; step 4 handles the **CLI**; step 5 handles the **whole-repo validator**; steps 6–7 confirm all four artefacts are in sync. Skipping step 4 leaves the CLI binary stale — it will run against new artefacts with old validators and a mismatched coverage-preset vocabulary. Skipping step 5 leaves `.validators/lint.py` on its scaffold-time snapshot — any fix or rule change landed in `tools/lint.py` since then stays invisible to the adopter's own CI.
 
 ---
 

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -12,6 +12,19 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 from dataclasses import dataclass
 
+
+def _ensure_utf8_stdio() -> None:
+    # A legacy Windows console code page (e.g. cp1252) can't encode the status
+    # glyphs printed below, crashing the linter mid-report with a
+    # UnicodeEncodeError regardless of whether the repo itself is clean.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+
+_ensure_utf8_stdio()
+
+
 @dataclass
 class LintError:
     file: str

--- a/tools/render_trace_matrix.py
+++ b/tools/render_trace_matrix.py
@@ -28,6 +28,18 @@ import argparse
 import sys
 from pathlib import Path
 
+
+def _ensure_utf8_stdio() -> None:
+    # Same class of bug as tools/lint.py: the "✓ traced" / "⚠ traced"
+    # cells below aren't encodable on a legacy Windows console code page, and
+    # this renderer writes straight to stdout when --out is omitted.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+
+_ensure_utf8_stdio()
+
 try:
     import yaml
 except ImportError:  # pragma: no cover - environment guard

--- a/tools/tests/test_lint_encoding.py
+++ b/tools/tests/test_lint_encoding.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Windows legacy-code-page regression test for tools/lint.py and
+tools/render_trace_matrix.py.
+
+Both scripts print/write non-ASCII status glyphs straight to stdout/stderr.
+Under a legacy Windows console code page (e.g. cp1252 — the default when
+stdout isn't a UTF-8-configured terminal), that used to crash mid-report with
+a UnicodeEncodeError, even on a fully valid repo. Forces PYTHONIOENCODING to a
+legacy code page for the subprocess so the regression reproduces
+deterministically on any OS, and drives each script down its happy, error, and
+warning-reporting paths so all of the glyphs are exercised, not just the
+easy ones.
+
+Run:  python tools/tests/test_lint_encoding.py
+Exit: 0 = all checks pass; 1 = a check failed.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+LINT = os.path.join(REPO_ROOT, "tools", "lint.py")
+TRACE_MATRIX = os.path.join(REPO_ROOT, "tools", "render_trace_matrix.py")
+LEGACY_CODE_PAGE = "cp1252"
+
+_failures = []
+
+
+def check(cond, msg):
+    if not cond:
+        _failures.append(msg)
+    return cond
+
+
+def _legacy_env():
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = LEGACY_CODE_PAGE
+    return env
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+def _decode(raw_bytes):
+    return raw_bytes.decode("utf-8", errors="replace")
+
+
+def _run(script, *args, env_root=None):
+    env = _legacy_env()
+    if env_root is not None:
+        env["REPO_ROOT"] = env_root
+    r = subprocess.run([sys.executable, script, *args], capture_output=True, env=env)
+    return r.returncode, _decode(r.stdout) + _decode(r.stderr)
+
+
+# ── lint.py: clean repo — happy path (search/scan/check/summary/pass glyphs) ─
+
+def check_lint_clean():
+    work = tempfile.mkdtemp(prefix="lint-encoding-clean-")
+    try:
+        _write(os.path.join(work, "canon", "elements", "app.yaml"), "id: APP-1\nname: Test App\n")
+        code, out = _run(LINT, env_root=work)
+        check(code == 0, f"lint.py clean repo: expected exit 0, got {code}: {out}")
+        check("UnicodeEncodeError" not in out, f"lint.py clean repo crashed on encoding: {out}")
+        check("PASSED" in out, f"lint.py clean repo: missing success report: {out}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+# ── lint.py: atomicity violation — error-reporting path ─────────────────────
+
+def check_lint_error():
+    work = tempfile.mkdtemp(prefix="lint-encoding-error-")
+    try:
+        _write(
+            os.path.join(work, "canon", "elements", "app.yaml"),
+            "id: APP-1\nname: Test App\nrelations:\n  - REL-1\n",
+        )
+        code, out = _run(LINT, env_root=work)
+        check(code == 1, f"lint.py error repo: expected exit 1, got {code}: {out}")
+        check("UnicodeEncodeError" not in out, f"lint.py error repo crashed on encoding: {out}")
+        # Phase 3+ errors are only counted, not detailed, in the final summary
+        # (a separate pre-existing gap — see PR description) — assert on what
+        # the script actually prints today.
+        check("Validation FAILED" in out, f"lint.py error repo: missing error report: {out}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+# ── lint.py: policy warning — warning-reporting path ─────────────────────────
+# (Uses the ownerless-Active-status policy check, not referential integrity —
+# a relation's plain-string source/target hits an unrelated pre-existing
+# AttributeError in _check_referential_integrity, out of scope for this fix.)
+
+def check_lint_warning():
+    work = tempfile.mkdtemp(prefix="lint-encoding-warning-")
+    try:
+        _write(
+            os.path.join(work, "canon", "elements", "app.yaml"),
+            "id: APP-1\nname: Test App\nmetadata:\n  status: Active\n",
+        )
+        code, out = _run(LINT, env_root=work)
+        check(code == 0, f"lint.py warning repo: expected exit 0, got {code}: {out}")
+        check("UnicodeEncodeError" not in out, f"lint.py warning repo crashed on encoding: {out}")
+        check("POLICY" in out, f"lint.py warning repo: missing warning report: {out}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+# ── render_trace_matrix.py: default stdout write, "traced" cell ─────────────
+
+def check_trace_matrix_stdout():
+    work = tempfile.mkdtemp(prefix="trace-matrix-encoding-")
+    try:
+        _write(
+            os.path.join(work, "canon", "elements", "01_motivation", "requirements", "req.yaml"),
+            "id: REQUIREMENT-1\nname: Test requirement\n",
+        )
+        _write(
+            os.path.join(work, "canon", "verifications", "verif.yaml"),
+            "id: VERIFICATION-1\nverifies: REQUIREMENT-1\nmethod: test\noutcome: pass\n",
+        )
+        code, out = _run(TRACE_MATRIX, "--root", work)
+        check(code == 0, f"render_trace_matrix.py: expected exit 0, got {code}: {out}")
+        check("UnicodeEncodeError" not in out, f"render_trace_matrix.py crashed on encoding: {out}")
+        check("traced" in out, f"render_trace_matrix.py: missing rendered trace status: {out}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def main():
+    check_lint_clean()
+    check_lint_error()
+    check_lint_warning()
+    check_trace_matrix_stdout()
+
+    if _failures:
+        print(f"FAIL: {len(_failures)} check(s) failed:")
+        for f in _failures:
+            print(f"  - {f}")
+        return 1
+    print("PASS: all encoding regression checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `tools/lint.py` prints status glyphs (🔍 📂 ✓ ❌ ⚠️ 📊 ✅) straight to stdout/stderr. Under a legacy Windows console code page (e.g. `cp1252` — the common default when stdout isn't a UTF-8-configured terminal), that crashed the whole-repo validator mid-report with a `UnicodeEncodeError`, even on a fully valid repo. Reproduced the exact crash locally against the pre-fix file.
- `tools/render_trace_matrix.py` carries the identical bug (writes a `"✓ traced"` / `"⚠ traced"` cell to stdout by default when `--out` is omitted) — confirmed while investigating the "worth confirming rather than assuming" note in the report, and fixed with the same one-liner.
- Fix: reconfigure `sys.stdout`/`sys.stderr` to UTF-8 at import time in both scripts, guarded by `hasattr(stream, "reconfigure")`. No dependency on the invoker setting an env var or code page first. Visible glyph output is unchanged.
- `RELEASING.md`'s adopter upgrade procedure had **no step at all** for re-fetching the vendored `.validators/lint.py` copy (only specs/skill-bundle/CLI were covered) — added step 5 so this fix, and any future `tools/lint.py` change, actually reaches existing adopters on upgrade instead of staying invisible until a fresh scaffold.
- New regression test `tools/tests/test_lint_encoding.py`: forces a legacy code page (`PYTHONIOENCODING=cp1252`) on the subprocess and drives both scripts through their happy, error, and warning-reporting paths (not just the clean-repo case). New `windows-latest` CI job (`.github/workflows/lint-encoding-test.yml`), gated on changes to either script.

## Found but not fixed here (separate concern)
While building the warning-path fixture, found two pre-existing bugs in `tools/lint.py`, unrelated to encoding:
- `_check_referential_integrity` raises an unhandled `AttributeError` on the standard plain-string `source`/`target` relation shape — every real example under `notations/` uses this shape (`source: APP-1`, not `source: {id: APP-1}`), so this path appears to crash on realistic data today. The regression test's warning-path fixture uses the ownerless-Active-status policy check instead, to avoid this unrelated crash.
- Phase 3+ errors (e.g. the atomicity violation) are counted in the final summary but never printed with detail — only Phase-1 YAML-syntax errors get the itemized `❌ ERRORS FOUND` report. `_report_errors()` is never called from `_report_summary()`.

Flagging both for separate triage rather than folding into this PR.

## Test plan
- [x] `tools/tests/test_lint_encoding.py` — verified it fails with `UnicodeEncodeError` against a pre-fix copy of both scripts, and passes against the fix.
- [x] `node scripts/check-notations.mjs` — clean.
- [x] `node scripts/check-workflow-scripts.mjs` — clean (new workflow's script reference resolves).
- [x] Manually re-read the tail of every edited/created file for truncation.