### PR TITLE
feat(decisions-cli): interactive one-card admission review (review)

### DIFF
--- a/.github/workflows/decisions-cli-test.yml
+++ b/.github/workflows/decisions-cli-test.yml
@@ -10,7 +10,7 @@ name: decisions-cli test
 # conformance (test_decisions_integrity.py); plus a Node unit test driving the
 # interactive `review` one-card loop directly — stop/resume, reject-requires-
 # reason — since its TTY guard makes it untestable from a piped subprocess
-# (test_review_unit.mjs). Epic vkgeorgia/strategy#854.
+# (test_review_unit.mjs). Epic HUB-854.
 
 on:
   pull_request:

--- a/.github/workflows/decisions-cli-test.yml
+++ b/.github/workflows/decisions-cli-test.yml
@@ -6,8 +6,11 @@ name: decisions-cli test
 # architecture/methodology/2026-07-28-ingest-admission-decision-contract.md).
 # Deterministic, no API key. Drives the real CLI end-to-end against synthetic
 # fixtures: list-undecided / record / apply across both source gates, the
-# ADMIT-007 tool/human authority guard, and schema conformance.
-# Implementation: packages/decisions-cli/tests/test_decisions_integrity.py.
+# ADMIT-007 tool/human authority guard, review's non-TTY refusal, and schema
+# conformance (test_decisions_integrity.py); plus a Node unit test driving the
+# interactive `review` one-card loop directly — stop/resume, reject-requires-
+# reason — since its TTY guard makes it untestable from a piped subprocess
+# (test_review_unit.mjs). Epic vkgeorgia/strategy#854.
 
 on:
   pull_request:
@@ -42,3 +45,6 @@ jobs:
 
       - name: Run decisions-cli integrity test
         run: python packages/decisions-cli/tests/test_decisions_integrity.py
+
+      - name: Run decisions-cli review unit test
+        run: node packages/decisions-cli/tests/test_review_unit.mjs

--- a/packages/decisions-cli/README.md
+++ b/packages/decisions-cli/README.md
@@ -39,6 +39,7 @@ Absence of a `decisions[]` row for an item means **undecided**, never rejected �
 | `list-undecided <org-root> [--source-gate <path>]` | Every candidate / segment / amendment the source gate currently presents that has no matching `decisions[]` row yet. |
 | `record <org-root> --item-ref <ref> --decision accept\|reject\|defer --by <id> --at <date> [--reason <text>] [--kind <k>] [--reviewer-authority ai_reviewed\|expert_confirmed] [--source-gate <path>]` | Upsert one decision row — idempotent per `item_ref`; a later `record` call for the same item replaces the earlier row. |
 | `apply <org-root> [--source-gate <path>]` | Apply every `accept` / `reject` row as a CONTRACT §6.1 transition on the artefact it names; `defer` rows are left untouched (the row is the audit trail). |
+| `review <org-root> [--source-gate <path>] [--by <handle>]` | Interactive one-card review over `list-undecided`: present each undecided item (id/kind, confidence, flags, source, summary — whatever the gate artifact already carries, no LLM), prompt `accept`\|`reject`\|`defer`\|`stop`, and call `record` for each answer. |
 
 ## What `apply` can and cannot transition
 
@@ -47,6 +48,16 @@ Absence of a `decisions[]` row for an item means **undecided**, never rejected �
 This only works on an artefact that is **already admission_state-bearing** — today, that means reg-intel's proposed `SEGMENT` / `REQUIREMENT` / `CONSTRAINT` / `AMENDMENT` artefacts under `_intake/processing/{segments,candidates,amendments}/<id>.yaml`. An ingest-pipeline candidate (`_intake/processing/candidates/<ref>.json`) is pre-canon and carries `admitted_to: pending`, not `admission_state` — it has no CONTRACT §6.1 lifecycle to transition yet. `record` / `list-undecided` work the same way for both pipelines; `apply` reports an ingest candidate's row as `not_admission_state_bearing` rather than silently skipping it or fabricating a transition — promoting a candidate into canon-shaped form is still a manual step (CONTRACT §6), same as before this CLI existed.
 
 **ADMIT-007.** `apply` refuses to write `reviewer_authority: ai_reviewed` when `--by` doesn't look like a tool id, and refuses `expert_confirmed` when it does (a hyphenated `*-cli` / `*-reviewer` / `*-bot` / `*-scanner` id or an `@scope/name`). This is a footgun-catcher, not a security boundary — CONTRACT ADMIT-007 is a content-based rule about who actually admitted the record, which no string heuristic can fully verify.
+
+## `review` — interactive one-card admission review
+
+`review` is an optional convenience over `list-undecided` + `record` for a human working a queue at a terminal, one item at a time (hub epic `vkgeorgia/strategy#854`). It invents no new decision path: every `accept` / `reject` / `defer` answer is exactly one `record` call, same contract as above.
+
+- **One card at a time.** Each undecided item is shown with whatever the gate artifact already carries — `id` / `kind`, `confidence`, `flags` (`coverage_flag` + `validation_flags` for a review-queue candidate), `source` (`derived_from_source` for a review-digest item), and a short `summary` (`coverage_reason` / segment `locator` / amendment `change_description`). No LLM involved — absent fields are simply omitted from the card.
+- **`stop` (alias `quit`) is a first-class exit**, not a decision. It leaves the current card and everything after it in the snapshot **undecided** — absence of a `decisions[]` row is never `reject`. `apply` is never run automatically on stop.
+- **Resume** is just running `review` again on the same gate: the queue is recomputed via `list-undecided`'s same set-difference, so only what's still undecided is presented.
+- **`--by`** sets the reviewer handle used for every `record` call this session; if omitted, `review` prompts for it once before the first card.
+- **TTY only.** If stdin is not a TTY, `review` exits non-zero pointing at `list-undecided` / `record` directly — the ingest / reg-intel skill's conversational review step is the agent-assisted path for a non-interactive session.
 
 ## Layout
 
@@ -60,6 +71,7 @@ packages/decisions-cli/
     map-in.mjs         # review-queue.yaml / review-digest.yaml -> flat gate-item list; undecided diff
     record.mjs          # upsert one decision row
     apply.mjs           # locate the admission_state artefact by item_ref; perform the §6.1 transition
+    review.mjs           # interactive one-card review loop over list-undecided / record
   schemas/
     decisions-reviewed.schema.json
 ```
@@ -70,4 +82,10 @@ A deterministic, no-API-key, no-network integrity test drives the CLI end-to-end
 
 ```
 python packages/decisions-cli/tests/test_decisions_integrity.py
+```
+
+`review`'s TTY guard makes its interactive loop untestable from a piped subprocess by design (the integrity test above covers the non-TTY refusal); the loop itself — one card at a time, stop/resume, reject-requires-reason — is covered by a Node unit test that drives `runReview()` directly with a scripted `ask()` in place of a real terminal:
+
+```
+node packages/decisions-cli/tests/test_review_unit.mjs
 ```

--- a/packages/decisions-cli/README.md
+++ b/packages/decisions-cli/README.md
@@ -51,7 +51,7 @@ This only works on an artefact that is **already admission_state-bearing** — t
 
 ## `review` — interactive one-card admission review
 
-`review` is an optional convenience over `list-undecided` + `record` for a human working a queue at a terminal, one item at a time (hub epic `vkgeorgia/strategy#854`). It invents no new decision path: every `accept` / `reject` / `defer` answer is exactly one `record` call, same contract as above.
+`review` is an optional convenience over `list-undecided` + `record` for a human working a queue at a terminal, one item at a time (hub epic `HUB-854`). It invents no new decision path: every `accept` / `reject` / `defer` answer is exactly one `record` call, same contract as above.
 
 - **One card at a time.** Each undecided item is shown with whatever the gate artifact already carries — `id` / `kind`, `confidence`, `flags` (`coverage_flag` + `validation_flags` for a review-queue candidate), `source` (`derived_from_source` for a review-digest item), and a short `summary` (`coverage_reason` / segment `locator` / amendment `change_description`). No LLM involved — absent fields are simply omitted from the card.
 - **`stop` (alias `quit`) is a first-class exit**, not a decision. It leaves the current card and everything after it in the snapshot **undecided** — absence of a `decisions[]` row is never `reject`. `apply` is never run automatically on stop.

--- a/packages/decisions-cli/decisions.mjs
+++ b/packages/decisions-cli/decisions.mjs
@@ -15,11 +15,13 @@
 import { readFile, access } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
+import { createInterface } from 'node:readline/promises';
 
 import { loadGateItems, undecided } from './src/map-in.mjs';
 import { loadDecisions, findSourceGate } from './src/io.mjs';
 import { record, RecordError } from './src/record.mjs';
 import { applyDecisions } from './src/apply.mjs';
+import { runReview } from './src/review.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -60,6 +62,12 @@ function usage() {
     '  apply <org-root> [--source-gate <path>]',
     '                                 Apply every accept/reject row as a CONTRACT §6.1 transition;',
     '                                 defer rows are left untouched (audit trail only).',
+    '  review <org-root> [--source-gate <path>] [--by <handle>]',
+    '                                 Interactive one-card review: present each undecided item',
+    '                                 (id/kind, confidence/flags, source, summary), prompt',
+    '                                 accept|reject|defer|stop, call `record`. `stop` exits without',
+    '                                 `apply` and without deciding the rest. TTY only — requires a',
+    '                                 real terminal on stdin.',
     '  --version, -v                  Print the CLI version',
     '  --help, -h                     Show this help',
   ].join('\n');
@@ -148,6 +156,39 @@ async function cmdApply(args) {
   return problems > 0 ? 1 : 0;
 }
 
+async function cmdReview(args) {
+  const { _, flags } = parseArgs(args);
+  const orgRoot = _[0];
+  if (!orgRoot) { console.error('review: missing <org-root>'); return 1; }
+
+  if (!process.stdin.isTTY) {
+    console.error(
+      'review: stdin is not a TTY — this is an interactive command.\n' +
+      'Use `list-undecided` / `record` directly instead (the ingest/reg-intel skill\'s conversational review step covers agent-assisted review).'
+    );
+    return 1;
+  }
+
+  let sourceGatePath;
+  try { sourceGatePath = await resolveSourceGate(orgRoot, flags); }
+  catch (err) { console.error(`review: ${err.message}`); return 2; }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const result = await runReview({
+      orgRoot,
+      sourceGatePath,
+      by: flags.by,
+      asOf: flags['as-of'] || today(),
+      ask: (prompt) => rl.question(prompt),
+      log: (msg) => console.log(msg),
+    });
+    return result.undecided > 0 ? 1 : 0;
+  } finally {
+    rl.close();
+  }
+}
+
 async function main() {
   const [, , cmd, ...rest] = process.argv;
   if (!cmd || cmd === '--help' || cmd === '-h') { console.log(usage()); return 0; }
@@ -157,6 +198,7 @@ async function main() {
     case 'list-undecided': return cmdListUndecided(rest);
     case 'record':         return cmdRecord(rest);
     case 'apply':           return cmdApply(rest);
+    case 'review':          return cmdReview(rest);
     default:
       console.error(`Unknown command: ${cmd}\n`);
       console.error(usage());

--- a/packages/decisions-cli/src/map-in.mjs
+++ b/packages/decisions-cli/src/map-in.mjs
@@ -26,7 +26,7 @@ export function detectSourceGateKind(path) {
 
 // Beyond item_ref/kind, an item MAY carry `confidence`, `flags` (array of strings)
 // and `summary` — all read straight off fields the gate artifact already emits, for
-// `review`'s one-card view (issue #855). No LLM, no synthesis: absent fields are
+// `review`'s one-card view (HUB-855). No LLM, no synthesis: absent fields are
 // simply omitted from the card.
 function itemsFromReviewQueue(text) {
   const candidates = readMapList(text, 'candidates', ['validation_flags']);

--- a/packages/decisions-cli/src/map-in.mjs
+++ b/packages/decisions-cli/src/map-in.mjs
@@ -24,20 +24,46 @@ export function detectSourceGateKind(path) {
   return null;
 }
 
+// Beyond item_ref/kind, an item MAY carry `confidence`, `flags` (array of strings)
+// and `summary` — all read straight off fields the gate artifact already emits, for
+// `review`'s one-card view (issue #855). No LLM, no synthesis: absent fields are
+// simply omitted from the card.
 function itemsFromReviewQueue(text) {
-  const candidates = readMapList(text, 'candidates');
+  const candidates = readMapList(text, 'candidates', ['validation_flags']);
   return candidates
     .filter((c) => c.ref)
-    .map((c) => ({ item_ref: c.ref, kind: c.kind || 'unknown' }));
+    .map((c) => {
+      const flags = [
+        ...(c.coverage_flag ? [c.coverage_flag] : []),
+        ...(Array.isArray(c.validation_flags) ? c.validation_flags : []),
+      ];
+      return {
+        item_ref: c.ref,
+        kind: c.kind || 'unknown',
+        ...(c.extraction_confidence != null ? { confidence: c.extraction_confidence } : {}),
+        ...(flags.length ? { flags } : {}),
+        ...(c.coverage_reason ? { summary: c.coverage_reason } : {}),
+      };
+    });
 }
 
 function itemsFromReviewDigest(text) {
   const sources = readNestedList(text, 'sources', ['segments', 'candidates', 'amendments']);
   const items = [];
   for (const src of sources) {
-    for (const s of src.segments || []) if (s.id) items.push({ item_ref: s.id, kind: 'segment', derived_from_source: src.id });
-    for (const c of src.candidates || []) if (c.id) items.push({ item_ref: c.id, kind: c.kind || 'candidate', derived_from_source: src.id });
-    for (const a of src.amendments || []) if (a.id) items.push({ item_ref: a.id, kind: 'amendment', derived_from_source: src.id });
+    for (const s of src.segments || []) if (s.id) items.push({
+      item_ref: s.id, kind: 'segment', derived_from_source: src.id,
+      ...(s.extraction_confidence != null ? { confidence: s.extraction_confidence } : {}),
+      ...(s.locator ? { summary: s.locator } : {}),
+    });
+    for (const c of src.candidates || []) if (c.id) items.push({
+      item_ref: c.id, kind: c.kind || 'candidate', derived_from_source: src.id,
+      ...(c.extraction_confidence != null ? { confidence: c.extraction_confidence } : {}),
+    });
+    for (const a of src.amendments || []) if (a.id) items.push({
+      item_ref: a.id, kind: 'amendment', derived_from_source: src.id,
+      ...(a.change_description ? { summary: a.change_description } : {}),
+    });
   }
   return items;
 }

--- a/packages/decisions-cli/src/review.mjs
+++ b/packages/decisions-cli/src/review.mjs
@@ -1,0 +1,79 @@
+// `review` — optional interactive one-card admission review loop over
+// list-undecided / record (epic vkgeorgia/strategy#854, issue #855). Every
+// accept/reject/defer here is exactly one `record` call — this module invents no
+// new decision path or schema. `stop` is a first-class exit: the pending queue is
+// a snapshot taken at review start, so a card left unanswered when the reviewer
+// stops simply stays undecided — `list-undecided` (via a later `review` run) is
+// the resume cursor, no separate session-state file.
+
+import { loadGateItems, undecided } from './map-in.mjs';
+import { loadDecisions, defaultDecisionsPath } from './io.mjs';
+import { record } from './record.mjs';
+
+const DECISIONS = new Set(['accept', 'reject', 'defer']);
+const STOP = new Set(['stop', 'quit']);
+
+function formatCard(item, index, total) {
+  const lines = [`[${index + 1}/${total}] ${item.item_ref}  (${item.kind})`];
+  if (item.derived_from_source) lines.push(`  source: ${item.derived_from_source}`);
+  if (item.confidence !== undefined && item.confidence !== null) lines.push(`  confidence: ${item.confidence}`);
+  if (Array.isArray(item.flags) && item.flags.length) lines.push(`  flags: ${item.flags.join('; ')}`);
+  if (item.summary) lines.push(`  summary: ${item.summary}`);
+  return lines.join('\n');
+}
+
+// `ask(prompt) -> Promise<string>` is injected so a real TTY (node:readline/promises)
+// and a scripted test harness share the same loop. Returns
+// { recorded, undecided, stopped } — `undecided` is what's left in the snapshot,
+// including anything left unanswered by `stop`.
+export async function runReview({ orgRoot, sourceGatePath, by, asOf, ask, log = () => {} }) {
+  const { items } = await loadGateItems(sourceGatePath);
+  const decisionsPath = defaultDecisionsPath(sourceGatePath);
+  const existing = await loadDecisions(decisionsPath);
+  const pending = undecided(items, existing ? existing.decisions : []);
+
+  if (pending.length === 0) {
+    log('review: nothing undecided — the queue is clear.');
+    return { recorded: 0, undecided: 0, stopped: false };
+  }
+
+  let reviewerHandle = (by || '').trim();
+  while (!reviewerHandle) reviewerHandle = (await ask('reviewer handle (--by): ')).trim();
+
+  let recorded = 0;
+  let stopped = false;
+
+  for (let i = 0; i < pending.length; i++) {
+    const item = pending[i];
+    log(formatCard(item, i, pending.length));
+
+    let decision = null;
+    while (!decision) {
+      const answer = (await ask('accept | reject | defer | stop > ')).trim().toLowerCase();
+      if (STOP.has(answer)) decision = 'stop';
+      else if (DECISIONS.has(answer)) decision = answer;
+      else log(`  unrecognised answer ${JSON.stringify(answer)} — accept | reject | defer | stop`);
+    }
+
+    if (decision === 'stop') { stopped = true; break; }
+
+    let reason;
+    if (decision === 'reject') {
+      while (!reason) reason = (await ask('reason (required): ')).trim();
+    } else if (decision === 'defer') {
+      reason = (await ask('reason (optional, recommended): ')).trim() || undefined;
+    }
+
+    const { row, replaced } = await record({
+      orgRoot, sourceGatePath, asOf,
+      itemRef: item.item_ref, kind: item.kind, decision,
+      by: reviewerHandle, at: asOf, reason,
+    });
+    recorded++;
+    log(`  ${replaced ? 'updated' : 'recorded'}: ${row.item_ref} -> ${row.decision}`);
+  }
+
+  const remaining = pending.length - recorded;
+  log(`\nrecorded=${recorded} undecided=${remaining}`);
+  return { recorded, undecided: remaining, stopped };
+}

--- a/packages/decisions-cli/src/review.mjs
+++ b/packages/decisions-cli/src/review.mjs
@@ -1,5 +1,5 @@
 // `review` — optional interactive one-card admission review loop over
-// list-undecided / record (epic vkgeorgia/strategy#854, issue #855). Every
+// list-undecided / record (HUB-854, task HUB-855). Every
 // accept/reject/defer here is exactly one `record` call — this module invents no
 // new decision path or schema. `stop` is a first-class exit: the pending queue is
 // a snapshot taken at review start, so a card left unanswered when the reviewer

--- a/packages/decisions-cli/src/yaml.mjs
+++ b/packages/decisions-cli/src/yaml.mjs
@@ -61,22 +61,33 @@ export function readBlockScalars(text, key) {
 }
 
 // Read a top-level list-of-maps `key:` (e.g. `decisions:`). Returns an array of flat
-// objects (one per `- ` item; each item's scalar fields only — no nested sub-lists).
-export function readMapList(text, key) {
+// objects (one per `- ` item; each item's scalar fields only — no nested sub-lists),
+// except for any field named in `arrayKeys`, which is instead collected as a string
+// array (e.g. review-queue.yaml's per-candidate `validation_flags: [...]`). Still not
+// a general YAML parser — arrayKeys is for the one known list-of-scalars shape a
+// caller needs, not arbitrary nesting.
+export function readMapList(text, key, arrayKeys = []) {
   if (typeof text !== 'string') return [];
+  const arraySet = new Set(arrayKeys);
   const lines = text.split(/\r?\n/);
   const start = lines.findIndex((l) => new RegExp(`^${key}:[ \\t]*(#.*)?$`).test(l));
   if (start < 0) return [];
   const items = [];
   let cur = null;
+  let openArrayKey = null;
   for (let i = start + 1; i < lines.length; i++) {
     const l = lines[i];
     if (l.trim() === '') continue;
     if (/^\S/.test(l)) break;
     let m = l.match(/^[ \t]+-[ \t]+([A-Za-z0-9_]+):[ \t]*(.*)$/);
-    if (m) { cur = {}; cur[m[1]] = cleanScalar(m[2]); items.push(cur); continue; }
+    if (m) { cur = {}; cur[m[1]] = cleanScalar(m[2]); items.push(cur); openArrayKey = null; continue; }
+    if (!cur) continue;
+    const lm = l.match(/^[ \t]+-[ \t]+(.+)$/);
+    if (lm && openArrayKey) { cur[openArrayKey].push(cleanScalar(lm[1])); continue; }
+    m = l.match(/^[ \t]+([A-Za-z0-9_]+):[ \t]*$/);
+    if (m && arraySet.has(m[1])) { cur[m[1]] = []; openArrayKey = m[1]; continue; }
     m = l.match(/^[ \t]+([A-Za-z0-9_]+):[ \t]*(.*)$/);
-    if (m && cur) cur[m[1]] = cleanScalar(m[2]);
+    if (m) { cur[m[1]] = cleanScalar(m[2]); openArrayKey = null; }
   }
   return items;
 }

--- a/packages/decisions-cli/tests/test_decisions_integrity.py
+++ b/packages/decisions-cli/tests/test_decisions_integrity.py
@@ -25,6 +25,15 @@ against synthetic fixtures for both source gates it must answer:
   E. Schema conformance — the decisions.reviewed.yaml `apply` just read
      back satisfies schemas/decisions-reviewed.schema.json's required
      top-level keys, the decisions[] row shape, and its enums.
+  F. `review`'s non-TTY guard: piped stdin (no real terminal) is refused with
+     a message pointing at list-undecided / record, never a silent hang or a
+     partial interactive session (issue #855 item 7).
+  G. Stop/resume semantics via record + list-undecided, the same primitives
+     `review` calls: seed 3 undecided, record 1 (simulating "answer one card,
+     then stop"), assert list-undecided still shows exactly 2 (never marked
+     rejected by the stop), record the rest, assert 0 undecided, and confirm
+     apply's per-decision outcome is unaffected by having been recorded across
+     two sessions instead of one (issue #855 item 9).
 
 Run:  python packages/decisions-cli/tests/test_decisions_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).
@@ -326,6 +335,98 @@ def part_e_schema_conformance(org):
             check(row["reviewer_authority"] in authority_enum, f"E: decision row {row.get('item_ref')} has reviewer_authority {row['reviewer_authority']!r} outside the schema enum")
 
 
+# ── Part F — `review` refuses a non-TTY stdin ─────────────────────────────
+
+def part_f_review_non_tty():
+    with tempfile.TemporaryDirectory(prefix="decisions-review-tty-") as td:
+        org = Path(td)
+        processing = org / "_intake" / "processing"
+        write(processing / "review-queue.yaml", (
+            'generated_by: "@transitrix/ingest-cli"\n'
+            f'org_root: "{org}"\n'
+            'field_artefacts: []\n'
+            'candidates:\n'
+            '  - ref: "cand-x"\n'
+            '    kind: "element"\n'
+        ))
+
+        r = subprocess.run(["node", CLI, "review", str(org)], capture_output=True, text=True, stdin=subprocess.DEVNULL)
+        check(r.returncode != 0, f"F: review with non-TTY stdin expected a non-zero exit, got {r.returncode}")
+        check("list-undecided" in r.stderr and "record" in r.stderr,
+              f"F: expected the non-TTY message to point at list-undecided/record, got: {r.stderr!r}")
+        check(not (processing / "decisions.reviewed.yaml").exists(),
+              "F: a refused non-TTY review must not create decisions.reviewed.yaml")
+
+
+# ── Part G — stop/resume via record + list-undecided (what `review` calls) ─
+
+def part_g_stop_resume():
+    with tempfile.TemporaryDirectory(prefix="decisions-stop-resume-") as td:
+        org = Path(td)
+        processing = org / "_intake" / "processing"
+        cand_dir = processing / "candidates"
+        cand_dir.mkdir(parents=True)
+
+        cand_a, cand_b, cand_c = (cand_dir / f"cand-{s}.json" for s in ("a", "b", "c"))
+        for f in (cand_a, cand_b, cand_c):
+            f.write_text(json.dumps({"kind": "element", "admitted_to": "pending"}), encoding="utf-8")
+        ref_a, ref_b, ref_c = str(cand_a), str(cand_b), str(cand_c)
+
+        write(processing / "review-queue.yaml", (
+            'generated_by: "@transitrix/ingest-cli"\n'
+            f'org_root: "{org}"\n'
+            'field_artefacts: []\n'
+            'candidates:\n'
+            f'  - ref: "{ref_a}"\n'
+            '    kind: "element"\n'
+            f'  - ref: "{ref_b}"\n'
+            '    kind: "element"\n'
+            f'  - ref: "{ref_c}"\n'
+            '    kind: "element"\n'
+        ))
+
+        r = run_cli("list-undecided", str(org))
+        check("total: 3  decided: 0  undecided: 3" in r.stdout, f"G: expected 3 undecided at seed, got: {r.stdout!r}")
+
+        # Simulate "answer one card, then stop" — the rest must stay undecided,
+        # never defaulted to any decision.
+        r = run_cli("record", str(org), "--item-ref", ref_a, "--decision", "accept", "--by", "j.reviewer", "--at", "2026-07-29")
+        check(r.returncode == 0, f"G: record cand-a failed: {r.stderr or r.stdout}")
+
+        r = run_cli("list-undecided", str(org))
+        check("total: 3  decided: 1  undecided: 2" in r.stdout, f"G: expected 2 undecided after simulated stop, got: {r.stdout!r}")
+        check(ref_b in r.stdout and ref_c in r.stdout, f"G: expected cand-b and cand-c still listed as undecided, got: {r.stdout!r}")
+
+        # Resume: record the rest in a later "session".
+        r = run_cli("record", str(org), "--item-ref", ref_b, "--decision", "reject", "--by", "j.reviewer", "--at", "2026-07-29", "--reason", "duplicate")
+        check(r.returncode == 0, f"G: record cand-b failed: {r.stderr or r.stdout}")
+        r = run_cli("record", str(org), "--item-ref", ref_c, "--decision", "defer", "--by", "j.reviewer", "--at", "2026-07-29")
+        check(r.returncode == 0, f"G: record cand-c failed: {r.stderr or r.stdout}")
+
+        r = run_cli("list-undecided", str(org))
+        check("total: 3  decided: 3  undecided: 0" in r.stdout, f"G: expected 0 undecided after resume, got: {r.stdout!r}")
+
+        # apply's per-decision outcome is the same regardless of how many sessions it
+        # took to record it — accept/reject on a pre-canon ingest candidate both come
+        # back not_admission_state_bearing (part A); a deferred row never reaches
+        # artefact lookup at all (no_transition, ADR §3) — none silently skipped or
+        # fabricated into a transition.
+        r = run_cli("apply", str(org))
+
+        def outcome_for(ref):
+            for line in r.stdout.splitlines():
+                if line.startswith(ref):
+                    return line
+            return None
+
+        a_line = outcome_for(ref_a)
+        check(a_line is not None and "not_admission_state_bearing" in a_line, f"G: expected cand-a (accept) outcome not_admission_state_bearing, got: {a_line!r}")
+        b_line = outcome_for(ref_b)
+        check(b_line is not None and "not_admission_state_bearing" in b_line, f"G: expected cand-b (reject) outcome not_admission_state_bearing, got: {b_line!r}")
+        c_line = outcome_for(ref_c)
+        check(c_line is not None and "no_transition" in c_line, f"G: expected cand-c (defer) outcome no_transition, got: {c_line!r}")
+
+
 if not shutil.which("node"):
     print("SKIP: `node` not found on PATH (the CLI is Node).")
     sys.exit(0)
@@ -340,6 +441,8 @@ part_c_record_validation()
 part_d_apply_is_idempotent(_reg_intel_org)
 part_e_schema_conformance(_reg_intel_org)
 shutil.rmtree(_reg_intel_org, ignore_errors=True)
+part_f_review_non_tty()
+part_g_stop_resume()
 
 if _failures:
     print("FAIL - decisions-cli integrity:")

--- a/packages/decisions-cli/tests/test_decisions_integrity.py
+++ b/packages/decisions-cli/tests/test_decisions_integrity.py
@@ -27,13 +27,13 @@ against synthetic fixtures for both source gates it must answer:
      top-level keys, the decisions[] row shape, and its enums.
   F. `review`'s non-TTY guard: piped stdin (no real terminal) is refused with
      a message pointing at list-undecided / record, never a silent hang or a
-     partial interactive session (issue #855 item 7).
+     partial interactive session (HUB-855 item 7).
   G. Stop/resume semantics via record + list-undecided, the same primitives
      `review` calls: seed 3 undecided, record 1 (simulating "answer one card,
      then stop"), assert list-undecided still shows exactly 2 (never marked
      rejected by the stop), record the rest, assert 0 undecided, and confirm
      apply's per-decision outcome is unaffected by having been recorded across
-     two sessions instead of one (issue #855 item 9).
+     two sessions instead of one (HUB-855 item 9).
 
 Run:  python packages/decisions-cli/tests/test_decisions_integrity.py
 Exit: 0 = all pass; 1 = a check failed (message localises the problem).

--- a/packages/decisions-cli/tests/test_review_unit.mjs
+++ b/packages/decisions-cli/tests/test_review_unit.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Unit test for `review` — the interactive one-card admission review loop
+// (src/review.mjs, epic vkgeorgia/strategy#854, issue #855). The CLI's TTY guard
+// makes the real `review` command untestable from a piped subprocess (by design —
+// see test_decisions_integrity.py's non-TTY guard check), so this test drives
+// runReview() directly with a scripted `ask()` in place of a real terminal.
+//
+// Covers: one card at a time in order; an unrecognised answer reprompts without
+// consuming a card; `stop` exits leaving the rest genuinely undecided (not
+// deferred); resume (list-undecided / a second runReview call) picks up only
+// what's left; reject requires a non-empty reason, defer's reason is optional;
+// an empty --by prompts for one.
+//
+// Run: node packages/decisions-cli/tests/test_review_unit.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runReview } from '../src/review.mjs';
+import { loadDecisions } from '../src/io.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+function scriptedAsk(answers) {
+  let i = 0;
+  return async () => {
+    if (i >= answers.length) throw new Error(`scriptedAsk: ran out of answers (asked ${i + 1} times)`);
+    return answers[i++];
+  };
+}
+
+async function main() {
+  const dir = await mkdtemp(join(tmpdir(), 'decisions-review-'));
+  const processing = join(dir, '_intake', 'processing');
+  await mkdir(processing, { recursive: true });
+
+  const sourceGatePath = join(processing, 'review-queue.yaml');
+  await writeFile(sourceGatePath, [
+    'generated_by: "@transitrix/ingest-cli"',
+    `org_root: "${dir}"`,
+    'field_artefacts: []',
+    'candidates:',
+    '  - ref: "cand-1"',
+    '    kind: "element"',
+    '    extraction_confidence: "high"',
+    '  - ref: "cand-2"',
+    '    kind: "element"',
+    '  - ref: "cand-3"',
+    '    kind: "relation"',
+  ].join('\n'), 'utf8');
+
+  const log = [];
+  const collect = (m) => log.push(m);
+
+  // ── Round 1: accept cand-1, then an unrecognised answer, then stop ────────
+  const r1 = await runReview({
+    orgRoot: dir,
+    sourceGatePath,
+    by: 'j.reviewer',
+    asOf: '2026-07-29',
+    ask: scriptedAsk(['accept', 'bogus', 'stop']),
+    log: collect,
+  });
+
+  check(r1.recorded === 1, `round 1: expected recorded=1, got ${r1.recorded}`);
+  check(r1.undecided === 2, `round 1: expected undecided=2, got ${r1.undecided}`);
+  check(r1.stopped === true, 'round 1: expected stopped=true');
+  check(log.some((l) => l.includes('unrecognised answer')), 'round 1: expected a reprompt message for the bogus answer');
+
+  const decisionsPath = join(processing, 'decisions.reviewed.yaml');
+  let doc = await loadDecisions(decisionsPath);
+  check(doc !== null, 'round 1: decisions.reviewed.yaml was not created');
+  check(doc.decisions.length === 1, `round 1: expected 1 decision row on disk, got ${doc.decisions.length}`);
+  check(doc.decisions[0].item_ref === 'cand-1' && doc.decisions[0].decision === 'accept',
+    `round 1: expected cand-1/accept on disk, got ${JSON.stringify(doc.decisions[0])}`);
+
+  // ── Round 2 (resume): only cand-2/cand-3 should be presented ──────────────
+  const log2 = [];
+  const r2 = await runReview({
+    orgRoot: dir,
+    sourceGatePath,
+    by: '', // empty --by must prompt
+    asOf: '2026-07-29',
+    ask: scriptedAsk([
+      'j.reviewer',       // --by prompt
+      'reject', '',       // reject cand-2, empty reason must re-prompt...
+      'duplicate entry',  // ...then a real reason
+      'defer', '',        // defer cand-3, empty reason is fine (optional)
+    ]),
+    log: (m) => log2.push(m),
+  });
+
+  check(r2.recorded === 2, `round 2: expected recorded=2, got ${r2.recorded}`);
+  check(r2.undecided === 0, `round 2: expected undecided=0, got ${r2.undecided}`);
+  check(r2.stopped === false, 'round 2: expected stopped=false (queue exhausted, not stopped)');
+  check(!log2.some((l) => l.includes('cand-1')), 'round 2: cand-1 must not be re-presented — it is already decided');
+
+  doc = await loadDecisions(decisionsPath);
+  check(doc.decisions.length === 3, `round 2: expected 3 decision rows on disk after resume, got ${doc.decisions.length}`);
+  const byRef = Object.fromEntries(doc.decisions.map((d) => [d.item_ref, d]));
+  check(byRef['cand-2']?.decision === 'reject' && byRef['cand-2']?.reason === 'duplicate entry',
+    `round 2: expected cand-2/reject with reason, got ${JSON.stringify(byRef['cand-2'])}`);
+  check(byRef['cand-3']?.decision === 'defer' && byRef['cand-3']?.reason === undefined,
+    `round 2: expected cand-3/defer with no reason, got ${JSON.stringify(byRef['cand-3'])}`);
+
+  // ── Round 3: nothing left undecided — the loop must not prompt at all ─────
+  const r3 = await runReview({
+    orgRoot: dir,
+    sourceGatePath,
+    by: 'j.reviewer',
+    asOf: '2026-07-29',
+    ask: scriptedAsk([]), // any ask() call here is a bug — the queue is empty
+    log: () => {},
+  });
+  check(r3.recorded === 0 && r3.undecided === 0 && r3.stopped === false,
+    `round 3: expected an immediate clean exit, got ${JSON.stringify(r3)}`);
+
+  await rm(dir, { recursive: true, force: true });
+
+  if (_failures.length) {
+    console.log('FAIL - decisions-cli review unit test:');
+    for (const f of _failures) console.log(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log('PASS - decisions-cli review (one-card stop/resume) unit test: all checks passed.');
+  process.exit(0);
+}
+
+main().catch((err) => { console.error(err && err.stack ? err.stack : err); process.exit(2); });

--- a/packages/decisions-cli/tests/test_review_unit.mjs
+++ b/packages/decisions-cli/tests/test_review_unit.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Unit test for `review` — the interactive one-card admission review loop
-// (src/review.mjs, epic vkgeorgia/strategy#854, issue #855). The CLI's TTY guard
+// (src/review.mjs, HUB-854, task HUB-855). The CLI's TTY guard
 // makes the real `review` command untestable from a piped subprocess (by design —
 // see test_decisions_integrity.py's non-TTY guard check), so this test drives
 // runReview() directly with a scripted `ask()` in place of a real terminal.


### PR DESCRIPTION
## Summary
- Adds `transitrix-decisions review <org-root> [--source-gate <path>] [--by <handle>]` — an optional TTY loop over the existing `list-undecided`/`record` contract: one undecided item at a time (id/kind, confidence, flags, source, summary — read straight off the gate artifact, no LLM), prompting `accept`|`reject`|`defer`|`stop`.
- `stop` is a first-class exit: the rest of the queue stays undecided (never defaulted to reject); resume is just running `review` again, since the pending set is recomputed via the same `list-undecided` set-difference each time.
- Non-TTY stdin is refused with a message pointing at `list-undecided`/`record` (the agent-assisted path is the ingest/reg-intel skill's conversational step — HUB-856, not yet started).
- `map-in.mjs` now surfaces `confidence`/`flags`/`source`/`summary` fields the gate artifacts already carry (previously discarded down to `item_ref`/`kind`); `yaml.mjs`'s `readMapList` gained an opt-in `arrayKeys` param to parse `validation_flags` without becoming a general YAML parser.
- Added a Node unit test (`test_review_unit.mjs`) driving `runReview()` directly with a scripted `ask()`, since the TTY guard makes the real command untestable from a piped subprocess. Extended the existing Python integrity test with the non-TTY refusal and a stop/resume scenario over `record`/`list-undecided`.

Closes HUB-855 (epic HUB-854).

## Test plan
- [x] `node packages/decisions-cli/tests/test_review_unit.mjs` passes locally
- [x] Manual check: `review` on a non-TTY stdin exits 1 with a message naming `list-undecided`/`record`
- [x] Manual check: `list-undecided` / `--help` output unaffected by the parser changes
- [ ] CI: `python packages/decisions-cli/tests/test_decisions_integrity.py` (no Python available in this dev environment to run locally — verified by careful manual trace of the new Part F/G scenarios against `apply.mjs`'s actual `locateArtefact`/`defer` short-circuit behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)