### PR TITLE
feat(notations): add document-view engine and MRD layout

### DIFF
--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -119,6 +119,7 @@ Each notation file carries its own ID using the same grammar; the TYPE names the
 | `ACTION_CARD` | `*.action-card.transitrix.yaml` (deprecated alias: `*.activity-card.transitrix.yaml`) |
 | `COMPLIANCE_IMPACT` | `*.compliance-impact.transitrix.yaml` |
 | `COVERAGE_METRIC` | `*.coverage-metric.transitrix.yaml` |
+| `MRD` | `*.mrd.transitrix.yaml` |
 
 BPMN diagrams use their `process.id` as the document identifier; that field is a free-form string defined by the spec, not by this appendix.
 

--- a/notations/README.md
+++ b/notations/README.md
@@ -35,9 +35,13 @@ Each produces a derived report or table from a declarative view-config, per [`RE
 | [22-coverage-metric.md](./views/reports/22-coverage-metric.md) | `coverage-metric` | Report-config view over coverage of canon — counts subjects with zero admitted obligations from each regime, broken down per jurisdiction; distinguishes "Not yet modelled" (modelling gap) from "No obligation asserted (modelled fact)". | `*.coverage-metric.transitrix.yaml` | draft |
 | [23-actions-tree.md](./views/reports/23-actions-tree.md) | `actions-tree` | Report-config view over the `ACTION` element catalogue — renders the strategic portfolio as a top-down tree from Initiative through Programme, Project, to Task. | `*.actions-tree.transitrix.yaml` | draft |
 
-### Document views
+### Document views (D = 1)
 
-Renders a standard document (MRD, SRS, SDD, …) from canon. [`views/documents/`](views/documents/) is reserved — no spec lives there yet.
+Each renders a standard document (MRD, SRS, SDD, …) from canon.
+
+| Spec | Short name | Purpose | File extension | Status |
+|---|---|---|---|---|
+| [29-mrd.md](./views/documents/29-mrd.md) | `mrd` | Marketing Requirements Document — groups admitted `REQUIREMENT`s under the `NEED` each one serves. | `*.mrd.transitrix.yaml` | draft |
 
 Every view notation follows the convention `*.<short-name>.transitrix.yaml`. Every file begins with a `notation: <short-name>` header — see each spec's "File header" section and [CONTRACT.md](CONTRACT.md) §3 for the rule.
 

--- a/notations/examples/mrd/README.md
+++ b/notations/examples/mrd/README.md
@@ -1,0 +1,55 @@
+# MRD notation — examples
+
+File extension: **`.mrd.transitrix.yaml`**
+
+The MRD (Marketing Requirements Document) view is a **document-rendering configuration** over `NEED` ([`../../ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §7.28) and `REQUIREMENT` ([`../../elements/15-requirement.md`](../../elements/15-requirement.md)) — it groups admitted requirements under the stakeholder/user need each one serves, via `REQUIREMENT.serves`. The view document declares which slice to render — it carries no canonical content of its own. See [`../../views/documents/29-mrd.md`](../../views/documents/29-mrd.md) for the view spec and the render contract.
+
+**Pattern, not adopter instance.** The scenario (customers needing timely notice of a service outage) is a generic, invented example — the same fixture already used by the [`../validation/`](../validation/) worked example — chosen to exercise the MRD layout's grouping behaviour with more than one requirement under one need. It names no real product, organisation, or adopter.
+
+## Files in this folder
+
+| File | Description |
+|---|---|
+| [`incident-status.mrd.transitrix.yaml`](incident-status.mrd.transitrix.yaml) | MRD document config for one need (`NEED-TIMELY-OUTAGE-STATUS-1`), scoped to `project-product`-origin requirements. Renders one section with two requirements grouped under it. |
+| [`canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml`](canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml) | The `NEED` this document is scoped to — reused from [`../validation/`](../validation/), which exercises the same fixture for the `NEED` → `VALIDATION` leg. |
+| [`canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-PAGE-1.yaml`](canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-PAGE-1.yaml) | A `REQUIREMENT` serving the need above — reused from [`../validation/`](../validation/). |
+| [`canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-EMAIL-1.yaml`](canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-EMAIL-1.yaml) | A second, new `REQUIREMENT` serving the same need — added so the worked example demonstrates the layout grouping more than one requirement under a single need section. |
+| [`canon/elements/01_motivation/stakeholders/STAKEHOLDER-ENTERPRISE-CUSTOMERS-1.yaml`](canon/elements/01_motivation/stakeholders/STAKEHOLDER-ENTERPRISE-CUSTOMERS-1.yaml) | The `STAKEHOLDER` the need's `stakeholder` field resolves to — reused from [`../validation/`](../validation/). |
+| [`canon/elements/02_business/actors/ACTOR-ENTERPRISE-CUSTOMERS-1.yaml`](canon/elements/02_business/actors/ACTOR-ENTERPRISE-CUSTOMERS-1.yaml) | The `ACTOR` the stakeholder's identity resolves to (`STAKEHOLDER.actor` is required) — reused from [`../validation/`](../validation/). |
+
+Unlike the `canon/` fragment under [`../validation/`](../validation/) and [`../verification/`](../verification/) (whose subject is the element notations themselves), this folder's top-level file is the **view document** — the `canon/` tree here exists only so the view has admitted `NEED` / `REQUIREMENT` elements to render, mirroring how a `.mrd.transitrix.yaml` file would sit alongside the rest of an adopter's canon.
+
+## Notation header
+
+Every file starts with:
+
+```yaml
+notation: mrd
+```
+
+## Shape
+
+An MRD view file carries the shared envelope (`notation:`, `spec_version:`, `methodology_version:`) plus a single `view` object. The `view` names the need scope (an explicit `include` list or a `filter` on stakeholder), the requirement scope (an explicit `include` list or a `filter` on `origin`), and the ordering knobs for sections and the requirements within them.
+
+```yaml
+notation: mrd
+spec_version: "0.1"
+methodology_version: "3.1.0"
+
+view:
+  id: MRD-<NAME>-1
+  name: "..."
+  scope:
+    needs:
+      include: [NEED-...]
+    requirements:
+      filter:
+        origin: [project-product]
+  include_unserved_needs: true
+```
+
+The full field set, the render contract, and the validation rules are in [`../../views/documents/29-mrd.md`](../../views/documents/29-mrd.md).
+
+## Preview
+
+Open any `.mrd.transitrix.yaml` file in VS Code with Transitrix Studio installed once the document-view engine ships (consumer-side, tracked separately).

--- a/notations/examples/mrd/canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml
+++ b/notations/examples/mrd/canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml
@@ -1,0 +1,21 @@
+notation: need
+id: NEED-TIMELY-OUTAGE-STATUS-1
+name: "Customers need to know service status within minutes of an outage starting"
+description: >
+  When the service is degraded or unavailable, affected customers need a
+  reliable, timely signal that something is wrong and that it is being
+  worked on — independent of whatever mechanism (status page, email,
+  in-app banner) ends up delivering that signal.
+
+stakeholder: STAKEHOLDER-ENTERPRISE-CUSTOMERS-1
+
+zone: canon
+admitted_at: "2026-07-30"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-07-30"
+valid_to: null

--- a/notations/examples/mrd/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-EMAIL-1.yaml
+++ b/notations/examples/mrd/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-EMAIL-1.yaml
@@ -1,0 +1,19 @@
+notation: requirement
+id: REQUIREMENT-OUTAGE-STATUS-EMAIL-1
+name: "Email affected enterprise customers within 15 minutes of a confirmed outage"
+description: "Once a service-affecting outage impacting enterprise-tier customers is confirmed, the organisation must send a direct email notification to each affected account's registered contacts within 15 minutes of confirmation, summarising the impact and the time of the next update."
+
+origin: project-product
+severity: medium
+serves: NEED-TIMELY-OUTAGE-STATUS-1
+
+zone: canon
+admitted_at: "2026-08-04"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-04"
+valid_to: null

--- a/notations/examples/mrd/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-PAGE-1.yaml
+++ b/notations/examples/mrd/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-PAGE-1.yaml
@@ -1,0 +1,19 @@
+notation: requirement
+id: REQUIREMENT-OUTAGE-STATUS-PAGE-1
+name: "Publish an outage status update within 5 minutes of detection"
+description: "On automated detection of a service-affecting outage, the organisation must publish a status-page update describing the impact and that it is being investigated, within 5 minutes of detection."
+
+origin: project-product
+severity: high
+serves: NEED-TIMELY-OUTAGE-STATUS-1
+
+zone: canon
+admitted_at: "2026-07-30"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-07-30"
+valid_to: null

--- a/notations/examples/mrd/canon/elements/01_motivation/stakeholders/STAKEHOLDER-ENTERPRISE-CUSTOMERS-1.yaml
+++ b/notations/examples/mrd/canon/elements/01_motivation/stakeholders/STAKEHOLDER-ENTERPRISE-CUSTOMERS-1.yaml
@@ -1,0 +1,20 @@
+notation: stakeholder
+id: STAKEHOLDER-ENTERPRISE-CUSTOMERS-1
+name: "Enterprise customers"
+type: external
+actor: ACTOR-ENTERPRISE-CUSTOMERS-1
+concern: "Knowing promptly when the service they depend on is degraded or unavailable, and that it is being worked on."
+interest: high
+influence: medium
+description: "Enterprise-tier customers whose own operations depend on this service staying up, or on being told quickly when it is not."
+
+zone: canon
+admitted_at: "2026-07-30"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2024-01-01"
+valid_to: null

--- a/notations/examples/mrd/canon/elements/02_business/actors/ACTOR-ENTERPRISE-CUSTOMERS-1.yaml
+++ b/notations/examples/mrd/canon/elements/02_business/actors/ACTOR-ENTERPRISE-CUSTOMERS-1.yaml
@@ -1,0 +1,16 @@
+notation: actor
+id: ACTOR-ENTERPRISE-CUSTOMERS-1
+name: "Enterprise customer segment"
+type: business_unit
+description: "External organisations on an enterprise support tier; not part of the modelled org, represented here as a business_unit-typed actor for identity purposes."
+
+zone: canon
+admitted_at: "2026-07-30"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2024-01-01"
+valid_to: null

--- a/notations/examples/mrd/incident-status.mrd.transitrix.yaml
+++ b/notations/examples/mrd/incident-status.mrd.transitrix.yaml
@@ -1,0 +1,26 @@
+notation: mrd
+spec_version: "0.1"
+name: "Incident status communication — MRD"
+generated_at: "2026-08-04"
+methodology_version: "3.1.0"
+
+view:
+  id: MRD-INCIDENT-STATUS-1
+  name: "Incident status communication — MRD"
+  description: |
+    Stakeholder needs and the design-input requirements that satisfy them,
+    for outage / incident status communication to enterprise customers.
+
+  scope:
+    needs:
+      include: [NEED-TIMELY-OUTAGE-STATUS-1]
+    requirements:
+      filter:
+        origin: [project-product]
+
+  include_unserved_needs: true
+  empty_section_label: "No requirement traces to this need (current model)"
+
+  grouping:
+    order_needs_by: "id"
+    order_requirements_by: "id"

--- a/notations/views/documents/29-mrd.md
+++ b/notations/views/documents/29-mrd.md
@@ -1,0 +1,254 @@
+---
+notation: "MRD"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-08-04"
+status: "draft"
+file_extension: "*.mrd.transitrix.yaml"
+dsm_status: "not implemented — Studio document-view engine planned (consumer-side, tracked separately)"
+---
+
+# MRD — Document-View — Reference
+
+**Version:** 0.1
+**Date:** 2026-08-04
+**Status:** Draft — first concrete spec of the document-view class ([`views/documents/`](../documents/), per [`README.md`](../../README.md) §Views); establishes the layout pattern later document-view layouts in this class follow.
+**File extension:** `*.mrd.transitrix.yaml`
+**Scope:** A **document-rendering configuration** for the Marketing Requirements Document (MRD) layout — a stakeholder/user-need-oriented document body that groups admitted `REQUIREMENT` elements ([15-requirement.md](../../elements/15-requirement.md)) under the `NEED` ([`ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §7.28) each one serves. The document is a presentation surface — it carries no canonical content of its own. Everything it displays is **derived** from the `NEED` and `REQUIREMENT` catalogues.
+**Renderer:** Transitrix Studio — document-view engine (planned); Transitrix DSM (planned).
+
+---
+
+## File header
+
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../../CONTRACT.md). This notation's per-notation values:
+
+| Field | Value |
+|---|---|
+| `notation:` value | `mrd` |
+| File extension | `*.mrd.transitrix.yaml` |
+
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `mrd` (per [CONTRACT.md](../../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../../CONTRACT.md) §4. |
+| `view` | yes | object | the MRD view config — see §3 and §4 |
+
+Example header:
+
+```yaml
+notation: mrd
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+methodology_version: "3.1.0"
+view:
+  # ... see §3
+```
+
+---
+
+## 1. What this view is
+
+An MRD view answers one question: **for a given slice of the organisation's stakeholder/user needs, what design-input requirements exist to satisfy each one?** It renders the `NEED` catalogue ([`ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §7.28) as the document's section structure, and lists under each `NEED` the admitted `REQUIREMENT`s ([15-requirement.md](../../elements/15-requirement.md)) that trace back to it via `serves`.
+
+The renderer materialises that document from canon. Nothing is stored twice:
+
+- The fact that *a stakeholder needs something* is recorded once — on the `NEED` element ([`ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §7.28).
+- The fact that *a design-input obligation exists to satisfy that need* is recorded once — on the `REQUIREMENT` element ([15-requirement.md](../../elements/15-requirement.md)).
+- The fact that *a given requirement satisfies a given need* is recorded once — on `REQUIREMENT.serves` ([15-requirement.md](../../elements/15-requirement.md) §2.7).
+
+An MRD document declares **which slice of that catalogue pair to render** (which needs, which requirements) and **how** (ordering, whether an unserved need still gets a section). It does not redeclare any of the three facts above, and it does not add narrative prose of its own — every word a reader sees traces to a `name` / `description` field on an admitted `NEED` or `REQUIREMENT`.
+
+This mirrors how the Compliance Impact view ([21-compliance-impact.md](../reports/21-compliance-impact.md)) is a report-config over `ASSERTION` + process flow, and the Actions tree view ([23-actions-tree.md](../reports/23-actions-tree.md)) is a report-config over `ACTION` — MRD is the document-class counterpart, a config over the `NEED` / `REQUIREMENT` motivation-layer pair. Both views obey the reconstruction invariant ([ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §1.1): the canon is reconstructible from the elements alone; the view document adds no fact.
+
+**Not a template.** An MRD view config has no field for hand-authored document prose — no executive summary, no free-text section body, nothing typed directly into the view that isn't already a projection of a `NEED` or `REQUIREMENT` field. A field that exists only to carry prose into the rendered document belongs on the `NEED` or `REQUIREMENT` element itself (its `description`), not on the view.
+
+---
+
+## 2. When to use this view
+
+| Use case | Notation |
+|---|---|
+| Publish a stakeholder-facing document listing what the organisation has committed to build, organised by the need each commitment satisfies. | MRD view |
+| Audit which admitted needs still have no requirement written against them — a design-input gap. | MRD view — with `include_unserved_needs: true` (default, §4) |
+| Produce a narrower MRD scoped to one stakeholder group or one requirement origin (e.g. only `project-product`-origin requirements for one initiative). | MRD view — with `scope.needs.filter.stakeholder` / `scope.requirements.filter.origin` (§4) |
+| Hand-pick an explicit set of needs and/or requirements for a focused document. | MRD view — with `scope.needs.include` / `scope.requirements.include` (§4) |
+
+For the canonical authoring of a need, the obligation that satisfies it, or the trace between them, use the element primitives, not this view:
+
+| Concern | Authored as |
+|---|---|
+| The stakeholder/user need itself (what must be true, independent of how it's met). | `NEED` element ([`ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §7.28) at `canon/elements/01_motivation/needs/NEED-<…>.yaml`. |
+| The design-input obligation written to satisfy a need. | `REQUIREMENT` element ([15-requirement.md](../../elements/15-requirement.md)) at `canon/elements/01_motivation/requirements/REQUIREMENT-<…>.yaml`. |
+| The trace from a requirement back to the need it satisfies. | `REQUIREMENT.serves: NEED-…` ([15-requirement.md](../../elements/15-requirement.md) §2.7). |
+| Whether a need's requirement(s) were actually validated as meeting it. | `VALIDATION` element ([28-validation.md](../../elements/28-validation.md)) — out of scope for this view; a future document-view layout may render it. |
+
+---
+
+## 3. Document structure
+
+An MRD view file is a short, declarative document config. It does not own any canonical content. Two top-level keys plus the shared header:
+
+```yaml
+notation: mrd
+spec_version: "0.1"
+name: "Incident status communication — MRD"   # required per CONTRACT.md §1.1
+generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
+methodology_version: "3.1.0"
+
+view:
+  id: MRD-INCIDENT-STATUS-1
+  name: "Incident status communication — MRD"
+  description: "Stakeholder needs and the design-input requirements that satisfy them, for outage / incident status communication."
+
+  # Reserved — see §4. Not read by the render contract in this version of the spec.
+  standard: null
+
+  # What the document covers. Every key here filters/scopes/orders; none carries prose.
+  scope:
+    needs:
+      include: [NEED-TIMELY-OUTAGE-STATUS-1]
+      # filter:
+      #   stakeholder: [STAKEHOLDER-ENTERPRISE-CUSTOMERS-1]
+    requirements:
+      # include: [REQUIREMENT-OUTAGE-STATUS-PAGE-1]
+      filter:
+        origin: [project-product]
+
+  # Whether a need with zero matching requirements still gets an (empty) section.
+  include_unserved_needs: true
+  empty_section_label: "No requirement traces to this need (current model)"
+
+  # Ordering knobs.
+  grouping:
+    order_needs_by: "id"           # id | name | stakeholder
+    order_requirements_by: "id"    # id | name | severity
+```
+
+The document carries the canonical envelope (`notation:` header, `spec_version:`, `methodology_version:` pin per [CONTRACT.md](../../CONTRACT.md) §10), a `view` object, and scoping/ordering fields under it. Nothing under `view` is canonical content — it is all rendering configuration.
+
+---
+
+## 4. Fields
+
+Every field carries an explicit default, so a view with only the required envelope (`view.id`, `view.name`) renders deterministically — see §4.1.
+
+| Field | Required | Type | Default | Semantics |
+|---|---|---|---|---|
+| `view.id` | yes | string | — (required) | View identifier, canonical-grammar (`MRD-…`) per [IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §3.2 (`MRD` view-level TYPE). |
+| `view.name` | yes | string | — (required) | Human-readable name shown in the renderer. |
+| `view.description` | no | string | empty | Short description of the purpose of this document config (which needs, which requirement slice, why). Config-level metadata only — surfaced by tooling that lists saved view-configs ([REPORT_VIEW_CONFIG.md](../REPORT_VIEW_CONFIG.md) §4); it is **not** rendered into the document body, and carries no obligation on the renderer to display it anywhere in the output. |
+| `view.standard` | no | string | unset | Reserved for a future document-structure profile selector. **Inert in this version of the spec — not read by the render contract (§5).** Setting it has no effect on the rendered output. No document-view layout under [`views/documents/`](.) may document, default to, or emit a standard identifier (a named specification number or numbering convention) as a value of this or any other field; see §5 for the corresponding render-contract MUST and [check-notations.mjs](../../../scripts/check-notations.mjs) `DOC1` for the doc-lint guard. |
+| `view.scope.needs.include` | no ¹ | list | unset (use `filter`, or all admitted `NEED`s) | Explicit list of `NEED-…` IDs to render as document sections, in the order given (subject to `grouping.order_needs_by`). |
+| `view.scope.needs.filter.stakeholder` | no ¹ | list | unset (no filter) | List of `STAKEHOLDER-…` IDs. When present, only `NEED`s whose `stakeholder` field is in this list are in scope. |
+| `view.scope.requirements.include` | no ² | list | unset (use `filter`, or every `REQUIREMENT` that serves an in-scope need) | Explicit list of `REQUIREMENT-…` IDs. A listed requirement renders only if it also serves an in-scope `NEED` (§5.2) — this field narrows, it does not add requirements outside the need-trace relationship the layout is built on. |
+| `view.scope.requirements.filter.origin` | no ² | list | unset (no filter — every `origin`) | List of `origin` values from the closed vocabulary `legislative \| process-product \| project-product` ([15-requirement.md](../../elements/15-requirement.md) §2.1). Narrows which serving requirements appear under each need. |
+| `view.include_unserved_needs` | no | boolean | `true` | Whether an in-scope `NEED` with zero matching `REQUIREMENT`s still renders as a section (carrying `empty_section_label`). `false` omits it from the document entirely. |
+| `view.empty_section_label` | no | string | `"No requirement traces to this need (current model)"` | Label rendered under a need section that has no matching requirement (§5.3). |
+| `view.grouping.order_needs_by` | no | string | `id` | Section ordering key: `id`, `name`, `stakeholder`. |
+| `view.grouping.order_requirements_by` | no | string | `id` | Within-section ordering key for requirements: `id`, `name`, `severity`. |
+
+¹ **`scope.needs`** — both keys are optional and only ever *narrow* the section set. Omitting both renders every admitted `NEED` in canon as a section. If both `include` and `filter` are present, `include` wins and `filter` is ignored.
+
+² **`scope.requirements`** — both keys are optional and only ever *narrow* the requirement set within each in-scope need's section. Omitting both renders every admitted `REQUIREMENT` that serves an in-scope need. If both `include` and `filter` are present, `include` wins and `filter` is ignored.
+
+All references in `view.scope.needs.include`, `view.scope.needs.filter.stakeholder`, and `view.scope.requirements.include` resolve to canon primitives via the usual cross-reference rule ([IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §5).
+
+### 4.1 Zero-configuration default
+
+A view that carries only the required envelope —
+
+```yaml
+notation: mrd
+spec_version: "0.1"
+name: "Full MRD — all needs"           # required per CONTRACT.md §1.1
+generated_at: "2026-08-04"             # optional per CONTRACT.md §4
+methodology_version: "3.1.0"
+view:
+  id: MRD-ALL-1
+  name: "Full MRD — all needs"
+```
+
+— renders **deterministically**: one section per admitted `NEED` in canon (ordered by `id`), each listing every admitted `REQUIREMENT` that serves it (ordered by `id`, no origin filter), unserved needs rendered with the default empty-section label, `view.standard` unset and read by nothing. Each field a caller omits falls back to its §4 default; the result is reproducible from canon alone.
+
+Where a named, saved view-config of this notation lives in an adopter repo, and how a reader lists or re-runs it by name, is the registry convention in [REPORT_VIEW_CONFIG.md](../REPORT_VIEW_CONFIG.md) — the natural home for a document-config too, not only report-configs (§1 there).
+
+---
+
+## 5. Render contract
+
+This section is the **render contract**: the deterministic algorithm any conformant renderer (Studio, DSM, a per-build script) MUST follow to reproduce the document from canon. The contract names its inputs, its derivation steps, and a normative constraint on what the output may never contain.
+
+### 5.1 Inputs
+
+A conformant renderer reads exactly these canonical inputs:
+
+1. **`NEED` catalogue** — every `NEED-…` file under `canon/elements/01_motivation/needs/` in admitted state. Each contributes its `id`, `name`, `description`, and `stakeholder`.
+2. **`REQUIREMENT` catalogue** — every `REQUIREMENT-…` file under `canon/elements/01_motivation/requirements/` in admitted state. Each contributes its `id`, `name`, `description`, `origin`, `severity`, `level`, `kind`, and `serves`.
+3. **`STAKEHOLDER` catalogue** (optional, display-only) — a renderer MAY resolve a `NEED.stakeholder` reference to the `STAKEHOLDER.name` for display; if it does not (or the reference is absent from the input set the renderer was given), the raw `STAKEHOLDER-…` ID is shown instead. Either choice is deterministic and reproducible from canon; this input does not affect which needs or requirements are selected.
+
+The renderer reads **no other input**. In particular: the view document itself contributes only scope / ordering / labelling configuration — it never supplies a body sentence, a section heading beyond a `NEED`'s own `name`, or a value not traceable to an admitted element field.
+
+**Normative constraint — no standard identifiers.** A conformant renderer MUST NOT emit a standard identifier (a named specification number or numbering convention) anywhere in the rendered output of this layout — not as a section label, not as a default value, not as a value substituted for an unset field. `view.standard` (§4) is reserved and inert: no current or future revision of this layout may read it to select or emit such an identifier without a new, explicitly reviewed spec revision that lifts this constraint. This is checked at spec-authoring time by the `DOC1` doc-lint rule in [check-notations.mjs](../../../scripts/check-notations.mjs), which fails the build if this file (or any sibling document-view spec) ever documents one as a supported or default field value.
+
+### 5.2 Derivation
+
+1. **Resolve the need scope** from `view.scope.needs.include` or `view.scope.needs.filter.stakeholder` against the `NEED` catalogue; omitting both selects every admitted `NEED`. Sort the result per `view.grouping.order_needs_by`.
+2. **For each in-scope need**, resolve its requirement set: every admitted `REQUIREMENT` whose `serves` field equals the need's `id`, further narrowed by `view.scope.requirements.include` and/or `view.scope.requirements.filter.origin` (same include-wins-over-filter rule as step 1). Sort the result per `view.grouping.order_requirements_by`.
+3. **Render one section per in-scope need**, in the step-1 order: the need's `name` as the section heading, its `description` (if present) as the section's sole introductory text, followed by one entry per requirement from step 2 (its `id`, `name`, `description`, and any of `origin` / `severity` / `level` / `kind` it carries).
+4. **Unserved needs.** A need whose step-2 requirement set is empty renders as a section carrying `view.empty_section_label` (§5.3) when `view.include_unserved_needs` is `true` (the default); otherwise the need is omitted from the document entirely.
+5. **Requirements with no `serves` value, or whose `serves` value names a need outside scope, are never rendered** — they simply do not appear anywhere in an MRD document. This is expected layout behaviour, not an error condition; a `REQUIREMENT` with no need to trace to is out of scope for a need-oriented document by construction.
+
+### 5.3 Determinism
+
+Two renders of the same view-config against the same canon state produce **byte-identical** output: the selection in step 1, the per-section selection in step 2, and both sort orders in step 3 are fully specified by this contract and the config's own fields; the renderer introduces no timestamp, environment value, or non-canonical data into the body. `generated_at` (§1.1) is document metadata, not a rendered body field, and does not affect section content.
+
+---
+
+## 6. Relationship to other notations and elements
+
+```
+MRD view (this notation — document-config)
+  ├── reads   → NEED elements                  (ELEMENT_PRIMITIVES.md §7.28; admitted only)
+  │     └── stakeholder → STAKEHOLDER            (optional display-name resolution, §5.1)
+  ├── reads   → REQUIREMENT elements            (15-requirement.md; admitted only)
+  │     └── serves      → NEED                   (the grouping key, §5.2)
+  └── carries no canonical content of its own    (ELEMENT_PRIMITIVES.md §1.1)
+```
+
+Pairs with the `NEED`-side reverse-trace completeness rules (`NEED-COVERAGE-001` and the `NEED-VALIDATION-COVERAGE-…` family, [`ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §9) — a `NEED` with no serving `REQUIREMENT` is exactly the case `view.include_unserved_needs` / `view.empty_section_label` surface to a reader, the document-view analogue of the Compliance Impact view's modelling-gap distinction ([21-compliance-impact.md](../reports/21-compliance-impact.md) §5.3).
+
+Pairs with **Transitrix Studio's document-view engine** (consumer side, tracked separately) — the in-Studio renderer that implements §5.
+
+---
+
+## 7. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `MRD-001` | error | A required field from §4 is missing (`view.id`, `view.name`), or `id` does not match the canonical grammar `MRD-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §1). |
+| `MRD-002` | error | A value in `view.scope.needs.include`, `view.scope.needs.filter.stakeholder`, or `view.scope.requirements.include` does not resolve to an admitted canonical element of the expected TYPE (`NEED`, `STAKEHOLDER`, `REQUIREMENT` respectively). |
+| `MRD-003` | error | `view.scope.requirements.filter.origin` contains a value outside the closed vocabulary `legislative \| process-product \| project-product` ([15-requirement.md](../../elements/15-requirement.md) §2.1). |
+| `MRD-004` | warning | Both `include` and `filter` are present within the same scope block (`view.scope.needs` or `view.scope.requirements`) — `include` wins, `filter` is silently ignored. |
+| `MRD-005` | warning | The view selects zero needs after applying `view.scope.needs`, or every selected need resolves to zero requirements and `view.include_unserved_needs` is `false` — the rendered document will be empty. Usually indicates an over-narrow filter. |
+| `MRD-006` | error | A shipped document-view layout under [`views/documents/`](.) documents, defaults to, or would render a standard identifier as a value of `view.standard` or any other field, violating the §5.1 normative constraint. Guarded at spec-authoring time by the `DOC1` doc-lint rule ([check-notations.mjs](../../../scripts/check-notations.mjs)); at render time no conformant renderer may emit one regardless of what `view.standard` is set to. |
+
+The shared header rules `HDR-001..004` ([CONTRACT.md](../../CONTRACT.md) §2) apply in addition.
+
+---
+
+## 8. References
+
+- `NEED` element schema (the stakeholder/user need): [`ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §7.28.
+- `REQUIREMENT` element schema and the `serves` back-reference: [15-requirement.md](../../elements/15-requirement.md) §2.7.
+- `STAKEHOLDER` element schema (optional display-name resolution): [20-stakeholders.md](../../elements/20-stakeholders.md).
+- `VALIDATION` — the claim type checking whether a need was actually met (not rendered by this layout): [28-validation.md](../../elements/28-validation.md).
+- ID grammar and TYPE registry: [IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) (`MRD` registered in §3.2).
+- Reconstruction invariant (why view documents are not content homes): [`ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §1.1.
+- Sibling report-config views this document-config mirrors in shape: [21-compliance-impact.md](../reports/21-compliance-impact.md), [23-actions-tree.md](../reports/23-actions-tree.md).
+- Named view-config convention (where this view's saved configs live, how they're named, listed, and re-run): [REPORT_VIEW_CONFIG.md](../REPORT_VIEW_CONFIG.md).

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -263,14 +263,16 @@ export function deriveClassCounts(filesByClass) {
 }
 
 // Pure — no I/O. Extracts the stated "Diagram views (A = N)" / "Report views
-// (C = N)" counts from the README prose. Returns null for a count whose
-// pattern isn't found.
+// (C = N)" / "Document views (D = N)" counts from the README prose. Returns
+// null for a count whose pattern isn't found.
 export function parseStatedViewCounts(readmeText) {
   const dm = readmeText.match(/Diagram views\s*\(A\s*=\s*(\d+)\)/);
   const rm = readmeText.match(/Report views\s*\(C\s*=\s*(\d+)\)/);
+  const cm = readmeText.match(/Document views\s*\(D\s*=\s*(\d+)\)/);
   return {
     diagrams: dm ? parseInt(dm[1], 10) : null,
     reports: rm ? parseInt(rm[1], 10) : null,
+    documents: cm ? parseInt(cm[1], 10) : null,
   };
 }
 
@@ -314,6 +316,7 @@ async function checkNotationCounts(failures) {
   const stated = parseStatedViewCounts(readmeText);
   check(stated.diagrams, counts.diagrams, 'notations/README.md', '"Diagram views (A = N)"');
   check(stated.reports, counts.reports, 'notations/README.md', '"Report views (C = N)"');
+  check(stated.documents, counts.documents, 'notations/README.md', '"Document views (D = N)"');
   const em = readmeText.match(/The\s+\*\*(\d+)\*\*\s+element\s+notations/);
   check(em ? parseInt(em[1], 10) : null, elemCount, 'notations/README.md', '"The **N** element notations"');
 
@@ -331,6 +334,55 @@ async function checkNotationCounts(failures) {
   }
 }
 
+// --- DOC1: no standard identifiers in a document-view spec -----------------
+//
+// Every document-view layout (MRD today; SRS / SDD planned) is required to
+// never document, default to, or emit a "standard identifier" — a named
+// specification number or numbering convention (e.g. a value that looks like
+// `iso-29148` or `ieee-830`) — as a supported or default field value. This
+// check scans notations/views/documents/*.md for a documented *value* that
+// looks like one, inside a fields-table row. A narrative mention of a
+// standard's full name in prose (not a table row, not a code-span value) is
+// not what this guards against and is deliberately not flagged.
+
+const STANDARD_ID_VALUE_RE = /^(iso|ieee)[-_][a-z0-9._-]*$/i;
+
+// Pure — no I/O. Returns the list of offending code-span values (e.g.
+// ["iso-29148"]) found inside Markdown table rows in `text`. A code-span
+// appearing outside a table row (prose) is not inspected.
+export function findStandardIdentifierEmissions(text) {
+  const found = [];
+  for (const line of text.split('\n')) {
+    if (!line.startsWith('|')) continue; // only table-row lines
+    for (const m of line.matchAll(/`([^`]+)`/g)) {
+      const value = m[1].trim();
+      if (STANDARD_ID_VALUE_RE.test(value)) found.push(value);
+    }
+  }
+  return found;
+}
+
+async function checkNoStandardIdentifiers(failures) {
+  const dir = join(VIEWS_DIR, 'documents');
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (!e.isFile() || !e.name.endsWith('.md')) continue;
+    const abs = join(dir, e.name);
+    const text = await readFile(abs, 'utf8');
+    for (const value of findStandardIdentifierEmissions(text)) {
+      failures.push({
+        check: 'DOC1',
+        message: `${relPosix(abs)}: documents \`${value}\` as a field-table value — no document-view layout may document, default to, or emit a standard identifier.`,
+      });
+    }
+  }
+}
+
 // --- main ------------------------------------------------------------------
 
 async function main() {
@@ -342,6 +394,7 @@ async function main() {
     await checkLinks(failures);
     await checkVersion(failures);
     await checkNotationCounts(failures);
+    await checkNoStandardIdentifiers(failures);
   } catch (e) {
     console.error(`error: ${e.message}`);
     process.exit(2);

--- a/scripts/check-notations.test.mjs
+++ b/scripts/check-notations.test.mjs
@@ -7,15 +7,19 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { deriveClassCounts, parseStatedViewCounts } from './check-notations.mjs';
+import {
+  deriveClassCounts,
+  parseStatedViewCounts,
+  findStandardIdentifierEmissions,
+} from './check-notations.mjs';
 
 test('deriveClassCounts — positive: counts non-deprecated specs per class', () => {
   const counts = deriveClassCounts({
     diagrams: [{ deprecated: false }, { deprecated: false }, { deprecated: false }],
     reports: [{ deprecated: false }],
-    documents: [],
+    documents: [{ deprecated: false }],
   });
-  assert.deepEqual(counts, { diagrams: 3, reports: 1, documents: 0 });
+  assert.deepEqual(counts, { diagrams: 3, reports: 1, documents: 1 });
 });
 
 test('deriveClassCounts — negative: a deprecated spec does not count', () => {
@@ -43,14 +47,53 @@ test('deriveClassCounts — negative: moving a spec between class folders change
   assert.notEqual(before.reports, after.reports);
 });
 
-test('parseStatedViewCounts — positive: reads both counts from README-shaped prose', () => {
-  const text = '### Diagram views (A = 11)\n\nsome text\n\n### Report views (C = 4)\n';
+test('parseStatedViewCounts — positive: reads all three counts from README-shaped prose', () => {
+  const text = '### Diagram views (A = 11)\n\nsome text\n\n### Report views (C = 4)\n\nmore text\n\n### Document views (D = 1)\n';
   const stated = parseStatedViewCounts(text);
-  assert.deepEqual(stated, { diagrams: 11, reports: 4 });
+  assert.deepEqual(stated, { diagrams: 11, reports: 4, documents: 1 });
 });
 
 test('parseStatedViewCounts — negative: a missing pattern reports null, not zero', () => {
   const stated = parseStatedViewCounts('# Notations\n\nno counts stated here.\n');
   assert.equal(stated.diagrams, null);
   assert.equal(stated.reports, null);
+  assert.equal(stated.documents, null);
+});
+
+test('parseStatedViewCounts — negative: diagrams/reports present but document count still missing reports null', () => {
+  const text = '### Diagram views (A = 11)\n\n### Report views (C = 4)\n';
+  const stated = parseStatedViewCounts(text);
+  assert.equal(stated.documents, null);
+});
+
+test('findStandardIdentifierEmissions — positive: a clean fields table with no standard-identifier value', () => {
+  const text = [
+    '| Field | Required | Type | Default | Semantics |',
+    '|---|---|---|---|---|',
+    '| `view.standard` | no | string | unset | Reserved for future use; not read by the render contract. |',
+  ].join('\n');
+  assert.deepEqual(findStandardIdentifierEmissions(text), []);
+});
+
+test('findStandardIdentifierEmissions — positive: a narrative mention outside a table row is not flagged', () => {
+  const text = 'This layout deliberately avoids adopting a named specification numbering convention as a default.';
+  assert.deepEqual(findStandardIdentifierEmissions(text), []);
+});
+
+test('findStandardIdentifierEmissions — negative: a documented iso-… default value in a table row is flagged', () => {
+  const text = [
+    '| Field | Required | Type | Default | Semantics |',
+    '|---|---|---|---|---|',
+    '| `view.standard` | no | string | `iso-29148` | default document-structure profile |',
+  ].join('\n');
+  assert.deepEqual(findStandardIdentifierEmissions(text), ['iso-29148']);
+});
+
+test('findStandardIdentifierEmissions — negative: a documented ieee-… default value in a table row is flagged', () => {
+  const text = [
+    '| Field | Required | Type | Default | Semantics |',
+    '|---|---|---|---|---|',
+    '| `view.standard` | no | string | `ieee-830` | default document-structure profile |',
+  ].join('\n');
+  assert.deepEqual(findStandardIdentifierEmissions(text), ['ieee-830']);
 });

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -331,6 +331,7 @@ Use the matrix below to pick a notation. Full specs at `notations/<NN>-<name>.md
 | Single-project narrative view — goals served, dates, milestones, gate decisions | **Action Card** | `*.action-card.transitrix.yaml` |
 | Compliance overlay — which obligations hit which product / process stage / task, with each cell's status | **Compliance Impact** | `*.compliance-impact.transitrix.yaml` |
 | Coverage of canon — which subjects are dark for each regulatory regime, splitting modelling gaps from modelled exclusions | **Coverage Metric** | `*.coverage-metric.transitrix.yaml` |
+| Stakeholder-facing document listing design-input requirements grouped under the need each satisfies | **MRD** | `*.mrd.transitrix.yaml` |
 
 **Family rule:** the strategy-chain notations split by shape. **DGCA** uses the **flat form** — top-level arrays at the document root (`factors[]` / `goals[]` / `changes[]` / `actions[]`), cross-references upstream inside the flat arrays. **Goals tree** and **Action schedule** (both since v2.0) are **pure projections** — the view document carries only `view_config`, and each `GOAL-…` / `ACTION-…` lives as a standalone element file under `canon/elements/…`; the parent link (Goals) and predecessor / duration / cross-refs (Action) live on the element files, not in the view. In all three, hierarchy uses `parent: <SAME-TYPE>-…` on the child; no nested wrapper keys.
 
@@ -419,6 +420,7 @@ The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI
 | Compliance Impact | `templates/compliance-impact.compliance-impact.transitrix.yaml` |
 | Coverage Metric | `templates/coverage-metric.coverage-metric.transitrix.yaml` |
 | Actions tree | `templates/actions-tree.actions-tree.transitrix.yaml` |
+| MRD | `templates/mrd.mrd.transitrix.yaml` |
 
 ### Codex zone primitives (drop into `codex/external/<jurisdiction>/` or `codex/internal/` in Step 3)
 

--- a/transitrix/skills/onboard/templates/mrd.mrd.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/mrd.mrd.transitrix.yaml
@@ -1,0 +1,38 @@
+notation: mrd
+spec_version: "0.1"
+
+# MRD — Marketing Requirements Document. Spec: notations/views/documents/29-mrd.md
+# Document-config over NEED + REQUIREMENT (sibling of Compliance Impact / Actions
+# tree). Carries no canonical content — every section is DERIVED from the NEED
+# catalogue and the REQUIREMENT elements that serve it. This file only declares
+# which slice to render and how.
+
+name: "FILL-ME — e.g. Incident status communication — MRD"   # required per CONTRACT.md §1.1
+
+view:
+  id: MRD-FILL-ME-1
+  name: "FILL-ME — same as document name, or a shorter view label"
+  description: "FILL-ME — which needs, which requirement slice, why"
+
+  # Reserved — inert in this version of the spec. Do not set a standard identifier.
+  standard: null
+
+  # What the document covers. Use `include` OR `filter` per scope block (include wins).
+  scope:
+    needs:
+      include: [NEED-FILL-ME-1]
+      # filter:
+      #   stakeholder: [STAKEHOLDER-FILL-ME-1]
+    requirements:
+      # include: [REQUIREMENT-FILL-ME-1]
+      filter:
+        origin: [project-product]   # legislative | process-product | project-product
+
+  # Whether a need with zero matching requirements still gets an (empty) section.
+  include_unserved_needs: true
+  empty_section_label: "No requirement traces to this need (current model)"
+
+  # Ordering knobs.
+  grouping:
+    order_needs_by: "id"           # id | name | stakeholder
+    order_requirements_by: "id"    # id | name | severity


### PR DESCRIPTION
## Summary
- Introduces the document-view class under `notations/views/documents/`, sibling to the existing diagram/report view classes, with the MRD (Marketing Requirements Document) layout as its first concrete spec.
- MRD renders deterministically from admitted `NEED` + `REQUIREMENT` canon (grouped via `REQUIREMENT.serves`) — no hand-authored prose surface, no standard-identifier field.
- Reserves an inert `view.standard` field for a future document-structure profile selector; adds the `DOC1` doc-lint rule (with positive and negative unit tests) that fails the build if any shipped document-view layout documents, defaults to, or emits a standard identifier.
- Adds a worked example under `notations/examples/mrd/`, reusing the existing validation-example fixture plus one new requirement to demonstrate grouping two requirements under one need.
- Updates `notations/README.md` document-views table/count, `IDS_AND_REFERENCES.md` TYPE registry, and doc-lint's count/class checks.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] `node --test scripts/check-notations.test.mjs` — 10/10 pass
- [x] `npx @transitrix/cli validate --scope=repo` — passes