### PR TITLE
docs(skills): ingest/reg-intel conversational one-card review + stop/resume

### DIFF
--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -253,6 +253,19 @@ The queue is the human gate. It lists every field artefact (with its proposed `s
 
 Recording each accept/reject/defer is optional but recommended: [`@transitrix/decisions-cli`](https://github.com/transitrix/methodology/tree/main/packages/decisions-cli)'s `record` writes one row per candidate to `decisions.reviewed.yaml` beside the queue, and `apply` performs the CONTRACT §6.1 transition it names — never inventing a new admission state, never writing `reviewer_authority: expert_confirmed` on a tool's behalf (`ADMIT-007`).
 
+### Conversational one-card review (optional)
+
+When the reviewer works through the agent rather than the CLI's own TTY loop (`transitrix-decisions review`), drive the same `decisions.reviewed.yaml` contract one card at a time:
+
+1. Run `transitrix-decisions list-undecided <org-root> [--source-gate <path>]` — every candidate the queue currently presents that has no `decisions[]` row yet.
+2. Present **one card at a time**: id/kind, source, `extraction_confidence`, any validation/coverage flags, and a recommendation if one is present. Ask the reviewer for `accept` | `reject` | `defer` | `stop`.
+3. On `accept` / `reject` / `defer` → call `transitrix-decisions record <org-root> --item-ref <ref> --decision <accept|reject|defer> --by <handle> --at <date> [--reason <text>]` — never hand-edit `decisions.reviewed.yaml` when the CLI is available. Move to the next card.
+4. On `stop` → exit immediately. Summarise `N recorded, M undecided` from what `list-undecided` now reports. Do **not** apply. Do **not** defer the remaining cards — an unanswered card stays **undecided** (absence of a row is not a rejection), never silently marked anything.
+5. **Resume**, in a later session, is the same step: re-run `list-undecided` against the same `--source-gate` — it recomputes the pending set as a set-difference against `decisions.reviewed.yaml`, so only the still-undecided cards are re-presented. No separate session-state file.
+6. **Applying is a separate, explicit human ask.** Only when the reviewer asks to apply recorded decisions does the agent run `transitrix-decisions apply <org-root> [--source-gate <path>]` — never automatically at the end of a review loop, never on `stop`.
+
+Hard rules carried from the epic and CONTRACT unchanged: `merge` is not a new decision verb in v1 — a "these are duplicates" call from the reviewer is recorded as `accept` or `defer` with a reason string naming the existing id, never a new enum. `ADMIT-007` (tiered `reviewer_authority`) still applies to whatever `--by` handle the agent passes through. This is the agent-assisted counterpart to `transitrix-decisions review`'s TTY loop — same `list-undecided`/`record` contract, different surface; it never replaces the CLI path and never writes canon itself.
+
 ### Multi-batch naming — a stable filename, a dated directory when a batch is already unresolved
 
 `review-queue.yaml` is a **stable package filename**: the first batch for an org lands at the flat legacy path `_intake/processing/review-queue.yaml`, unchanged from every prior release. Re-running `review-queue` against the same candidates — the everyday idempotent-refresh workflow, admit a few, re-run to see what's left — keeps updating that same file in place: the exclusion list changing is real progress on the same batch, not a new one. Only when a re-run would produce **byte-identical** output to what's already there — nothing has moved since it was last written — is the existing file read as untouched/unresolved, and a genuinely concurrent batch instead gets its own **human-facing batch directory**, `type-scope-date-seq`:

--- a/transitrix/skills/reg-intel/SKILL.md
+++ b/transitrix/skills/reg-intel/SKILL.md
@@ -260,6 +260,8 @@ The digest is **read by a human**, who then either runs the canon / field admiss
 
 Recording each accept/reject/defer is optional but recommended: [`@transitrix/decisions-cli`](https://github.com/transitrix/methodology/tree/main/packages/decisions-cli)'s `record` writes one row per SEGMENT / candidate / AMENDMENT to `decisions.reviewed.yaml` beside the digest, and `apply` performs the CONTRACT §6.1 transition it names — never inventing a new admission state, never writing `reviewer_authority: expert_confirmed` on a tool's behalf (`ADMIT-007`).
 
+**Conversational one-card review (optional).** Same contract, same loop as the ingest skill's [conversational review step](https://github.com/transitrix/methodology/blob/main/transitrix/skills/ingest/SKILL.md#step-6--produce-the-review-queue): run `transitrix-decisions list-undecided <org-root> --source-gate <path to review-digest.yaml>`, present one SEGMENT / candidate / AMENDMENT at a time (id/kind, source, `extraction_confidence`, flags, recommendation if present), and record `accept` | `reject` | `defer` via `transitrix-decisions record`. `stop` exits without applying and without deferring whatever is left undecided; resume in a later session is just re-running `list-undecided` against the same digest. `apply` only runs on an explicit ask. Only the source artefact differs (`review-digest.yaml` instead of `review-queue.yaml`) — the rules, including the `merge`-is-not-a-verb and `ADMIT-007` constraints, are identical.
+
 ---
 
 ## The run loop, end-to-end


### PR DESCRIPTION
## Summary
- Ingest skill (Step 6) documents the conversational one-card review loop over `transitrix-decisions list-undecided`/`record`: one card at a time, `accept`/`reject`/`defer`/`stop`, with `stop` as a first-class exit (already-recorded rows stay, the unanswered card stays undecided — never silently deferred) and resume via re-running `list-undecided` against the same `--source-gate` (no session-state file).
- Reg-intel skill gets a short parallel pointer to the same contract (only the source artefact differs: `review-digest.yaml` vs `review-queue.yaml`).
- `apply` stays a separate, explicit human ask — never auto-run at the end of a loop or on `stop`.
- No schema changes, no new decision verb: a "these are duplicates" call is recorded as `accept`/`defer` with a reason string naming the existing id, not a `merge` enum (matches the epic's v1 scope).
- Doc-only change — `node scripts/check-notations.mjs` clean.

Closes HUB-856 (epic HUB-854). Sibling to PR #397 (`transitrix-decisions review` TTY loop, HUB-855) — same contract, different surface (agent-conversational vs CLI-TTY).

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] Re-read both edited files' tails after edit to confirm no truncation
- [ ] CI checks on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)