### PR TITLE
fix(notations): bump reqif package's stale methodology_version pin to 2.1.0

### DIFF
--- a/notations/examples/packages/reqif/transitrix.yaml
+++ b/notations/examples/packages/reqif/transitrix.yaml
@@ -3,7 +3,7 @@
 # permitted cross-reference (Transitrix.CanonRef, reqif.md §3) something real
 # to cite, plus the reqif/ package folder itself.
 transitrix: 1
-methodology_version: "2.0.0"
+methodology_version: "2.1.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/packages/reqif.md
+++ b/notations/packages/reqif.md
@@ -21,7 +21,7 @@ This is a package, not a core notation: nothing here changes `IDS_AND_REFERENCES
 
 ```yaml
 transitrix: 1
-methodology_version: "2.0.0"
+methodology_version: "2.1.0"
 packages: [reqif]
 ```
 


### PR DESCRIPTION
## Summary
- `notations/packages/reqif.md` and its worked example (`notations/examples/packages/reqif/transitrix.yaml`) were still pinned to `methodology_version: "2.0.0"` — the ReqIF-package PR branched before the v2.1.0 release cut and merged after it, so the pin never got bumped.
- This currently breaks `scripts/check-notations.mjs`'s V1 invariant (`methodology_version` pins must equal `notations/CURRENT_VERSION.yaml`) on `main` and on every PR branched from it since — including an unrelated PR opened moments ago.
- Bumps both pins to `2.1.0` to match the source of truth. No other change.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean (was: 2 findings, now: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)