### PR TITLE
ci: widen work-item reference guard to catch the unpunctuated form

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -428,7 +428,10 @@ jobs:
           # A reference to this repository's own issue or PR is untouched: a
           # plain `#12`, and the `closes #12` / `fixes #12` auto-close keywords,
           # mean what they say. Only work-item forms match: the `HUB-` prefix,
-          # or a hash-number dressed as task / epic / hub work.
+          # a hash-number dressed as task / epic / hub / issue work, or the
+          # unpunctuated `hub task 217` / `hub epic 391` spelling (the
+          # qualifier word `hub` is the discriminator there, so ordinary prose
+          # like `task 3 of the pipeline` stays clear).
           #
           # These patterns name nothing confidential, so they live here in the
           # open and the matched token IS printed. A contributor who cannot see
@@ -436,7 +439,7 @@ jobs:
           # class of reference accumulated in the first place. This file is
           # excluded from its own scan; that exclusion is also the escape hatch
           # for a doc that must legitimately show the form.
-          HUBREF='(\bHUB-[0-9]+|\b(task|epic|hub)s?[[:space:]:]+#[0-9]+)'
+          HUBREF='(\bHUB-[0-9]+|\b(task|epic|hub|issue)s?[[:space:]:]+#[0-9]+|\bhub[[:space:]]+(task|epic|issue)s?[[:space:]]+#?[0-9]+)'
 
           fail=0
           tmp="$(mktemp -d)"
@@ -493,3 +496,42 @@ jobs:
             exit 1
           fi
           echo "OK - no work-item references on any scanned surface."
+
+      - name: Self-test - work-item reference guard
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Exercises the actual live HUBREF pattern from the step above (by
+          # extracting it from this file) rather than a copy that could drift
+          # out of sync with it. Regresses the build if the guard stops
+          # catching the unpunctuated form or starts flagging ordinary prose.
+          HUBREF="$(grep -E "^[[:space:]]*HUBREF='" .github/workflows/public-surface-hygiene.yml \
+            | sed -E "s/^[[:space:]]*HUBREF='(.*)'\$/\1/")"
+          [ -n "$HUBREF" ] || { echo "::error::could not extract HUBREF pattern from the workflow file for self-test"; exit 1; }
+
+          fail=0
+          check() {
+            local expect="$1" input="$2" got=no-match
+            printf '%s\n' "$input" | grep -qiE "$HUBREF" && got=match
+            if [ "$got" != "$expect" ]; then
+              echo "::error::self-test failed for '$input' - expected $expect, got $got"
+              fail=1
+            fi
+          }
+
+          # Positive - must be flagged.
+          check match "hub task 217"
+          check match "hub epic 391"
+          check match "HUB-905"
+          check match "issue #7"
+
+          # Negative - must NOT be flagged.
+          check no-match "task 3 of the pipeline"
+          check no-match "closes #12"
+          check no-match "GitHub 3"
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "OK - work-item reference guard self-test passed (4 positive, 3 negative)."


### PR DESCRIPTION
## Summary
- The public-surface hygiene guard's work-item pattern required a `#`, so an unpunctuated reference like a bare "hub" + work-type + number slipped through the diff, full-tree, and PR-metadata scans.
- Widened the pattern to add "issue" alongside the existing keywords and to catch the unpunctuated spelling, discriminated by the qualifying "hub" word so ordinary prose ("task 3 of the pipeline") stays unaffected.
- Added a self-test step that extracts the live pattern from the workflow file and checks it against fixed positive/negative fixtures, so a future edit can't silently narrow or broaden the guard undetected.
- Full-tree sweep with the widened pattern found zero additional hits in this repository.

## Test plan
- [x] Self-test fixtures verified locally (4 positive matches, 3 negative non-matches) against the exact extracted pattern.
- [x] File tail/line-count checked after edit — no truncation.
- [ ] CI run on this PR (hygiene workflow, including the new self-test step) passes.