### PR TITLE
chore: fix stale templates/ note in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,8 +227,8 @@ docs/decisions/
 
 # Keep all .md files (documentation) EXCEPT internal-only files listed above
 # Keep all .yaml files in elements/, relations/, views/ (architecture)
-# Keep all forkable templates in templates/ (see templates/README.md) — these
-# ARE committed; not to be confused with the ignored AGENT RULES FILES above.
+# Forkable starter templates live in the separate transitrix/templates repo
+# (retired from a local templates/ dir here 2026-07-28).
 # Archive old files in 0.archive/ instead of deleting them
 # Only files explicitly listed above are ignored
 


### PR DESCRIPTION
## Summary
- `.gitignore`'s NOTES section referenced a local `templates/README.md` that no longer exists — `templates/` was retired 2026-07-28 (e75744c) when forkable templates moved to the separate `transitrix/templates` repo.
- Same class of fix as the immediately-preceding `.gitignore` stale-note cleanup (#404); caught during a routine repo-hygiene pass.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean (comment-only change, no notation impact)