### PR TITLE
feat(skills): add /transitrix:status skill (epic #819)

### DIFF
--- a/transitrix/skills/status/README.md
+++ b/transitrix/skills/status/README.md
@@ -1,0 +1,30 @@
+# Transitrix Status Skill
+
+A **read-only, on-demand view** of what is waiting behind every human gate in a Transitrix adopter repository — ADR, Work Item, canon element, REQUIREMENT/CONSTRAINT review-overdue, and ingest-batch phases, each with a count, in one table.
+
+This directory is the **`status` skill** within the `transitrix` plugin (the plugin root is [`transitrix/`](../../), which carries the shared [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) manifest, with one `skills/<name>/` directory per skill). Invoked as `/transitrix:status`.
+
+> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`) implements the `workflow-status` subcommand; the agent-facing protocol ([`SKILL.md`](SKILL.md)) only sequences it. The Step 0 pre-check stops cleanly if the CLI is not installed in a given environment.
+
+## Why it exists
+
+Each human gate the methodology defines is specified on its own, but none was counted in one place: ADR ratification, work-item tracking, canon element status, stale-review checks, and ingest-batch review each needed a separate command or scattered coverage. `workflow-status` answers "what is standing behind every gate, in which phase, how many" in a single invocation, and this skill is the conversational front door to it.
+
+## What it is not
+
+- It is **not** a writer — it never touches a zone, an operations record, or a batch; re-running is always safe (idempotent).
+- It is **not** a clock — no ages, no thresholds, no "oldest" figure. Phases and counts only.
+- It does **not** compute anything itself — if the CLI is absent, the skill says so rather than hand-assembling the table.
+
+## Usage
+
+```
+transitrix-ingest workflow-status [org-root]    # defaults to the current repo; prints Markdown to stdout
+transitrix-ingest workflow-status --format yaml
+transitrix-ingest workflow-status --data-free
+transitrix-ingest workflow-status --out status.md
+```
+
+The CLI is also reachable as `npx @transitrix/ingest-cli workflow-status ...` once the package is published to npm; until then, the local-install form is primary.
+
+See [`SKILL.md`](SKILL.md) for the agent-facing protocol and the report's field reference.

--- a/transitrix/skills/status/SKILL.md
+++ b/transitrix/skills/status/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: Transitrix Status
+description: "On-demand view of what is waiting behind every human gate in a Transitrix adopter repository — ADR proposed/accepted/superseded (author:agent broken out), Work Item phase, canon element status, REQUIREMENT/CONSTRAINT review-overdue, and ingest batches awaiting review. One table, phases and counts only (no ages, no thresholds), plus the ids in every open phase so the caller can act on them. Read-only — never writes a zone, an operations record, or a batch."
+when_to_use: 'User says "what''s waiting on review", "show me the workflow status", "what''s stuck in the queue", "how many ADRs are still proposed", "give me a status of every human gate", or wants a single on-demand view of open items across ADRs, work items, canon status, overdue reviews, and ingest batches without hand-counting files.'
+min_version: "2.1.0"
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# Transitrix Status Skill
+
+A **read-only, on-demand view** of everything standing behind a human gate in a Transitrix adopter repository — one table, across every gate the methodology defines, rather than five separate commands.
+
+This directory is the **`status` skill** within the `transitrix` plugin (the plugin root is [`transitrix/`](../../), which carries the shared [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) manifest, one `skills/<name>/` directory per skill). Invoked as `/transitrix:status`.
+
+> **Status — operational.** The deterministic CLI (`@transitrix/ingest-cli`) implements `workflow-status`; this `SKILL.md` only sequences it. Run the Step 0 pre-check first.
+
+---
+
+## The one rule
+
+**Sequence and format only — never count.** This skill has no logic of its own: it runs `transitrix-ingest workflow-status` and relays what it prints. The agent MUST NOT walk `operations/`, `canon/`, or `_intake/` and tabulate a table itself — that produces a count that can silently drift from what the CLI would report. If the CLI is absent, say so (Step 0) rather than approximating.
+
+---
+
+## Step 0 — CLI-presence pre-check
+
+The work is done by the CLI, never reimplemented in the agent:
+
+```
+transitrix-ingest --version             # primary — local install
+# or, once the package is published to npm:
+npx @transitrix/ingest-cli --version    # equivalent — same binary
+```
+
+- **Present** under either name → proceed. Use whichever form resolved (the subcommand and flags below are identical between the two).
+- **Absent** under both → tell the user to install the CLI (clone the methodology repo, `npm install -g ./packages/ingest-cli`); do not hand-assemble the table.
+
+---
+
+## Step 1 — Run the report
+
+```
+transitrix-ingest workflow-status [org-root]    # defaults to the current repo; prints a Markdown table to stdout
+```
+
+Flags, all optional:
+
+- `--out <path>` — write the report to a file instead of printing it.
+- `--format md|yaml` — `yaml` for a digest job or CI; identical counts to the default Markdown table.
+- `--data-free` — phases and counts only, no ids, no repo path — safe to share outside the organisation (same shareability contract as `repo-check`).
+
+Sources scanned, each degrading gracefully to an omitted section when its folder is absent — no error:
+
+| Object | Phase source |
+|---|---|
+| ADR | `operations/decisions/*.md` `status:` (`author: agent` proposed broken out as its own row — [`method/02`](../../../method/02-team-operations.md) §6.7) |
+| Work Item | `operations/work-items/*.md` `status:` |
+| Canon element | `canon/**` top-level `status:` |
+| REQUIREMENT/CONSTRAINT | overdue for review (reuses `check-stale`'s scan) |
+| Ingest batch | `_intake/processing/**/review-queue.yaml` present = awaiting review |
+
+A record whose phase field is missing or outside the vocabulary lands in an `unknown` row — never dropped, never bucketed into a valid phase.
+
+**Time is out of scope.** The report has no age column, no threshold, no "oldest" figure — phases and counts only. Do not add one when relaying the result.
+
+---
+
+## Step 2 — Relay the report
+
+Return the table (or the file path, if `--out` was used) as-is. Below the table the CLI lists the ids in every non-terminal phase with at least one record — pass that list through unedited so the user can act on it directly (open the ADR, chase the overdue review, resolve the batch).
+
+Nothing here mutates the repo; re-running is always safe and gives the same answer for the same tree.


### PR DESCRIPTION
## Summary
- Adds `transitrix/skills/status/{SKILL.md,README.md}` — a thin skill sequencing the already-shipped `transitrix-ingest workflow-status` CLI, invoked as `/transitrix:status`.
- Step 0 CLI-presence pre-check mirrors `repo-check`'s pattern; the skill relays the CLI's Markdown table + open-item id list unedited and never counts/scans itself.
- No CLI or CONTRACT changes — the `workflow-status` command and its docs wiring already landed in `main` (PRs #383/#384).

## Task
HUB-825 (epic HUB-819).

## Test plan
- [x] `node scripts/check-notations.mjs` — doc-lint clean.
- [x] Ran `transitrix-ingest workflow-status` locally against this repo (empty table, graceful degrade) and against `acme-corp` (populated table + id list) to confirm the skill's documented output matches the CLI's real output exactly.
- [x] Re-read both new files after writing — no truncation, both parse as intended Markdown.