### PR TITLE
docs: changelog and manifest pin for 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [3.1.0] — 2026-07-31
+
+Bump category: **MINOR** — additive core vocabulary and tooling only; no migration recipe required.
+
+### Added
+
+- **`RISK` element type** (`ELEMENT_PRIMITIVES.md` §7.26) — motivation-layer projected event (likelihood / impact / residual / owner; `threatens` / `treated_by`). Additive alongside the ArchiMate Risk and Security Overlay mapping in `CONTRACT.md` §8.1. Rules `RISK-001..004`, `RISK-COVERAGE-001`. (#416)
+- **`METRIC` element type** (`ELEMENT_PRIMITIVES.md` §7.27) — managed indicator (unit / target / `direction_of_good` / `measures`), distinct from report-config `COVERAGE_METRIC`. Rules `METRIC-001..004`. (#417)
+- **`NEED` element type + `VALIDATION` claim** (`ELEMENT_PRIMITIVES.md` §7.28, `elements/28-validation.md`) — stakeholder/user need upstream of `REQUIREMENT`; `VALIDATION` mirrors `VERIFICATION` but anchors on `NEED` with a validation-method vocabulary. `REQUIREMENT.serves` optional back-reference. Rules `NEED-001..002`, `NEED-COVERAGE-001`, `NEED-VALIDATION-COVERAGE-001..002`, `REQ-SERVES-001`, `VALID-001..006`. Worked example under `notations/examples/validation/`. (#419)
+- **`REQUIREMENT.level` and `REQUIREMENT.kind`** — optional ISO/IEC/IEEE 29148 specification-tier ladder (`stakeholder` / `system` / `software`) and functional/quality classification. Rules `REQ-005`, `REQ-006`. (#418)
+- **Weekly Dependabot** with gated auto-merge for this repository's manifests and Actions. (#420)
+- **Interactive one-card admission review** on `@transitrix/decisions-cli` (`review`), plus ingest/reg-intel conversational one-card review + stop/resume skill docs. (#397, #398)
+- **Onboard skill** absorbs adopter starter templates previously living in the companion reference repo; teaching-content docs migrate into this repository. (#406, #405)
+- **CI gates** — PR-description disclosure policy; commit-message scan with no PR-metadata carve-out; fail-closed when a hygiene value cannot be evaluated; committed content carries no work-item reference. (#413, #412, #408, #411)
+
+### Changed
+
+- **`VERIFICATION` wording** — documents verification only (not full V&V); `verifies` has only ever resolved to `REQUIREMENT`. (#415)
+- **Public-surface hygiene** — work-item references use a neutral form in committed content; four remaining neutral-form cleanups. (#409, #403)
+
+### Fixed
+
+- **Stale-base squash restore** — content a stale-base squash had reverted is restored. (#414)
+- **`.gitignore` notes** — stale `templates/` commentary trimmed. (#410, #404)
+
+---
+
 ## [3.0.0] — 2026-07-29
 
 Bump category: **MAJOR** — the ISO 14971 risk-management chain is removed from the public core. `VERIFICATION` and the rest of the compliance/V&V spine are unaffected. Decision of record: the 2026-07-29 core-scope decision.

--- a/method/02-team-operations.md
+++ b/method/02-team-operations.md
@@ -146,7 +146,7 @@ Deliberately **not** one-file-per-record like ADR/WI: a single file, `operations
 ---
 ### FB-0002
 type: notation-gap
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 raised_by: modeler
 date: "2026-07-27"
 status: sent-upstream

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -810,7 +810,7 @@ Structural layout of a view document:
 ```yaml
 notation: dgca                # §1 — required header
 spec_version: "0.1"           # §1 — optional header
-methodology_version: "3.0.0"  # manifest-pinned methodology version
+methodology_version: "3.1.0"  # manifest-pinned methodology version
 name: "Retail strategy chain" # §1.1 — required document name
 
 view:                         # view identity block — id only; name lives at root per §1.1
@@ -891,7 +891,7 @@ views/
 ```yaml
 view_id: DGCA-RETAIL-1               # canonical ID of the view being captured
 generated_at: "2026-06-20T14:30:00Z" # ISO-8601 UTC timestamp — matches the file name
-methodology_version: "3.0.0"          # methodology version in use at generation time
+methodology_version: "3.1.0"          # methodology version in use at generation time
 # …notation-specific element list follows (format defined per notation spec)…
 ```
 

--- a/notations/COVERAGE_PROFILES.md
+++ b/notations/COVERAGE_PROFILES.md
@@ -24,7 +24,7 @@ A profile is declared at the repository root in `transitrix.yaml` under the `cov
 
 ```yaml
 transitrix: 1
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core         # short form — name a shipped preset
@@ -250,7 +250,7 @@ The shipped presets (`minimal`, `core`, `full`) are *re-defined per methodology 
 ```yaml
 # transitrix.yaml
 transitrix: 1
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 notations: [dgca, goals, activities, capability-map, applications]
 zones: [canon, field]
 # coverage_profile omitted → defaults to `full`

--- a/notations/CURRENT_VERSION.yaml
+++ b/notations/CURRENT_VERSION.yaml
@@ -5,4 +5,4 @@
 # placeholder allowlist in scripts/check-notations.mjs. Enforced by that
 # script's V1 check. See notations/CONTRACT.md §10 for the versioning and
 # compatibility policy this pin follows.
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -29,7 +29,7 @@ A worked example lives at `transitrix.yaml` in the [acme-corp reference repo](ht
 
 ```yaml
 transitrix: 1                       # manifest schema version (integer)
-methodology_version: "3.0.0"        # the methodology release this repo conforms to
+methodology_version: "3.1.0"        # the methodology release this repo conforms to
 notations: [dgca, goals, action, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md

--- a/notations/PACKAGES.md
+++ b/notations/PACKAGES.md
@@ -20,7 +20,7 @@ A package is declared at the repository root in `transitrix.yaml` under the `pac
 
 ```yaml
 transitrix: 1
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core

--- a/notations/examples/compliance-impact/README.md
+++ b/notations/examples/compliance-impact/README.md
@@ -25,7 +25,7 @@ A compliance-impact view file carries the shared envelope (`notation:`, `spec_ve
 ```yaml
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 view:
   id: COMPLIANCE_IMPACT-<NAME>-1

--- a/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
+++ b/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 name: "Retail product — GDPR obligations"
 
 view:

--- a/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
+++ b/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 id: DGCA-DATA-RESIDENCY-1
 name: "EU data-residency DGCA chain"

--- a/notations/examples/dgca/startup.dgca.transitrix.yaml
+++ b/notations/examples/dgca/startup.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 id: DGCA-STARTUP-1
 name: "Product launch — strategy chain"

--- a/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 id: DGCA-STRATEGY-2026-DGA
 name: "Strategy 2026 — DGA view"

--- a/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 id: DGCA-STRAT-1
 name: "Strategy 2026 — DGCA chain"

--- a/notations/examples/packages/reqif-workflow/transitrix.yaml
+++ b/notations/examples/packages/reqif-workflow/transitrix.yaml
@@ -4,7 +4,7 @@
 # (packages/reqif-cli/tests/test_reqif_integrity.py Part B) stays unaffected
 # by content the XML converter does not carry (see this folder's README).
 transitrix: 1
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/packages/reqif/transitrix.yaml
+++ b/notations/examples/packages/reqif/transitrix.yaml
@@ -3,7 +3,7 @@
 # permitted cross-reference (Transitrix.CanonRef, reqif.md §3) something real
 # to cite, plus the reqif/ package folder itself.
 transitrix: 1
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/scenarios/README.md
+++ b/notations/examples/scenarios/README.md
@@ -26,7 +26,7 @@ A post-reclassification scenarios view file carries no canonical content. It dec
 ```yaml
 notation: scenarios
 spec_version: "0.3"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 view:
   id: SCENARIOS-2027-CUT-1

--- a/notations/packages/reqif.md
+++ b/notations/packages/reqif.md
@@ -21,7 +21,7 @@ This is a package, not a core notation: nothing here changes `IDS_AND_REFERENCES
 
 ```yaml
 transitrix: 1
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 packages: [reqif]
 ```
 

--- a/notations/views/02-dgca.md
+++ b/notations/views/02-dgca.md
@@ -154,7 +154,7 @@ A DGCA document opens with a shared header block (`notation:`, `spec_version:`, 
 ```yaml
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 id: DGCA-LAUNCH-1
 name: "Product launch strategy chain"
 period: "2026"
@@ -188,7 +188,7 @@ notation: dgca
 spec_version: "0.1"
 id: DGCA-RETAIL-1
 name: "Retail strategy chain 2026"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 view_config:
   goals:

--- a/notations/views/04-goals.md
+++ b/notations/views/04-goals.md
@@ -117,7 +117,7 @@ After goals are promoted to `canon/elements/01_motivation/goals/`, the view beco
 ```yaml
 notation: goals
 spec_version: "0.1"
-methodology_version: "3.0.0"          # required from v2.0 onward
+methodology_version: "3.1.0"          # required from v2.0 onward
 
 id: GOALS-STRAT-2026-1                 # required — GOALS-[<middle>-]<INTEGER>
 name: "Strategy 2026 — Goals Tree"    # required per CONTRACT.md §1.1

--- a/notations/views/07-action.md
+++ b/notations/views/07-action.md
@@ -128,7 +128,7 @@ After actions are promoted to `canon/elements/05_implementation/actions/`, the v
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "3.0.0"          # required from v2.0 onward
+methodology_version: "3.1.0"          # required from v2.0 onward
 
 id: ACTION_SCHED-PLATFORM-2026-1      # required — ACTION_SCHED-[<middle>-]<INTEGER>
 name: "Platform Launch 2026"          # required per CONTRACT.md §1.1
@@ -344,7 +344,7 @@ Both views are projections of the same underlying schedule. A document never "be
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 id: ACTION_SCHED-MINIMAL-1
 name: "Minimal schedule example"           # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                # optional per CONTRACT.md §4

--- a/notations/views/11-scenarios.md
+++ b/notations/views/11-scenarios.md
@@ -45,7 +45,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 view:
   # ... see §3
 ```
@@ -95,7 +95,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Optimistic vs Conservative — 2027 cut"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                       # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 view:
   id: SCENARIOS-<NAME>-1
@@ -152,7 +152,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "All scenarios"                   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 view:
   id: SCENARIOS-ALL-1
   name: "All scenarios"

--- a/notations/views/21-compliance-impact.md
+++ b/notations/views/21-compliance-impact.md
@@ -45,7 +45,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 view:
   # ... see §3
 ```
@@ -103,7 +103,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Retail product — GDPR obligations"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 view:
   id: COMPLIANCE_IMPACT-RETAIL-GDPR-1
@@ -190,7 +190,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Full compliance matrix"          # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 view:
   id: COMPLIANCE_IMPACT-ALL-1
   name: "Full compliance matrix"

--- a/notations/views/22-coverage-metric.md
+++ b/notations/views/22-coverage-metric.md
@@ -45,7 +45,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Retail product — regime coverage"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 view:
   id: COVERAGE_METRIC-RETAIL-1
@@ -199,7 +199,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Full coverage metric"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 view:
   id: COVERAGE_METRIC-ALL-1
   name: "Full coverage metric"

--- a/transitrix/skills/feedback/SKILL.md
+++ b/transitrix/skills/feedback/SKILL.md
@@ -179,7 +179,7 @@ element"* — which passes.
    ---
    ### FB-0003
    type: notation-gap
-   methodology_version: "3.0.0"
+   methodology_version: "3.1.0"
    raised_by: Modeler
    date: "2026-07-28"
    status: open

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -158,7 +158,7 @@ The root `transitrix.yaml` pins which methodology release this repo conforms to 
 
 ```yaml
 transitrix: 1
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 notations: [dgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```

--- a/transitrix/skills/onboard/templates/action.action.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/action.action.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: action
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 # Action schedule — pure projection over standalone ACTION elements.
 # Spec: notations/views/07-action.md (v2.0). No action data is authored inline.

--- a/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: coverage-metric
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 # Coverage Metric. Spec: notations/views/22-coverage-metric.md
 # Report-config over the coverage read of canon (sibling of Compliance Impact).

--- a/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: goals
 spec_version: "0.1"
-methodology_version: "3.0.0"
+methodology_version: "3.1.0"
 
 # Goals tree — pure projection over standalone GOAL elements.
 # Spec: notations/views/04-goals.md (v2.0). No element data is authored inline.


### PR DESCRIPTION
## Summary
- Adds the Keep-a-Changelog entry for **3.1.0** (MINOR — additive vocabulary + tooling since 3.0.0).
- Bumps the worked-example `methodology_version` in `notations/MANIFEST.md` to `3.1.0`.

No migration recipe — additive only.

## Test plan
- [x] `node scripts/check-notations.mjs`
- [ ] Tag `v3.1.0` + GitHub Release after merge
- [ ] Companion acme-corp `transitrix.yaml` pin bump