### PR TITLE
docs: migrate acme-corp teaching-content docs into methodology (HUB-804)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,0 +1,86 @@
+# Getting started with Transitrix
+
+A first modelling session in the Transitrix **architecture-as-text** methodology. You'll author a view, create an element primitive it references, and validate — all as plain YAML under Git.
+
+The fastest path for a brand-new repo is the **onboarding Skill** (`/transitrix:onboard`), which scaffolds the zoned layout and walks you through your first file. This guide is the manual equivalent, illustrated against the worked [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) example repo.
+
+## Prerequisites
+
+- Git.
+- VS Code with **Transitrix Studio** — live diagram preview + inline validation as you edit (recommended).
+- Basic YAML.
+- *Optional:* `npx @transitrix/cli validate <file>` for command-line validation. On Windows PowerShell with a restricted execution policy, use `npx.cmd` instead of `npx` — see Step 5.
+
+## Step 1 — Understand the layout
+
+A Transitrix repo has three parallel **zones** ([`notations/CONTRACT.md`](notations/CONTRACT.md) §5):
+
+- **`canon/`** — the authoritative model. View documents in `canon/views/<notation>/`; element primitives in `canon/elements/<NN>_<layer>/<plural-type>/`; first-class relations in `canon/relations/`.
+- **`field/`** — raw inputs (interviews, surveys, …); not authoritative.
+- **`codex/`** — external laws/regulations + internal policies/standards, faithful to source.
+
+Read [`notations/README.md`](notations/README.md) for the notation index and family selection.
+
+## Step 2 — Author your first view (a Goals tree)
+
+The Goals tree is the simplest starting point. The onboarding Skill copies a starter template (`templates/goals.dgca.transitrix.yaml` from its bundle) into `canon/views/goals/<domain>.dgca.transitrix.yaml`; the `transitrix/acme-corp` worked example already has one under [`canon/views/goals/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/goals). Keep the `notation: goals` / `spec_version:` header — it's required ([`CONTRACT.md`](notations/CONTRACT.md) §1). Fill the `FILL-ME` placeholders. A Goals tree is flat top-level arrays — `goal_types[]` + `goals[]`, hierarchy via `parent: GOAL-…` ([`notations/views/04-goals.md`](notations/views/04-goals.md)).
+
+## Step 3 — Create an element primitive
+
+Elements referenced across documents get a standalone file. Create a `GOAL` under the motivation layer:
+
+```bash
+cp .templates/elements/01_motivation_template.yaml \
+   canon/elements/01_motivation/goals/GOAL-REVENUE-1.yaml
+```
+
+Set the canonical envelope ([`notations/ELEMENT_PRIMITIVES.md`](notations/ELEMENT_PRIMITIVES.md) §3): `notation: goal`, a canonical `id` (`GOAL-REVENUE-1` — no leading zeros), `name`, the per-TYPE fields (§7.2), the **admission record** (`zone`/`admitted_at`/`admitted_by`/`gate_checks`, §6) and the **primitive lifecycle** (`valid_from`/`valid_to`, §7). See the worked examples in `transitrix/acme-corp`'s [`canon/elements/01_motivation/goals/`](https://github.com/transitrix/acme-corp/tree/main/canon/elements/01_motivation/goals).
+
+The view then references the element by ID — it doesn't duplicate it.
+
+## Step 4 — Relationships
+
+Two ways to link, depending on whether time matters ([`ELEMENT_PRIMITIVES.md`](notations/ELEMENT_PRIMITIVES.md) §3, [`elements/17-relations.md`](notations/elements/17-relations.md)):
+
+- **Inline cross-reference** — a typed-ID field: `owner_role: ROLE-…`, `goal.factors: [DRIVER-…]`, `action.goals: [GOAL-…]`, `rule.applies_to: [PROCESS-…]`. Plural → array, singular → one ID ([`IDS_AND_REFERENCES.md`](notations/IDS_AND_REFERENCES.md) §5). Timeless within the host file. This covers most links.
+- **First-class time-aware relation (`REL`)** — a `canon/relations/REL-…yaml` file with its own `valid_from`/`valid_to`. Use it only for the links where history matters. The `type` enum is **closed**: `parent`, `goal_parent`, `action_goal`, `unit_parent` ([`17-relations.md`](notations/elements/17-relations.md) §3). A re-parenting is two REL files (one ended, one new) — see the worked example's `canon/relations/REL-CAP-V11-PARENT-*.yaml`.
+
+## Step 5 — Validate
+
+- **Studio** previews and validates on save.
+- **CLI:** `npx @transitrix/cli validate canon/views/goals/strategy-2026.dgca.transitrix.yaml`. All canonical `*.<short-name>.transitrix.yaml` extensions are accepted without `--ext`; pass `--ext <notation-name>` only for a non-canonical extension outside the built-in registry.
+- **On Windows PowerShell** with a restricted execution policy (the default on many workstations), invoke as `npx.cmd @transitrix/cli validate <file>` — the unsuffixed `npx` resolves to a `.ps1` wrapper that the policy refuses to launch. From `cmd.exe`, WSL, or a shell on macOS/Linux, plain `npx` is fine.
+- The rules: the shared header (`HDR-001..004`, [`CONTRACT.md`](notations/CONTRACT.md) §2), lifecycle (`LIFECYCLE-001..004`, §7), element placement (`ELEM-001..005`, [`ELEMENT_PRIMITIVES.md`](notations/ELEMENT_PRIMITIVES.md) §9), plus each notation's own "Validation rules" table.
+
+## Step 6 — Commit and open a PR
+
+```bash
+git checkout -b feature/strategy-2026-goals
+git add canon/
+git commit -m "docs(canon): add 2026 goals tree + revenue goal"
+git push origin feature/strategy-2026-goals
+```
+
+Architecture changes review as a diff, like code.
+
+## Step 7 — What next
+
+Based on what you built, add the adjacent artefact ([`notations/README.md`](notations/README.md) family selection):
+
+- Built a **Goals tree** → add a **DGCA** or **DGA** chain to link goals to driving drivers and delivery actions.
+- Built **DGCA** → add a **Capability map** for the same domain.
+- Built a **Capability map** → add an **Applications catalogue**.
+
+## Naming conventions
+
+Every typed ID is `<TYPE>-[<middle>-]<INTEGER>` — uppercase TYPE from the registry ([`IDS_AND_REFERENCES.md`](notations/IDS_AND_REFERENCES.md) §1, §3.1), no leading zeros (`GOAL-REVENUE-1`, not `GOAL-REVENUE-001`). `CAPABILITY` uses the V/H sub-grammar (`CAPABILITY-V1.2`). Element files are named `<ID>.yaml`. Full conventions: [`notations/CONVENTIONS.md`](notations/CONVENTIONS.md).
+
+## Getting help
+
+- Methodology canon: [`notations/`](notations/) (start at [`README.md`](notations/README.md)).
+- Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](notations/ELEMENT_PRIMITIVES.md).
+- An adopter repo's own agent guide is scaffolded by the onboarding Skill from [`transitrix/skills/onboard/templates/AGENTS.md`](transitrix/skills/onboard/templates/AGENTS.md).
+
+---
+
+**Happy architecting! 🏗️**

--- a/README.md
+++ b/README.md
@@ -48,12 +48,15 @@ Using the Claude Code plugin workflow instead? Same result, from the terminal `c
 /transitrix:onboard
 ```
 
-Prefer to do it by hand, or not working with a coding agent? Follow the manual walkthrough in **[`GETTING_STARTED.md`](https://github.com/transitrix/acme-corp/blob/main/GETTING_STARTED.md)** in the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo — same approach, against the worked `acme_corp` example. To validate as you go, install **Transitrix Studio** (VS Code) for live preview, or run `npx @transitrix/cli validate <file>` (on Windows PowerShell, use `npx.cmd` — see [Validation](#validation-in-one-paragraph)).
+Prefer to do it by hand, or not working with a coding agent? Follow the manual walkthrough in **[`GETTING_STARTED.md`](GETTING_STARTED.md)** — same approach, illustrated against the worked [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) example. To validate as you go, install **Transitrix Studio** (VS Code) for live preview, or run `npx @transitrix/cli validate <file>` (on Windows PowerShell, use `npx.cmd` — see [Validation](#validation-in-one-paragraph)).
 
 New to the ideas behind it? Read **[`method/01-methodology.md`](method/01-methodology.md)** for the *why* — but you don't need it to start.
 
 ## Documentation
 
+- **[`GETTING_STARTED.md`](GETTING_STARTED.md)** — a first modelling session, step by step, illustrated against the `acme-corp` worked example.
+- **[`WALKTHROUGH.md`](WALKTHROUGH.md)** — a guided tour of the `acme-corp` worked example, read as one story.
+- **[`notations/CONVENTIONS.md`](notations/CONVENTIONS.md)** — ID grammar, naming, and best-practice checklist for authoring canon content.
 - **[`patterns/implementation-tiers.md`](patterns/implementation-tiers.md)** — two implementation tiers (Simple / Full): what belongs in each, where the boundary sits, and how the upgrade path works.
 - **[`method/01-methodology.md`](method/01-methodology.md)** — the methodology overview: model, principles, zones, change lifecycle.
 - **[`notations/README.md`](notations/README.md)** — the canonical notation index; [`notations/CONTRACT.md`](notations/CONTRACT.md) and the per-notation specs are the authoritative source for the model in detail.
@@ -71,6 +74,7 @@ Process & releases:
 Tooling:
 
 - **[`integration/studio.md`](integration/studio.md)** — how to use Transitrix Studio (the reference VS Code extension and CLI for editing all Transitrix custom formats).
+- **[`integration/plantuml.md`](integration/plantuml.md)** — adopter guide for the supplementary `.puml` diagram workflow (sequence, component, deployment, …).
 - **[`integration/tooling.md`](integration/tooling.md)** — broader tooling and ecosystem notes.
 - **[`integration/ci-example.yaml`](integration/ci-example.yaml)** — CI template that gates pull requests on validation.
 - **[`transitrix/`](transitrix/)** — the Claude / Copilot Agent Skills plugin (`skills/onboard/`, `skills/ingest/`, …).

--- a/WALKTHROUGH.md
+++ b/WALKTHROUGH.md
@@ -1,0 +1,90 @@
+<!-- DRAFT — structure only. Final narrative voice & positioning are owned by the
+     comms / strategy layer (STYLE_GUIDE §3 voice tests, §3.5 no retired terms).
+     This file is the demo SPINE: each beat maps to the notation/view that tells it.
+     Fictional, data-free. -->
+
+# acme_corp — a Transitrix walkthrough
+
+> **What this is.** [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) (`acme_corp`) is a
+> fictional mid-size EU direct-to-consumer online retailer, modelled end-to-end in Transitrix. This
+> walkthrough reads that repository as one story — from "who they are" to "audit-ready" — so the
+> notations connect into a coherent picture rather than standing as isolated diagrams.
+>
+> _Fictional and data-free. GDPR / NIS2 / e-commerce appear here only as demonstration
+> material._
+
+## The story in eight beats
+
+Each beat links to where it lives in the `acme-corp` repo.
+
+1. **Who they are — the as-is enterprise.**
+   Products, the system estate, capabilities at their current maturity, and the
+   order-lifecycle state machine managed by the Order Management System.
+   → [`canon/views/products/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/products) ·
+     [`canon/views/applications/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/applications) ·
+     [`canon/views/capabilities/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/capabilities) ·
+     [`canon/views/state/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/state) (order lifecycle — Application layer, Mermaid) ·
+     [`canon/views/c4component/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/c4component) (application containers — Application layer, Mermaid) ·
+     [`canon/views/er/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/er) (domain entity model — Application layer, Mermaid) ·
+     [`canon/views/c4deployment/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/c4deployment) (deployment topology — Technology layer, Mermaid) ·
+     [`canon/views/c4infrastructure/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/c4infrastructure) (network zones — Technology layer, Mermaid)
+
+2. **The pressure — why they had to change.**
+   External drivers (a GDPR enforcement wave, incoming NIS2) and the real obligations
+   behind them; the coverage read shows where the model was still "dark".
+   → [`canon/views/dgca/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/dgca) (drivers) ·
+     [`codex/`](https://github.com/transitrix/acme-corp/tree/main/codex) (the obligations) ·
+     [`canon/views/coverage-metric/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/coverage-metric)
+
+3. **What they decided to become — the intent.**
+   The goal tree: compliance, resilience, growth — and the portfolio quadrant that
+   shows which goals demand immediate action versus which shape the longer horizon.
+   → [`canon/views/goals/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/goals) ·
+     [`canon/views/dgca/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/dgca) ·
+     [`canon/views/quadrant/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/quadrant) (goal prioritisation — Strategy layer, Mermaid)
+
+4. **The transformation — how.**
+   The changes, target capability maturity, alternative paths considered.
+   → [`canon/views/dgca/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/dgca) ·
+     [`canon/views/capabilities/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/capabilities) ·
+     [`canon/views/scenarios/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/scenarios)
+
+5. **The delivery — the work.**
+   The readiness programme as a scheduled project: dependencies, critical path, milestones.
+   → [`canon/views/action/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/action) ·
+     [`canon/views/timeline/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/timeline) (programme milestones — Implementation & Migration layer, Mermaid)
+
+6. **How it runs day-to-day.**
+   From the process landscape down to one detailed process, a value-chain blueprint
+   with the obligations lane, and the application-layer sequence showing how OMS and
+   CRM coordinate during a GDPR erasure sweep.
+   → [`canon/views/processmap/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/processmap) ·
+     [`canon/views/bpmn/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/bpmn) ·
+     [`canon/views/process-blueprint/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/process-blueprint) ·
+     [`canon/views/sequence/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/sequence) (erasure event — Application layer, Mermaid) ·
+     [`canon/views/journey/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/journey) (customer order journey — Business layer, Mermaid)
+
+7. **The proof — compliance, made legible.**
+   Which obligations hit which products and processes, with each cell's status; the gaps
+   that got closed.
+   → [`canon/views/compliance-impact/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/compliance-impact) ·
+     [`canon/views/sankey/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/sankey) (obligation volume by regulation and subject — Business layer, Mermaid)
+
+8. **The outcome — audit-ready and machine-runnable.**
+   Coverage before → after, and the decisions log that records how the architecture was
+   governed along the way.
+   → [`canon/views/coverage-metric/`](https://github.com/transitrix/acme-corp/tree/main/canon/views/coverage-metric) ·
+     [`operations/decisions/`](https://github.com/transitrix/acme-corp/tree/main/operations/decisions)
+
+## How to read it yourself
+
+Clone [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) and open any view file in
+**Transitrix Studio** (VS Code) for a live diagram, or render with
+`npx @transitrix/cli validate <file>`. The whole-repo model integrity is gated in that repo's CI
+(`.github/workflows/architecture-validate.yaml`). New to the methodology itself? Start with
+[`GETTING_STARTED.md`](GETTING_STARTED.md).
+
+---
+
+<!-- TODO (comms/strategy): replace beat blurbs with the final success-story prose.
+     Keep fictional + data-free; no client names. -->

--- a/integration/plantuml.md
+++ b/integration/plantuml.md
@@ -1,0 +1,102 @@
+# PlantUML diagrams — adopter guide
+
+An adopter repository may use [PlantUML](https://plantuml.com) for supplementary architectural diagrams (sequence, component, deployment, class, state, activity). Transitrix notation files (goals, BPMN, DGCA, capability map, …) are rendered by Transitrix Studio — this guide covers the separate `.puml` workflow.
+
+---
+
+## 1. Install the extension
+
+**VS Code:** Transitrix Studio renders `.puml` files natively — no separate PlantUML extension needed. If you have followed [`GETTING_STARTED.md`](../GETTING_STARTED.md), Studio (`transitrix.transitrix-studio`) is already installed. Open any `.puml` file and run **Transitrix: Preview PlantUML** from the Command Palette (`Ctrl+Shift+P` → `transitrixStudio.previewPuml`).
+
+**JetBrains (IntelliJ IDEA, PyCharm, …):** install "PlantUML Integration" by Eugene Steinberg from the JetBrains Marketplace (`com.github.eightpillow.plantuml`).
+
+**Recommended VS Code workspace extensions** are listed in the repo's `.vscode/extensions.json` — VS Code will prompt you to install them when you open the repo.
+
+---
+
+## 2. Use the shared header
+
+Every `.puml` file in `diagrams/` starts with:
+
+```plantuml
+!include transitrix-theme.puml
+@startuml
+
+' ... your diagram content here ...
+
+@enduml
+```
+
+> The `@startuml` / `@enduml` delimiters go **after** the `!include` line.
+
+The theme file (`diagrams/transitrix-theme.puml`) does two things:
+
+- **`!pragma layout smetana`** — switches PlantUML to its pure-Java layout engine. This removes the Graphviz external dependency, eliminating the single largest source of "it renders differently on my machine."
+- **Transitrix skin** — petrol palette, no shadows, uniform stroke weight; any diagram you produce is recognisably on-brand.
+
+---
+
+## 3. Pinned toolchain (deterministic rendering)
+
+**VS Code:** Transitrix Studio bundles the PlantUML engine internally (no JAR, no Java, no Graphviz). Nothing to configure.
+
+**JetBrains:** the PlantUML Integration plugin uses your local Java + PlantUML JAR. To pin the version:
+
+1. Download the pinned JAR:
+   ```
+   https://github.com/plantuml/plantuml/releases/download/v1.2024.8/plantuml-1.2024.8.jar
+   ```
+   Save it to `.plantuml/plantuml.jar` (gitignored; each contributor downloads once).
+
+2. In Settings → Other Settings → PlantUML, set the PlantUML JAR path to `.plantuml/plantuml.jar` and Graphviz to "no external tool" (Smetana layout is active via `!pragma layout smetana` in the theme file, making Graphviz unnecessary).
+
+3. **Java:** JDK or JRE 11+ must be on your `PATH`. `java -version` should succeed.
+
+---
+
+## 4. What a good diagram looks like
+
+- **Structure through petrol** — borders, edges, and connectors use petrol `#004d67`. Fills are light petrol tints (see the adopter repo's `diagrams/README.md` for the tint levels).
+- **Hierarchy through tint depth** — deeper petrol tint for higher-level nodes, lighter for lower. Never switch hue to signal hierarchy.
+- **Emphasis through amber / orange** — `#ffaf00` for "this matters," `#ff4d00` for focus/active. Use sparingly.
+- **Status through the functional palette** — `#1f7a3f` success, `#a76b00` warning, `#b3261e` error, `#3b6cb3` info. Never repurpose amber as "warning" or orange as "error."
+- **No shadowing.** No variable stroke weight. Emphasis is colour only.
+
+Example starter diagram:
+
+```plantuml
+!include transitrix-theme.puml
+@startuml Order fulfilment flow
+
+actor Customer #e8f2f5
+participant "Order Service" as OS #e8f2f5
+participant "Payment Service" as PS #e8f2f5
+participant "Fulfilment Service" as FS #e8f2f5
+
+Customer -> OS : Place order
+OS -> PS : Authorise payment
+PS --> OS : Authorised
+OS -> FS : Dispatch order
+FS --> Customer : Shipment confirmation
+
+@enduml
+```
+
+---
+
+## 5. CI validation
+
+A `.github/workflows/puml-lint.yml` workflow (see [`integration/ci-example.yaml`](ci-example.yaml) for the pattern) validates every `.puml` file in `diagrams/` on push and pull request. It downloads the pinned PlantUML JAR and runs a syntax check (no rendering) — no Graphviz needed, thanks to Smetana.
+
+If the check fails, PlantUML prints the line number and a description of the error. Fix the flagged lines and re-push.
+
+---
+
+## 6. Files (in an adopter repo)
+
+| Path | Purpose |
+|---|---|
+| `diagrams/transitrix-theme.puml` | Shared theme — `!include` this in every `.puml` |
+| `diagrams/README.md` | Colour contract and tint reference |
+| `.vscode/extensions.json` | Workspace extension recommendations |
+| `.github/workflows/puml-lint.yml` | CI syntax check |

--- a/notations/CONVENTIONS.md
+++ b/notations/CONVENTIONS.md
@@ -1,0 +1,164 @@
+# Transitrix naming conventions & best practices
+
+Conventions for IDs, file names, and element content in a Transitrix repo. The authoritative grammar and registry are [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md); the element-file shape is [`ELEMENT_PRIMITIVES.md`](ELEMENT_PRIMITIVES.md).
+
+## Naming conventions
+
+### Element IDs
+
+**Format:** `<TYPE>-[<middle segment(s)>-]<INTEGER>` — the canonical grammar ([`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §1). The terminal integer is ≥ 1 with **no leading zeros** (sorting is numeric); middle segments (a domain code, period, programme name) are optional and uppercase.
+
+#### TYPE prefixes (canonical registry)
+
+Use exactly these prefixes; the abbreviated forms `ACT`, `CHG`, `FAC`, `CAP`, `SCN`, `APP`, `PROC`, `PROD` are not valid TYPEs. Authoritative list: [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §3.
+
+**Element types**
+
+| TYPE | What it is | Layer folder |
+|---|---|---|
+| `DRIVER` | strategic driver (external / internal) | `01_motivation/factors/` |
+| `GOAL` | strategic or tactical goal | `01_motivation/goals/` |
+| `CONSTRAINT` | design / operating constraint | `01_motivation/constraints/` |
+| `REQUIREMENT` | positive obligation | `01_motivation/requirements/` |
+| `ACTOR` | active-structure identity — `person`, `business_unit`, or `system` | `02_business/actors/` |
+| `STAKEHOLDER` | interest-holding actor (`internal` / `external`); references an `ACTOR` for identity | `01_motivation/stakeholders/` |
+| `CAPABILITY` | capability — V/H address, e.g. `CAPABILITY-V1.2` | `02_business/capabilities/` |
+| `PROCESS` | business process | `02_business/processes/` |
+| `PRODUCT` | product or service | `02_business/products/` |
+| `ROLE` | business role | `02_business/roles/` |
+| `RULE` | business rule | `02_business/rules/` |
+| `APPLICATION` | application | `03_application/applications/` |
+| `INTEGRATION` | integration between applications | `03_application/integrations/` |
+| `CHANGE` | business transformation (BDN change layer) | `05_implementation/changes/` |
+| `ACTION` | initiative / workstream | `05_implementation/actions/` |
+
+`SCENARIO`, `ISSUE` are **view-defined** (live inside their view document, not as standalone element files) — see [`ELEMENT_PRIMITIVES.md`](ELEMENT_PRIMITIVES.md) §4.
+
+`EQUIPMENT` is catalogued at `canon/elements/04_technology/equipment/`; `BUSINESS_OBJECT` (replaces `INFORMATION_ENTITY`, deprecated alias for one release) is catalogued at `canon/elements/02_business/business-objects/` — both are first-class standalone elements as of ADR 2026-06-08.
+
+**Document-level types** — the view file's own ID; the TYPE names the notation
+
+| TYPE | Notation file |
+|---|---|
+| `DGCA` | `*.dgca.transitrix.yaml` |
+| `GOALS_TREE` | `*.goals.transitrix.yaml` |
+| `ACTIVITIES_NET` | `*.activities.transitrix.yaml` |
+| `CAPABILITY_MAP` | `*.capability-map.transitrix.yaml` |
+| `PROCESS_MAP` | `*.process-map.transitrix.yaml` |
+| `PRODUCTS_CAT` | `*.products.transitrix.yaml` |
+| `APPLICATIONS_CAT` | `*.applications.transitrix.yaml` |
+| `SCENARIOS` | `*.scenarios.transitrix.yaml` |
+| `BLOCKS` | `*.blocks.transitrix.yaml` |
+| `PROCESS_BLUEPRINT` | `*.process-blueprint.transitrix.yaml` |
+| `ACTION_CARD` | `*.action-card.transitrix.yaml` |
+| `COMPLIANCE_IMPACT` | `*.compliance-impact.transitrix.yaml` |
+
+#### Domain codes
+
+Optional middle segments — short uppercase abbreviations (`ORD`, `PAY`, `USR`, `EU`, `OPS`, …): `GOAL-REVENUE-1`, `ACTION-CRM-EU-1`, `PROCESS-ORD-FULFILL-1`.
+
+#### Sequence numbers
+
+Plain positive integers from `1`, **no leading zeros**: `GOAL-REV-1`, `ROLE-SALES-1`, `APPLICATION-ORD-API-1`.
+
+### Element ID examples
+
+```
+✓ GOAL-REVENUE-1          "Triple revenue in 3 years"
+✓ PROCESS-ORD-FULFILL-1   "Order Fulfilment"
+✓ APPLICATION-OMS-1       "Order Management System"
+✓ CAPABILITY-V1.2         "Order Fulfilment" (V/H sub-grammar)
+✓ REL-CAP-V11-PARENT-1    parent relation
+
+✗ goal-1                  (TYPE must be uppercase)
+✗ APP-OMS-1               (APP is not a TYPE — use APPLICATION)
+✗ GOAL-REVENUE-001        (no leading zeros)
+✗ APPLICATION_OMS_1       (use hyphens between segments, not underscores)
+```
+
+### File names
+
+Element primitives are named **`<ID>.yaml`** — the file name *is* the canonical ID (`GOAL-REVENUE-1.yaml`, `APPLICATION-OMS-1.yaml`). View documents are `<domain>.<ext>.transitrix.yaml` (`strategy-2026.dgca.transitrix.yaml`). No spaces; no underscores standing in for hyphens.
+
+### Relation IDs
+
+First-class relations are `REL-[<middle>-]<INTEGER>` ([`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §1), one file per relation in `canon/relations/`. The *kind* of link lives in the file's `type` field (closed enum `parent` / `goal_parent` / `action_goal` / `unit_parent`), not in the ID — though a readable convention encodes the endpoints in the middle segments: `REL-CAP-V11-PARENT-1`. See [`elements/17-relations.md`](elements/17-relations.md).
+
+### Directory organisation
+
+```
+canon/
+  elements/<NN>_<layer>/<plural-type>/<ID>.yaml   # one element per file
+  relations/REL-….yaml                            # one relation per file (flat)
+  assertions/ASSERTION-….yaml
+  views/<notation>/<domain>.<short>.transitrix.yaml
+field/<sub>/<ID>.yaml
+codex/external/<jurisdiction>/<ID>.yaml , codex/internal/<ID>.yaml
+```
+
+---
+
+## Best practices
+
+### 1. Write clear descriptions
+
+Explain *what* the element is and *why* it exists in 1–3 scannable sentences. `description: "Order API"` is too thin; name the responsibility and the consumers.
+
+### 2. Carry the full envelope
+
+Every element-primitive file carries ([`ELEMENT_PRIMITIVES.md`](ELEMENT_PRIMITIVES.md) §3): the `notation:` header, identity (`id`/`name`/optional subtype `type`), the **admission record** (`zone`/`admitted_at`/`admitted_by`/`gate_checks`, [`CONTRACT.md`](CONTRACT.md) §6), and the **primitive lifecycle** (`valid_from`/`valid_to`, §7). There is **no** `metadata{}` / `properties{}` wrapper — fields sit at the top level.
+
+### 3. Model relationships the canonical way
+
+- **Inline cross-reference** for most links — a typed-ID field (`owner_role: ROLE-…`, `goals: [GOAL-…]`, `applies_to: [PROCESS-…]`). Plural → array, singular → one ID ([`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §5).
+- **First-class `REL` file** only when the link's history matters, and only for the closed `type` enum ([`elements/17-relations.md`](elements/17-relations.md)).
+
+(Transitrix does **not** model arbitrary ArchiMate relationships — `Serving`/`Assignment`/`Access`/… are not part of the canonical model.)
+
+### 4. Lifecycle, not free-text status
+
+Temporal validity is `valid_from`/`valid_to` ([`CONTRACT.md`](CONTRACT.md) §7); derived states (Planned/Active/Retired) come from comparing those to today. An optional top-level `status` records authoring/workflow state where a notation defines one. Time-varying attributes (a capability's maturity, an application's vendor) live in a `<ID>.history.yaml` sidecar (§9), not inline.
+
+### 5. Quote dates
+
+All dates are quoted ISO 8601 `YYYY-MM-DD` ([`CONTRACT.md`](CONTRACT.md) §4): `valid_from: "2026-05-26"`.
+
+### 6. Ownership is a typed reference
+
+Accountability is `owner_role: ROLE-…` (a typed reference to a ROLE element), not a free-text handle.
+
+### 7. Tag for discoverability
+
+Optional `tags: [...]` — e.g. `["customer-facing", "critical"]`.
+
+---
+
+## Quality checklist
+
+Before committing:
+
+- [ ] Every ID follows `<TYPE>-[<middle>-]<INTEGER>` with a canonical TYPE prefix; no leading zeros.
+- [ ] No duplicate IDs within the relevant uniqueness scope ([`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §4).
+- [ ] Element files named `<ID>.yaml`, placed in the correct `<NN>_<layer>/<plural-type>/` folder.
+- [ ] Each element carries `notation:` + admission record + `valid_from`/`valid_to`.
+- [ ] Cross-references resolve to a defined element of the correct TYPE.
+- [ ] Dates are quoted ISO 8601.
+- [ ] Descriptions explain "what" and "why".
+- [ ] Validates in Studio / `npx @transitrix/cli validate <file>` (Windows PowerShell: use `npx.cmd`).
+
+## Common mistakes
+
+| Mistake | Example | Fix |
+|---|---|---|
+| Abbreviated TYPE prefix | `APP-OMS-1`, `PROC-ORD-1` | `APPLICATION-OMS-1`, `PROCESS-ORD-1` |
+| Leading zeros | `GOAL-REVENUE-001` | `GOAL-REVENUE-1` |
+| Lowercase TYPE | `goal-1` | `GOAL-1` |
+| Underscores between segments | `APPLICATION_OMS_1` | `APPLICATION-OMS-1` |
+| `metadata`/`properties` wrappers | nested `properties: { … }` | flat top-level fields (§3 envelope) |
+| Arbitrary ArchiMate relations | a `Serving` REL | inline cross-reference, or a closed-enum `REL` |
+| `title` for the label | `title: "…"` | `name: "…"` |
+| Unquoted date | `valid_from: 2026-05-26` | `valid_from: "2026-05-26"` |
+
+---
+
+**Authoritative sources:** [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md), [`ELEMENT_PRIMITIVES.md`](ELEMENT_PRIMITIVES.md), [`CONTRACT.md`](CONTRACT.md). An adopter pins its methodology version in its own `transitrix.yaml` ([`MANIFEST.md`](MANIFEST.md)).


### PR DESCRIPTION
## Summary
- Adds `GETTING_STARTED.md` (tutorial), `notations/CONVENTIONS.md` (naming conventions), `integration/plantuml.md` (PlantUML adopter guide), and `WALKTHROUGH.md` (guided tour of the worked example) — migrated from `transitrix/acme-corp`, which held teaching content that belongs here instead.
- Internal links rebased for the new location; links into acme-corp's own model content (where the worked example actually lives, e.g. `canon/views/goals/`) point directly at that repo.
- README's Quick start and Documentation sections repointed at the new in-repo locations.
- Doc-lint (`node scripts/check-notations.mjs`) passes clean.

Part of hub task HUB-860 (epic HUB-804). Companion PR [transitrix/acme-corp#53](https://github.com/transitrix/acme-corp/pull/53) leaves a one-line redirect stub at each of the four old paths.

## Test plan
- [x] `node scripts/check-notations.mjs` clean.
- [ ] Spot-check the new pages render correctly on GitHub.
- [ ] Confirm the acme-corp companion PR's stubs point back here correctly.