### PR TITLE
ci: add weekly Dependabot coverage with gated auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  # Four independently published CLI packages — each is its own manifest.
+  - package-ecosystem: "npm"
+    directory: "/packages/decisions-cli"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/packages/ingest-cli"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/packages/reg-intel-cli"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/packages/reqif-cli"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions workflow files.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+
+# Weekly Dependabot updates auto-merge on green, gated by this repository's
+# own CI — including Public-surface hygiene, since this repo is public.
+# `dependabot.yml` already excludes major-version bumps; the metadata check
+# below is a second, independent gate on the same property.
+#
+# `gh pr checks --watch` blocks until every check on the PR has concluded and
+# exits non-zero on any failure, so the merge step below never runs unless
+# every required workflow — including hygiene — has already passed.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Wait for checks, then merge on green
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          gh pr checks "$PR_URL" --watch --fail-fast
+          gh pr merge --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml`: weekly updates for all four npm CLI packages (`decisions-cli`, `ingest-cli`, `reg-intel-cli`, `reqif-cli`) and the GitHub Actions ecosystem, security/patch/minor only — major-version bumps stay excluded for the twice-yearly wave.
- Add `.github/workflows/dependabot-auto-merge.yml`: auto-merges a Dependabot PR only after every check on it — including Public-surface hygiene — has already concluded successfully, and only for non-major bumps.
- Confirmed Dependabot alerts are already enabled on this repository (verified via the API, no action needed).

## Test plan
- [x] `node scripts/check-workflow-scripts.mjs` passes locally
- [x] Re-read both new files in full after writing to confirm no truncation
- [ ] CI green on this PR (ADL guard, Notations doc-lint, Public-surface hygiene, PR description policy, etc.)