### PR TITLE
docs: cite the 3.0.0 decision by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [3.0.0] — 2026-07-29
 
-Bump category: **MAJOR** — the ISO 14971 risk-management chain is removed from the public core. `VERIFICATION` and the rest of the compliance/V&V spine are unaffected. Decision of record: ADR `cross-project/2026-07-29-design-controls-private-module` (strategy hub), superseding `methodology/2026-07-29-design-controls-as-a-package`.
+Bump category: **MAJOR** — the ISO 14971 risk-management chain is removed from the public core. `VERIFICATION` and the rest of the compliance/V&V spine are unaffected. Decision of record: the 2026-07-29 core-scope decision.
 
 ### Breaking changes
 

--- a/migrations/2.1-to-3.0/README.md
+++ b/migrations/2.1-to-3.0/README.md
@@ -12,8 +12,7 @@ version 2.1 to 3.0. Format per [`notations/CONTRACT.md`](../../notations/CONTRAC
 **3.0 removes the ISO 14971 risk-management chain from the public core.**
 `HAZARD`, `RISK_CONTROL`, the design-controls trace-matrix view, its reference
 renderer, and their validation rules leave this repository (decision of record:
-ADR `cross-project/2026-07-29-design-controls-private-module` in the strategy
-hub). `VERIFICATION` and the rest of the compliance/V&V spine
+the 2026-07-29 core-scope decision). `VERIFICATION` and the rest of the compliance/V&V spine
 (`REQUIREMENT`, `ASSERTION`) are **unaffected** — this is not a schema change to
 any type that stays in core.
 


### PR DESCRIPTION
Two spots in the 3.0.0 material referenced the decision by a path rather than by name. Text-only; no behaviour, no schema, no rule changes.

Worth merging before the v3.0.0 release notes go out, since both files ship in the release.