### PR TITLE
feat(ingest): review-queue semantic_links for cross-candidate edges

### DIFF
--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -301,7 +301,12 @@ async function cmdReviewQueue(args) {
   const suggPath = join(stageDir(r.orgRoot, 'processing'), 'relation-suggestions.json');
   try { suggestions = JSON.parse(await readFile(suggPath, 'utf8')); } catch { /* none */ }
 
-  const queue = await buildReviewQueue({ orgRoot: r.orgRoot, candidatesDir: r.dir, profile: r.profile, suggestions });
+  // Pick up semantic links emitted by `emit-candidates`, if present.
+  let semanticLinks = [];
+  const semanticLinksPath = join(stageDir(r.orgRoot, 'processing'), 'semantic-links.json');
+  try { semanticLinks = JSON.parse(await readFile(semanticLinksPath, 'utf8')); } catch { /* none */ }
+
+  const queue = await buildReviewQueue({ orgRoot: r.orgRoot, candidatesDir: r.dir, profile: r.profile, suggestions, semanticLinks });
   const out = flags.out
     ? resolve(flags.out)
     : await resolveBatchPath({ processingDir: stageDir(r.orgRoot, 'processing'), filename: 'review-queue.yaml', scope: flags.scope, content: dump(queue) });
@@ -311,6 +316,7 @@ async function cmdReviewQueue(args) {
   console.log(`review queue  ->  ${out}`);
   console.log(`  coverage_profile: ${queue.coverage_profile}`);
   console.log(`  ${queue.field_artefacts.length} field artefact(s), ${queue.candidates.length} candidate(s) (${flagged} flagged), ${queue.relation_suggestions.length} relation suggestion(s).`);
+  if (queue.semantic_links) console.log(`  ${queue.semantic_links.length} semantic link(s) — review-only, no closed REL kind yet.`);
   if (queue.excluded_admitted.length) {
     console.log(`  ${queue.excluded_admitted.length} candidate(s) excluded — already admitted to canon (idempotent re-run).`);
   }
@@ -338,6 +344,9 @@ async function cmdEmitCandidates(args) {
     console.log(`emit-candidates  derived_from ${res.derivedFrom}`);
     console.log(`  ${res.candidates.length} candidate(s) -> ${res.dir}`);
     console.log(`  ${res.suggestions.length} relation suggestion(s) held back (relation-conservative) -> ${res.suggPath}`);
+    if (res.semanticLinks && res.semanticLinks.length) {
+      console.log(`  ${res.semanticLinks.length} semantic link(s) (no closed REL kind yet) -> ${res.semanticLinksPath}`);
+    }
     if (res.unresolved && res.unresolved.written.length) {
       console.log(`  ${res.unresolved.written.length} untyped object(s) parked (non-admitted) -> ${res.unresolved.dir}`);
     }

--- a/packages/ingest-cli/src/emit-candidates.mjs
+++ b/packages/ingest-cli/src/emit-candidates.mjs
@@ -38,6 +38,10 @@ function safeName(s) {
 export function shapeCandidates(derivedFrom, result) {
   const candidates = [];
   const suggestions = [];
+  // Review-only edges the source states but for which no closed REL kind exists
+  // (17-relations.md §3) — never shaped into a relation candidate, never admitted.
+  // Passed through as-is; the extraction prompt is the one place `link_type` is chosen.
+  const semanticLinks = [...(result.semantic_links || [])];
 
   for (const el of result.elements || []) {
     const c = {
@@ -103,7 +107,7 @@ export function shapeCandidates(derivedFrom, result) {
     candidates.push(c);
   }
 
-  return { candidates, suggestions };
+  return { candidates, suggestions, semanticLinks };
 }
 
 // Surface ID-grammar violations at emit time (F14): an element/assertion id or a
@@ -166,7 +170,7 @@ export async function emitCandidates({ orgRoot, fieldArtefactPath, resultPath, c
   try { result = JSON.parse(await readFile(resultPath, 'utf8')); }
   catch (err) { throw new Error(`could not read extraction result ${resultPath}: ${err.message}`); }
 
-  const { candidates, suggestions } = shapeCandidates(derivedFrom, result);
+  const { candidates, suggestions, semanticLinks } = shapeCandidates(derivedFrom, result);
   const warnings = collectIdWarnings(candidates);
 
   // Entity-match proposals (F8): for each element candidate whose name matches an
@@ -203,6 +207,10 @@ export async function emitCandidates({ orgRoot, fieldArtefactPath, resultPath, c
   const suggPath = join(resolve(orgRoot), '_intake', 'processing', 'relation-suggestions.json');
   await writeFile(suggPath, JSON.stringify(suggestions, null, 2) + '\n', 'utf8');
 
+  // Semantic links feed the review queue the same way — review-only, never candidates.
+  const semanticLinksPath = join(resolve(orgRoot), '_intake', 'processing', 'semantic-links.json');
+  await writeFile(semanticLinksPath, JSON.stringify(semanticLinks, null, 2) + '\n', 'utf8');
+
   // Mechanism 2 (CONTRACT §13): standalone objects ingestion could not TYPE are parked,
   // non-admitted, in the shared canon/unresolved/ holding area — never dropped, never
   // guessed. The CLI emits `proposed`-untyped records (no admission record); a human
@@ -214,7 +222,7 @@ export async function emitCandidates({ orgRoot, fieldArtefactPath, resultPath, c
   });
   const unresolved = await writeUnresolved(orgRoot, records);
 
-  return { derivedFrom, dir, candidates, suggestions, suggPath, warnings,
+  return { derivedFrom, dir, candidates, suggestions, suggPath, semanticLinks, semanticLinksPath, warnings,
            unresolved: { ...unresolved, skipped: skipped.length } };
 }
 

--- a/packages/ingest-cli/src/review-queue.mjs
+++ b/packages/ingest-cli/src/review-queue.mjs
@@ -1,8 +1,9 @@
 // `review-queue` — assemble the human gate for a batch. Lists the field artefacts
 // referenced by the candidates (with their PROPOSED source_quality, for the human to
 // confirm), every candidate with its derived_from / extraction_confidence / coverage
-// + validation flags, and any below-threshold relation suggestions. Emitted as YAML
-// (write-only via the dumper). NOTHING here is admitted to canon.
+// + validation flags, any below-threshold relation suggestions, and any semantic links
+// (typed edges with no closed REL kind yet). Emitted as YAML (write-only via the
+// dumper). NOTHING here is admitted to canon.
 
 import { readFile, writeFile, access, readdir, mkdir } from 'node:fs/promises';
 import { join, resolve, dirname } from 'node:path';
@@ -74,7 +75,7 @@ async function readSourceArtefact(orgRoot, id) {
   };
 }
 
-export async function buildReviewQueue({ orgRoot, candidatesDir, profile, suggestions = [] }) {
+export async function buildReviewQueue({ orgRoot, candidatesDir, profile, suggestions = [], semanticLinks = [] }) {
   const loaded = await loadCandidates(candidatesDir);
   // Read (never write) canon so the queue is idempotent against it: a candidate that
   // already passed the human gate is excluded, not re-listed for re-approval.
@@ -148,6 +149,7 @@ export async function buildReviewQueue({ orgRoot, candidatesDir, profile, sugges
     candidates,
     excluded_admitted,
     relation_suggestions: suggestions,
+    ...(semanticLinks.length ? { semantic_links: semanticLinks } : {}),
     gate: { admits_to_canon: false },
   };
 }

--- a/transitrix/skills/ingest/prompts/README.md
+++ b/transitrix/skills/ingest/prompts/README.md
@@ -25,6 +25,10 @@ Each prompt is self-contained (it can be fed to an agent independently) and emit
     { "rel_kind": "stakeholding", "from": "STAKEHOLDER-CFO-1", "to": "GOAL-RET-1",
       "extraction_confidence": "high", "extraction_notes": "..." }
   ],
+  "semantic_links": [
+    { "link_type": "requirement_dependency", "from": "REQUIREMENT-A-1", "to": "REQUIREMENT-B-1",
+      "confidence": "medium", "rationale": "source states A cannot be met until B is satisfied, but no closed REL kind exists for this edge" }
+  ],
   "unresolved": [
     { "ingest_field": "materials", "related_to": ["PRODUCT-WIDGET-1"],
       "data": ["Steel 316L", "Rubber gasket B12"] }
@@ -37,6 +41,7 @@ Each prompt is self-contained (it can be fed to an agent independently) and emit
 - **Two axes, never merged.** `extraction_confidence` (`high|medium|low`) answers *"did I read the document correctly"* — it is a review flag on the candidate, **separate** from the field artefact's `source_quality` (trust in the *source*). A prompt **never** outputs `source_quality`; that lives on the field artefact and is the CLI's / human's concern.
 - **Entity-strong, relation-conservative.** Extract entities readily. For relations, only mark `extraction_confidence: high` when the source states the relation plainly; otherwise mark `medium`/`low` and let the pipeline hold it back as a *suggestion* (the CLI only promotes `high` relations to candidates).
 - **Canonical IDs.** Every element carries an ID per `<TYPE>-[<middle>-]<INTEGER>` ([IDS §1](https://raw.githubusercontent.com/transitrix/methodology/main/notations/IDS_AND_REFERENCES.md)); relations reference element IDs in `from`/`to`. Never invent a TYPE or a relation kind — use the registries.
+- **Semantic links, not invented relation kinds.** When the source plainly states a typed edge between two candidates but no closed REL kind covers it ([17-relations.md §3](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/17-relations.md)), emit it as a `semantic_links[]` entry (`link_type`, `from`, `to`, `confidence`, `rationale`) instead of forcing it into `relations[]` with a made-up `rel_kind`. Semantic links are review-only — the CLI never shapes them into relation candidates and they are never admitted to canon.
 - **Propose, never admit.** The agent reads the field artefact body only (not its admission record), extracts, and stops. Admission to canon is a separate human gate; the CLI writes candidates as `admitted_to: pending`.
 - **Zero information loss — never drop, never guess (CONTRACT §12 / §13).** A source field that maps to no schema field of a *known* entity goes in that element's optional **`extensions:`** map (an open key-value bag, carried verbatim to the admitted entity). A *standalone object whose TYPE you cannot determine* — not merely an extra field on a known entity — goes in the top-level **`unresolved[]`** array, each item `{ ingest_field, data, related_to? }`; the CLI parks it in `canon/unresolved/` for a human to resolve. Never invent a TYPE to make an object fit, and never silently discard data — when in doubt between an `extensions:` key and an `unresolved[]` object, prefer `unresolved[]`.
 

--- a/transitrix/skills/ingest/schemas/review-queue.schema.json
+++ b/transitrix/skills/ingest/schemas/review-queue.schema.json
@@ -125,6 +125,22 @@
         "additionalProperties": true
       }
     },
+    "semantic_links": {
+      "type": "array",
+      "description": "Optional. Review-only typed edges between candidates (or between a candidate and an admitted element) for which no closed REL kind exists (17-relations.md §3) — distinct from relation_suggestions, which holds back a real rel_kind on low confidence. A semantic link is never shaped into a relation candidate and never admitted to canon; once a canonical relation kind covers the edge, re-extract it as a relation candidate instead. Present only when at least one link exists.",
+      "items": {
+        "type": "object",
+        "required": ["link_type", "from", "to", "confidence", "rationale"],
+        "properties": {
+          "link_type": { "type": "string", "description": "Free-form label for the suspected edge (e.g. 'requirement_dependency'). Not a closed REL kind — never validated against 17-relations.md, never written to a rel_kind field." },
+          "from": { "type": "string", "description": "Source endpoint — a candidate ref or canonical element ID." },
+          "to": { "type": "string", "description": "Target endpoint — a candidate ref or canonical element ID." },
+          "confidence": { "type": "string", "enum": ["high", "medium", "low"] },
+          "rationale": { "type": "string", "description": "Why the extractor suspects this edge — the reviewer's basis for confirming or discarding it." }
+        },
+        "additionalProperties": true
+      }
+    },
     "gate": {
       "type": "object",
       "description": "Invariant statement for auditors and tooling: this skill admits nothing.",

--- a/transitrix/skills/ingest/tests/fixtures/extraction-result.json
+++ b/transitrix/skills/ingest/tests/fixtures/extraction-result.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Fixture extraction result — a canned stand-in for what the agent produces by running prompts/ over the sample interview. Used by the deterministic integrity test so emit-candidates has an input without an LLM. Mixes a high relation (-> candidate) and a medium relation (-> held-back suggestion).",
+  "_comment": "Fixture extraction result — a canned stand-in for what the agent produces by running prompts/ over the sample interview. Used by the deterministic integrity test so emit-candidates has an input without an LLM. Mixes a high relation (-> candidate), a medium relation (-> held-back suggestion), and a semantic_links entry (-> review-only edge, no closed REL kind).",
   "elements": [
     { "id": "GOAL-RETENTION-1", "name": "Improve customer retention above 90%", "element_type": "GOAL", "extraction_confidence": "high" },
     { "id": "DRIVER-CHURN-1", "name": "Rising customer churn", "element_type": "DRIVER", "extraction_confidence": "medium", "extraction_notes": "driver behind the retention goal" },
@@ -10,5 +10,9 @@
   "relations": [
     { "rel_kind": "stakeholding", "from": "STAKEHOLDER-OPS-1", "to": "GOAL-RETENTION-1", "extraction_confidence": "high", "extraction_notes": "accountable owner stated the goal directly" },
     { "rel_kind": "contributes_to", "from": "DRIVER-CHURN-1", "to": "GOAL-RETENTION-1", "extraction_confidence": "medium", "extraction_notes": "inferred causal link — held back as a suggestion" }
+  ],
+  "semantic_links": [
+    { "link_type": "requirement_dependency", "from": "REQUIREMENT-COMPLIANCE-1", "to": "CONSTRAINT-DATA-RESIDENCY-1",
+      "confidence": "medium", "rationale": "source implies the reporting duty presumes the residency rule holds, but no closed REL kind covers a REQUIREMENT-to-CONSTRAINT edge — surfaced for review, not invented as a rel_kind" }
   ]
 }

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -9,7 +9,8 @@ Deterministic, no-API-key guard. Nine parts:
      (scaffold-intake -> convert -> privacy-scan -> field-artefact -> emit-candidates
      -> validate -> review-queue) and asserts the outputs: a conformant field artefact with a
      proposed source_quality, candidate files, a review queue with the gate closed,
-     the two-axes rule (a candidate carrying source_quality is flagged), and THE ONE
+     the two-axes rule (a candidate carrying source_quality is flagged), a semantic
+     link (no closed REL kind) carried through review-only, and THE ONE
      RULE — canon/ is never written.
   C. IG-5 regressions — capability V/H ID is accepted, a non-closed rel_kind is
      flagged, derived_from merges across sources.
@@ -205,6 +206,13 @@ def part_b_pipeline():
             s = json.load(open(sugg, encoding="utf-8"))
             check(any(x.get("rel_kind") == "contributes_to" for x in s), "medium relation was not held back as a suggestion")
 
+        # semantic links: a typed edge with no closed REL kind passes through untouched.
+        sem = os.path.join(org, "_intake", "processing", "semantic-links.json")
+        if check(os.path.isfile(sem), "semantic-links.json missing"):
+            sl = json.load(open(sem, encoding="utf-8"))
+            check(any(x.get("link_type") == "requirement_dependency" for x in sl),
+                  "semantic link from the fixture was not carried through to semantic-links.json")
+
         r = run_cli("validate", cand_dir)
         check(r.returncode == 0, f"validate flagged the clean fixture candidates (exit {r.returncode}): {r.stdout}")
 
@@ -216,6 +224,7 @@ def part_b_pipeline():
             check(q.get("gate", {}).get("admits_to_canon") is False, "review queue gate.admits_to_canon must be False")
             check(isinstance(q.get("candidates"), list) and len(q["candidates"]) >= 1, "review queue lists no candidates")
             check(len(q.get("relation_suggestions", [])) >= 1, "review queue did not carry the held-back suggestion")
+            check(len(q.get("semantic_links", [])) >= 1, "review queue did not carry the semantic link")
             fas = q.get("field_artefacts") or []
             check(any(fa.get("source_hash") == expected_hash for fa in fas),
                   "review queue did not carry the field artefact's source_hash through")


### PR DESCRIPTION
## Summary
- Adds an optional, review-only `semantic_links` section to the review-queue schema for typed edges between candidates when no closed REL kind exists yet.
- `emit-candidates` passes source-stated semantic links through to `_intake/processing/semantic-links.json`; `review-queue` merges them into the queue when present.
- Semantic links are never shaped into relation candidates and never admitted to canon — distinct from `relation_suggestions`, which holds back a real `rel_kind` on low confidence.

## Test plan
- [x] `node --check` on all changed `.mjs` files
- [x] JSON validity of schema + fixture
- [x] Manual unit exercise of `shapeCandidates` and `buildReviewQueue` against the updated fixture — semantic link extracted and carried through correctly
- [x] `node scripts/check-notations.mjs` clean
- [ ] CI: `transitrix/skills/ingest/tests/test_ingest_integrity.py` (no local Python interpreter available in this environment to run it directly)