### PR TITLE
chore(gitignore): ignore stray debug.log at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+debug.log
 .npm
 coverage/
 .nyc_output/


### PR DESCRIPTION
## Summary
- Routine hygiene pass found an untracked `debug.log` (Chromium/crashpad crash log) at repo root not covered by existing `npm-debug.log*`/`yarn-debug.log*` patterns.
- Adds a plain `debug.log` ignore entry.

## Test plan
- [x] `git clean -ndx` before/after — file no longer surfaces as untracked-and-unignored.