### PR TITLE
feat(notations): ReqIF package — workflow-state, revisions, suspect links (epic #813)

### DIFF
--- a/.github/workflows/reqif-cli-test.yml
+++ b/.github/workflows/reqif-cli-test.yml
@@ -1,11 +1,13 @@
 name: ReqIF package test
 
 # Integration test for @transitrix/reqif-cli + the ReqIF domain package's
-# worked example (notations/packages/reqif.md, packages/reqif-cli/).
+# worked examples (notations/packages/reqif.md, packages/reqif-cli/).
 # Deterministic, no API key. Drives the real CLI end-to-end against the
-# worked fixture: validate, round trip, first-class SpecRelation, the
-# package -> canon citation, broken-input rejection, and a removal test.
-# Implementation: packages/reqif-cli/tests/test_reqif_integrity.py.
+# base worked fixture (validate, round trip, first-class SpecRelation, the
+# package -> canon citation, broken-input rejection, a removal test —
+# test_reqif_integrity.py) and the workflow-state/revisions/suspect-links
+# worked fixture (transition enforcement, revision history, suspect links —
+# test_reqif_workflow.py).
 
 on:
   pull_request:
@@ -13,6 +15,7 @@ on:
       - 'packages/reqif-cli/**'
       - 'notations/packages/reqif.md'
       - 'notations/examples/packages/reqif/**'
+      - 'notations/examples/packages/reqif-workflow/**'
       - '.github/workflows/reqif-cli-test.yml'
   workflow_dispatch:
   schedule:
@@ -42,3 +45,6 @@ jobs:
 
       - name: Run ReqIF package integrity test
         run: python packages/reqif-cli/tests/test_reqif_integrity.py
+
+      - name: Run ReqIF package workflow-state test
+        run: python packages/reqif-cli/tests/test_reqif_workflow.py

--- a/notations/PACKAGES.md
+++ b/notations/PACKAGES.md
@@ -2,7 +2,7 @@
 title: "Domain Packages — optional, removable vocabulary extensions"
 version: "0.1"
 author: "Valerii Korobeinikov"
-last_updated: "2026-07-28"
+last_updated: "2026-07-29"
 status: "draft"
 ---
 
@@ -113,7 +113,7 @@ Like a coverage-profile preset, the set of packages a methodology version ships 
 
 | `packages:` name | Spec | Status |
 |---|---|---|
-| `reqif` | [`packages/reqif.md`](packages/reqif.md) | base object model landed; this spec's own §6-required experimental-status declaration and review date are pending — see its Evolution section |
+| `reqif` | [`packages/reqif.md`](packages/reqif.md) | object model + workflow-state/revisions/suspect-links landed; this spec's own §6-required experimental-status declaration and review date are pending — see its Evolution section |
 
 ---
 

--- a/notations/examples/packages/reqif-workflow/README.md
+++ b/notations/examples/packages/reqif-workflow/README.md
@@ -1,0 +1,32 @@
+# ReqIF package — workflow-state, revisions, suspect links (worked example)
+
+A second, minimal adopter-repo slice exercising the ReqIF package's **experimental surface** ([`notations/packages/reqif.md`](../../../packages/reqif.md) §2.9): workflow state, revision history, and suspect-link mechanics on top of the base object model from [`notations/examples/packages/reqif/`](../reqif/).
+
+**Kept in its own folder, not added to the base worked example.** `workflow_state`, `revision`, `revisions`, and `recorded_target_revision` are top-level package-tooling fields that the converter ([`packages/reqif-cli/src/reqif-xml.mjs`](../../../../packages/reqif-cli/src/reqif-xml.mjs)) does not carry through ReqIF XML export/import in v1 — they are a tool behaviour, not part of the ReqIF standard (epic vkgeorgia/strategy#813). Adding them to the base fixture would make its `roundtrip` command fail, since a reimported object would lose fields the exporter never wrote. Isolating them here keeps [`notations/examples/packages/reqif/`](../reqif/)'s own round-trip demonstration (task #387/#828) untouched.
+
+**Pattern, not adopter instance.** The scenario (a battery-shutdown requirement) is a generic, invented example. It names no real product, organisation, or adopter.
+
+## Files in this folder
+
+| File | Kind | Role |
+|---|---|---|
+| [`transitrix.yaml`](transitrix.yaml) | manifest | Declares `packages: [reqif]`, same as the base example. |
+| [`canon/elements/01_motivation/requirements/REQUIREMENT-BATTERY-LOW-POWER-SHUTDOWN-1.yaml`](canon/elements/01_motivation/requirements/REQUIREMENT-BATTERY-LOW-POWER-SHUTDOWN-1.yaml) | core `REQUIREMENT` | The core element the package cites. |
+| [`reqif/spec-objects/so-battery-shutdown-req-1.yaml`](reqif/spec-objects/so-battery-shutdown-req-1.yaml) | `spec-object` | Carries `workflow_state: reviewed` and `revision: 1` — an object that has opted into the experimental surface. |
+| [`reqif/spec-objects/so-battery-shutdown-rationale-1.yaml`](reqif/spec-objects/so-battery-shutdown-rationale-1.yaml) | `spec-object` | No `workflow_state` field — demonstrates the implicit-`draft` default (reqif.md §2.9). |
+| [`reqif/spec-relations/sr-battery-elaborates-1.yaml`](reqif/spec-relations/sr-battery-elaborates-1.yaml) | `spec-relation` | Carries `recorded_target_revision: 1`, matching the target's revision at fixture authoring time — not yet suspect. |
+| [`reqif/spec-hierarchies/sh-root-1.yaml`](reqif/spec-hierarchies/sh-root-1.yaml) | `spec-hierarchy` | Outline over both objects. |
+
+## What it demonstrates
+
+Exercised end-to-end, against a temp-dir copy (never the checked-in fixture itself), by [`packages/reqif-cli/tests/test_reqif_workflow.py`](../../../../packages/reqif-cli/tests/test_reqif_workflow.py):
+
+- **Workflow-state transitions are enforced.** `transitrix-reqif transition <dir> so-battery-shutdown-req-1 approved` succeeds (`reviewed -> approved`, the single legal next step); attempting to skip straight to `superseded` is rejected (exit 1), never silently applied.
+- **Revision history is queryable.** `transitrix-reqif revise <dir> so-battery-shutdown-req-1 ReqIF.Text "<new text>"` bumps the object's `revision` and appends the pre-change `values` snapshot to `revisions`; `transitrix-reqif history <dir> so-battery-shutdown-req-1` prints "what changed, when" oldest first.
+- **Suspect links fire.** Before any `revise`, `transitrix-reqif suspect <dir>` reports `sr-battery-elaborates-1` as not suspect (its `recorded_target_revision` matches the target's current `revision`). After revising the target's text, the same relation is reported `SUSPECT` — and a relation whose target doesn't resolve at all (a different failure mode, caught by `REQIF-004`) never appears in the `suspect` report, so a suspect link and "no relation exists" are never visually indistinguishable.
+
+## References
+
+- [`notations/packages/reqif.md`](../../../packages/reqif.md) §2.9 — the schema this fixture exercises.
+- [`notations/examples/packages/reqif/`](../reqif/) — the base worked example (object model, converter, round trip).
+- [`PACKAGES.md`](../../../PACKAGES.md) — the mechanism this package is shipped under.

--- a/notations/examples/packages/reqif-workflow/canon/elements/01_motivation/requirements/REQUIREMENT-BATTERY-LOW-POWER-SHUTDOWN-1.yaml
+++ b/notations/examples/packages/reqif-workflow/canon/elements/01_motivation/requirements/REQUIREMENT-BATTERY-LOW-POWER-SHUTDOWN-1.yaml
@@ -1,0 +1,18 @@
+notation: requirement
+id: REQUIREMENT-BATTERY-LOW-POWER-SHUTDOWN-1
+name: "Graceful shutdown on critical battery level"
+description: "The system must save all open state and power down gracefully once battery level falls below the critical threshold, so no in-progress work is lost."
+
+origin: project-product
+severity: high
+
+zone: canon
+admitted_at: "2026-07-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-07-28"
+valid_to: null

--- a/notations/examples/packages/reqif-workflow/reqif/spec-hierarchies/sh-root-1.yaml
+++ b/notations/examples/packages/reqif-workflow/reqif/spec-hierarchies/sh-root-1.yaml
@@ -1,0 +1,9 @@
+package: reqif
+kind: spec-hierarchy
+id: sh-root-1
+name: "Battery low-power shutdown requirements outline"
+children:
+  - object: so-battery-shutdown-req-1
+    children: []
+  - object: so-battery-shutdown-rationale-1
+    children: []

--- a/notations/examples/packages/reqif-workflow/reqif/spec-object-types/sot-rationale-note-workflow-1.yaml
+++ b/notations/examples/packages/reqif-workflow/reqif/spec-object-types/sot-rationale-note-workflow-1.yaml
@@ -1,0 +1,9 @@
+package: reqif
+kind: spec-object-type
+id: sot-rationale-note-workflow-1
+name: "Rationale note (workflow-tracked)"
+attributes:
+  - key: "ReqIF.Name"
+    datatype: STRING
+  - key: "ReqIF.Text"
+    datatype: XHTML

--- a/notations/examples/packages/reqif-workflow/reqif/spec-object-types/sot-requirement-workflow-1.yaml
+++ b/notations/examples/packages/reqif-workflow/reqif/spec-object-types/sot-requirement-workflow-1.yaml
@@ -1,0 +1,11 @@
+package: reqif
+kind: spec-object-type
+id: sot-requirement-workflow-1
+name: "Requirement (workflow-tracked)"
+attributes:
+  - key: "ReqIF.Name"
+    datatype: STRING
+  - key: "ReqIF.Text"
+    datatype: XHTML
+  - key: "Transitrix.CanonRef"
+    datatype: STRING

--- a/notations/examples/packages/reqif-workflow/reqif/spec-objects/so-battery-shutdown-rationale-1.yaml
+++ b/notations/examples/packages/reqif-workflow/reqif/spec-objects/so-battery-shutdown-rationale-1.yaml
@@ -1,0 +1,7 @@
+package: reqif
+kind: spec-object
+id: so-battery-shutdown-rationale-1
+type: sot-rationale-note-workflow-1
+values:
+  ReqIF.Name: "Why a critical threshold, not zero"
+  ReqIF.Text: "Shutting down at zero leaves no headroom to flush state; the critical threshold is set high enough that a full graceful shutdown always completes before power loss."

--- a/notations/examples/packages/reqif-workflow/reqif/spec-objects/so-battery-shutdown-req-1.yaml
+++ b/notations/examples/packages/reqif-workflow/reqif/spec-objects/so-battery-shutdown-req-1.yaml
@@ -1,0 +1,10 @@
+package: reqif
+kind: spec-object
+id: so-battery-shutdown-req-1
+type: sot-requirement-workflow-1
+workflow_state: reviewed
+revision: 1
+values:
+  ReqIF.Name: "Graceful shutdown on critical battery level"
+  ReqIF.Text: "The system shall save all open state and power down gracefully once battery level falls below the critical threshold."
+  Transitrix.CanonRef: "REQUIREMENT-BATTERY-LOW-POWER-SHUTDOWN-1"

--- a/notations/examples/packages/reqif-workflow/reqif/spec-relations/sr-battery-elaborates-1.yaml
+++ b/notations/examples/packages/reqif-workflow/reqif/spec-relations/sr-battery-elaborates-1.yaml
@@ -1,0 +1,7 @@
+package: reqif
+kind: spec-relation
+id: sr-battery-elaborates-1
+type: "elaborates"
+source: so-battery-shutdown-rationale-1
+target: so-battery-shutdown-req-1
+recorded_target_revision: 1

--- a/notations/examples/packages/reqif-workflow/transitrix.yaml
+++ b/notations/examples/packages/reqif-workflow/transitrix.yaml
@@ -1,0 +1,11 @@
+# Worked package instance — notations/examples/packages/reqif-workflow/README.md.
+# A second, minimal adopter-repo slice, isolated from
+# notations/examples/packages/reqif/ so that fixture's `roundtrip` command
+# (packages/reqif-cli/tests/test_reqif_integrity.py Part B) stays unaffected
+# by content the XML converter does not carry (see this folder's README).
+transitrix: 1
+methodology_version: "2.1.0"
+notations: [requirement]
+zones: [canon]
+coverage_profile: core
+packages: [reqif]

--- a/notations/packages/reqif.md
+++ b/notations/packages/reqif.md
@@ -2,7 +2,7 @@
 title: "ReqIF-shaped requirements interchange — domain package"
 version: "0.1"
 author: "Valerii Korobeinikov"
-last_updated: "2026-07-28"
+last_updated: "2026-07-29"
 status: "draft"
 ---
 
@@ -165,6 +165,43 @@ children:
 | `name` | no | Human-readable long name (ReqIF `SPECIFICATION` `LONG-NAME`). |
 | `children` | yes | List of outline nodes. Each node is `{ object, children }`: `object` is a `so-…` id (must resolve within the package, REQIF-006, §5); `children` is the same shape, recursively — an empty list for a leaf node. |
 
+### 2.9 Workflow state, revisions, and suspect links — experimental surface
+
+The epic's own experimental surface (vkgeorgia/strategy#813): tool behaviour layered on top of `spec-object` and `spec-relation`, not part of the ReqIF standard itself. **Not carried through the converter (§6) in v1** — these are top-level YAML fields the reference implementation's own tooling reads and writes; `transitrix-reqif export`/`import` do not represent them in ReqIF XML, so a folder using this surface should not be expected to round-trip identically through `transitrix-reqif roundtrip` (the worked example demonstrating this surface is kept separate from the one demonstrating round trip — see [`notations/examples/packages/reqif-workflow/`](../../notations/examples/packages/reqif-workflow/)).
+
+**Workflow state** — a `spec-object` MAY carry `workflow_state`, one of `draft`, `reviewed`, `approved`, `baselined`, `superseded`. Absent means `draft`. Transitions are **strictly linear, one step at a time** — `draft → reviewed → approved → baselined → superseded`, no skipping and no going backward. The reference implementation's `transition` command (§6) is the only sanctioned writer of this field; it rejects any edge that is not the object's current state's single legal next step.
+
+```yaml
+package: reqif
+kind: spec-object
+id: so-print-retry-req-1
+type: sot-requirement-basic-1
+workflow_state: reviewed
+values: { ... }
+```
+
+**Revisions** — a `spec-object` MAY carry `revision` (its current revision number, a positive integer; absent means `1`) and `revisions` (a list of prior snapshots, oldest first). Each snapshot is `{ revision, values, recorded_at }` — the object's `values` map exactly as it stood before the edit that ended that revision, and an ISO-8601 timestamp. The reference implementation's `revise` command (§6) is the only sanctioned writer of both fields together, so the two never drift apart; "what changed, when" (per requirement object) is answered by the `history` command, or by reading `revisions` directly.
+
+```yaml
+revision: 2
+revisions:
+  - revision: 1
+    values: { "ReqIF.Text": "previous wording" }
+    recorded_at: "2026-07-28T21:45:04Z"
+```
+
+**Suspect links** — a `spec-relation` MAY carry `recorded_target_revision` (a positive integer; absent means `1`, i.e. recorded against the target's original text). A relation is **suspect** when its target's current `revision` has moved past `recorded_target_revision` — its target's text changed after the relation was drawn. Suspicion is always **computed**, never stored as a mutable flag on the relation (a stored flag could go stale the moment a further revision happens without a matching re-check); the reference implementation's `suspect` command (§6) computes it fresh from the two revision numbers. A relation whose target does not resolve at all is a distinct failure (`REQIF-004`) and never appears in the `suspect` report — a suspect link and "no relation exists" are never visually indistinguishable.
+
+```yaml
+package: reqif
+kind: spec-relation
+id: sr-print-retry-elaborates-1
+type: "elaborates"
+source: so-print-retry-rationale-1
+target: so-print-retry-req-1
+recorded_target_revision: 1
+```
+
 ---
 
 ## 3. The one permitted cross-reference — `Transitrix.CanonRef`
@@ -201,6 +238,8 @@ Run by `@transitrix/reqif-cli validate <reqif-folder>` ([`packages/reqif-cli`](.
 | `REQIF-005` | error | A `Transitrix.CanonRef` attribute value is present but is not a grammar-valid core id, or its TYPE prefix is not `REQUIREMENT` or `CONSTRAINT` (§3). |
 | `REQIF-006` | error | A `spec-hierarchy` node's `object` does not resolve to a `spec-object` id present in the package. |
 | `REQIF-007` | error | A `spec-object-type` attribute, or a `spec-object` value keyed by one, names a datatype outside the supported set (§2.6). |
+| `REQIF-008` | error | A `spec-object.workflow_state` value is present but is not one of the five states in §2.9. |
+| `REQIF-009` | error | A `spec-object.revision` or a `spec-relation.recorded_target_revision` value is present but is not a positive integer (§2.9). |
 
 No rule here reaches into `canon/`, `field/`, or `codex/` — package-internal integrity only, per [`PACKAGES.md`](../PACKAGES.md) §4.2.
 
@@ -213,8 +252,14 @@ No rule here reaches into `canon/`, `field/`, or `codex/` — package-internal i
 - `transitrix-reqif export <reqif-folder> <out.reqif>` — reads the four object kinds from a `reqif/` folder and emits a ReqIF-conformant XML document (`REQ-IF` root, `DATATYPES` / `SPEC-TYPES` / `SPEC-OBJECTS` / `SPEC-RELATIONS` / `SPECIFICATIONS` sections).
 - `transitrix-reqif import <in.reqif> <reqif-folder>` — reads a ReqIF XML document and writes the four object kinds back out as YAML files.
 - `transitrix-reqif roundtrip <reqif-folder>` — exports then re-imports into memory (no disk write) and asserts the resulting object set is identical to the one loaded from `<reqif-folder>` — the package's own demonstration of the epic's round-trip success signal.
+- `transitrix-reqif transition <reqif-folder> <spec-object-id> <new-state>` — advances a `spec-object`'s `workflow_state` by exactly one legal step (§2.9); rejects (exit 1, no write) any other edge.
+- `transitrix-reqif revise <reqif-folder> <spec-object-id> <ReqIF.Attr> <new-value>` — changes one value, bumping `revision` and appending the pre-change `values` snapshot to `revisions` (§2.9).
+- `transitrix-reqif history <reqif-folder> <spec-object-id>` — prints a `spec-object`'s revision history, oldest first.
+- `transitrix-reqif suspect <reqif-folder>` — lists every `spec-relation` with its computed suspect status (§2.9).
 
 **`Transitrix.CanonRef` in XML.** The one-way core citation (§3) is not a special XML construct — it is exported as an ordinary `ATTRIBUTE-VALUE-STRING` like any other attribute on the `spec-object`'s type, so it survives the round trip without any converter-side special case.
+
+**The experimental surface (§2.9) is not carried through this converter in v1.** `workflow_state`, `revision`, `revisions`, and `recorded_target_revision` are top-level fields the four `export`/`import`/`validate`/`roundtrip` commands do not read or write — only `transition`, `revise`, `history`, and `suspect` do. A folder exercising the experimental surface is not expected to round-trip identically through `roundtrip`; the worked example demonstrating it ([`notations/examples/packages/reqif-workflow/`](../../notations/examples/packages/reqif-workflow/)) is kept separate from the one demonstrating round trip ([`notations/examples/packages/reqif/`](../../notations/examples/packages/reqif/)) for exactly this reason.
 
 ---
 
@@ -222,8 +267,9 @@ No rule here reaches into `canon/`, `field/`, or `codex/` — package-internal i
 
 **Landed (v0.1, 2026-07-28):** object model (§2), the one-way canon citation (§3), the package validator (§5), and the YAML↔ReqIF-XML converter (§6) — the base ReqIF-shaped layer.
 
+**Landed (2026-07-29):** workflow state, revision history, and suspect-link mechanics (§2.9) — the package's explicitly experimental surface. `REQIF-008`/`REQIF-009` (§5) and the `transition`/`revise`/`history`/`suspect` commands (§6). Not carried through the XML converter in v1 (§6). Worked example: [`notations/examples/packages/reqif-workflow/`](../../notations/examples/packages/reqif-workflow/).
+
 **Pending (separate, sibling package work):**
-- Workflow state (`draft → reviewed → approved → baselined → superseded`), revision history, and suspect-link mechanics on `spec-object` — this package's explicitly experimental surface, deliberately kept out of this document until it lands, per [`PACKAGES.md`](../PACKAGES.md) §6's instruction that a package's rough edges stay contained inside the package.
 - This document's **removal procedure** and **experimental-status declaration** — both required by [`PACKAGES.md`](../PACKAGES.md) §6 ("required, not implied"), demonstrated as a test against the worked package instance, rather than asserted in prose here.
 
 ---

--- a/packages/reqif-cli/README.md
+++ b/packages/reqif-cli/README.md
@@ -31,6 +31,12 @@ transitrix-reqif <command> [args]
 | `import <in.reqif> <reqif-folder>` | Read a ReqIF XML document and write the four object kinds back out as YAML. |
 | `validate <reqif-folder>` | Run the package's own validator — `REQIF-001..007`, [`notations/packages/reqif.md`](../../notations/packages/reqif.md) §5. Package-internal only; never resolves a `Transitrix.CanonRef` against an adopter's `canon/`. |
 | `roundtrip <reqif-folder>` | Export then re-import in memory (no disk write) and assert the resulting object set is identical to the one loaded from the folder — the package's own demonstration of the epic's round-trip success signal. |
+| `transition <reqif-folder> <spec-object-id> <new-state>` | Advance a `spec-object`'s `workflow_state` by exactly one legal step (`draft → reviewed → approved → baselined → superseded`); rejects any other edge. |
+| `revise <reqif-folder> <spec-object-id> <ReqIF.Attr> <new-value>` | Change one value, bumping `revision` and snapshotting the pre-change `values` into `revisions`. |
+| `history <reqif-folder> <spec-object-id>` | Print a `spec-object`'s revision history, oldest first. |
+| `suspect <reqif-folder>` | List every `spec-relation` with its computed suspect status — flagged when its target's text changed since the relation was recorded. |
+
+The last four commands are the package's experimental surface (`REQIF-008`/`REQIF-009`, [`notations/packages/reqif.md`](../../notations/packages/reqif.md) §2.9) — not represented in ReqIF XML, so a folder exercising them is not expected to round-trip identically through `roundtrip`. Worked example: [`notations/examples/packages/reqif-workflow/`](../../notations/examples/packages/reqif-workflow/).
 
 ## The object model
 

--- a/packages/reqif-cli/package.json
+++ b/packages/reqif-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/reqif-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Reference converter + validator for the ReqIF-shaped domain package (notations/packages/reqif.md) — YAML ↔ ReqIF XML, package-internal referential integrity. Standalone: never wired into @transitrix/ingest-cli or core validators.",
   "type": "module",
   "bin": {

--- a/packages/reqif-cli/reqif.mjs
+++ b/packages/reqif-cli/reqif.mjs
@@ -6,13 +6,16 @@
 // folder plus the `packages:` line in an adopter's transitrix.yaml leaves no
 // trace (PACKAGES.md §4.3).
 //
-// Commands: export, import, validate, roundtrip.
+// Commands: export, import, validate, roundtrip, transition, revise, history, suspect.
 // Exit codes: 0 = ok · 1 = findings (validation errors / roundtrip mismatch) · 2 = usage/error
 
 import { readFile, writeFile } from 'node:fs/promises';
-import { loadPackage, writePackage, normalizeModel, deepEqual } from './src/model.mjs';
+import { loadPackage, writePackage, writeOne, normalizeModel, deepEqual } from './src/model.mjs';
 import { modelToReqifXml, reqifXmlToModel } from './src/reqif-xml.mjs';
 import { validatePackage } from './src/validate.mjs';
+import { currentState, isValidTransition, applyTransition } from './src/workflow.mjs';
+import { reviseObject, historyOf } from './src/revisions.mjs';
+import { computeSuspectLinks } from './src/suspect.mjs';
 
 function usage() {
   return `@transitrix/reqif-cli — ReqIF-shaped package converter + validator (notations/packages/reqif.md)
@@ -20,8 +23,14 @@ function usage() {
 Usage:
   transitrix-reqif export <reqif-folder> <out.reqif>     Write the package as ReqIF XML.
   transitrix-reqif import <in.reqif> <reqif-folder>       Write a ReqIF XML document as package YAML.
-  transitrix-reqif validate <reqif-folder>                Run the package's own validator (REQIF-001..007).
+  transitrix-reqif validate <reqif-folder>                Run the package's own validator (REQIF-001..009).
   transitrix-reqif roundtrip <reqif-folder>                Export then re-import in memory; assert an identical object set.
+  transitrix-reqif transition <reqif-folder> <spec-object-id> <new-state>
+                                                            Advance a spec-object's workflow_state by exactly one legal step.
+  transitrix-reqif revise <reqif-folder> <spec-object-id> <ReqIF.Attr> <new-value>
+                                                            Change one value, snapshotting the prior values into the object's revision history.
+  transitrix-reqif history <reqif-folder> <spec-object-id> Print a spec-object's revision history, oldest first.
+  transitrix-reqif suspect <reqif-folder>                  List every spec-relation with its computed suspect status.
 `;
 }
 
@@ -77,14 +86,81 @@ async function cmdRoundtrip(args) {
   return 1;
 }
 
+function findSpecObject(model, id) {
+  const so = model.specObjects.find(o => o.id === id);
+  if (!so) throw new Error(`no spec-object "${id}" in this package`);
+  return so;
+}
+
+async function cmdTransition(args) {
+  const [dir, id, toState] = args;
+  if (!dir || !id || !toState) { console.error('usage: transitrix-reqif transition <reqif-folder> <spec-object-id> <new-state>'); return 2; }
+  const model = await loadPackage(dir);
+  let so;
+  try { so = findSpecObject(model, id); } catch (err) { console.error(err.message); return 2; }
+  const from = currentState(so);
+  if (!isValidTransition(from, toState)) {
+    console.error(`transition  rejected — "${from}" -> "${toState}" is not a legal step for spec-object "${id}" (notations/packages/reqif.md §2.9).`);
+    return 1;
+  }
+  const updated = applyTransition(so, toState);
+  await writeOne(dir, 'spec-object', updated);
+  console.log(`transition  spec-object "${id}": "${from}" -> "${toState}".`);
+  return 0;
+}
+
+async function cmdRevise(args) {
+  const [dir, id, key, value] = args;
+  if (!dir || !id || !key || value === undefined) { console.error('usage: transitrix-reqif revise <reqif-folder> <spec-object-id> <ReqIF.Attr> <new-value>'); return 2; }
+  const model = await loadPackage(dir);
+  let so;
+  try { so = findSpecObject(model, id); } catch (err) { console.error(err.message); return 2; }
+  const recordedAt = new Date().toISOString();
+  const updated = reviseObject(so, { [key]: value }, recordedAt);
+  await writeOne(dir, 'spec-object', updated);
+  console.log(`revise  spec-object "${id}": revision ${updated.revision - 1} -> ${updated.revision} ("${key}" changed, recorded ${recordedAt}).`);
+  return 0;
+}
+
+async function cmdHistory(args) {
+  const [dir, id] = args;
+  if (!dir || !id) { console.error('usage: transitrix-reqif history <reqif-folder> <spec-object-id>'); return 2; }
+  const model = await loadPackage(dir);
+  let so;
+  try { so = findSpecObject(model, id); } catch (err) { console.error(err.message); return 2; }
+  const entries = historyOf(so);
+  console.log(`history  spec-object "${id}" — ${entries.length} revision(s):`);
+  for (const e of entries) {
+    console.log(`  revision ${e.revision}${e.recorded_at ? ` (superseded ${e.recorded_at})` : ' (current)'}: ${JSON.stringify(e.values)}`);
+  }
+  return 0;
+}
+
+async function cmdSuspect(args) {
+  const [dir] = args;
+  if (!dir) { console.error('usage: transitrix-reqif suspect <reqif-folder>'); return 2; }
+  const model = await loadPackage(dir);
+  const links = computeSuspectLinks(model);
+  const suspectCount = links.filter(l => l.suspect).length;
+  console.log(`suspect  ${suspectCount}/${links.length} spec-relation(s) flagged suspect:`);
+  for (const l of links) {
+    console.log(`  [${l.suspect ? 'SUSPECT' : 'ok'}] "${l.id}" (${l.type}) -> "${l.target}" — recorded at revision ${l.recordedTargetRevision}, target now at revision ${l.targetRevision}.`);
+  }
+  return 0;
+}
+
 async function main(argv) {
   const [cmd, ...args] = argv;
   if (!cmd || cmd === '--help' || cmd === '-h') { console.log(usage()); return cmd ? 0 : 1; }
   switch (cmd) {
-    case 'export':    return cmdExport(args);
-    case 'import':    return cmdImport(args);
-    case 'validate':  return cmdValidate(args);
-    case 'roundtrip': return cmdRoundtrip(args);
+    case 'export':     return cmdExport(args);
+    case 'import':     return cmdImport(args);
+    case 'validate':   return cmdValidate(args);
+    case 'roundtrip':  return cmdRoundtrip(args);
+    case 'transition': return cmdTransition(args);
+    case 'revise':     return cmdRevise(args);
+    case 'history':    return cmdHistory(args);
+    case 'suspect':    return cmdSuspect(args);
     default:
       console.error(`unknown command: ${cmd}\n\n${usage()}`);
       return 1;

--- a/packages/reqif-cli/src/model.mjs
+++ b/packages/reqif-cli/src/model.mjs
@@ -53,6 +53,15 @@ export async function writePackage(dir, model) {
   }
 }
 
+// Writes a single object back to its own file, leaving every other file in
+// `dir` untouched — used by commands (`transition`, `revise`) that update
+// exactly one spec-object or spec-relation in place.
+export async function writeOne(dir, kind, item) {
+  const sub = join(dir, SUBFOLDER[kind]);
+  await mkdir(sub, { recursive: true });
+  await writeFile(join(sub, `${item.id}.yaml`), dump(item), 'utf8');
+}
+
 // Deep-sorts a model's four arrays by id so two models built from the same
 // object set compare equal regardless of read/write order (directory listing
 // order, XML section order, etc.).

--- a/packages/reqif-cli/src/revisions.mjs
+++ b/packages/reqif-cli/src/revisions.mjs
@@ -1,0 +1,41 @@
+// Revision history — the package's experimental surface, notations/packages/reqif.md
+// §2.9. A `spec-object` MAY carry `revision` (its current revision number,
+// default 1 when absent) and `revisions` (a list of past snapshots). The
+// `revise` CLI command is the only writer of both fields together, so the
+// two never drift apart.
+//
+// A snapshot captures the object's `values` map exactly as it stood *before*
+// the edit being applied, tagged with the revision number that is ending —
+// so "what changed, when" (epic vkgeorgia/strategy#813's #829 acceptance
+// criterion) is answerable by diffing two adjacent entries (or the last
+// entry against the object's current `values`).
+
+export function currentRevision(specObject) {
+  return Number.isInteger(specObject.revision) ? specObject.revision : 1;
+}
+
+// Returns a new spec-object: `values` merged with `changes`, `revision`
+// bumped by one, and a snapshot of the pre-change `values` appended to
+// `revisions`. `recordedAt` is an ISO-8601 timestamp string supplied by the
+// caller (the CLI stamps it at invocation time; keeping it a parameter, not
+// a `new Date()` call inside this module, keeps the function pure and
+// testable).
+export function reviseObject(specObject, changes, recordedAt) {
+  const fromRevision = currentRevision(specObject);
+  const priorValues = { ...specObject.values };
+  const snapshot = { revision: fromRevision, values: priorValues, recorded_at: recordedAt };
+  return {
+    ...specObject,
+    values: { ...specObject.values, ...changes },
+    revision: fromRevision + 1,
+    revisions: [...(specObject.revisions || []), snapshot],
+  };
+}
+
+// "What changed, when" — the full history plus the current state, oldest
+// first, for a `history` command to print.
+export function historyOf(specObject) {
+  const entries = (specObject.revisions || []).map(r => ({ revision: r.revision, values: r.values, recorded_at: r.recorded_at }));
+  entries.push({ revision: currentRevision(specObject), values: specObject.values, recorded_at: null });
+  return entries;
+}

--- a/packages/reqif-cli/src/suspect.mjs
+++ b/packages/reqif-cli/src/suspect.mjs
@@ -1,0 +1,47 @@
+// Suspect links — the package's experimental surface, notations/packages/reqif.md
+// §2.9. A `spec-relation` MAY carry `recorded_target_revision`: the target
+// `spec-object`'s `revision` (revisions.mjs) at the moment the relation was
+// recorded. Absent means 1 — the relation was recorded against the target's
+// original text, before any `revise` had happened.
+//
+// A relation is *suspect* when its target's current revision has moved past
+// the revision the relation was recorded against — i.e. the target's text
+// changed after the relation was drawn. This is computed, never stored: the
+// alternative (a mutable `suspect: true` flag written into the relation
+// file) could go stale the moment a further `revise` happens without a
+// matching re-check, so suspicion is always derived fresh from the two
+// revision numbers, the same way ReqIF tools compute it in practice.
+
+import { currentRevision } from './revisions.mjs';
+
+function recordedTargetRevision(specRelation) {
+  return Number.isInteger(specRelation.recorded_target_revision) ? specRelation.recorded_target_revision : 1;
+}
+
+// Returns one entry per spec-relation whose target resolves within the
+// model: { id, source, target, type, recordedTargetRevision, targetRevision,
+// suspect }. A relation is absent from this list only if its target does
+// not resolve (REQIF-004 already flags that as a validation error) — every
+// resolvable relation gets an explicit `suspect: true|false`, so a suspect
+// link is never visually indistinguishable from "no relation exists": the
+// latter simply has no entry at all.
+export function computeSuspectLinks(model) {
+  const objectById = new Map(model.specObjects.map(o => [o.id, o]));
+  const out = [];
+  for (const r of model.specRelations) {
+    const target = objectById.get(r.target);
+    if (!target) continue;
+    const recorded = recordedTargetRevision(r);
+    const targetRevision = currentRevision(target);
+    out.push({
+      id: r.id,
+      source: r.source,
+      target: r.target,
+      type: r.type,
+      recordedTargetRevision: recorded,
+      targetRevision,
+      suspect: targetRevision > recorded,
+    });
+  }
+  return out;
+}

--- a/packages/reqif-cli/src/validate.mjs
+++ b/packages/reqif-cli/src/validate.mjs
@@ -4,6 +4,7 @@
 // package's own content only).
 
 import { isValidPackageId, isValidCoreId, coreIdType } from './ids.mjs';
+import { isWorkflowState } from './workflow.mjs';
 
 const SUPPORTED_DATATYPES = new Set(['STRING', 'XHTML', 'DATE', 'INTEGER', 'BOOLEAN']);
 const CORE_REF_TYPES = new Set(['REQUIREMENT', 'CONSTRAINT']);
@@ -38,8 +39,16 @@ export function validatePackage(model) {
     }
   }
 
+  function isPositiveInt(v) { return Number.isInteger(v) && v >= 1; }
+
   for (const so of model.specObjects) {
     checkId('spec-object', so.id, `spec-object "${so.id}"`);
+    if ('workflow_state' in so && !isWorkflowState(so.workflow_state)) {
+      flag('REQIF-008', `spec-object "${so.id}": workflow_state "${so.workflow_state}" is not one of draft/reviewed/approved/baselined/superseded (reqif.md §2.9).`);
+    }
+    if ('revision' in so && !isPositiveInt(so.revision)) {
+      flag('REQIF-009', `spec-object "${so.id}": revision "${so.revision}" is not a positive integer (reqif.md §2.9).`);
+    }
     if (!sotIds.has(so.type)) {
       flag('REQIF-003', `spec-object "${so.id}": type "${so.type}" does not resolve to a spec-object-type in this package.`);
     } else {
@@ -62,6 +71,9 @@ export function validatePackage(model) {
     checkId('spec-relation', sr.id, `spec-relation "${sr.id}"`);
     if (!soIds.has(sr.source)) flag('REQIF-004', `spec-relation "${sr.id}": source "${sr.source}" does not resolve to a spec-object in this package.`);
     if (!soIds.has(sr.target)) flag('REQIF-004', `spec-relation "${sr.id}": target "${sr.target}" does not resolve to a spec-object in this package.`);
+    if ('recorded_target_revision' in sr && !isPositiveInt(sr.recorded_target_revision)) {
+      flag('REQIF-009', `spec-relation "${sr.id}": recorded_target_revision "${sr.recorded_target_revision}" is not a positive integer (reqif.md §2.9).`);
+    }
   }
 
   function checkHierarchyNode(node, where) {

--- a/packages/reqif-cli/src/workflow.mjs
+++ b/packages/reqif-cli/src/workflow.mjs
@@ -1,0 +1,47 @@
+// Workflow-state — the package's experimental surface, notations/packages/reqif.md
+// §2.9. A `spec-object` MAY carry a top-level `workflow_state` field; absent
+// means `draft` (the sequence's starting state). This module is the single
+// place the state graph and its enforcement live — the `transition` CLI
+// command is the only writer of this field, so a state written by this
+// package's own tooling always arrived via a legal edge.
+//
+// Strictly linear, one step at a time — no skips, no jump straight to
+// `superseded` from an earlier state (epic vkgeorgia/strategy#813's own
+// acceptance criterion for #829: "no skipping draft -> approved without
+// reviewed").
+
+export const WORKFLOW_STATES = ['draft', 'reviewed', 'approved', 'baselined', 'superseded'];
+
+const NEXT = {
+  draft: 'reviewed',
+  reviewed: 'approved',
+  approved: 'baselined',
+  baselined: 'superseded',
+};
+
+export function isWorkflowState(v) {
+  return typeof v === 'string' && WORKFLOW_STATES.includes(v);
+}
+
+// A spec-object with no `workflow_state` is implicitly `draft` — this keeps
+// every object from the base package (notations/packages/reqif.md §2.5, the
+// #387 worked example) valid without modification; the experimental surface
+// is opt-in.
+export function currentState(specObject) {
+  return specObject.workflow_state || 'draft';
+}
+
+export function isValidTransition(from, to) {
+  return NEXT[from] === to;
+}
+
+// Returns a new spec-object with `workflow_state` advanced to `to`, or throws
+// if the edge from the object's current state to `to` is not the single
+// legal next step.
+export function applyTransition(specObject, to) {
+  const from = currentState(specObject);
+  if (!isValidTransition(from, to)) {
+    throw new Error(`illegal transition "${from}" -> "${to}" for spec-object "${specObject.id}" (allowed: "${from}" -> "${NEXT[from] || '(none — terminal state)'}")`);
+  }
+  return { ...specObject, workflow_state: to };
+}

--- a/packages/reqif-cli/tests/test_reqif_workflow.py
+++ b/packages/reqif-cli/tests/test_reqif_workflow.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Integration test for the ReqIF package's experimental surface — workflow
+state, revision history, and suspect links (notations/packages/reqif.md
+§2.9; vkgeorgia/strategy#813, task #829).
+
+Deterministic, no-API-key guard. Drives the real CLI end-to-end against a
+temp-dir copy of the worked fixture
+(notations/examples/packages/reqif-workflow/) — the checked-in fixture is
+never mutated:
+
+  A. Validator — the worked example's reqif/ folder validates clean as
+     checked in (workflow_state / revision on so-battery-shutdown-req-1 are
+     grammar-valid; the rationale object's implicit default is `draft`).
+  B. Workflow-state transitions are enforced — the single legal next step
+     (`reviewed` -> `approved`) succeeds; skipping a state (`draft` ->
+     `approved` on the rationale object, still implicitly `draft`) is
+     rejected, exit 1, and leaves the object's state unchanged on disk.
+  C. Revision history is queryable — `revise` bumps the revision counter and
+     snapshots the pre-change values; `history` reports both the old and the
+     new text, oldest first.
+  D. Suspect links fire, and are distinguishable from "no relation exists" —
+     the relation onto the just-revised object is reported `SUSPECT`; a
+     relation whose target does not resolve at all never appears in the
+     `suspect` report (a different, absence, case).
+  E. Validator catches broken workflow/revision input — REQIF-008 (bad
+     workflow_state) and REQIF-009 (non-integer revision / recorded_target_revision)
+     each fire on a deliberately malformed fixture.
+
+Run:  python packages/reqif-cli/tests/test_reqif_workflow.py
+Exit: 0 = all pass; 1 = a check failed (message localises the problem).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.exit("FAIL: PyYAML is required (pip install pyyaml).")
+
+HERE = os.path.dirname(os.path.abspath(__file__))           # packages/reqif-cli/tests
+PKG_DIR = os.path.dirname(HERE)                              # packages/reqif-cli
+REPO_ROOT = os.path.dirname(os.path.dirname(PKG_DIR))         # repo root
+CLI = os.path.join(PKG_DIR, "reqif.mjs")
+FIXTURE = Path(REPO_ROOT) / "notations" / "examples" / "packages" / "reqif-workflow"
+REQIF_DIR = FIXTURE / "reqif"
+
+_failures = []
+
+
+def check(cond, msg):
+    if not cond:
+        _failures.append(msg)
+    return cond
+
+
+def run_cli(*args):
+    return subprocess.run(["node", CLI, *args], capture_output=True, text=True)
+
+
+def load_yaml(path):
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+
+
+def fresh_copy():
+    td = tempfile.mkdtemp(prefix="reqif-workflow-")
+    dst = Path(td) / "reqif"
+    shutil.copytree(REQIF_DIR, dst)
+    return dst
+
+
+# ── Part A — validator clean on the worked example, as checked in ────────
+
+def part_a_validate_clean():
+    r = run_cli("validate", str(REQIF_DIR))
+    check(r.returncode == 0, f"A: validate exited {r.returncode} on the worked example: {r.stderr or r.stdout}")
+    check("clean" in r.stdout, f"A: expected a clean validate report, got: {r.stdout!r}")
+
+
+# ── Part B — workflow-state transitions enforced ──────────────────────────
+
+def part_b_transition_enforced():
+    d = fresh_copy()
+
+    r = run_cli("transition", str(d), "so-battery-shutdown-req-1", "approved")
+    check(r.returncode == 0, f"B: expected the legal 'reviewed'->'approved' transition to succeed, got exit {r.returncode}: {r.stderr or r.stdout}")
+    so = load_yaml(d / "spec-objects" / "so-battery-shutdown-req-1.yaml")
+    check(so.get("workflow_state") == "approved", f"B: expected workflow_state 'approved' after transition, got {so.get('workflow_state')!r}")
+
+    # so-battery-shutdown-rationale-1 carries no workflow_state -> implicit 'draft'.
+    before = load_yaml(d / "spec-objects" / "so-battery-shutdown-rationale-1.yaml")
+    check("workflow_state" not in before, "B: expected the rationale object to start with no workflow_state (implicit draft)")
+
+    r2 = run_cli("transition", str(d), "so-battery-shutdown-rationale-1", "approved")
+    check(r2.returncode == 1, f"B: expected skipping 'draft'->'approved' to be rejected (exit 1), got {r2.returncode}: {r2.stderr or r2.stdout}")
+    after = load_yaml(d / "spec-objects" / "so-battery-shutdown-rationale-1.yaml")
+    check("workflow_state" not in after, "B: a rejected transition must not modify the object's file on disk")
+
+    shutil.rmtree(d.parent, ignore_errors=True)
+
+
+# ── Part C — revision history queryable ───────────────────────────────────
+
+def part_c_revise_and_history():
+    d = fresh_copy()
+    original = load_yaml(d / "spec-objects" / "so-battery-shutdown-req-1.yaml")
+    old_text = original["values"]["ReqIF.Text"]
+    new_text = "The system shall save all open state and power down gracefully once battery level falls below 8 percent."
+
+    r = run_cli("revise", str(d), "so-battery-shutdown-req-1", "ReqIF.Text", new_text)
+    check(r.returncode == 0, f"C: expected revise to succeed, got exit {r.returncode}: {r.stderr or r.stdout}")
+
+    revised = load_yaml(d / "spec-objects" / "so-battery-shutdown-req-1.yaml")
+    check(revised.get("revision") == 2, f"C: expected revision 2 after one revise, got {revised.get('revision')!r}")
+    check(revised["values"]["ReqIF.Text"] == new_text, "C: expected the object's current text to be the revised text")
+    revisions = revised.get("revisions") or []
+    check(len(revisions) == 1, f"C: expected exactly one snapshot in revisions, got {len(revisions)}")
+    if revisions:
+        check(revisions[0]["values"]["ReqIF.Text"] == old_text, "C: expected the snapshot to hold the pre-revise text")
+
+    h = run_cli("history", str(d), "so-battery-shutdown-req-1")
+    check(h.returncode == 0, f"C: expected history to succeed, got exit {h.returncode}: {h.stderr or h.stdout}")
+    check(old_text in h.stdout, "C: expected history output to include the old (superseded) text")
+    check(new_text in h.stdout, "C: expected history output to include the current text")
+
+    shutil.rmtree(d.parent, ignore_errors=True)
+
+
+# ── Part D — suspect links fire, distinguishable from "no relation" ──────
+
+def part_d_suspect_links():
+    d = fresh_copy()
+
+    before = run_cli("suspect", str(d))
+    check(before.returncode == 0, f"D: expected suspect to succeed, got exit {before.returncode}: {before.stderr or before.stdout}")
+    check("SUSPECT" not in before.stdout, f"D: expected no suspect relation before any revise, got:\n{before.stdout}")
+    check("sr-battery-elaborates-1" in before.stdout, "D: expected the relation to be reported (not suspect) before any revise")
+
+    run_cli("revise", str(d), "so-battery-shutdown-req-1", "ReqIF.Text", "Revised text for suspect-link demonstration.")
+
+    after = run_cli("suspect", str(d))
+    check(after.returncode == 0, f"D: expected suspect to succeed after revise, got exit {after.returncode}: {after.stderr or after.stdout}")
+    check("SUSPECT" in after.stdout, f"D: expected sr-battery-elaborates-1 to be flagged SUSPECT after revising its target, got:\n{after.stdout}")
+
+    # A relation whose target does not resolve at all is a different failure
+    # mode (REQIF-004) and must never be reported by `suspect` — so a suspect
+    # link is never visually indistinguishable from "no relation exists".
+    (d / "spec-relations" / "sr-dangling-1.yaml").write_text(
+        'package: reqif\nkind: spec-relation\nid: sr-dangling-1\ntype: "elaborates"\n'
+        'source: so-battery-shutdown-rationale-1\ntarget: so-does-not-exist-1\n',
+        encoding="utf-8",
+    )
+    dangling = run_cli("suspect", str(d))
+    check("sr-dangling-1" not in dangling.stdout, "D: a relation with an unresolvable target must not appear in the suspect report")
+
+    shutil.rmtree(d.parent, ignore_errors=True)
+
+
+# ── Part E — validator catches broken workflow/revision input ────────────
+
+def part_e_validator_catches_broken_input():
+    with tempfile.TemporaryDirectory(prefix="reqif-workflow-broken-") as td:
+        broken = Path(td) / "reqif"
+        for sub in ("spec-object-types", "spec-objects", "spec-relations", "spec-hierarchies"):
+            (broken / sub).mkdir(parents=True)
+
+        (broken / "spec-object-types" / "sot-x-1.yaml").write_text(
+            'package: reqif\nkind: spec-object-type\nid: sot-x-1\nname: "X"\n'
+            'attributes:\n  - key: "ReqIF.Text"\n    datatype: STRING\n',
+            encoding="utf-8",
+        )
+        (broken / "spec-objects" / "so-x-1.yaml").write_text(
+            'package: reqif\nkind: spec-object\nid: so-x-1\ntype: sot-x-1\n'
+            'workflow_state: "not-a-real-state"\nrevision: "two"\n'
+            'values:\n  ReqIF.Text: "hello"\n',
+            encoding="utf-8",
+        )
+        (broken / "spec-objects" / "so-y-1.yaml").write_text(
+            'package: reqif\nkind: spec-object\nid: so-y-1\ntype: sot-x-1\n'
+            'values:\n  ReqIF.Text: "world"\n',
+            encoding="utf-8",
+        )
+        (broken / "spec-relations" / "sr-x-1.yaml").write_text(
+            'package: reqif\nkind: spec-relation\nid: sr-x-1\ntype: "elaborates"\n'
+            'source: so-y-1\ntarget: so-x-1\nrecorded_target_revision: "one"\n',
+            encoding="utf-8",
+        )
+
+        r = run_cli("validate", str(broken))
+        combined = (r.stdout or "") + (r.stderr or "")
+        check(r.returncode == 1, f"E: expected exit 1 on broken input, got {r.returncode}")
+        for code in ("REQIF-008", "REQIF-009"):
+            check(code in combined, f"E: expected {code} to fire on the broken fixture; got:\n{combined}")
+
+
+if not shutil.which("node"):
+    print("SKIP: `node` not found on PATH (the CLI is Node).")
+    sys.exit(0)
+if not os.path.isfile(CLI):
+    sys.exit(f"FAIL: CLI entry point missing: {CLI}")
+
+part_a_validate_clean()
+part_b_transition_enforced()
+part_c_revise_and_history()
+part_d_suspect_links()
+part_e_validator_catches_broken_input()
+
+if _failures:
+    print("FAIL - ReqIF package workflow-state/revisions/suspect-links integration test:")
+    for f in _failures:
+        print(f"  - {f}")
+    sys.exit(1)
+print("PASS - ReqIF package experimental surface (workflow-state, revisions, suspect links): all checks passed.")
+sys.exit(0)


### PR DESCRIPTION
## Summary

Part of HUB-813. Adds the ReqIF domain package's own experimental surface on top of the base object model (#387/PR #387):

- **Workflow state** — `draft -> reviewed -> approved -> baselined -> superseded`, strictly linear, enforced by a new `transition` command that rejects any other edge.
- **Revision history** — `revise` + `history`, snapshotting an object's pre-change values on every edit.
- **Suspect links** — `suspect`, computed fresh from a relation's recorded target revision vs. the target's current revision (never a stored, staleness-prone flag), and distinguishable in output from "no relation exists" (an unresolvable target never appears in the suspect report — that's REQIF-004's job, a different failure mode).

New REQIF-008/REQIF-009 validator rules catch invalid `workflow_state` values and non-integer revision counters.

None of this is carried through the ReqIF XML converter in v1 — a stated, documented limitation, not an oversight — so the worked example lives in its own fixture (`notations/examples/packages/reqif-workflow/`), kept separate from `notations/examples/packages/reqif/` so that fixture's own roundtrip test stays unaffected.

Explicitly experimental per the epic — this stays in the package, not core, until the experiment's result says otherwise (`notations/PACKAGES.md` reversibility contract).

## Test plan

- [x] `node scripts/check-notations.mjs` — doc-lint clean
- [x] `node --check` on all new/changed `.mjs` files
- [x] Manually exercised `transition`/`revise`/`history`/`suspect` end-to-end against a temp copy of the worked fixture (Python/pytest unavailable in this sandbox, so verified behavior directly via the CLI):
  - legal `reviewed -> approved` transition succeeds
  - illegal `draft -> approved` (skipping `reviewed`) rejected, exit 1, object unchanged on disk
  - `revise` bumps revision counter, snapshots pre-change values; `history` shows old + new text, oldest first
  - `suspect` flags the relation onto the revised object as `SUSPECT`, with a dangling-target relation never appearing in the report
- [x] Base `reqif` fixture still validates clean (unaffected by the new sibling fixture)
- [ ] CI's `packages/reqif-cli/tests/test_reqif_workflow.py` (Python 3.12 + PyYAML, `.github/workflows/reqif-cli-test.yml`) — will confirm on this PR's checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)