### PR TITLE
fix(scripts): derive baseline-manifest scope from admitted canon, not a fixed TYPE list

### DIFF
--- a/patterns/baseline-audit-trail.md
+++ b/patterns/baseline-audit-trail.md
@@ -26,15 +26,15 @@ None of these need a new mechanism. CONTRACT.md §6/§6.2/§7 already carries ev
 git tag design-review-2026-Q3 <commit>
 ```
 
-`scripts/baseline-manifest.mjs` turns that tag into a **manifest** — the frozen `REQUIREMENT` / `ASSERTION` set exactly as it stood at that ref:
+`scripts/baseline-manifest.mjs` turns that tag into a **manifest** — the whole admitted `canon/` set exactly as it stood at that ref, not a fixed `REQUIREMENT` / `ASSERTION` subset:
 
 ```
 node scripts/baseline-manifest.mjs <ref> [--root <adopter-repo>] [--out <file.md>]
 ```
 
 - **Read-only.** It reads every file via `git show <ref>:<path>` — it never runs `git checkout`, so it never disturbs the working tree and is safe to run against a tag from years ago while the working tree sits on a different branch.
-- **Split by `reviewer_authority`** ([CONTRACT.md](../notations/CONTRACT.md) §6.2) — the manifest separates `expert_confirmed` requirements from `ai_reviewed` ones, so an auditor can see at a glance how much of the baseline rests on the top authority tier versus the AI-reviewed tier.
-- **Carries `REQ-COVERAGE-001` as it existed at that ref** — each requirement's compliance-coverage gap status ([CONTRACT.md](../notations/CONTRACT.md) §8) is computed from the `ASSERTION` set *at that same ref*, not from today's canon. A baseline answers "what did the model say then", not "what does it say now".
+- **Scope is every admitted TYPE, derived from the ID on each file under `canon/`** (excluding `canon/views/`, which holds view/report/document configs, not individually admitted elements) — not a hardcoded directory list. A TYPE registered after the script was last touched appears in the manifest without any change to it.
+- **`REQUIREMENT` carries additional detail** — split by `reviewer_authority` ([CONTRACT.md](../notations/CONTRACT.md) §6.2), so an auditor can see at a glance how much of the baseline rests on the top authority tier versus the AI-reviewed tier, plus `REQ-COVERAGE-001` as it existed at that ref — each requirement's compliance-coverage gap status ([CONTRACT.md](../notations/CONTRACT.md) §8) is computed from the `ASSERTION` set *at that same ref*, not from today's canon. A baseline answers "what did the model say then", not "what does it say now".
 
 Run it against any ref git can resolve — a tag, a branch, a SHA. There is nothing tag-specific in the mechanism; tags are simply the natural, human-legible way to mark a baseline commit.
 
@@ -68,7 +68,7 @@ No new field, no separate sign-off document: **PR approver + `reviewer_authority
 ## Guardrails — what this pattern does not claim
 
 - **Git ≠ Part 11 e-signatures.** A git commit authenticated by an SSH key or a GitHub account is not a 21 CFR Part 11 electronic signature. This pattern documents an audit trail and a review/approval mapping; it makes no claim of Part 11 compliance, and an adopter operating under Part 11 needs a signature mechanism this pattern does not provide.
-- **Pattern, not adopter instance.** Nothing here names or implies any specific adopter, product, or regulatory submission. `scripts/baseline-manifest.mjs` and the mapping above are generic over any repository that carries `REQUIREMENT` / `ASSERTION` / `VERIFICATION`.
+- **Pattern, not adopter instance.** Nothing here names or implies any specific adopter, product, or regulatory submission. `scripts/baseline-manifest.mjs` and the mapping above are generic over any repository's admitted `canon/` content, whatever TYPEs it carries.
 - **No new claim about coverage reporting.** Compliance and V&V coverage over the baselined content is specified and shipped independently ([21-compliance-impact.md](../notations/views/reports/21-compliance-impact.md), [22-coverage-metric.md](../notations/views/reports/22-coverage-metric.md)). This pattern adds nothing to that surface — it only names the baseline/audit-trail/review-approval story that sits alongside it.
 
 ## When to use

--- a/scripts/baseline-manifest.mjs
+++ b/scripts/baseline-manifest.mjs
@@ -1,27 +1,38 @@
 #!/usr/bin/env node
 // Baseline manifest — read-only, git-native.
 //
-// A `git tag` IS a baseline: the ref names a frozen commit,
-// and this script reads the admitted REQUIREMENT / ASSERTION set exactly as
-// it stood at that ref — via `git show <ref>:<path>`, never `git checkout`,
-// so running it never disturbs the working tree. See patterns/baseline-audit-trail.md.
+// A `git tag` IS a baseline: the ref names a frozen commit, and this script
+// reports the whole admitted canon set exactly as it stood at that ref — via
+// `git show <ref>:<path>`, never `git checkout`, so running it never disturbs
+// the working tree. See patterns/baseline-audit-trail.md.
+//
+// Scope is NOT a hardcoded TYPE list. Every `.yaml` file under `canon/`
+// (excluding `canon/views/`, which holds view/report/document configs, not
+// individually admitted elements) is read; its TYPE is the leading segment of
+// its `id` field, per the ID grammar (IDS_AND_REFERENCES.md §1). A TYPE
+// registered after this script was last touched — REQUIREMENT, ASSERTION,
+// VERIFICATION, NEED, VALIDATION, RISK, METRIC, or whatever lands next —
+// appears automatically; nothing here enumerates the registry.
+//
+// REQUIREMENT additionally gets a reviewer-authority breakdown and its
+// REQ-COVERAGE-001 gap status against the ASSERTION set (CONTRACT.md §6.2,
+// §8), both exactly as they stood at that ref. Every other admitted TYPE is
+// listed in the generic admitted-set-by-type section.
 //
 // Usage:
 //   node scripts/baseline-manifest.mjs <ref> [--root <adopter-repo>] [--out <file.md>]
 //
 // <ref> is any ref git can resolve to a commit — a tag, a branch, a SHA.
-// Requirements are split by `reviewer_authority` (CONTRACT.md §6.2) and each
-// carries its REQ-COVERAGE-001 gap status (CONTRACT.md §8) as it stood at
-// that ref — not as it stands today.
 //
 // Exit codes: 0 ok · 2 error (bad ref, not a git repo)
 
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
 
-const REQUIREMENTS_DIR = 'canon/elements/01_motivation/requirements';
-const ASSERTIONS_DIR = 'canon/assertions';
+const CANON_DIR = 'canon';
+const EXCLUDED_CANON_SUBDIR = 'canon/views';
 
 function git(gitArgs, cwd, { quiet } = {}) {
   return execFileSync('git', gitArgs, {
@@ -36,29 +47,47 @@ function argVal(args, flag, dflt) {
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
 }
 
-function listYamlAt(ref, dir, cwd) {
+// Recursively lists every `.yaml` file under `canon/` at `ref`, excluding
+// `canon/views/` — the whole admitted-set scope, not a per-TYPE directory
+// list. A newly registered TYPE, wherever the registry places its catalogue
+// under `canon/`, is picked up without touching this function.
+function listYamlAt(ref, cwd) {
   let out;
   try {
-    out = git(['ls-tree', '-r', '--name-only', ref, '--', dir], cwd, { quiet: true });
+    out = git(['ls-tree', '-r', '--name-only', ref, '--', CANON_DIR], cwd, { quiet: true });
   } catch {
     return [];
   }
-  return out.split('\n').map(s => s.trim()).filter(f => f.endsWith('.yaml'));
+  return out
+    .split('\n')
+    .map(s => s.trim())
+    .filter(f => f.endsWith('.yaml'))
+    .filter(f => f !== EXCLUDED_CANON_SUBDIR && !f.startsWith(`${EXCLUDED_CANON_SUBDIR}/`));
 }
 
 // Targeted field extraction over flat top-level YAML scalars — the same
 // convention scripts/adl-harvest.mjs uses for front-matter, applied here to
-// whole-file YAML (REQUIREMENT / ASSERTION carry no front-matter fence).
-// Not a general YAML parser: sufficient for the scalar fields this script
-// reads, and adds no new dependency to the root scripts/ toolchain.
+// whole-file YAML (canon elements carry no front-matter fence). Not a
+// general YAML parser: sufficient for the scalar fields this script reads,
+// and adds no new dependency to the root scripts/ toolchain.
 function field(text, name) {
   const m = text.match(new RegExp(`^${name}:\\s*"?([^"\\n#]*?)"?\\s*(?:#.*)?$`, 'm'));
   return m ? m[1].trim() : undefined;
 }
 
-function loadAt(ref, dir, cwd) {
+// TYPE is the ID's leading segment — uppercase letters/digits/underscore, up
+// to (not including) the first hyphen — IDS_AND_REFERENCES.md §1. TYPE names
+// never contain a hyphen (multi-word TYPEs use underscore instead), so the
+// first hyphen always bounds it correctly, including on capability-style
+// addresses (`CAPABILITY-V1.2` → `CAPABILITY`).
+export function deriveType(id) {
+  const m = id.match(/^([A-Z][A-Z0-9_]*)-/);
+  return m ? m[1] : undefined;
+}
+
+function loadAt(ref, cwd) {
   const out = [];
-  for (const path of listYamlAt(ref, dir, cwd)) {
+  for (const path of listYamlAt(ref, cwd)) {
     // `<rev>:<path>` resolves relative to the repo top; the `./` form makes it
     // relative to cwd instead — needed since `path` came from `ls-tree` run
     // with cwd = the adopter root, which may be a subdirectory of this repo
@@ -66,8 +95,11 @@ function loadAt(ref, dir, cwd) {
     const text = git(['show', `${ref}:./${path}`], cwd);
     const id = field(text, 'id');
     if (!id) continue;
+    const type = deriveType(id);
+    if (!type) continue;
     out.push({
       id,
+      type,
       path,
       // CONTRACT.md §6.1 — absent admission_state means active (back-compat).
       admission_state: field(text, 'admission_state') || 'active',
@@ -79,23 +111,42 @@ function loadAt(ref, dir, cwd) {
   return out;
 }
 
-function render(ref, requirements, assertions) {
+// Pure — groups already-loaded elements by TYPE. Exported so the fixture
+// tests can exercise the grouping/report logic without shelling out to git.
+export function groupByType(elements) {
+  const byType = new Map();
+  for (const el of elements) {
+    if (!byType.has(el.type)) byType.set(el.type, []);
+    byType.get(el.type).push(el);
+  }
+  return byType;
+}
+
+// Pure — renders the manifest body from a flat list of loaded elements
+// (admission-state filtering happens here, same as loadAt's caller used to
+// do inline). Exported for the same reason as groupByType.
+export function render(ref, elements) {
+  const active = elements.filter(e => e.admission_state === 'active');
+  const byType = groupByType(active);
+
+  const requirements = byType.get('REQUIREMENT') || [];
+  const assertions = byType.get('ASSERTION') || [];
   const assertedAbout = new Set(assertions.map(a => a.about).filter(Boolean));
   const tiers = { expert_confirmed: [], ai_reviewed: [] };
   for (const r of requirements) (tiers[r.reviewer_authority] ??= []).push(r);
 
   const lines = [];
-  lines.push(`# Design-controls baseline manifest — ${ref}`);
+  lines.push(`# Canon baseline manifest — ${ref}`);
   lines.push('');
   lines.push(
     '> Derived by `scripts/baseline-manifest.mjs`, read-only from git history via ' +
-    '`git show` — the working tree was never checked out. Regenerate against a ' +
-    'different ref for a different baseline.'
+    '`git show` — the working tree was never checked out. Scope is every admitted ' +
+    '`id:` found under `canon/` (excluding `canon/views/`), not a fixed TYPE list — ' +
+    'regenerate against a different ref for a different baseline.'
   );
   lines.push('');
   lines.push(
-    `${requirements.length} admitted REQUIREMENT(s), ${assertions.length} admitted ` +
-    `ASSERTION(s) at this baseline.`
+    `${active.length} admitted element(s) across ${byType.size} TYPE(s) at this baseline.`
   );
   lines.push('');
   lines.push('## Requirements by reviewer authority');
@@ -126,6 +177,25 @@ function render(ref, requirements, assertions) {
       : '**No REQ-COVERAGE-001 gaps** at this baseline.'
   );
   lines.push('');
+
+  lines.push('## Admitted set by type');
+  lines.push('');
+  const typesSorted = [...byType.keys()].sort();
+  if (typesSorted.length === 0) {
+    lines.push('_none_');
+    lines.push('');
+  } else {
+    lines.push('| TYPE | Count | expert_confirmed | ai_reviewed |');
+    lines.push('|---|---|---|---|');
+    for (const type of typesSorted) {
+      const rows = byType.get(type);
+      const expert = rows.filter(r => r.reviewer_authority === 'expert_confirmed').length;
+      const ai = rows.filter(r => r.reviewer_authority === 'ai_reviewed').length;
+      lines.push(`| \`${type}\` | ${rows.length} | ${expert} | ${ai} |`);
+    }
+    lines.push('');
+  }
+
   return lines.join('\n');
 }
 
@@ -146,10 +216,9 @@ function main() {
     process.exit(2);
   }
 
-  const requirements = loadAt(ref, REQUIREMENTS_DIR, root).filter(r => r.admission_state === 'active');
-  const assertions = loadAt(ref, ASSERTIONS_DIR, root).filter(a => a.admission_state === 'active');
+  const elements = loadAt(ref, root);
 
-  const text = render(ref, requirements, assertions);
+  const text = render(ref, elements);
   if (out) {
     writeFileSync(resolve(out), text, 'utf8');
     console.error(`written: ${out}`);
@@ -158,4 +227,9 @@ function main() {
   }
 }
 
-main();
+// Guard so `import { render, groupByType, deriveType } from
+// './baseline-manifest.mjs'` (the fixture tests in
+// baseline-manifest.test.mjs) doesn't also run the CLI.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/baseline-manifest.test.mjs
+++ b/scripts/baseline-manifest.test.mjs
@@ -1,0 +1,115 @@
+// Unit + fixture tests for scripts/baseline-manifest.mjs.
+// Run: node --test scripts/baseline-manifest.test.mjs
+//
+// deriveType/render are exercised as pure functions (no filesystem, no
+// subprocess). A fixture-repository test drives the real CLI against a
+// throwaway git repo to prove the end-to-end scope: every TYPE under
+// canon/ (not a hardcoded subset) reaches the rendered manifest.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { deriveType, groupByType, render } from './baseline-manifest.mjs';
+
+const SCRIPT_PATH = fileURLToPath(new URL('./baseline-manifest.mjs', import.meta.url));
+
+test('deriveType — positive: reads the TYPE prefix ahead of the first hyphen', () => {
+  assert.equal(deriveType('REQUIREMENT-DATA-RETENTION-1'), 'REQUIREMENT');
+  assert.equal(deriveType('NEED-1'), 'NEED');
+  assert.equal(deriveType('TARGET_STATE-CLOUD-1'), 'TARGET_STATE'); // underscore TYPE, hyphenated middle
+  assert.equal(deriveType('CAPABILITY-V1.2'), 'CAPABILITY'); // V/H address, not a plain integer
+});
+
+test('deriveType — negative: a malformed id yields no TYPE', () => {
+  assert.equal(deriveType('not-an-id'), undefined);
+  assert.equal(deriveType('123-FOO'), undefined);
+});
+
+test('groupByType — positive: an unlisted TYPE is grouped, not dropped', () => {
+  // Nothing in baseline-manifest.mjs enumerates TYPE names — grouping is
+  // driven entirely by what deriveType finds on each element's id. A TYPE
+  // this test invents on the spot (never referenced by the script) proves
+  // the omission the epic flagged cannot recur: registering a TYPE without
+  // touching this script does not silently exclude it.
+  const elements = [
+    { id: 'REQUIREMENT-1', type: 'REQUIREMENT', admission_state: 'active', reviewer_authority: 'expert_confirmed' },
+    { id: 'WIDGET-1', type: 'WIDGET', admission_state: 'active', reviewer_authority: 'expert_confirmed' },
+  ];
+  const byType = groupByType(elements);
+  assert.ok(byType.has('WIDGET'), 'an invented, never-hardcoded TYPE must still be grouped');
+  assert.equal(byType.get('WIDGET').length, 1);
+});
+
+test('render — positive: every admitted TYPE appears in the admitted-set-by-type table', () => {
+  const elements = [
+    { id: 'REQUIREMENT-1', type: 'REQUIREMENT', admission_state: 'active', reviewer_authority: 'expert_confirmed' },
+    { id: 'ASSERTION-1', type: 'ASSERTION', admission_state: 'active', reviewer_authority: 'expert_confirmed', about: 'REQUIREMENT-1' },
+    { id: 'VERIFICATION-1', type: 'VERIFICATION', admission_state: 'active', reviewer_authority: 'expert_confirmed' },
+    { id: 'NEED-1', type: 'NEED', admission_state: 'active', reviewer_authority: 'expert_confirmed' },
+    { id: 'VALIDATION-1', type: 'VALIDATION', admission_state: 'active', reviewer_authority: 'expert_confirmed' },
+    { id: 'RISK-1', type: 'RISK', admission_state: 'active', reviewer_authority: 'expert_confirmed' },
+    { id: 'METRIC-1', type: 'METRIC', admission_state: 'active', reviewer_authority: 'ai_reviewed' },
+  ];
+  const text = render('v-test', elements);
+  for (const type of ['REQUIREMENT', 'ASSERTION', 'VERIFICATION', 'NEED', 'VALIDATION', 'RISK', 'METRIC']) {
+    assert.ok(text.includes(`| \`${type}\` |`), `${type} missing from the admitted-set-by-type table`);
+  }
+  assert.ok(!text.includes('Design-controls'), 'title must not name the retired design-controls capability');
+});
+
+test('render — negative: a proposed (non-active) element is excluded from every count', () => {
+  const elements = [
+    { id: 'REQUIREMENT-1', type: 'REQUIREMENT', admission_state: 'proposed', reviewer_authority: 'expert_confirmed' },
+  ];
+  const text = render('v-test', elements);
+  assert.ok(text.includes('0 admitted element(s)'));
+  assert.ok(!text.includes('REQUIREMENT-1'));
+});
+
+test('fixture repository — one element per registered TYPE reaches the manifest, unmodified script', async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'baseline-manifest-fixture-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const run = (args, opts = {}) =>
+    execFileSync('git', args, { cwd: dir, encoding: 'utf8', ...opts });
+
+  run(['init', '-q']);
+  run(['config', 'user.email', 'fixture@example.com']);
+  run(['config', 'user.name', 'Fixture']);
+
+  const fixtureTypes = [
+    ['canon/elements/01_motivation/requirements/REQUIREMENT-1.yaml', 'REQUIREMENT-1'],
+    ['canon/assertions/ASSERTION-1.yaml', 'ASSERTION-1'],
+    ['canon/verifications/VERIFICATION-1.yaml', 'VERIFICATION-1'],
+    ['canon/elements/01_motivation/needs/NEED-1.yaml', 'NEED-1'],
+    ['canon/validations/VALIDATION-1.yaml', 'VALIDATION-1'],
+    ['canon/elements/01_motivation/risks/RISK-1.yaml', 'RISK-1'],
+    ['canon/elements/01_motivation/metrics/METRIC-1.yaml', 'METRIC-1'],
+  ];
+  for (const [path, id] of fixtureTypes) {
+    const full = join(dir, path);
+    mkdirSync(full.replace(/[^/\\]+$/, ''), { recursive: true });
+    writeFileSync(full, `id: ${id}\nzone: canon\n`, 'utf8');
+  }
+  // A view document under canon/views/ must NOT be picked up as an element.
+  const viewPath = join(dir, 'canon/views/dgca/example.dgca.transitrix.yaml');
+  mkdirSync(viewPath.replace(/[^/\\]+$/, ''), { recursive: true });
+  writeFileSync(viewPath, 'notation: dgca\nid: DGCA-1\n', 'utf8');
+
+  run(['add', '-A']);
+  run(['commit', '-q', '-m', 'fixture baseline']);
+  run(['tag', 'fixture-baseline']);
+
+  const output = execFileSync('node', [SCRIPT_PATH, 'fixture-baseline'], { cwd: dir, encoding: 'utf8' });
+
+  for (const [, id] of fixtureTypes) {
+    const type = id.replace(/-1$/, '');
+    assert.ok(output.includes(`| \`${type}\` |`), `${type} missing from fixture manifest output`);
+  }
+  assert.ok(!output.includes('DGCA'), 'canon/views/ content must not appear as an admitted element');
+  assert.ok(output.includes(`${fixtureTypes.length} admitted element(s)`));
+});


### PR DESCRIPTION
## Summary
- `scripts/baseline-manifest.mjs` hardcoded two directories (REQUIREMENT, ASSERTION); every TYPE registered since was silently omitted with no message.
- Scope now derives from every `id:` found under `canon/` (excluding `canon/views/`), so a newly registered TYPE appears without touching this script.
- Output title no longer names the retired design-controls capability.

## Test plan
- [x] `node --test scripts/baseline-manifest.test.mjs` — pure-function tests plus a fixture-repository integration test (one element per TYPE, a `canon/views/` document confirmed excluded)
- [x] `node scripts/check-notations.mjs` — clean