### PR TITLE
feat(notations): add the agreement axis (draft/agreed/disputed)

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -231,6 +231,40 @@ The routing that decides which drafts a tool may auto-admit to `ai_reviewed` (hi
 
 **Recording the decision.** A human reviewing a `proposed` draft may record accept/reject/defer against the pipeline's review artifact (`review-queue.yaml` or `review-digest.yaml`) in a shared, machine-readable form — `decisions.reviewed.yaml`, applied by [`@transitrix/decisions-cli`](https://github.com/transitrix/methodology/tree/main/packages/decisions-cli). This is a recommended recording convention, not a new admission state or lifecycle: `apply` performs exactly the `proposed → active | rejected` transitions above (`defer` leaves the artefact `proposed`, same as not touching it at all), and never writes `reviewer_authority: expert_confirmed` on a tool's behalf (`ADMIT-007`). Recording by hand, without the CLI, remains equally valid.
 
+### 6.3 Agreement axis — has the accountable party committed?
+
+Admission (§6.1) asks whether a **record** has passed its zone gate; agreement asks whether the **statement** is owed. The two are independent — an admitted, regulation-derived requirement the organisation has not yet committed to, and a requirement agreed in a workshop before it passed the canon gate, both occur in practice, so a single ladder cannot express them: agreement can *precede* admission. (Per the 2026-07-31 requirements-management cut-line decision.)
+
+`agreement` is a closed three-value axis carried by `REQUIREMENT`, `CONSTRAINT`, and `NEED` **only** — the elements whose statement is something an accountable party can *own*. It does **not** apply to `VERIFICATION` / `VALIDATION`: those record a comparison between an expected and an obtained result (an anchor, a `method`, an `outcome`, `evidence` — a shape both specs already have), and a machine may perform that comparison because the evidence carries the authority, not a signer. Widening the axis to cover them would collapse commitment and attestation back together — the named signature they need is already expressible as the admission record (`admitted_by` + `admitted_at` + `reviewer_authority: expert_confirmed`, a human guaranteed by `ADMIT-007`).
+
+```yaml
+agreement: agreed            # draft | agreed | disputed — absent ⇒ agreed (back-compat)
+agreed_by: "v.korobeinikov"  # required whenever `agreement` is written explicitly
+agreed_at: "2026-08-04"      # optional; quoted ISO 8601 date (§4) — when this value was last set
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `agreement` | no | string | `draft` \| `agreed` \| `disputed`. **Absent ⇒ `agreed`** — matches `admission_state` (§6.1) and `reviewer_authority` (§6.2): a human-authored element that predates this axis needs no change. |
+| `agreed_by` | when `agreement` is present | string | Person handle or tool identifier that set the current `agreement` value. Required whenever `agreement` is written, so the write-authority rule below has something to check. |
+| `agreed_at` | no | string | Date `agreement` was last set — quoted ISO 8601 per §4. |
+
+- **`draft`** — the statement is recorded but the accountable party has not yet committed to it. Either a human or a tool may write this value.
+- **`agreed`** — the accountable party has committed. **Written only by a human** (`AGREE-002`) — the mirror of `ADMIT-007`'s human-only `expert_confirmed` tier, and the reason the axis is worth having: it is the one place the model records that a *person* took on an obligation.
+- **`disputed`** — the accountable party has raised a substantive objection. `disputed` is not `rejected` (§6.1): the record stays in the model — an external obligation may be non-negotiable, and the dispute concerns the organisation's response to it, not the record's continued existence in canon. Either a human or a tool may write this value.
+
+**Reports, never filters.** Like `reviewer_authority` (§6.2), `agreement` adds **no** new exclusion from derived views or from any coverage / cross-cutting rule (`REQ-COVERAGE-001`, `NEED-COVERAGE-001`, …). A `draft` or `disputed` REQUIREMENT is still admitted canon if `admission_state` says so, still counts toward coverage, and still appears in every rendered view exactly as an `agreed` one does. Displaying the value — a badge, a column a reader filters by hand in a spreadsheet export — is a presentation concern; no validator, view generator, or cross-cutting rule may use `agreement` to decide whether an element is included.
+
+#### 6.3.1 Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `AGREE-001` | error | `agreement` is present and not one of `draft` / `agreed` / `disputed`. |
+| `AGREE-002` | error | `agreement: agreed` but `agreed_by` identifies a tool rather than a human (§6.2's tool-identifier convention) — a tool must never write `agreed`. |
+| `AGREE-003` | error | `agreement` is present (any of the three values) but `agreed_by` is missing. |
+
+`AGREE-002` and `AGREE-003` can both describe an `agreement: agreed` record with no `agreed_by`; a validator MAY report either or both. A reference implementation of this check lives in [`scripts/check-agreement.mjs`](../scripts/check-agreement.mjs).
+
 ---
 
 ## 7. Primitive lifecycle

--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -580,6 +580,8 @@ Already shipped (worked example `CONSTRAINT-GDPR-RESIDENCY-1`). Same field set a
 
 **Hierarchy — `parent`.** CONSTRAINT MAY carry the same optional `parent` field defined for REQUIREMENT in [elements/15-requirement.md](elements/15-requirement.md) §2.4 — same-TYPE (`parent: CONSTRAINT-…`), inline, not time-aware. A broad restriction ("no personal data outside the EEA without safeguards") decomposes into narrower ones ("no PII in analytics logs sent outside the EEA", "no PII in raw log storage outside the EEA"). Same origin-agnostic semantics: any two CONSTRAINTs may be linked regardless of `origin`. Cross-TYPE hierarchies (CONSTRAINT → REQUIREMENT, or vice versa) are not supported — CONSTRAINT and REQUIREMENT are peer motivation-layer elements ([elements/15-requirement.md](elements/15-requirement.md) §1), not decompositions of one another. Structure only, no traversal semantics: an assertion mechanism against CONSTRAINT is still out of scope for v1 ([elements/16-assertion.md](elements/16-assertion.md) §1, §7), so aggregation across the hierarchy is a downstream tooling concern.
 
+**Agreement — has the accountable party committed?** CONSTRAINT MAY carry the same optional agreement axis defined for REQUIREMENT in [CONTRACT.md](CONTRACT.md) §6.3 (`agreement: draft | agreed | disputed`, independent of admission). Absent ⇒ `agreed`; only a human may write `agreed` (`AGREE-002`); the axis reports and never filters a view.
+
 ### 7.14 `EQUIPMENT` — `04_technology/equipment/`
 
 Physical instrument, device, or facility a process stage depends on (ArchiMate Physical element). Promoted from Process Blueprint view-defined to first-class standalone in the `04_technology` layer (ADR 2026-06-08; first catalogued TYPE for this layer).
@@ -990,6 +992,8 @@ There is no ArchiMate counterpart for `NEED`: ArchiMate 3.x has no need element 
 
 **`stakeholder` is inline, not a first-class time-aware `REL`** — consistent with `ASSESSMENT.assesses` (§7.16) and `STAKEHOLDER.actor` (§7.15). A need re-attributed to a different stakeholder is captured by versioning the `NEED` element itself (`valid_to` the old, admit a new), not by relation re-binding.
 
+**Agreement — has the accountable party committed?** NEED MAY carry the same optional agreement axis defined for REQUIREMENT in [CONTRACT.md](CONTRACT.md) §6.3 (`agreement: draft | agreed | disputed`, independent of admission) — here, whether the stakeholder has confirmed the need is accurately captured, distinct from whether the need has been admitted to canon. Absent ⇒ `agreed`; only a human may write `agreed` (`AGREE-002`); the axis reports and never filters a view.
+
 ```yaml
 # canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml
 notation: need
@@ -1037,7 +1041,7 @@ Before `NEED` existed, there was no anchor for the claim that a delivered thing 
 
 ## 9. Validation rules
 
-Element-primitive-specific rules. The shared header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2), lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3), and sidecar (`VERSIONED-001..005`, [CONTRACT.md](CONTRACT.md) §9.3) rules apply to element files in addition to these.
+Element-primitive-specific rules. The shared header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2), lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3), and sidecar (`VERSIONED-001..005`, [CONTRACT.md](CONTRACT.md) §9.3) rules apply to element files in addition to these. `CONSTRAINT` and `NEED` additionally carry the agreement-axis rules (`AGREE-001..003`, [CONTRACT.md](CONTRACT.md) §6.3.1) — the REQUIREMENT-side counterpart is in [elements/15-requirement.md](elements/15-requirement.md) §4.
 
 | Rule | Severity | Description |
 |---|---|---|

--- a/notations/elements/15-requirement.md
+++ b/notations/elements/15-requirement.md
@@ -10,7 +10,7 @@ status: "draft"
 
 **Scope:** The `REQUIREMENT` element type in the motivation layer of an organisation's canon — a positive obligation the organisation must fulfil ("must submit", "must register", "must obtain approval"). The shared header / zone / admission / lifecycle contracts are defined in [CONTRACT.md](../CONTRACT.md); the TYPE registry sits in [IDS_AND_REFERENCES.md](../IDS_AND_REFERENCES.md) §3.1.
 
-Requirements are **zone primitives**: each requirement is a single YAML file under `canon/elements/01_motivation/requirements/`, named by its canonical ID, carrying the admission record ([CONTRACT.md](../CONTRACT.md) §6, `zone: canon`) plus the primitive lifecycle ([CONTRACT.md](../CONTRACT.md) §7) and the requirement-specific frontmatter below.
+Requirements are **zone primitives**: each requirement is a single YAML file under `canon/elements/01_motivation/requirements/`, named by its canonical ID, carrying the admission record ([CONTRACT.md](../CONTRACT.md) §6, `zone: canon`) plus the primitive lifecycle ([CONTRACT.md](../CONTRACT.md) §7) and the requirement-specific frontmatter below. A REQUIREMENT MAY also carry the **agreement axis** ([CONTRACT.md](../CONTRACT.md) §6.3, `agreement: draft | agreed | disputed`) — a second, independent axis from admission, recording whether the accountable party has committed to the obligation. Absent ⇒ `agreed`; only a human may write `agreed` (`AGREE-002`).
 
 ---
 
@@ -304,11 +304,14 @@ A `REQUIREMENT` records *what the design must do*; a `NEED` ([`ELEMENT_PRIMITIVE
 | `REQ-VERIF-COVERAGE-002` | warning | A REQUIREMENT has one or more admitted `VERIFICATION`s targeting it, but none has reached `outcome: pass` or `outcome: fail` — every verification against it is still `not_yet_run` or `inconclusive` ([27-verification.md](27-verification.md) §3). The trace link exists but has not closed. Distinct from, and mutually exclusive with, `REQ-VERIF-COVERAGE-001` by construction. Cross-cutting, same computation basis. |
 | `REQ-STALE-001` | warning | `next_review_at` is set and is in the past relative to today (§2.3). The requirement is due for re-review. Time-dependent — the same file may pass on one day and fire on the next; surfaced by the `check-stale` CLI command (§5) so evaluation is explicit rather than embedded in every validate pass. Applies symmetrically to CONSTRAINT ([`ELEMENT_PRIMITIVES.md`](../ELEMENT_PRIMITIVES.md) §7.13). Malformed / unparseable `next_review_at` values silently skip evaluation (the CLI flags them in a separate line rather than firing a false stale). Mirrors `ASSERT-008` ([16-assertion.md](16-assertion.md) §5). |
 
-The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](../CONTRACT.md) §7.3) and header (`HDR-001..004`, [CONTRACT.md](../CONTRACT.md) §2) rules apply to REQUIREMENT files in addition to the REQ-* rules above. The aggregated compliance-and-verification-domain rules table (covering REQUIREMENT, ASSERTION, and VERIFICATION) lives in [CONTRACT.md](../CONTRACT.md) §8.
+The shared lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](../CONTRACT.md) §7.3), header (`HDR-001..004`, [CONTRACT.md](../CONTRACT.md) §2), and agreement-axis (`AGREE-001..003`, [CONTRACT.md](../CONTRACT.md) §6.3.1) rules apply to REQUIREMENT files in addition to the REQ-* rules above. The aggregated compliance-and-verification-domain rules table (covering REQUIREMENT, ASSERTION, and VERIFICATION) lives in [CONTRACT.md](../CONTRACT.md) §8.
 
 ---
 
 ## 5. Evolution
+
+**Landed (2026-08-04, agreement axis):**
+- [CONTRACT.md](../CONTRACT.md) §6.3 — the `agreement: draft | agreed | disputed` axis, independent of admission, applying symmetrically to REQUIREMENT / CONSTRAINT / NEED. Absent ⇒ `agreed` (back-compat, no migration). `AGREE-001..003` (§6.3.1) validate the closed vocabulary, the required `agreed_by` writer attribution, and the human-only write authority on `agreed` (mirrors `ADMIT-007`). Per the 2026-07-31 requirements-management cut-line decision, which also moves the `reqif` package's `draft` / `approved` workflow states down into this axis (`approved` renamed `agreed`, since "approval" is spoken for by tiered approval, §6.2).
 
 **Landed (v0.7, 2026-07-30):**
 - §2.5 + §2 schema — optional `level: stakeholder | system | software` field, the ISO/IEC/IEEE 29148 StRS → SyRS → SRS specification-tier ladder. No new TYPE. Distinct from `origin` (authority chain) and `parent` (structural decomposition, no level semantics) — both documented explicitly to head off conflation. `REQ-005` enforces the closed vocabulary.

--- a/scripts/check-agreement.mjs
+++ b/scripts/check-agreement.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Agreement-axis checker — CONTRACT.md §6.3, reference implementation.
+//
+// Validates the AGREE-* rules over REQUIREMENT / CONSTRAINT / NEED files:
+//   AGREE-001  `agreement` present and not draft|agreed|disputed.
+//   AGREE-002  `agreement: agreed` but `agreed_by` identifies a tool.
+//   AGREE-003  `agreement` present but `agreed_by` is missing.
+//
+// `agreed_by` tool-detection reuses the same convention as `ADMIT-007`'s
+// footgun-catcher (packages/decisions-cli/src/apply.mjs): an npm-scoped name
+// or a hyphenated *-cli / *-reviewer / *-bot / *-scanner id reads as a tool;
+// anything else reads as a human handle. Not a security boundary — catches
+// the common mistake of a tool defaulting/copy-pasting `agreed`.
+//
+// Usage:
+//   node scripts/check-agreement.mjs [--root <adopter-repo>]
+//
+// Exit codes: 0 clean · 1 findings · 2 script-internal error
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const AGREEMENT_TYPES = ['REQUIREMENT', 'CONSTRAINT', 'NEED'];
+const AGREEMENT_VALUES = ['draft', 'agreed', 'disputed'];
+
+const TOOL_ID_RE = /^@|-cli$|-reviewer(?:-\w+)?$|-bot$|-scanner$/i;
+
+export function looksLikeTool(id) {
+  return TOOL_ID_RE.test(String(id || ''));
+}
+
+// Targeted top-level scalar extraction — same convention as
+// scripts/baseline-manifest.mjs's `field()`; not a general YAML parser.
+function field(text, name) {
+  const m = text.match(new RegExp(`^${name}:\\s*"?([^"\\n#]*?)"?\\s*(?:#.*)?$`, 'm'));
+  return m ? m[1].trim() : undefined;
+}
+
+export function deriveType(id) {
+  const m = id?.match(/^([A-Z][A-Z0-9_]*)-/);
+  return m ? m[1] : undefined;
+}
+
+// Pure check over an already-extracted {agreement, agreed_by} pair.
+// Returns a list of finding codes — empty means clean (including the
+// back-compat case where `agreement` is absent entirely).
+export function checkAgreement({ agreement, agreed_by: agreedBy } = {}) {
+  if (agreement === undefined) return [];
+
+  if (!AGREEMENT_VALUES.includes(agreement)) {
+    return ['AGREE-001'];
+  }
+  if (!agreedBy) {
+    return ['AGREE-003'];
+  }
+  const findings = [];
+  if (agreement === 'agreed' && looksLikeTool(agreedBy)) {
+    findings.push('AGREE-002');
+  }
+  return findings;
+}
+
+async function walk(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walk(p)));
+    else if (entry.isFile() && entry.name.endsWith('.yaml')) out.push(p);
+  }
+  return out;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const rootFlagIndex = args.indexOf('--root');
+  const root = resolve(rootFlagIndex >= 0 && args[rootFlagIndex + 1] ? args[rootFlagIndex + 1] : '.');
+  const canonElements = join(root, 'canon', 'elements');
+
+  const files = await walk(canonElements);
+  let findingsCount = 0;
+
+  for (const file of files) {
+    const text = await readFile(file, 'utf8');
+    const id = field(text, 'id');
+    const type = deriveType(id);
+    if (!type || !AGREEMENT_TYPES.includes(type)) continue;
+
+    const agreement = field(text, 'agreement');
+    const agreedBy = field(text, 'agreed_by');
+    const codes = checkAgreement({ agreement, agreed_by: agreedBy });
+    for (const code of codes) {
+      findingsCount++;
+      console.log(`${code}  ${file}  (id=${id}, agreement=${agreement}, agreed_by=${agreedBy || '(absent)'})`);
+    }
+  }
+
+  if (findingsCount > 0) {
+    console.log(`\n${findingsCount} finding(s).`);
+    process.exitCode = 1;
+  } else {
+    console.log('check-agreement: clean.');
+  }
+}
+
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 2;
+  });
+}

--- a/scripts/check-agreement.test.mjs
+++ b/scripts/check-agreement.test.mjs
@@ -1,0 +1,143 @@
+// Unit + fixture tests for scripts/check-agreement.mjs.
+// Run: node --test scripts/check-agreement.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkAgreement, looksLikeTool, deriveType } from './check-agreement.mjs';
+
+const SCRIPT_PATH = fileURLToPath(new URL('./check-agreement.mjs', import.meta.url));
+
+test('checkAgreement — positive: absent agreement is untouched (byte-identical back-compat)', () => {
+  assert.deepEqual(checkAgreement({}), []);
+  assert.deepEqual(checkAgreement(), []);
+});
+
+test('checkAgreement — positive: a human writing agreed passes', () => {
+  assert.deepEqual(checkAgreement({ agreement: 'agreed', agreed_by: 'v.korobeinikov' }), []);
+});
+
+test('checkAgreement — positive: draft/disputed accept either a human or a tool writer', () => {
+  assert.deepEqual(checkAgreement({ agreement: 'draft', agreed_by: 'reg-intel-scanner' }), []);
+  assert.deepEqual(checkAgreement({ agreement: 'draft', agreed_by: 'v.korobeinikov' }), []);
+  assert.deepEqual(checkAgreement({ agreement: 'disputed', agreed_by: '@transitrix/ingest-cli' }), []);
+  assert.deepEqual(checkAgreement({ agreement: 'disputed', agreed_by: 'v.korobeinikov' }), []);
+});
+
+test('checkAgreement — negative: a tool writing agreed fails AGREE-002', () => {
+  assert.deepEqual(checkAgreement({ agreement: 'agreed', agreed_by: 'ingest-reviewer-claude' }), ['AGREE-002']);
+  assert.deepEqual(checkAgreement({ agreement: 'agreed', agreed_by: '@transitrix/reg-intel-cli' }), ['AGREE-002']);
+  assert.deepEqual(checkAgreement({ agreement: 'agreed', agreed_by: 'reg-intel-scanner' }), ['AGREE-002']);
+});
+
+test('checkAgreement — negative: an invalid enum value fails AGREE-001', () => {
+  assert.deepEqual(checkAgreement({ agreement: 'approved', agreed_by: 'v.korobeinikov' }), ['AGREE-001']);
+});
+
+test('checkAgreement — negative: agreement present with no writer fails AGREE-003', () => {
+  assert.deepEqual(checkAgreement({ agreement: 'draft' }), ['AGREE-003']);
+  assert.deepEqual(checkAgreement({ agreement: 'agreed' }), ['AGREE-003']);
+});
+
+test('looksLikeTool — matches the decisions-cli ADMIT-007 tool-identifier convention', () => {
+  assert.equal(looksLikeTool('ingest-reviewer-claude'), true);
+  assert.equal(looksLikeTool('reg-intel-scanner'), true);
+  assert.equal(looksLikeTool('some-cli'), true);
+  assert.equal(looksLikeTool('@transitrix/ingest-cli'), true);
+  assert.equal(looksLikeTool('nightly-bot'), true);
+  assert.equal(looksLikeTool('v.korobeinikov'), false);
+  assert.equal(looksLikeTool(''), false);
+  assert.equal(looksLikeTool(undefined), false);
+});
+
+test('deriveType — reads the TYPE prefix ahead of the first hyphen', () => {
+  assert.equal(deriveType('REQUIREMENT-DATA-ERASURE-1'), 'REQUIREMENT');
+  assert.equal(deriveType('CONSTRAINT-GDPR-RESIDENCY-1'), 'CONSTRAINT');
+  assert.equal(deriveType('NEED-TIMELY-OUTAGE-STATUS-1'), 'NEED');
+  assert.equal(deriveType(undefined), undefined);
+});
+
+// --- fixture-repo end-to-end test -------------------------------------
+
+function writeYaml(dir, filename, lines) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, filename), lines.join('\n') + '\n', 'utf8');
+}
+
+test('CLI — positive: a fixture repo with only absent/human-agreed elements is clean (exit 0)', () => {
+  const root = mkdtempSync(join(tmpdir(), 'check-agreement-clean-'));
+  try {
+    const reqDir = join(root, 'canon', 'elements', '01_motivation', 'requirements');
+    writeYaml(reqDir, 'REQUIREMENT-1.yaml', [
+      'notation: requirement',
+      'id: REQUIREMENT-1',
+      'name: "No agreement field at all"',
+      'zone: canon',
+    ]);
+    writeYaml(reqDir, 'REQUIREMENT-2.yaml', [
+      'notation: requirement',
+      'id: REQUIREMENT-2',
+      'name: "Human-agreed"',
+      'agreement: agreed',
+      'agreed_by: "v.korobeinikov"',
+      'zone: canon',
+    ]);
+
+    const out = execFileSync('node', [SCRIPT_PATH, '--root', root], { encoding: 'utf8' });
+    assert.match(out, /clean/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI — negative: a tool-written agreed element fails with exit 1 and reports AGREE-002', () => {
+  const root = mkdtempSync(join(tmpdir(), 'check-agreement-dirty-'));
+  try {
+    const needDir = join(root, 'canon', 'elements', '01_motivation', 'needs');
+    writeYaml(needDir, 'NEED-1.yaml', [
+      'notation: need',
+      'id: NEED-1',
+      'name: "Tool-agreed need"',
+      'agreement: agreed',
+      'agreed_by: "ingest-reviewer-claude"',
+      'zone: canon',
+    ]);
+
+    let threw = false;
+    let output = '';
+    try {
+      execFileSync('node', [SCRIPT_PATH, '--root', root], { encoding: 'utf8' });
+    } catch (err) {
+      threw = true;
+      output = err.stdout;
+      assert.equal(err.status, 1);
+    }
+    assert.ok(threw, 'CLI must exit non-zero on a finding');
+    assert.match(output, /AGREE-002/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI — a TYPE outside REQUIREMENT/CONSTRAINT/NEED is never evaluated for AGREE-*', () => {
+  const root = mkdtempSync(join(tmpdir(), 'check-agreement-outside-scope-'));
+  try {
+    const capDir = join(root, 'canon', 'elements', '05_implementation', 'capabilities');
+    writeYaml(capDir, 'CAPABILITY-1.yaml', [
+      'notation: capability',
+      'id: CAPABILITY-1',
+      'name: "Not an agreement-axis TYPE"',
+      'agreement: not-a-real-value', // would fail AGREE-001 if this TYPE were in scope
+      'zone: canon',
+    ]);
+
+    const out = execFileSync('node', [SCRIPT_PATH, '--root', root], { encoding: 'utf8' });
+    assert.match(out, /clean/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds CONTRACT.md §6.3 — a second axis independent of admission: whether the accountable party has committed to a `REQUIREMENT` / `CONSTRAINT` / `NEED` statement (`agreement: draft | agreed | disputed`, absent ⇒ `agreed`). Only a human may write `agreed` (`AGREE-002`), mirroring `ADMIT-007`'s human-only `expert_confirmed` tier. The axis reports and never filters a view or coverage rule.
- Cross-references the axis from `15-requirement.md` and `ELEMENT_PRIMITIVES.md` (`CONSTRAINT` §7.13, `NEED` §7.28).
- Adds `scripts/check-agreement.mjs`, a reference implementation of `AGREE-001..003` (invalid enum, missing writer, tool-writes-agreed), with `node --test` coverage.

## Test plan
- [x] `node --test scripts/check-agreement.test.mjs` — 11/11 pass (positive: absent/human-agreed/draft-disputed-either-writer; negative: tool-writes-agreed, invalid enum, missing writer; CLI fixture-repo end-to-end)
- [x] `node scripts/check-notations.mjs` — clean against the changed files (unrelated pre-existing findings only under a gitignored local worktree dir)

Signed-off-by: transitrix <279946036+transitrix@users.noreply.github.com>