### PR TITLE
feat(notations): separately-distributed packages, validator discovery, envelope row

### DIFF
--- a/notations/PACKAGES.md
+++ b/notations/PACKAGES.md
@@ -1,8 +1,8 @@
 ---
 title: "Domain Packages — optional, removable vocabulary extensions"
-version: "0.1"
+version: "0.2"
 author: "Valerii Korobeinikov"
-last_updated: "2026-07-29"
+last_updated: "2026-08-04"
 status: "draft"
 ---
 
@@ -16,7 +16,7 @@ A repository that declares no packages is unaffected by this document: no additi
 
 ## 1. Where a package is declared
 
-A package is declared at the repository root in `transitrix.yaml` under the `packages` key — a flat list, sibling to `coverage_profile`, not nested inside it.
+A package is declared at the repository root in `transitrix.yaml` under the `packages` key — a flat list, sibling to `coverage_profile`, not nested inside it. A list entry takes one of two shapes, one per package class (§7):
 
 ```yaml
 transitrix: 1
@@ -25,6 +25,19 @@ notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core
 packages: [reqif]              # optional — zero or more shipped package names
+```
+
+- **Shipped** (§7.1) — a bare name, e.g. `reqif` above. The name must be one the pinned `methodology_version` ships.
+- **Externally-distributed** (§7.2) — a map, carrying its own version and a declared compatibility range against core:
+
+```yaml
+packages:
+  - reqif                      # a shipped package can sit alongside an external one
+  - name: acme-widgets
+    distribution: external
+    version: "1.2.0"
+    compatible_with: ">=3.1.0 <4.0.0"
+    validator: "acme-widgets/validate.mjs"
 ```
 
 `packages` absent, or an empty list, means no package is active — equivalent and interchangeable.
@@ -51,7 +64,7 @@ A package is:
 - **A top-level folder** in the adopter repository, at the same level as `canon/`, `field/`, `codex/` — e.g. `reqif/` — named after the package's declared name in `packages:`.
 - **Not a zone.** [`CONTRACT.md`](CONTRACT.md) §5's zone model (`canon` / `field` / `codex`, each with its own trust contract) does not extend to packages. A package is a fourth kind of thing: optional, self-contained, and removable in a way no zone is (data is never migrated between zones, but a package folder can simply be deleted).
 - **Self-describing.** A package ships its own spec document (§6), its own object types, and its own validator/tooling. Core specs, core validators, and core tooling carry zero package-specific logic (§4.2).
-- **Shipped by the methodology**, the same way a coverage-profile preset is shipped ([`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) §3). An adopter cannot declare an arbitrary package name in `packages:` — only a name the pinned `methodology_version` ships (§7).
+- **Either shipped by the methodology, or independently declared.** A *shipped* package name works the same way a coverage-profile preset does ([`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) §3): an adopter cannot declare an arbitrary bare name — only one the pinned `methodology_version` ships (§7.1). An *externally-distributed* package (§7.2) is maintained outside a core release; it declares its own name, version, and compatibility range instead of appearing in core's shipped-package registry.
 
 ---
 
@@ -74,6 +87,8 @@ No package-specific check is ever wired into a core validator (`packages/ingest-
 
 This is what makes absence silent (§5): a core validator that has never heard of a package cannot warn about it.
 
+**Discovery is a lookup, not a check.** `@transitrix/ingest-cli`'s `check-packages` command resolves, for each declared package, the path to its own validator entry point — from the shipped-package registry (§7.1) for a shipped name, or from the declaration itself (§7.2, `validator:`) for an externally-distributed one — and, if that path exists, runs it as a subprocess. `check-packages` reads an exit code and stdout; it never parses what a validator checks. This is the same boundary a name → membership table already keeps for a coverage preset (`coverage-presets.mjs` knows a preset's TYPE list, never why a TYPE belongs to it) — a name → path table carries no more package-specific knowledge than a name → membership table does. No package-specific rule (an `if` on a package name, a hardcoded field name) ever appears in core.
+
 ### 4.3 Removal is tested, not just documented
 
 A package's own spec document (§6) states its removal procedure. The baseline procedure — delete the package folder, remove its name from `packages:` — is the same for every package; a package MAY add package-specific steps (e.g. clearing a generated cache) but MUST NOT require any change to a file outside its own folder plus the one line in `transitrix.yaml`. The procedure is demonstrated as a test against a worked instance of the package, not asserted in prose alone.
@@ -93,7 +108,7 @@ A repository whose `packages:` list omits a given package name behaves, for that
 
 ## 6. What a package's own spec must state
 
-Each shipped package ships a spec document (convention: `notations/packages/<name>.md`) that states, at minimum:
+Each shipped or externally-distributed package ships a spec document (convention: `notations/packages/<name>.md` for a shipped package; wherever the external package's own repository keeps it) that states, at minimum:
 
 | Element | Requirement |
 |---|---|
@@ -102,18 +117,44 @@ Each shipped package ships a spec document (convention: `notations/packages/<nam
 | **Validator** | What the package's own tooling checks, and where that tooling lives. |
 | **Removal procedure** | The baseline two-step procedure (§4.3) plus any package-specific addition. |
 | **Experimental status and review date** | Whether the package is experimental, and the date its status is next reviewed. **Required, not implied** — a package that says nothing about its status is not thereby stable; silence is not a valid value here. Core specs are never refactored to accommodate a package's experimental surface — an experimental package's rough edges stay contained inside the package. |
+| **Core envelope** | Does this package's own object types carry [`CONTRACT.md`](CONTRACT.md)'s core envelope — the required header (§2), admission record (§6), and lifecycle (§7) — yes or no. **Required, not implied**; silence is invalid here for the same reason it is above. Answering "yes" means **citing** `CONTRACT.md` §2/§6/§7, never restating their field lists — the package's own validator enforces those core rule codes against the package's objects. Answering "no" requires one explicit sentence saying why not (e.g. an interchange-format package whose objects arrive pre-admission and are never themselves admitted). Either way, no parallel core-envelope-shaped rule is invented inside the package. |
 
 ---
 
 ## 7. Version pinning
 
-Like a coverage-profile preset, the set of packages a methodology version ships is part of that version's registry. A `packages:` entry naming a package the pinned `methodology_version` does not ship is rejected (§8, `PKG-001`) — the same discipline [`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) §7 applies to preset names.
+Two package classes, distinguished by the declaration shape a `packages:` entry uses (§1).
 
 ### 7.1 Shipped packages
+
+Like a coverage-profile preset, the set of *shipped* packages a methodology version carries is part of that version's registry. A bare `packages:` entry naming a package the pinned `methodology_version` does not ship is rejected (§8, `PKG-001`) — the same discipline [`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) §7 applies to preset names. A shipped package's own version and compatibility travel with the methodology release that carries it (§9) — it carries no independent `version:`/`compatible_with:` of its own.
 
 | `packages:` name | Spec | Status |
 |---|---|---|
 | `reqif` | [`packages/reqif.md`](packages/reqif.md) | object model + workflow-state/revisions/suspect-links landed; experimental, reviewed by 2027-01-28 ([`reqif.md`](packages/reqif.md) §8) |
+
+### 7.2 Externally-distributed packages
+
+A package maintained outside a core release — not in the §7.1 table — is declared as a map, not a bare string (§1):
+
+```yaml
+packages:
+  - name: acme-widgets
+    distribution: external
+    version: "1.2.0"
+    compatible_with: ">=3.1.0 <4.0.0"
+    validator: "acme-widgets/validate.mjs"
+```
+
+| Key | Required | Semantics |
+|---|---|---|
+| `name` | yes | The package's own name — the same role a shipped package's bare `packages:` entry plays; used for its top-level folder (§3) and to correlate with its own spec (§6). |
+| `distribution` | yes | Fixed value `external` — the class marker; a map entry lacking it, or spelling any required key wrong, is still typo-rejected (§8, `PKG-001`), never silently accepted as some third shape. |
+| `version` | yes | The package's own SemVer version — independent of `methodology_version` (§9's "out of scope" restriction on independent versioning applies only to shipped packages, §7.1). |
+| `compatible_with` | yes | A SemVer range the pinned `methodology_version` must satisfy for this declaration to be valid — comparator terms space-separated (`>=3.1.0 <4.0.0`). A repo whose `methodology_version` falls outside the range is rejected (§8, `PKG-002`). |
+| `validator` | yes | A path, relative to the adopter repo root, to the package's own validator entry point (§4.2's discovery note) — a script `check-packages` runs if the path exists, and silently skips if it does not (declared-but-not-installed is absence, not an error). |
+
+A required key missing or unparseable is `PKG-001` (§8) — the same rule a shipped-name typo trips, so an adopter sees one class of error for "this `packages:` entry does not resolve," regardless of which shape it took.
 
 ---
 
@@ -121,9 +162,10 @@ Like a coverage-profile preset, the set of packages a methodology version ships 
 
 | Rule | Severity | Description |
 |---|---|---|
-| `PKG-001` | error | `packages` is present and either not a list, or names an entry that is not a package shipped by the pinned `methodology_version`. |
+| `PKG-001` | error | `packages` is present and either not a list, or names a bare entry that is not a package shipped by the pinned `methodology_version` (§7.1), or is a map entry (§7.2) missing/malformed one of `name`, `distribution`, `version`, `compatible_with`, `validator`. |
+| `PKG-002` | error | An externally-distributed package's `compatible_with` range (§7.2) does not admit the repo's pinned `methodology_version`, or the range itself does not parse. |
 
-No other rule is defined here. A one-way-reference violation is caught by existing core referential-integrity checking (§4.1); a package's internal consistency is governed entirely by that package's own spec and tooling (§4.2), never by a core rule code.
+No other rule is defined here. A one-way-reference violation is caught by existing core referential-integrity checking (§4.1); a package's internal consistency is governed entirely by that package's own spec and tooling (§4.2), never by a core rule code. Implementation: `@transitrix/ingest-cli`'s `check-packages` command (`packages/ingest-cli/src/packages.mjs`).
 
 ---
 
@@ -131,7 +173,7 @@ No other rule is defined here. A one-way-reference violation is caught by existi
 
 - **Cross-package references.** Two packages referencing each other's objects is undefined; each shipped package's own spec must say whether it permits this (default: no).
 - **Per-package coverage profiles.** A package either is or isn't declared; there is no partial/profiled adoption of a package's own vocabulary in v1.
-- **Package versioning independent of `methodology_version`.** A package's spec ships and versions together with the methodology release that carries it (§7); it does not carry its own independent SemVer line in v1.
+- **Independent versioning for a *shipped* package.** A shipped package's spec ships and versions together with the methodology release that carries it (§7.1); it does not carry its own independent SemVer line in v1. (An *externally-distributed* package does — that is the point of the class, §7.2 — so this restriction does not extend to it.)
 
 ---
 
@@ -139,5 +181,6 @@ No other rule is defined here. A one-way-reference violation is caught by existi
 
 - [`MANIFEST.md`](MANIFEST.md) §2 — the `packages:` field on `transitrix.yaml`.
 - [`COVERAGE_PROFILES.md`](COVERAGE_PROFILES.md) — the depth axis (§2 of this document draws the boundary between the two).
-- [`CONTRACT.md`](CONTRACT.md) §5 — the zone model packages sit outside of.
+- [`CONTRACT.md`](CONTRACT.md) §5 — the zone model packages sit outside of; §2/§6/§7 — the core envelope a package's own spec states its relationship to (§6).
 - [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §3.1 — the closed core TYPE registry a package's ID grammar must stay disjoint from.
+- [`packages/ingest-cli/src/packages.mjs`](../packages/ingest-cli/src/packages.mjs) — `check-packages`: declaration parsing, `PKG-001`/`PKG-002`, and package-agnostic validator-entry-point discovery (§4.2).

--- a/notations/packages/reqif.md
+++ b/notations/packages/reqif.md
@@ -1,8 +1,8 @@
 ---
 title: "ReqIF-shaped requirements interchange — domain package"
-version: "0.1"
+version: "0.2"
 author: "Valerii Korobeinikov"
-last_updated: "2026-07-29"
+last_updated: "2026-08-04"
 status: "draft"
 ---
 
@@ -227,7 +227,7 @@ One artefact per file, named by its canonical package id (§2.2).
 
 ## 5. Validation rules — the package's own validator
 
-Run by `@transitrix/reqif-cli validate <reqif-folder>` ([`packages/reqif-cli`](../../packages/reqif-cli) in this repo — the reference implementation shipped alongside this spec). Never wired into `packages/ingest-cli`, `scripts/check-notations.mjs`, or Studio's validator registry ([`PACKAGES.md`](../PACKAGES.md) §4.2) — this tooling runs only when explicitly invoked against a `reqif/` folder.
+Run by `@transitrix/reqif-cli validate <reqif-folder>` ([`packages/reqif-cli`](../../packages/reqif-cli) in this repo — the reference implementation shipped alongside this spec). No REQIF-specific rule is ever wired into `packages/ingest-cli`, `scripts/check-notations.mjs`, or Studio's validator registry ([`PACKAGES.md`](../PACKAGES.md) §4.2) — the checks in the table below live only here and in `reqif-cli`. `@transitrix/ingest-cli`'s `check-packages` command ([`PACKAGES.md`](../PACKAGES.md) §4.2, §7.1) may invoke this validator generically (a name → path lookup, run as a subprocess) when `@transitrix/reqif-cli` is installed in the adopter repo; it never learns what the table below checks.
 
 | Rule | Severity | Description |
 |---|---|---|
@@ -286,7 +286,15 @@ Per [`PACKAGES.md`](../PACKAGES.md) §6, core specs are never refactored to acco
 
 ---
 
-## 9. Evolution
+## 9. Core envelope statement
+
+**No.** This package does not carry [`CONTRACT.md`](../CONTRACT.md)'s core envelope — the required header (§2), admission record (§6), or lifecycle (§7) — on any of its four object kinds (§2.1). None of `spec-object-type`, `spec-object`, `spec-relation`, or `spec-hierarchy` is ever admitted; `package: reqif` + `kind: <…>` (§2.3) is the only pair the package's own tooling reads, and no core validator reads it at all ([`PACKAGES.md`](../PACKAGES.md) §4.2).
+
+This package is a requirements-*interchange* layer (§Scope): its objects are the YAML-shaped equivalent of ReqIF XML on the wire, arriving and round-tripping through `export`/`import` (§6) before any admission decision is made about them. Admission is what the core envelope marks — a human-gated decision that an object belongs in `canon/`, `field/`, or `codex/` ([`CONTRACT.md`](../CONTRACT.md) §6). A `spec-object` sitting in `reqif/spec-objects/` has made no such claim about itself; the one place it touches core is the one-way `Transitrix.CanonRef` citation (§3), which points *at* an already-admitted `REQUIREMENT`/`CONSTRAINT` — it never asserts that the citing `spec-object` itself is, or needs to become, an admitted core object.
+
+---
+
+## 10. Evolution
 
 **Landed (v0.1, 2026-07-28):** object model (§2), the one-way canon citation (§3), the package validator (§5), and the YAML↔ReqIF-XML converter (§6) — the base ReqIF-shaped layer.
 
@@ -294,11 +302,14 @@ Per [`PACKAGES.md`](../PACKAGES.md) §6, core specs are never refactored to acco
 
 **Landed (2026-07-29):** removal procedure (§7) and experimental-status declaration (§8) — both required by [`PACKAGES.md`](../PACKAGES.md) §6 ("required, not implied"), demonstrated against the worked example that landed with the base layer above.
 
+**Landed (2026-08-04):** core envelope statement (§9) — required by [`PACKAGES.md`](../PACKAGES.md) §6's envelope row ("required, not implied"). No object-model or validator change; a declaration this package already satisfied by construction.
+
 ---
 
-## 10. References
+## 11. References
 
 - [`PACKAGES.md`](../PACKAGES.md) — the mechanism this package is shipped under: where a package is declared, the reversibility contract, absence-is-silence, what a package's spec must state.
+- [`CONTRACT.md`](../CONTRACT.md) §2, §6, §7 — the core envelope (header, admission record, lifecycle) this package's objects do not carry (§9).
 - [`IDS_AND_REFERENCES.md`](../IDS_AND_REFERENCES.md) §1 — the core id grammar this package's grammar (§2.2) is disjoint from.
 - [`MANIFEST.md`](../MANIFEST.md) §2 — the `packages:` field on `transitrix.yaml`.
 - [`elements/15-requirement.md`](../elements/15-requirement.md) — the core `REQUIREMENT` type a `spec-object` may cite via `Transitrix.CanonRef` (§3).

--- a/packages/ingest-cli/README.md
+++ b/packages/ingest-cli/README.md
@@ -45,6 +45,7 @@ transitrix-ingest <command> [args]
 | `resolve-placement <TYPE>` | ✅ | Print a TYPE's `ELEMENT_PRIMITIVES.md` §4 materialisation mode + layer + folder. |
 | `workflow-status [org-root]` | ✅ | Report every human gate's phase + count — ADR/WI status, canon element status, REQUIREMENT/CONSTRAINT review-overdue, ingest batches awaiting review, reg-intel digests awaiting review. Read-only; phases and counts only, no age/time. `[--out <path>] [--format md\|yaml] [--data-free]`. |
 | `check-placement [org-root]` | ✅ | Flag admitted elements sitting outside their §4 folder (read-only over `canon/`). |
+| `check-packages [org-root]` | ✅ | Validate `packages:` declarations (`PKG-001`/`PKG-002`, `PACKAGES.md` §8) and run each declared package's own validator entry point, if present — package-agnostic discovery, never package-specific logic (`PACKAGES.md` §4.2, §7). |
 
 ## Multi-batch naming
 
@@ -68,6 +69,7 @@ packages/ingest-cli/
     field-artefact.mjs # emit a field artefact + proposed source_quality
     coverage.mjs       # resolve coverage_profile (preset/custom) + classify in/out
     coverage-presets.mjs # shipped preset membership (COVERAGE_PROFILES §3/§3.1)
+    packages.mjs       # parse `packages:` declarations, PKG-001/PKG-002, validator-entry-point discovery (PACKAGES.md)
     placement.mjs      # TYPE -> materialisation mode/layer/folder (ELEMENT_PRIMITIVES §4)
     validate.mjs       # candidate contract checks (in code) + candidate loader
     review-queue.mjs   # assemble + emit the human review queue

--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -26,12 +26,13 @@ import { validateCandidate, loadCandidates } from './src/validate.mjs';
 import { readCoverageProfile, parseProfileDecl } from './src/coverage.mjs';
 import { buildReviewQueue, writeReviewQueue } from './src/review-queue.mjs';
 import { resolveBatchPath } from './src/batch-path.mjs';
-import { dump } from './src/yaml.mjs';
+import { dump, readTopScalar } from './src/yaml.mjs';
 import { buildProfileSuggestion } from './src/suggest-profile.mjs';
 import { emitCandidates } from './src/emit-candidates.mjs';
 import { emitCodexArtefact } from './src/codex-artefact.mjs';
 import { resolvePlacement, checkCanonPlacement } from './src/placement.mjs';
 import { repoCheck } from './src/repo-check.mjs';
+import { parsePackagesDecl, validatePackagesDecl, runPackageValidators } from './src/packages.mjs';
 import { checkStale } from './src/check-stale.mjs';
 import { computeWorkflowStatus, renderMarkdown, toReportObject } from './src/workflow-status.mjs';
 import { runPrivacyScan, parsePrivacyGateConfig } from './src/privacy-scan.mjs';
@@ -89,6 +90,8 @@ function usage() {
     '  suggest-profile <candidates-dir>  Propose a coverage-profile delta for out-of-profile TYPEs (read-only; prints to stdout)',
     '  repo-check [org-root]          Data-free health report (version, profile, zone/TYPE counts, integrity flags); read-only',
     '  check-placement [org-root]     Flag admitted elements sitting outside their ELEMENT_PRIMITIVES §4 folder',
+    '  check-packages [org-root]      Validate `packages:` declarations (PKG-001/PKG-002) and run each',
+    '                                 declared package\'s own validator entry point, if present (PACKAGES.md §4.2, §7)',
     '  check-stale [org-root]         List REQUIREMENT/CONSTRAINT elements whose next_review_at has passed (REQ-STALE-001)',
     '  workflow-status [org-root]     Report every human gate\'s phase + count (ADR/WI/canon/overdue/ingest batch); read-only',
     '                 [--out <path>] [--format md|yaml] [--data-free]',
@@ -390,6 +393,44 @@ async function cmdResolvePlacement(args) {
   return 0;
 }
 
+// Validate `packages:` declarations and run each declared package's own
+// validator entry point, if present. Package-agnostic (PACKAGES.md §4.2):
+// this command never contains logic specific to any one package — it parses
+// the declaration, checks shape/typo/compat (PKG-001/PKG-002), resolves each
+// entry's declared entry point, and runs it if it exists. A repo declaring no
+// packages reports that and exits 0 — every other command's output is
+// unaffected by this one (§5 absence is silence).
+async function cmdCheckPackages(args) {
+  const { _ } = parseArgs(args);
+  const orgRoot = _[0]
+    ? (await findOrgRoot(resolve(_[0])) || resolve(_[0]))
+    : (await findOrgRoot(process.cwd()));
+  if (!orgRoot) { console.error('check-packages: not inside a Transitrix workspace (no _intake/ found); pass <org-root>.'); return 2; }
+
+  const text = await readManifestText(orgRoot);
+  const entries = parsePackagesDecl(text || '');
+  if (entries.length === 0) {
+    console.log('check-packages  no packages declared — nothing to check (PACKAGES.md §5, absence is silence).');
+    return 0;
+  }
+
+  const methodologyVersion = text ? readTopScalar(text, 'methodology_version') : null;
+  const findings = validatePackagesDecl(entries, { methodologyVersion });
+  for (const f of findings) console.error(`  ${f.rule}  ${f.name ? `"${f.name}": ` : ''}${f.message}`);
+
+  const validEntries = entries.filter((e) => e.kind !== 'malformed');
+  const results = await runPackageValidators(orgRoot, validEntries);
+  for (const r of results) {
+    if (!r.ran) console.log(`  ${r.name}  validator entry point not present — skipped (absence is silence)`);
+    else console.log(`  ${r.name}  validator ${r.ok ? 'passed' : 'FAILED'}${r.output ? `\n    ${r.output.split('\n').join('\n    ')}` : ''}`);
+  }
+
+  const ranCount = results.filter((r) => r.ran).length;
+  const failedCount = results.filter((r) => r.ran && !r.ok).length;
+  console.log(`\ncheck-packages  ${entries.length} package(s) declared; ${findings.length} declaration finding(s); ${ranCount} validator(s) ran, ${failedCount} failed.`);
+  return (findings.length > 0 || failedCount > 0) ? 1 : 0;
+}
+
 // List REQUIREMENT / CONSTRAINT files whose next_review_at is in the past
 // (REQ-STALE-001; 15-requirement.md §2.3, §4). Read-only over canon/.
 async function cmdCheckStale(args) {
@@ -483,6 +524,7 @@ async function main(argv) {
     case 'suggest-profile': return cmdSuggestProfile(args);
     case 'repo-check':      return cmdRepoCheck(args);
     case 'check-placement': return cmdCheckPlacement(args);
+    case 'check-packages':  return cmdCheckPackages(args);
     case 'check-stale':     return cmdCheckStale(args);
     case 'workflow-status': return cmdWorkflowStatus(args);
     case 'resolve-placement': return cmdResolvePlacement(args);

--- a/packages/ingest-cli/src/coverage.mjs
+++ b/packages/ingest-cli/src/coverage.mjs
@@ -22,7 +22,7 @@ import { PRESETS, PRESET_NAMES, LAYERS } from './coverage-presets.mjs';
 // ── Value cleaning ───────────────────────────────────────────────
 
 // Trim, strip a trailing ` # comment`, and unquote a scalar value.
-function clean(v) {
+export function clean(v) {
   if (v === null || v === undefined) return null;
   let s = String(v).trim();
   const h = s.indexOf(' #');
@@ -33,7 +33,7 @@ function clean(v) {
 
 // Parse a YAML inline list `[A, B]` / `[]` into an array. Returns null if `v` is not
 // a bracketed list (so the caller can treat the value as block-style).
-function parseInlineList(v) {
+export function parseInlineList(v) {
   let s = String(v).trim();
   if (!s.startsWith('[')) return null;
   s = s.replace(/^\[/, '').replace(/\][ \t]*(#.*)?$/, '').trim();

--- a/packages/ingest-cli/src/packages.mjs
+++ b/packages/ingest-cli/src/packages.mjs
@@ -1,0 +1,230 @@
+// Domain-package declaration parsing, PKG-001/PKG-002 validation, and
+// validator-entry-point discovery (notations/PACKAGES.md §1, §7, §4.2).
+//
+// Two declared classes, per PACKAGES.md §7:
+//   - shipped      — a bare `packages:` list entry naming a package the pinned
+//                     methodology_version ships (§7.1). Its validator entry
+//                     point is looked up in SHIPPED_PACKAGES below — a plain
+//                     name -> path table, the same posture as
+//                     coverage-presets.mjs's name -> membership table. This
+//                     file never encodes what a shipped package's validator
+//                     checks, only where it lives.
+//   - external     — a map entry (`name`, `version`, `compatible_with`,
+//                     `validator`) declaring a package maintained outside a
+//                     core release (§7.2). `validator` is a path, relative to
+//                     the adopter repo root, to the package's own entry
+//                     point script — declared by the adopter, not core.
+//
+// Discovery is package-agnostic (§4.2): this module resolves a path and, if
+// it exists, runs it as a subprocess. It never parses a validator's checks or
+// output beyond exit code + stdout — the same boundary coverage.mjs keeps
+// around a coverage preset's membership, never its meaning.
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { clean, parseInlineList } from './coverage.mjs';
+
+const execFileAsync = promisify(execFile);
+
+// Packages shipped with core (PACKAGES.md §7.1). A shipped package's own
+// validator ships as a separate npm package, never bundled into
+// @transitrix/ingest-cli (§4.2) — discovery only checks whether that npm
+// package happens to be installed in the adopter repo's node_modules/.
+export const SHIPPED_PACKAGES = {
+  reqif: {
+    npmPackage: '@transitrix/reqif-cli',
+    bin: 'reqif.mjs',
+    validatorArgs: (folder) => ['validate', folder],
+  },
+};
+
+export const SHIPPED_PACKAGE_NAMES = new Set(Object.keys(SHIPPED_PACKAGES));
+
+const EXTERNAL_REQUIRED_FIELDS = ['name', 'version', 'compatible_with', 'validator'];
+
+// ── Declaration parsing ──────────────────────────────────────────
+
+// Parse the `packages:` declaration out of manifest text into normalised
+// entries. Each entry is one of:
+//   { kind: 'shipped',   name, raw }
+//   { kind: 'external',  name, version, compatible_with, validator, distribution, raw }
+//   { kind: 'malformed', raw, reason }
+// Zero-dependency, purpose-built reader for this one constrained shape (same
+// posture as coverage.mjs's parseProfileDecl) — not a general YAML parser.
+export function parsePackagesDecl(text) {
+  if (typeof text !== 'string') return [];
+  const norm = text.replace(/\r\n/g, '\n');
+
+  // Inline form: `packages: [reqif]` / `packages: []`.
+  const inlineM = norm.match(/^packages:[ \t]*(\[[^\]]*\])[ \t]*(#.*)?$/m);
+  if (inlineM) {
+    return parseInlineList(inlineM[1]).map((name) => ({ kind: 'shipped', name, raw: name }));
+  }
+
+  // Block form: `packages:\n  - reqif\n  - name: foo\n    version: "1.0.0"\n    ...`.
+  const lines = norm.split('\n');
+  const idx = lines.findIndex((l) => /^packages:[ \t]*$/.test(l));
+  if (idx < 0) return [];
+
+  const block = [];
+  for (let i = idx + 1; i < lines.length; i++) {
+    const ln = lines[i];
+    if (ln.trim() === '' || ln.trim().startsWith('#')) continue;
+    if (/^\S/.test(ln)) break; // next top-level key ends the block
+    block.push(ln);
+  }
+
+  const entries = [];
+  let cur = null;
+  const flush = () => { if (cur) { entries.push(finalizeEntry(cur)); cur = null; } };
+
+  for (const ln of block) {
+    const itemM = ln.match(/^[ \t]*-[ \t]*(.*)$/);
+    if (itemM) {
+      flush();
+      const rest = itemM[1].trim();
+      if (!rest) { cur = { fields: {}, raw: '' }; continue; }
+      const kv = rest.match(/^([a-z_]+):[ \t]*(.*)$/);
+      if (kv) {
+        cur = { fields: {}, raw: rest };
+        if (kv[2].trim()) cur.fields[kv[1]] = clean(kv[2]);
+      } else {
+        entries.push({ kind: 'shipped', name: clean(rest), raw: rest });
+      }
+      continue;
+    }
+    // Continuation line inside a map item: `    key: value`.
+    const kv = ln.match(/^[ \t]+([a-z_]+):[ \t]*(.*)$/);
+    if (kv && cur) {
+      cur.fields[kv[1]] = clean(kv[2]);
+      cur.raw += `, ${kv[1]}: ${kv[2].trim()}`;
+    }
+  }
+  flush();
+  return entries;
+}
+
+function finalizeEntry(item) {
+  const f = item.fields;
+  if (!f.name) return { kind: 'malformed', raw: item.raw, reason: 'map entry under `packages:` is missing required key `name`' };
+  const missing = EXTERNAL_REQUIRED_FIELDS.filter((k) => !f[k]);
+  if (missing.length > 0) {
+    return { kind: 'malformed', raw: item.raw, name: f.name, reason: `externally-distributed package "${f.name}" is missing required field(s): ${missing.join(', ')}` };
+  }
+  return {
+    kind: 'external',
+    name: f.name,
+    version: f.version,
+    compatible_with: f.compatible_with,
+    validator: f.validator,
+    distribution: f.distribution || 'external',
+    raw: item.raw,
+  };
+}
+
+// ── PKG-001 / PKG-002 validation ─────────────────────────────────
+
+// Minimal semver comparator — major.minor.patch only (no pre-release), which
+// is all methodology_version and compatible_with ever carry.
+function parseSemver(v) {
+  const m = String(v).trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function cmpSemver(a, b) {
+  for (let i = 0; i < 3; i++) { if (a[i] !== b[i]) return a[i] - b[i]; }
+  return 0;
+}
+
+// `compatible_with` is a space-separated list of comparator terms, e.g.
+// ">=3.1.0 <4.0.0". Every term must hold for the version to satisfy the range.
+function satisfiesRange(version, range) {
+  const v = parseSemver(version);
+  if (!v) return null; // version itself unparseable — caller reports separately
+  const terms = String(range).trim().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return null;
+  for (const term of terms) {
+    const m = term.match(/^(>=|<=|>|<|=)(\d+\.\d+\.\d+)/);
+    if (!m) return null; // malformed term — caller reports separately
+    const bound = parseSemver(m[2]);
+    const c = cmpSemver(v, bound);
+    const ok = { '>=': c >= 0, '<=': c <= 0, '>': c > 0, '<': c < 0, '=': c === 0 }[m[1]];
+    if (!ok) return false;
+  }
+  return true;
+}
+
+// Validate parsed `packages:` entries. Returns [{ rule: 'PKG-001'|'PKG-002', name?, message }].
+// `methodologyVersion` is the repo's own pinned core version (for PKG-002).
+export function validatePackagesDecl(entries, { methodologyVersion } = {}) {
+  const findings = [];
+  for (const e of entries) {
+    if (e.kind === 'malformed') {
+      findings.push({ rule: 'PKG-001', name: e.name, message: e.reason });
+      continue;
+    }
+    if (e.kind === 'shipped') {
+      if (!SHIPPED_PACKAGE_NAMES.has(e.name)) {
+        findings.push({
+          rule: 'PKG-001',
+          name: e.name,
+          message: `"${e.name}" is not a package shipped by the pinned methodology_version (known: ${[...SHIPPED_PACKAGE_NAMES].join(', ') || '(none)'}) — a typo, or this is meant to be declared as an externally-distributed package (PACKAGES.md §7.2).`,
+        });
+      }
+      continue;
+    }
+    // external
+    if (!parseSemver(e.version)) {
+      findings.push({ rule: 'PKG-001', name: e.name, message: `externally-distributed package "${e.name}" has a malformed \`version\` ("${e.version}") — expected major.minor.patch.` });
+    }
+    const sat = methodologyVersion ? satisfiesRange(methodologyVersion, e.compatible_with) : null;
+    if (sat === null && e.compatible_with) {
+      findings.push({ rule: 'PKG-002', name: e.name, message: `externally-distributed package "${e.name}" has a malformed \`compatible_with\` range ("${e.compatible_with}") — expected comparator terms like ">=3.1.0 <4.0.0".` });
+    } else if (sat === false) {
+      findings.push({ rule: 'PKG-002', name: e.name, message: `externally-distributed package "${e.name}" declares compatible_with "${e.compatible_with}", which does not admit this repo's methodology_version "${methodologyVersion}".` });
+    }
+  }
+  return findings;
+}
+
+// ── Validator entry-point discovery ──────────────────────────────
+
+// Resolve each declared package's validator entry point, if present on disk.
+// Package-agnostic: never branches on package name beyond a name -> path
+// lookup, never inspects a validator's content.
+export function resolveValidatorEntryPoints(orgRoot, entries) {
+  return entries.map((e) => {
+    if (e.kind === 'malformed') return { name: e.name || '(malformed)', present: false };
+    if (e.kind === 'shipped') {
+      const reg = SHIPPED_PACKAGES[e.name];
+      if (!reg) return { name: e.name, present: false };
+      const npmParts = reg.npmPackage.split('/'); // e.g. ['@transitrix', 'reqif-cli']
+      const entryPoint = join(orgRoot, 'node_modules', ...npmParts, reg.bin);
+      return { name: e.name, present: existsSync(entryPoint), entryPoint, args: reg.validatorArgs(join(orgRoot, e.name)) };
+    }
+    const entryPoint = join(orgRoot, e.validator);
+    return { name: e.name, present: existsSync(entryPoint), entryPoint, args: [join(orgRoot, e.name)] };
+  });
+}
+
+// Run every present validator entry point as a subprocess
+// (`node <entryPoint> <args...>`). Core never parses the validator's checks —
+// only its exit code and stdout. An absent entry point is silently skipped
+// (§5 absence is silence extends to "declared but not installed/present").
+export async function runPackageValidators(orgRoot, entries) {
+  const resolved = resolveValidatorEntryPoints(orgRoot, entries);
+  const results = [];
+  for (const r of resolved) {
+    if (!r.present) { results.push({ name: r.name, ran: false }); continue; }
+    try {
+      const { stdout } = await execFileAsync(process.execPath, [r.entryPoint, ...r.args]);
+      results.push({ name: r.name, ran: true, ok: true, output: stdout.trim() });
+    } catch (err) {
+      results.push({ name: r.name, ran: true, ok: false, output: String(err.stdout || err.message || '').trim() });
+    }
+  }
+  return results;
+}

--- a/packages/ingest-cli/src/packages.test.mjs
+++ b/packages/ingest-cli/src/packages.test.mjs
@@ -1,0 +1,216 @@
+// Unit + fixture tests for src/packages.mjs (PACKAGES.md §1, §7, §4.2, §8).
+// Run: node --test packages/ingest-cli/src/packages.test.mjs
+//
+// parsePackagesDecl/validatePackagesDecl are exercised as pure functions (no
+// filesystem). resolveValidatorEntryPoints/runPackageValidators are exercised
+// against a throwaway fixture directory to prove the extension points for
+// real: an external package's declared validator actually runs when present,
+// and is silently skipped when absent.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parsePackagesDecl,
+  validatePackagesDecl,
+  resolveValidatorEntryPoints,
+  runPackageValidators,
+  SHIPPED_PACKAGES,
+} from './packages.mjs';
+
+// ── parsePackagesDecl ────────────────────────────────────────────
+
+test('parsePackagesDecl — positive: inline shipped-form list', () => {
+  const entries = parsePackagesDecl('transitrix: 1\npackages: [reqif]\n');
+  assert.deepEqual(entries, [{ kind: 'shipped', name: 'reqif', raw: 'reqif' }]);
+});
+
+test('parsePackagesDecl — positive: absent packages: key yields no entries', () => {
+  assert.deepEqual(parsePackagesDecl('transitrix: 1\nzones: [canon]\n'), []);
+});
+
+test('parsePackagesDecl — positive: empty inline list yields no entries', () => {
+  assert.deepEqual(parsePackagesDecl('packages: []\n'), []);
+});
+
+test('parsePackagesDecl — positive: block form mixing a shipped name and an external map', () => {
+  const text = [
+    'transitrix: 1',
+    'packages:',
+    '  - reqif',
+    '  - name: acme-widgets',
+    '    distribution: external',
+    '    version: "1.2.0"',
+    '    compatible_with: ">=3.1.0 <4.0.0"',
+    '    validator: "acme-widgets/validate.mjs"',
+    'zones: [canon]',
+    '',
+  ].join('\n');
+  const entries = parsePackagesDecl(text);
+  assert.equal(entries.length, 2);
+  assert.deepEqual(entries[0], { kind: 'shipped', name: 'reqif', raw: 'reqif' });
+  assert.equal(entries[1].kind, 'external');
+  assert.equal(entries[1].name, 'acme-widgets');
+  assert.equal(entries[1].version, '1.2.0');
+  assert.equal(entries[1].compatible_with, '>=3.1.0 <4.0.0');
+  assert.equal(entries[1].validator, 'acme-widgets/validate.mjs');
+});
+
+test('parsePackagesDecl — negative: an external map missing required fields is malformed, not silently dropped', () => {
+  const text = [
+    'packages:',
+    '  - name: acme-widgets',
+    '    version: "1.2.0"',
+    '',
+  ].join('\n');
+  const entries = parsePackagesDecl(text);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].kind, 'malformed');
+  assert.match(entries[0].reason, /compatible_with/);
+  assert.match(entries[0].reason, /validator/);
+});
+
+// ── validatePackagesDecl — PKG-001 / PKG-002 ─────────────────────
+
+test('validatePackagesDecl — positive: a shipped, known name produces no finding', () => {
+  const findings = validatePackagesDecl([{ kind: 'shipped', name: 'reqif' }], { methodologyVersion: '3.1.0' });
+  assert.deepEqual(findings, []);
+});
+
+test('validatePackagesDecl — negative: a typo in a shipped-form name is PKG-001, actionable', () => {
+  const findings = validatePackagesDecl([{ kind: 'shipped', name: 'reqiff' }], { methodologyVersion: '3.1.0' });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, 'PKG-001');
+  assert.match(findings[0].message, /reqiff/);
+  assert.match(findings[0].message, /not a package shipped/);
+});
+
+test('validatePackagesDecl — negative: a malformed block-form entry surfaces as PKG-001', () => {
+  const findings = validatePackagesDecl(
+    [{ kind: 'malformed', name: 'acme-widgets', reason: 'missing required field(s): validator' }],
+    { methodologyVersion: '3.1.0' },
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, 'PKG-001');
+});
+
+test('validatePackagesDecl — positive: an external package whose compatible_with admits methodology_version produces no finding', () => {
+  const findings = validatePackagesDecl(
+    [{ kind: 'external', name: 'acme-widgets', version: '1.2.0', compatible_with: '>=3.1.0 <4.0.0', validator: 'x/validate.mjs' }],
+    { methodologyVersion: '3.1.0' },
+  );
+  assert.deepEqual(findings, []);
+});
+
+test('validatePackagesDecl — negative: an external package whose compatible_with excludes methodology_version is PKG-002', () => {
+  const findings = validatePackagesDecl(
+    [{ kind: 'external', name: 'acme-widgets', version: '1.2.0', compatible_with: '>=4.0.0', validator: 'x/validate.mjs' }],
+    { methodologyVersion: '3.1.0' },
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, 'PKG-002');
+  assert.match(findings[0].message, /does not admit/);
+});
+
+test('validatePackagesDecl — negative: a malformed external version is PKG-001', () => {
+  const findings = validatePackagesDecl(
+    [{ kind: 'external', name: 'acme-widgets', version: 'not-a-version', compatible_with: '>=3.1.0', validator: 'x/validate.mjs' }],
+    { methodologyVersion: '3.1.0' },
+  );
+  assert.ok(findings.some((f) => f.rule === 'PKG-001' && /malformed \`version\`/.test(f.message)));
+});
+
+// ── resolveValidatorEntryPoints / runPackageValidators — fixture ─
+
+function makeFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'pkg-test-'));
+  return root;
+}
+
+test('resolveValidatorEntryPoints — positive: an external package validator present on disk resolves present:true', () => {
+  const root = makeFixture();
+  try {
+    mkdirSync(join(root, 'acme-widgets'), { recursive: true });
+    writeFileSync(join(root, 'acme-widgets', 'validate.mjs'), 'console.log("ok");\n');
+    const resolved = resolveValidatorEntryPoints(root, [
+      { kind: 'external', name: 'acme-widgets', validator: 'acme-widgets/validate.mjs' },
+    ]);
+    assert.equal(resolved.length, 1);
+    assert.equal(resolved[0].present, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveValidatorEntryPoints — negative: a declared but not-installed validator resolves present:false, not an error', () => {
+  const root = makeFixture();
+  try {
+    const resolved = resolveValidatorEntryPoints(root, [
+      { kind: 'external', name: 'acme-widgets', validator: 'acme-widgets/validate.mjs' },
+    ]);
+    assert.equal(resolved[0].present, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveValidatorEntryPoints — negative: a shipped package with no node_modules install resolves present:false', () => {
+  const root = makeFixture();
+  try {
+    const resolved = resolveValidatorEntryPoints(root, [{ kind: 'shipped', name: 'reqif' }]);
+    assert.equal(resolved[0].present, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('runPackageValidators — positive: a present external validator actually runs and reports pass', async () => {
+  const root = makeFixture();
+  try {
+    mkdirSync(join(root, 'acme-widgets'), { recursive: true });
+    writeFileSync(join(root, 'acme-widgets', 'validate.mjs'), 'process.exit(0);\n');
+    const results = await runPackageValidators(root, [
+      { kind: 'external', name: 'acme-widgets', validator: 'acme-widgets/validate.mjs' },
+    ]);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].ran, true);
+    assert.equal(results[0].ok, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('runPackageValidators — negative: a present external validator that exits non-zero is reported as a failure, not silently swallowed', async () => {
+  const root = makeFixture();
+  try {
+    mkdirSync(join(root, 'acme-widgets'), { recursive: true });
+    writeFileSync(join(root, 'acme-widgets', 'validate.mjs'), 'console.error("bad object"); process.exit(1);\n');
+    const results = await runPackageValidators(root, [
+      { kind: 'external', name: 'acme-widgets', validator: 'acme-widgets/validate.mjs' },
+    ]);
+    assert.equal(results[0].ran, true);
+    assert.equal(results[0].ok, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('runPackageValidators — negative: a declared but absent validator is skipped (ran:false), not attempted', async () => {
+  const root = makeFixture();
+  try {
+    const results = await runPackageValidators(root, [
+      { kind: 'external', name: 'acme-widgets', validator: 'acme-widgets/validate.mjs' },
+    ]);
+    assert.equal(results[0].ran, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('SHIPPED_PACKAGES — positive: reqif is registered with a name -> path lookup only (no reqif-specific check logic)', () => {
+  assert.ok(SHIPPED_PACKAGES.reqif);
+  assert.equal(typeof SHIPPED_PACKAGES.reqif.npmPackage, 'string');
+  assert.equal(typeof SHIPPED_PACKAGES.reqif.bin, 'string');
+});

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -35,6 +35,7 @@ const REPO_ROOT = join(dirname(__filename), '..');
 const CATALOGUE_PATH = join(REPO_ROOT, 'notations', 'README.md');
 const EXAMPLES_DIR = join(REPO_ROOT, 'notations', 'examples');
 const NOTATIONS_DIR = join(REPO_ROOT, 'notations');
+const PACKAGES_SPEC_DIR = join(REPO_ROOT, 'notations', 'packages');
 const VERSION_SOT = join(REPO_ROOT, 'notations', 'CURRENT_VERSION.yaml');
 
 // Files that legitimately carry a non-SoT methodology_version (placeholders).
@@ -383,6 +384,45 @@ async function checkNoStandardIdentifiers(failures) {
   }
 }
 
+// --- PKGDOC1: every package spec states its core-envelope answer -----------
+//
+// PACKAGES.md §6 requires each shipped package's own spec to state, plainly,
+// whether its objects carry the core envelope — "required, not implied";
+// silence is not a valid value. This is a doc-lint invariant, not a runtime
+// one: an adopter repo never carries a package's spec, only its data, so
+// there is nothing for @transitrix/ingest-cli to check here — this is
+// checked once, at the source, over notations/packages/*.md.
+
+// Pure — no I/O. Returns null when `text` states a plain Yes/No core-envelope
+// answer (citing CONTRACT.md when the answer is "No"), or a reason string
+// when it doesn't.
+export function checkPackageEnvelopeStatement(text) {
+  const headingRe = /^##\s+\d+\.\s+Core envelope statement\s*$/m;
+  const m = text.match(headingRe);
+  if (!m) return 'missing a "## N. Core envelope statement" section (PACKAGES.md §6\'s required envelope row).';
+  const rest = text.slice(text.indexOf(m[0]) + m[0].length);
+  const nextHeadingIdx = rest.search(/^##\s/m);
+  const section = nextHeadingIdx >= 0 ? rest.slice(0, nextHeadingIdx) : rest;
+  const answerM = section.match(/\*\*(Yes|No)\.\*\*/);
+  if (!answerM) return 'Core envelope statement section does not open with a plain **Yes.**/**No.** answer.';
+  if (answerM[1] === 'No' && !/CONTRACT\.md/.test(section)) {
+    return 'Core envelope statement answers "No" but does not cite CONTRACT.md for why not.';
+  }
+  return null;
+}
+
+async function checkPackageEnvelopeStatements(failures) {
+  let entries;
+  try { entries = await readdir(PACKAGES_SPEC_DIR, { withFileTypes: true }); } catch { return; }
+  for (const e of entries) {
+    if (!e.isFile() || !e.name.endsWith('.md')) continue;
+    const abs = join(PACKAGES_SPEC_DIR, e.name);
+    const text = await readFile(abs, 'utf8');
+    const reason = checkPackageEnvelopeStatement(text);
+    if (reason) failures.push({ check: 'PKGDOC1', message: `${relPosix(abs)}: ${reason}` });
+  }
+}
+
 // --- main ------------------------------------------------------------------
 
 async function main() {
@@ -395,6 +435,7 @@ async function main() {
     await checkVersion(failures);
     await checkNotationCounts(failures);
     await checkNoStandardIdentifiers(failures);
+    await checkPackageEnvelopeStatements(failures);
   } catch (e) {
     console.error(`error: ${e.message}`);
     process.exit(2);

--- a/scripts/check-notations.test.mjs
+++ b/scripts/check-notations.test.mjs
@@ -11,6 +11,7 @@ import {
   deriveClassCounts,
   parseStatedViewCounts,
   findStandardIdentifierEmissions,
+  checkPackageEnvelopeStatement,
 } from './check-notations.mjs';
 
 test('deriveClassCounts — positive: counts non-deprecated specs per class', () => {
@@ -96,4 +97,51 @@ test('findStandardIdentifierEmissions — negative: a documented ieee-… defaul
     '| `view.standard` | no | string | `ieee-830` | default document-structure profile |',
   ].join('\n');
   assert.deepEqual(findStandardIdentifierEmissions(text), ['ieee-830']);
+});
+
+test('checkPackageEnvelopeStatement — positive: a "No." answer citing CONTRACT.md passes', () => {
+  const text = [
+    '## 9. Core envelope statement',
+    '',
+    '**No.** This package does not carry CONTRACT.md\'s envelope on any object kind.',
+    '',
+    '## 10. Evolution',
+  ].join('\n');
+  assert.equal(checkPackageEnvelopeStatement(text), null);
+});
+
+test('checkPackageEnvelopeStatement — positive: a "Yes." answer passes without needing a CONTRACT.md citation', () => {
+  const text = [
+    '## 6. Core envelope statement',
+    '',
+    '**Yes.** Every object carries the core envelope, per CONTRACT.md §2/§6/§7.',
+  ].join('\n');
+  assert.equal(checkPackageEnvelopeStatement(text), null);
+});
+
+test('checkPackageEnvelopeStatement — negative: no section at all fails', () => {
+  const text = '## 5. Validation rules\n\nsome rules\n';
+  assert.match(checkPackageEnvelopeStatement(text), /missing a "## N\. Core envelope statement" section/);
+});
+
+test('checkPackageEnvelopeStatement — negative: a section present but silent on yes/no fails', () => {
+  const text = [
+    '## 9. Core envelope statement',
+    '',
+    'This package interacts with the core envelope in some ways.',
+    '',
+    '## 10. Evolution',
+  ].join('\n');
+  assert.match(checkPackageEnvelopeStatement(text), /does not open with a plain/);
+});
+
+test('checkPackageEnvelopeStatement — negative: a "No." answer that never cites CONTRACT.md fails', () => {
+  const text = [
+    '## 9. Core envelope statement',
+    '',
+    '**No.** This package just does not.',
+    '',
+    '## 10. Evolution',
+  ].join('\n');
+  assert.match(checkPackageEnvelopeStatement(text), /does not cite CONTRACT\.md/);
 });


### PR DESCRIPTION
## Summary
- Adds an externally-distributed package class to `PACKAGES.md` (§1, §7.2), declared with its own version and a `compatible_with` range checked against the pinned `methodology_version` (`PKG-002`).
- Adds package-agnostic validator-entry-point discovery: `ingest-cli`'s new `check-packages` command resolves each declared package's validator path and runs it as a subprocess, never inspecting what it checks.
- Adds a required §6 envelope-statement row — every package spec must say plainly whether its objects carry `CONTRACT.md`'s core envelope, and why not if not. `reqif.md` states its own answer (No, citing `CONTRACT.md`) as the worked case. `check-notations.mjs` gains a `PKGDOC1` doc-lint check enforcing the row is never silent.

## Test plan
- [x] `node --test packages/ingest-cli/src/packages.test.mjs` — 18 passing
- [x] `node --test scripts/check-notations.test.mjs` — 15 passing
- [x] `node scripts/check-notations.mjs` — clean (only pre-existing findings from an unrelated concurrent worktree)