### PR TITLE
feat(patterns): recreate design-controls quick wins (baseline manifest + audit story)

### DIFF
--- a/patterns/design-controls.md
+++ b/patterns/design-controls.md
@@ -1,0 +1,82 @@
+# Transitrix + Design-Controls Audit Story
+
+**Pattern type:** overlay
+**Complexity:** simple
+**Mechanism:** [`notations/CONTRACT.md`](../notations/CONTRACT.md) §6 (admission record), §6.1 (pre-admission lifecycle), §6.2 (reviewer authority), §7 (primitive lifecycle) — this pattern introduces **no new schema**. It names the audit-facing story an existing mechanism already tells and gives it a QA-facing vocabulary.
+
+---
+
+## Problem
+
+A regulated adopter running the design-controls domain — `REQUIREMENT` / `ASSERTION` / `VERIFICATION` / `HAZARD` / `RISK_CONTROL` ([CONTRACT.md](../notations/CONTRACT.md) §8) — eventually faces an auditor's three questions:
+
+1. **"What did the model say at the time of the design review?"** — a baseline.
+2. **"Who changed what, and when?"** — an audit trail.
+3. **"Who reviewed and approved this content, and on what authority?"** — a review/approval record.
+
+None of these need a new mechanism. CONTRACT.md §6/§6.2/§7 already carries every fact an auditor asks for; what is missing is a QA-facing name for the pattern and a thin script that packages the first question as an artefact instead of a manual `git log` walk. This pattern supplies both.
+
+## Solution
+
+### 1. Baseline — a `git tag` is a design-controls baseline
+
+**Convention:** when a design review, a milestone, or a regulatory submission needs a frozen snapshot of the design-controls model, tag the commit. The tag *is* the baseline — there is no separate baseline artefact to author, version, or keep in sync, because the git object it points at is already immutable.
+
+```
+git tag design-review-2026-Q3 <commit>
+```
+
+`scripts/baseline-manifest.mjs` turns that tag into a **manifest** — the frozen `REQUIREMENT` / `ASSERTION` set exactly as it stood at that ref:
+
+```
+node scripts/baseline-manifest.mjs <ref> [--root <adopter-repo>] [--out <file.md>]
+```
+
+- **Read-only.** It reads every file via `git show <ref>:<path>` — it never runs `git checkout`, so it never disturbs the working tree and is safe to run against a tag from years ago while the working tree sits on a different branch.
+- **Split by `reviewer_authority`** ([CONTRACT.md](../notations/CONTRACT.md) §6.2) — the manifest separates `expert_confirmed` requirements from `ai_reviewed` ones, so an auditor can see at a glance how much of the baseline rests on the top authority tier versus the AI-reviewed tier.
+- **Carries `REQ-COVERAGE-001` as it existed at that ref** — each requirement's compliance-coverage gap status ([CONTRACT.md](../notations/CONTRACT.md) §8) is computed from the `ASSERTION` set *at that same ref*, not from today's canon. A baseline answers "what did the model say then", not "what does it say now".
+
+Run it against any ref git can resolve — a tag, a branch, a SHA. There is nothing tag-specific in the mechanism; tags are simply the natural, human-legible way to mark a baseline commit.
+
+### 2. Audit trail — git history is the audit trail
+
+**Convention, articulated for a QA reader:** every canonical file's change history *is* the audit trail. Each commit that touches a `REQUIREMENT`, `ASSERTION`, `VERIFICATION`, `HAZARD`, or `RISK_CONTROL` file already records, immutably:
+
+| Auditor's question | Where the answer already lives |
+|---|---|
+| Who made this change? | The commit author (or the PR approver — see §3) |
+| When? | The commit timestamp |
+| What changed? | The commit diff |
+| Why? | The commit message / linked PR description |
+
+`git log --follow -- <path>` (or a Studio / DSM history view over the same commits) is the audit trail. Nothing needs to be authored separately, because nothing is asserted here that git does not already guarantee.
+
+### 3. Review/approval record — the admission record already is one
+
+**Mapping**, restated for an audit reader who does not think in terms of the admission gate:
+
+| Audit concept | Transitrix mechanism |
+|---|---|
+| The record was reviewed | A PR against the canon file, approved before merge |
+| The reviewer's identity | `admitted_by` ([CONTRACT.md](../notations/CONTRACT.md) §6) — the PR approver who ran the admission gate |
+| The reviewer's authority | `reviewer_authority: expert_confirmed` ([CONTRACT.md](../notations/CONTRACT.md) §6.2) — a human reviewer; `ai_reviewed` records a tool reviewer instead |
+| When it was approved | `admitted_at` |
+| What was checked | `gate_checks` — the standard canon checks (`uniqueness`, `consistency`, `completeness`) |
+
+No new field, no separate sign-off document: **PR approver + `reviewer_authority: expert_confirmed` + the admission gate together constitute the review/approval record.** An adopter that wants a single-line emitter over this mapping can derive it from the same fields `baseline-manifest.mjs` already reads — no separate schema to add if that becomes worth building.
+
+## Guardrails — what this pattern does not claim
+
+- **Git ≠ Part 11 e-signatures.** A git commit authenticated by an SSH key or a GitHub account is not a 21 CFR Part 11 electronic signature. This pattern documents an audit trail and a review/approval mapping; it makes no claim of Part 11 compliance, and an adopter operating under Part 11 needs a signature mechanism this pattern does not provide.
+- **Pattern, not adopter instance.** Nothing here names or implies any specific adopter, product, or regulatory submission. `scripts/baseline-manifest.mjs` and the mapping above are generic over any repository that carries the design-controls domain.
+- **No new claim about the SDS or trace matrix.** The engineering V&V and risk chain, and their rendering as a trace matrix, are specified and shipped independently ([27-verification.md](../notations/elements/27-verification.md), [28-hazard-risk-control.md](../notations/elements/28-hazard-risk-control.md), [24-design-controls-trace-matrix.md](../notations/views/24-design-controls-trace-matrix.md), [`tools/render_trace_matrix.py`](../tools/render_trace_matrix.py)). This pattern adds nothing to that surface beyond what is already shipped — it only names the baseline/audit-trail/review-approval story that sits alongside it.
+
+## When to use
+
+Once an adopter has admitted its first `REQUIREMENT` under the design-controls domain and expects a design review, an internal audit, or a regulatory submission to ask "what did the model say, and who approved it" — tag the commit and run `baseline-manifest.mjs` against it. There is no earlier point at which this pattern adds anything: before the first admitted requirement, there is nothing to baseline.
+
+## See also
+
+- [`notations/CONTRACT.md`](../notations/CONTRACT.md) §6, §6.1, §6.2, §7, §8 — the underlying mechanism.
+- [`notations/elements/15-requirement.md`](../notations/elements/15-requirement.md), [`16-assertion.md`](../notations/elements/16-assertion.md) — the elements a baseline manifest reads.
+- [`notations/views/24-design-controls-trace-matrix.md`](../notations/views/24-design-controls-trace-matrix.md) — the sibling audit surface for the V&V and risk chain.

--- a/patterns/index.md
+++ b/patterns/index.md
@@ -9,6 +9,7 @@ Concrete deployment guides for common enterprise scenarios. Each pattern covers 
 | Transitrix + Enterprise ADR Registry | [enterprise-adr-registry.md](enterprise-adr-registry.md) | Full | Transitrix repo as the enterprise ADL, aggregating cross-project architecture decisions. |
 | Enterprise Memory | [enterprise-memory.md](enterprise-memory.md) | Simple or Full | A Transitrix repo as a durable, EA-grounded memory for humans and AI agents — semantic canon + episodic record. Composes with Knowledge Store at enterprise scale. |
 | Personal Memory | [personal-memory.md](personal-memory.md) | Simple | Individual or small-team deployment: one repo as a personal second brain — goals, contacts, and decisions as structured, agent-queryable memory. |
+| Design-Controls Audit Story | [design-controls.md](design-controls.md) | Full | Overlay for adopters running the design-controls domain — a `git tag` baseline, git history as the audit trail, and the admission record as the review/approval record. No new schema. |
 
 ---
 
@@ -29,6 +30,7 @@ An adopter (or an adopter's agent) rarely asks "which pattern tier do I need" �
 | "We have several repos producing raw material — how does it become canon?" | [Knowledge Store](knowledge-store.md) |
 | "How do we make this repo a shared memory for humans and agents?" | [Enterprise Memory](enterprise-memory.md) |
 | "Can I use Transitrix as a personal second brain?" | [Personal Memory](personal-memory.md) |
+| "How do we baseline the design-controls model for an audit / design review?" | [Design-Controls Audit Story](design-controls.md) |
 | "Which deployment size fits us — Simple or Full?" | [`implementation-tiers.md`](implementation-tiers.md) |
 
 Not sure which tier fits your organisation? See [`implementation-tiers.md`](implementation-tiers.md) for the Simple vs Full comparison — what belongs in each, the upgrade trigger, and the upgrade path.

--- a/scripts/baseline-manifest.mjs
+++ b/scripts/baseline-manifest.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Design-controls baseline manifest — read-only, git-native.
+//
+// A `git tag` IS a design-controls baseline: the ref names a frozen commit,
+// and this script reads the admitted REQUIREMENT / ASSERTION set exactly as
+// it stood at that ref — via `git show <ref>:<path>`, never `git checkout`,
+// so running it never disturbs the working tree. See patterns/design-controls.md.
+//
+// Usage:
+//   node scripts/baseline-manifest.mjs <ref> [--root <adopter-repo>] [--out <file.md>]
+//
+// <ref> is any ref git can resolve to a commit — a tag, a branch, a SHA.
+// Requirements are split by `reviewer_authority` (CONTRACT.md §6.2) and each
+// carries its REQ-COVERAGE-001 gap status (CONTRACT.md §8) as it stood at
+// that ref — not as it stands today.
+//
+// Exit codes: 0 ok · 2 error (bad ref, not a git repo)
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REQUIREMENTS_DIR = 'canon/elements/01_motivation/requirements';
+const ASSERTIONS_DIR = 'canon/assertions';
+
+function git(gitArgs, cwd, { quiet } = {}) {
+  return execFileSync('git', gitArgs, {
+    encoding: 'utf8',
+    cwd,
+    stdio: ['ignore', 'pipe', quiet ? 'ignore' : 'pipe'],
+  });
+}
+
+function argVal(args, flag, dflt) {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+}
+
+function listYamlAt(ref, dir, cwd) {
+  let out;
+  try {
+    out = git(['ls-tree', '-r', '--name-only', ref, '--', dir], cwd, { quiet: true });
+  } catch {
+    return [];
+  }
+  return out.split('\n').map(s => s.trim()).filter(f => f.endsWith('.yaml'));
+}
+
+// Targeted field extraction over flat top-level YAML scalars — the same
+// convention scripts/adl-harvest.mjs uses for front-matter, applied here to
+// whole-file YAML (REQUIREMENT / ASSERTION carry no front-matter fence).
+// Not a general YAML parser: sufficient for the scalar fields this script
+// reads, and adds no new dependency to the root scripts/ toolchain.
+function field(text, name) {
+  const m = text.match(new RegExp(`^${name}:\\s*"?([^"\\n#]*?)"?\\s*(?:#.*)?$`, 'm'));
+  return m ? m[1].trim() : undefined;
+}
+
+function loadAt(ref, dir, cwd) {
+  const out = [];
+  for (const path of listYamlAt(ref, dir, cwd)) {
+    // `<rev>:<path>` resolves relative to the repo top; the `./` form makes it
+    // relative to cwd instead — needed since `path` came from `ls-tree` run
+    // with cwd = the adopter root, which may be a subdirectory of this repo
+    // (as with the notations/examples/ worked examples).
+    const text = git(['show', `${ref}:./${path}`], cwd);
+    const id = field(text, 'id');
+    if (!id) continue;
+    out.push({
+      id,
+      path,
+      // CONTRACT.md §6.1 — absent admission_state means active (back-compat).
+      admission_state: field(text, 'admission_state') || 'active',
+      // CONTRACT.md §6.2 — absent reviewer_authority means expert_confirmed (back-compat).
+      reviewer_authority: field(text, 'reviewer_authority') || 'expert_confirmed',
+      about: field(text, 'about'), // ASSERTION only
+    });
+  }
+  return out;
+}
+
+function render(ref, requirements, assertions) {
+  const assertedAbout = new Set(assertions.map(a => a.about).filter(Boolean));
+  const tiers = { expert_confirmed: [], ai_reviewed: [] };
+  for (const r of requirements) (tiers[r.reviewer_authority] ??= []).push(r);
+
+  const lines = [];
+  lines.push(`# Design-controls baseline manifest — ${ref}`);
+  lines.push('');
+  lines.push(
+    '> Derived by `scripts/baseline-manifest.mjs`, read-only from git history via ' +
+    '`git show` — the working tree was never checked out. Regenerate against a ' +
+    'different ref for a different baseline.'
+  );
+  lines.push('');
+  lines.push(
+    `${requirements.length} admitted REQUIREMENT(s), ${assertions.length} admitted ` +
+    `ASSERTION(s) at this baseline.`
+  );
+  lines.push('');
+  lines.push('## Requirements by reviewer authority');
+  lines.push('');
+  for (const tier of ['expert_confirmed', 'ai_reviewed']) {
+    const rows = (tiers[tier] || []).slice().sort((a, b) => a.id.localeCompare(b.id));
+    lines.push(`### ${tier} (${rows.length})`);
+    lines.push('');
+    if (rows.length === 0) {
+      lines.push('_none_');
+    } else {
+      lines.push('| Requirement | REQ-COVERAGE-001 |');
+      lines.push('|---|---|');
+      for (const r of rows) {
+        const gap = assertedAbout.has(r.id) ? 'covered' : '**gap — no ASSERTION**';
+        lines.push(`| \`${r.id}\` | ${gap} |`);
+      }
+    }
+    lines.push('');
+  }
+
+  const gapCount = requirements.filter(r => !assertedAbout.has(r.id)).length;
+  lines.push('---');
+  lines.push('');
+  lines.push(
+    gapCount
+      ? `**${gapCount} REQ-COVERAGE-001 gap(s)** at this baseline.`
+      : '**No REQ-COVERAGE-001 gaps** at this baseline.'
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const ref = args.find(a => !a.startsWith('--'));
+  if (!ref) {
+    console.error('usage: baseline-manifest.mjs <ref> [--root <adopter-repo>] [--out <file.md>]');
+    process.exit(2);
+  }
+  const root = resolve(argVal(args, '--root', '.'));
+  const out = argVal(args, '--out', null);
+
+  try {
+    git(['rev-parse', '--verify', `${ref}^{commit}`], root, { quiet: true });
+  } catch {
+    console.error(`error: ref does not resolve to a commit in ${root}: ${ref}`);
+    process.exit(2);
+  }
+
+  const requirements = loadAt(ref, REQUIREMENTS_DIR, root).filter(r => r.admission_state === 'active');
+  const assertions = loadAt(ref, ASSERTIONS_DIR, root).filter(a => a.admission_state === 'active');
+
+  const text = render(ref, requirements, assertions);
+  if (out) {
+    writeFileSync(resolve(out), text, 'utf8');
+    console.error(`written: ${out}`);
+  } else {
+    process.stdout.write(text);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Recreates the design-controls "quick wins" deliverable from epic HUB-754, per hub task HUB-834. The original attempt (PR #360, recreated as #362) was closed as superseded and the content never actually merged — this rebuilds it from the task's original scope.

- **`patterns/design-controls.md`** — new pattern doc naming the git-native audit story (baseline / audit trail / review-approval record) as a QA-facing overlay on the existing admission-record mechanism (`CONTRACT.md` §6/§6.2/§7). No new schema — every fact it names already exists in canon.
- **`scripts/baseline-manifest.mjs`** — read-only script (`git show <ref>:<path>`, never `git checkout`) that renders the admitted REQUIREMENT/ASSERTION set at a given ref (a git tag = a baseline), split by `reviewer_authority`, with each requirement's `REQ-COVERAGE-001` gap status as it stood at that ref.
- **`patterns/index.md`** — links the new pattern in the scenario table and the common-questions table.

Real-build design-controls items (VERIFICATION/HAZARD/RISK-CONTROL elements, reverse-trace validators, trace-matrix renderer) are already on `main` via #361/#368/#372/#375 and are untouched here.

## Test plan

- [x] `node scripts/check-notations.mjs` — doc-lint clean.
- [x] `node --check scripts/baseline-manifest.mjs` — syntax OK.
- [x] Ran the script against `notations/examples/design-controls` and `notations/examples/design-controls/reverse-trace-gaps` (HEAD and a real tag) — correct requirement/gap output, confirmed read-only (working tree untouched).
- [x] Verified error handling on an unresolvable ref (exit 2, clean message).
- [x] Re-read both new files' tails after writing — no truncation.

## Guardrails carried from the task

- Git ≠ Part 11 e-signatures — stated explicitly in the pattern doc.
- No adopter/organisation named or implied.
- No claim beyond what #360/#372/#375 already ship for the SDS/trace matrix.

Do not merge without review (same gate as the original #757).

🤖 Generated with [Claude Code](https://claude.com/claude-code)