### PR TITLE
chore: trim a stale note in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,8 +218,7 @@ _pitch*/
 run-methodology-agent.ps1
 
 # Architecture Decision Records — kept local until external contributors arrive.
-# Visible to local agents (orchestrator) on disk; not published to the open repo.
-# Revisit when contributors join (see win-claude/tasks.md).
+# Revisit when contributors join.
 docs/decisions/
 
 # ============================================================================


### PR DESCRIPTION
Two comment lines that no longer describe anything current. No behaviour change — the ignore rule itself is untouched.