### PR TITLE
feat(notations): link suspicion, content identity, mechanical-procedure hatch

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -951,3 +951,81 @@ Two terms in the methodology carry closely related names and must not be conflat
 **Rule:** the word **Activity** MUST NOT be used to describe project-domain work items. The word **Action** MUST NOT be used to describe process-domain steps. Validators that detect `notation: activity` on a project-schedule document (distinct from `notation: bpmn` / PROCESS `flow` contexts) MUST emit `ACTION-005`.
 
 **Historical note.** Prior to 2026-06-25 the project-domain primitive was called `ACTIVITY`. That name was deprecated in favour of `ACTION` to enforce this distinction, and as of the 1.0 release (2026-07-05) is fully removed: the `ACTIVITY` TYPE prefix, `activity_type` field, `activities:` array name, and `*.activities.transitrix.yaml` extension are no longer accepted — validators emit `ACTION-005` as an **error**, not a warning. See [IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §6 for the migration checklist.
+
+---
+
+## 16. Link suspicion, content identity, and the mechanical-procedure hatch
+
+A record that points at another primitive — a `REL`, an `ASSERTION`, a `VERIFICATION`, a `VALIDATION`, or an element that has committed to something (§6.3, when present) — carries a claim that was true of its target *at the time the claim was made*. Nothing here re-checks that claim; the far end can be rewritten afterward without anyone touching the record that pointed at it. This section defines a **derived** signal — never stored, never authored — that answers "has the thing I pointed at changed since I last looked at it?" from git history alone.
+
+Three pieces, in order: what "changed" means (§16.1), how the signal is computed (§16.2), and how a bulk, non-editorial edit is told apart from one that should raise the signal (§16.3).
+
+### 16.1 Content identity
+
+**Content identity is the whole endpoint, parsed and normalised — not a curated per-spec list of "material" fields.** Reformatting a file, reordering its keys, or editing a comment changes nothing about content identity; changing a statement always does. Concretely: every non-blank, non-comment line of the file is kept **except** the lines belonging to the administrative envelope this CONTRACT already defines by name —
+
+```
+zone, admitted_at, admitted_by, gate_checks, derived_from,                 (§6)
+admission_state, proposed_at, proposed_by, owner_to_confirm,
+rejected_at, rejected_by, rejection_reason,                                (§6.1)
+reviewer_authority,                                                        (§6.2)
+agreement, agreed_by, agreed_at,                                           (§6.3, when present)
+valid_from, valid_to                                                       (§7)
+```
+
+— the fields that record *who filed this and when*, never *what it says*. This is one generic exclusion list, defined once here, not a per-notation judgement call — a spec adding a new envelope field to §6 or §7 in a future revision extends this list in the same revision, not by inventing a second mechanism. The kept lines are whitespace-normalised, sorted, and hashed (`sha256:<hex>`, the same format `packages/ingest-cli/src/source-hash.mjs` uses for source fingerprints). Two files have the same content identity if and only if their non-envelope lines are the same multiset — order-independent, formatting-independent, comment-independent.
+
+This is deliberately **not** a general YAML parser: a reference implementation only needs to tell "this line is part of the statement" from "this line is bookkeeping," and a flat, line-oriented pass over the already-well-known envelope field names does that without adding a parsing dependency to the toolchain (the same posture `scripts/baseline-manifest.mjs` and `scripts/check-agreement.mjs` already take).
+
+### 16.2 Link suspicion — derived, never stored
+
+**Link suspicion is computed fresh from git on every check; no file ever carries a `suspicious: true` flag.** The alternative — writing the result back onto the record — is exactly the failure mode `packages/reqif-cli`'s stored-revision suspect-link mechanism (`notations/packages/reqif.md` §2.9) already rejects for its own domain: a mutable flag goes stale the moment it stops being recomputed. This section generalises the same posture — derived, not stored — to every addressable link record core already has, using git as the append-only ledger instead of a stored revision counter.
+
+The computation is one function of three inputs — an **anchor commit**, the **target's path**, and the **target's content identity (§16.1) at that commit versus now** — applied identically everywhere:
+
+> *Suspicious* ⟺ the target's content identity at the anchor commit differs from its content identity now, **and** §16.3's hatch does not explain the difference.
+
+The anchor is *when this record last looked at its target*, and it is resolved differently per application because "last looked at" means something different in each:
+
+| Application | Record | Target | Anchor commit |
+|---|---|---|---|
+| **Suspicion on a relation** | `REL` (`from`/`to`, [17-relations.md](elements/17-relations.md) §2) or `ASSERTION` (`about`, [16-assertion.md](elements/16-assertion.md) §2) | the endpoint(s) the record resolves to | the record file's own most recent commit — the last time anyone touched the link |
+| **Staleness on a comparison** | `VERIFICATION` (`verifies`, [27-verification.md](elements/27-verification.md) §2) or `VALIDATION` (`validates`, [28-validation.md](elements/28-validation.md) §2) | the `REQUIREMENT` / `NEED` it was run against | the record file's own most recent commit — the last time the protocol's target was current |
+| **Agreement lapse on an element** | a `REQUIREMENT` / `CONSTRAINT` / `NEED` carrying `agreement: agreed` (§6.3, when present) | itself | the most recent commit that touched the `agreement` / `agreed_by` / `agreed_at` lines specifically — the last time the accountable party actually committed, not the last time the file was edited for any reason |
+
+The third row is the one case where record and target are the same file: an element can be edited after it was agreed without anyone re-confirming, and that is exactly the condition worth surfacing. Anchoring on "last commit that touched the agreement fields" rather than "last commit that touched the file" is what makes an unrelated edit (fixing a typo in an unrelated field, admitting a sibling element) invisible while a rewritten statement after agreement is not.
+
+**Unresolvable and out-of-scope endpoints are silent, not suspicious.** A `REL-002` / `ASSERT-002` / `VERIF-002` / `VALID-002` endpoint-resolution failure is a validator error already; link suspicion only ever evaluates endpoints that resolve. A resolvable link that has never changed produces no finding — the same "suspect only ever appears with an explicit true/false, never a silent absence" distinction `reqif.md` §2.9 draws is not needed here because there is no stored flag to be silently missing; the report simply lists what it found suspicious and nothing else.
+
+**Reports, never filters — same guardrail as §6.3.** Suspicion is a presentation concern: a badge a reviewer sees, a line in a report. No validator, coverage rule, or view generator may use it to exclude a relation, an assertion, a verification, a validation, or an element from anything. A suspicious link is still a link.
+
+A reference implementation of §16.1 and §16.2 lives in [`scripts/check-link-suspicion.mjs`](../scripts/check-link-suspicion.mjs).
+
+### 16.3 The mechanical-procedure hatch
+
+A bulk, non-editorial edit — a scripted rename, a reformat that a naive diff can't tell from a rewrite, a declared migration — can legitimately touch a target's content identity without any accountable party having reconsidered the statement. Suspicion firing on every such edit would make the signal useless within one bulk pass. The hatch lets a process declare its edit mechanical — but **the declaration alone is never sufficient**; the checker independently verifies it before suppressing suspicion.
+
+A migration declares itself by writing a manifest alongside its recipe, under `migrations/<slug>/TRANSFORM.yaml`:
+
+```yaml
+mechanical: true
+applies_to:
+  - canon/elements/01_motivation/requirements/REQUIREMENT-DATA-ERASURE-1.yaml
+line_edits:
+  - from: "owner_role: ROLE-OLD-1"
+    to: "owner_role: ROLE-NEW-1"
+```
+
+`applies_to` names the exact files the migration touches — not a glob, not a pattern; a bulk edit already knows precisely which files it wrote. `line_edits` names, line for line, exactly what changed. The checker's verification is a replay, not a trust exercise: it takes the target's content identity lines *before* the edit, applies the declared `line_edits` to them, and checks the result matches the target's content identity lines *after* the edit exactly. A match suppresses suspicion. Anything left over — a line the manifest didn't declare, a declared edit that doesn't appear in the actual diff — means the manifest didn't fully explain the change, and suspicion stands **regardless of the `mechanical: true` flag**.
+
+This is the property that makes the hatch a checker-verified exemption rather than a mute button: **the editing tool cannot self-grant it.** Writing `mechanical: true` and walking away does nothing on its own; only a `line_edits` list the checker can independently replay and match does. A tool that declares itself mechanical but under- or over-states what it changed gets exactly the same suspicion result as a tool that made no declaration at all.
+
+**Validation rules.**
+
+| Rule | Severity | Description |
+|---|---|---|
+| `MECH-001` | info | A migration manifest under `migrations/<slug>/TRANSFORM.yaml` declares `mechanical: true` for a changed target, but replaying its `line_edits` against the target's before-state does not reproduce the after-state exactly — the hatch is refused and the change is reported exactly as if no manifest existed. |
+
+`MECH-001` is informational, not a build-breaking error: refusal does not fail validation, it only means §16.2's suspicion computation proceeds without the exemption. A reference implementation lives in [`scripts/check-link-suspicion.mjs`](../scripts/check-link-suspicion.mjs), alongside §16.1 and §16.2.
+
+**Additive.** Nothing in this section changes an existing schema, adds a required field to any TYPE, or alters an existing validation rule. A repository that declares no `migrations/*/TRANSFORM.yaml` manifest and never inspects link suspicion validates exactly as it did before this section existed.

--- a/scripts/check-link-suspicion.mjs
+++ b/scripts/check-link-suspicion.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+// Link suspicion, content identity, and the mechanical-procedure hatch —
+// CONTRACT.md §16, reference implementation.
+//
+// Nothing here is stored: every check re-derives its answer from git and the
+// current working tree. Three applications share one computation:
+//   - suspicion on a relation      REL (from/to) / ASSERTION (about)
+//   - staleness on a comparison    VERIFICATION (verifies) / VALIDATION (validates)
+//   - agreement lapse on an element  REQUIREMENT/CONSTRAINT/NEED with agreement: agreed
+//
+// Content identity (§16.1) is a line-oriented normalisation, not a general
+// YAML parser — the same posture scripts/baseline-manifest.mjs and
+// scripts/check-agreement.mjs already take: sufficient for the flat/shallow
+// canon shape, no new parsing dependency added to the root scripts/ toolchain.
+//
+// Usage:
+//   node scripts/check-link-suspicion.mjs [--root <adopter-repo>]
+//
+// Exit codes: 0 always on a normal run (informational — §16.2 "reports,
+// never filters") · 2 script-internal error.
+
+import { execFileSync } from 'node:child_process';
+import { readFile, readdir } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, resolve, relative, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// The administrative envelope (§16.1) — field names already defined by name
+// in CONTRACT.md §6 / §6.1 / §6.2 / §6.3 (when present) / §7. One list,
+// defined once; a spec revision that adds an envelope field extends this
+// list in the same revision rather than inventing a second mechanism.
+const ENVELOPE_FIELDS = [
+  'zone', 'admitted_at', 'admitted_by', 'gate_checks', 'derived_from',
+  'admission_state', 'proposed_at', 'proposed_by', 'owner_to_confirm',
+  'rejected_at', 'rejected_by', 'rejection_reason',
+  'reviewer_authority',
+  'agreement', 'agreed_by', 'agreed_at',
+  'valid_from', 'valid_to',
+];
+
+// --- content identity (§16.1) -------------------------------------------
+
+function stripComment(line) {
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') inQuotes = !inQuotes;
+    else if (ch === '#' && !inQuotes) return line.slice(0, i);
+  }
+  return line;
+}
+
+// Every non-blank, non-comment line of the file, except those belonging to
+// an ENVELOPE_FIELDS block (the key line and its more-indented continuation
+// lines), whitespace-normalised and sorted — order-independent,
+// formatting-independent, comment-independent.
+export function statementLines(text) {
+  const kept = [];
+  let skipIndent = null;
+  for (const raw of text.split('\n')) {
+    const stripped = stripComment(raw).replace(/\s+$/, '');
+    if (!stripped.trim()) continue;
+    const indent = stripped.match(/^ */)[0].length;
+    if (skipIndent !== null) {
+      if (indent > skipIndent) continue;
+      skipIndent = null;
+    }
+    const keyMatch = stripped.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*):/);
+    if (keyMatch && keyMatch[1].length === 0 && ENVELOPE_FIELDS.includes(keyMatch[2])) {
+      skipIndent = indent;
+      continue;
+    }
+    kept.push(stripped.trim().replace(/\s+/g, ' '));
+  }
+  return kept.sort();
+}
+
+export function contentIdentity(text) {
+  const hash = createHash('sha256').update(statementLines(text).join('\n')).digest('hex');
+  return `sha256:${hash}`;
+}
+
+function sameLines(a, b) {
+  return a.length === b.length && a.every((line, i) => line === b[i]);
+}
+
+// --- git plumbing — read-only, mirrors scripts/baseline-manifest.mjs ----
+
+function git(gitArgs, cwd, { quiet } = {}) {
+  return execFileSync('git', gitArgs, {
+    encoding: 'utf8',
+    cwd,
+    stdio: ['ignore', 'pipe', quiet ? 'ignore' : 'pipe'],
+  });
+}
+
+// The last commit that touched `relPath` at all, or — when `pattern` is
+// given — the last commit whose diff added/removed a line matching it
+// (git's pickaxe, `-G`). Used to anchor "agreement lapse" on the commit that
+// actually set the agreement fields, not the file's last edit for any reason.
+export function lastCommitTouching(root, relPath, pattern) {
+  const args = ['log', '-1', '--format=%H'];
+  if (pattern) args.push(`-G${pattern}`);
+  args.push('--', relPath);
+  let out;
+  try {
+    out = git(args, root, { quiet: true });
+  } catch {
+    return undefined;
+  }
+  const sha = out.trim();
+  return sha || undefined;
+}
+
+export function readAt(root, ref, relPath) {
+  try {
+    return git(['show', `${ref}:${relPath}`], root, { quiet: true });
+  } catch {
+    return undefined;
+  }
+}
+
+// --- the mechanical-procedure hatch (§16.3) ------------------------------
+
+function unquote(s) {
+  const m = s.match(/^"(.*)"$/);
+  return m ? m[1] : s;
+}
+
+function normalizeEditLine(s) {
+  return unquote(s.trim()).trim().replace(/\s+/g, ' ');
+}
+
+// Minimal parse of the fixed `migrations/<slug>/TRANSFORM.yaml` shape —
+// `mechanical: true`, `applies_to: [exact relative paths]`,
+// `line_edits: [{from, to}]`. Not a general YAML parser, same posture as
+// statementLines above.
+export function parseManifest(text) {
+  const manifest = { mechanical: false, applies_to: [], line_edits: [] };
+  let section = null;
+  let current = null;
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/\s+$/, '');
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    const topMatch = line.match(/^(\w+):\s*(.*)$/);
+    if (topMatch) {
+      const [, key, val] = topMatch;
+      if (key === 'mechanical') {
+        manifest.mechanical = val.trim() === 'true';
+        section = null;
+      } else if (key === 'applies_to') {
+        section = 'applies_to';
+      } else if (key === 'line_edits') {
+        section = 'line_edits';
+      }
+      continue;
+    }
+
+    if (section === 'applies_to') {
+      const m = line.match(/^\s*-\s*(.+)$/);
+      if (m) manifest.applies_to.push(unquote(m[1].trim()));
+    } else if (section === 'line_edits') {
+      const fromMatch = line.match(/^\s*-\s*from:\s*(.+)$/);
+      if (fromMatch) {
+        current = { from: normalizeEditLine(fromMatch[1]) };
+        manifest.line_edits.push(current);
+        continue;
+      }
+      const toMatch = line.match(/^\s*to:\s*(.+)$/);
+      if (toMatch && current) current.to = normalizeEditLine(toMatch[1]);
+    }
+  }
+  return manifest;
+}
+
+export async function loadMigrationManifests(root) {
+  let entries;
+  try {
+    entries = await readdir(join(root, 'migrations'), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const manifests = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    let text;
+    try {
+      text = await readFile(join(root, 'migrations', entry.name, 'TRANSFORM.yaml'), 'utf8');
+    } catch {
+      continue;
+    }
+    manifests.push({ slug: entry.name, ...parseManifest(text) });
+  }
+  return manifests;
+}
+
+// Replay a manifest's declared line_edits against the before-state and check
+// the result matches the after-state exactly. This is the independent
+// verification: the tool's `mechanical: true` declaration is never trusted
+// on its own — only a replay that reproduces the after-state suppresses
+// suspicion (§16.3, "the editing tool cannot self-grant it").
+export function replayExplains(beforeLines, afterLines, lineEdits) {
+  const working = [...beforeLines];
+  for (const edit of lineEdits) {
+    const idx = working.indexOf(edit.from);
+    if (idx === -1) return false;
+    working.splice(idx, 1, edit.to);
+  }
+  return sameLines(working.sort(), [...afterLines].sort());
+}
+
+// --- link suspicion (§16.2) ----------------------------------------------
+
+export async function checkSuspicion({ root, anchorCommit, targetRelPath, manifests = [] }) {
+  if (!anchorCommit) return { suspicious: false, reason: 'no-anchor' };
+
+  const beforeText = readAt(root, anchorCommit, targetRelPath);
+  if (beforeText === undefined) return { suspicious: false, reason: 'target-absent-at-anchor' };
+
+  let afterText;
+  try {
+    afterText = await readFile(join(root, ...targetRelPath.split('/')), 'utf8');
+  } catch {
+    return { suspicious: false, reason: 'target-absent-now' };
+  }
+
+  const beforeLines = statementLines(beforeText);
+  const afterLines = statementLines(afterText);
+  if (sameLines(beforeLines, afterLines)) return { suspicious: false };
+
+  const applicable = manifests.filter(m => m.applies_to.includes(targetRelPath));
+  for (const manifest of applicable) {
+    if (replayExplains(beforeLines, afterLines, manifest.line_edits)) {
+      return { suspicious: false, mechanical: true, manifest: manifest.slug };
+    }
+  }
+  return { suspicious: true, hatchRefused: applicable.some(m => m.mechanical) };
+}
+
+// --- repo scan — the three applications ----------------------------------
+
+async function walkYaml(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walkYaml(p)));
+    else if (entry.isFile() && entry.name.endsWith('.yaml')) out.push(p);
+  }
+  return out;
+}
+
+// Targeted top-level scalar extraction — same convention as
+// scripts/baseline-manifest.mjs's `field()`.
+function field(text, name) {
+  const m = text.match(new RegExp(`^${name}:\\s*"?([^"\\n#]*?)"?\\s*(?:#.*)?$`, 'm'));
+  return m ? m[1].trim() : undefined;
+}
+
+function toRel(root, absPath) {
+  return relative(root, absPath).split(sep).join('/');
+}
+
+async function buildIdIndex(root) {
+  const index = new Map();
+  for (const file of await walkYaml(join(root, 'canon'))) {
+    const text = await readFile(file, 'utf8');
+    const id = field(text, 'id');
+    if (id) index.set(id, toRel(root, file));
+  }
+  return index;
+}
+
+const LINK_FOLDERS = [
+  { dir: 'canon/relations', endpointFields: ['from', 'to'] },
+  { dir: 'canon/assertions', endpointFields: ['about'] },
+  { dir: 'canon/verifications', endpointFields: ['verifies'] },
+  { dir: 'canon/validations', endpointFields: ['validates'] },
+];
+
+export async function checkAll(rootArg) {
+  const root = resolve(rootArg);
+  const manifests = await loadMigrationManifests(root);
+  const index = await buildIdIndex(root);
+  const findings = [];
+
+  // Applications 1 & 2: suspicion on a relation / staleness on a comparison.
+  for (const { dir, endpointFields } of LINK_FOLDERS) {
+    for (const file of await walkYaml(join(root, dir))) {
+      const text = await readFile(file, 'utf8');
+      const recordRelPath = toRel(root, file);
+      const recordId = field(text, 'id');
+      const anchor = lastCommitTouching(root, recordRelPath);
+      for (const ef of endpointFields) {
+        const targetId = field(text, ef);
+        const targetRelPath = targetId && index.get(targetId);
+        if (!targetRelPath) continue; // unresolved — REL-002 / ASSERT-002 / etc's concern, not this one
+        const result = await checkSuspicion({ root, anchorCommit: anchor, targetRelPath, manifests });
+        if (result.suspicious) {
+          findings.push({
+            application: 'link',
+            record: recordRelPath, recordId,
+            target: targetRelPath, targetId,
+            anchor, hatchRefused: result.hatchRefused === true,
+          });
+        }
+      }
+    }
+  }
+
+  // Application 3: agreement lapse — REQUIREMENT/CONSTRAINT/NEED with agreement: agreed.
+  for (const file of await walkYaml(join(root, 'canon', 'elements'))) {
+    const text = await readFile(file, 'utf8');
+    if (field(text, 'agreement') !== 'agreed') continue;
+    const relPath = toRel(root, file);
+    const id = field(text, 'id');
+    const anchor = lastCommitTouching(root, relPath, '^(agreement|agreed_by|agreed_at):');
+    const result = await checkSuspicion({ root, anchorCommit: anchor, targetRelPath: relPath, manifests });
+    if (result.suspicious) {
+      findings.push({
+        application: 'agreement-lapse',
+        record: relPath, recordId: id,
+        target: relPath, targetId: id,
+        anchor, hatchRefused: result.hatchRefused === true,
+      });
+    }
+  }
+
+  return findings;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const rootFlagIndex = args.indexOf('--root');
+  const root = rootFlagIndex >= 0 && args[rootFlagIndex + 1] ? args[rootFlagIndex + 1] : '.';
+
+  const findings = await checkAll(root);
+  if (findings.length === 0) {
+    console.log('check-link-suspicion: clean — no suspicious links found.');
+    return;
+  }
+  for (const f of findings) {
+    const tag = f.application === 'agreement-lapse' ? 'AGREEMENT-LAPSE' : 'SUSPECT';
+    const hatchNote = f.hatchRefused ? '  [MECH-001: hatch declared but not verified]' : '';
+    console.log(`${tag}  ${f.record} (${f.recordId})  ->  ${f.target} (${f.targetId})  anchor=${f.anchor}${hatchNote}`);
+  }
+  console.log(`\n${findings.length} suspicious link(s). Informational — see CONTRACT.md §16.2.`);
+}
+
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 2;
+  });
+}

--- a/scripts/check-link-suspicion.test.mjs
+++ b/scripts/check-link-suspicion.test.mjs
@@ -1,0 +1,244 @@
+// Unit + fixture tests for scripts/check-link-suspicion.mjs.
+// Run: node --test scripts/check-link-suspicion.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  statementLines,
+  contentIdentity,
+  parseManifest,
+  replayExplains,
+  checkAll,
+} from './check-link-suspicion.mjs';
+
+// --- statementLines / contentIdentity — pure, no filesystem or git ------
+
+test('statementLines/contentIdentity — positive: reformat, key reorder, and comments raise nothing', () => {
+  const a = [
+    'notation: requirement',
+    'id: REQUIREMENT-1',
+    'name: "Erase user data within 30 days"',
+    'zone: canon',
+    'admitted_at: "2026-05-01"',
+  ].join('\n');
+  const b = [
+    '# a reformatted, key-reordered, commented copy of the same statement',
+    'zone: canon   # unchanged envelope field, different formatting',
+    'name:   "Erase user data within 30 days"',
+    'admitted_at: "2026-08-05"   # envelope field bumped, e.g. re-admission',
+    'id: REQUIREMENT-1',
+    'notation: requirement',
+  ].join('\n');
+  assert.deepEqual(statementLines(a), statementLines(b));
+  assert.equal(contentIdentity(a), contentIdentity(b));
+});
+
+test('statementLines/contentIdentity — negative: a changed statement changes content identity', () => {
+  const before = 'notation: requirement\nid: REQUIREMENT-1\nname: "Erase user data within 30 days"\n';
+  const after = 'notation: requirement\nid: REQUIREMENT-1\nname: "Erase user data within 14 days"\n';
+  assert.notEqual(contentIdentity(before), contentIdentity(after));
+});
+
+test('statementLines — excludes the full administrative envelope, including nested gate_checks', () => {
+  const text = [
+    'notation: requirement',
+    'id: REQUIREMENT-1',
+    'name: "Statement"',
+    'zone: canon',
+    'admitted_at: "2026-05-01"',
+    'admitted_by: "v.korobeinikov"',
+    'gate_checks:',
+    '  uniqueness: pass',
+    '  consistency: pass',
+    '  completeness: pass',
+    'valid_from: "2026-05-01"',
+    'valid_to: null',
+  ].join('\n');
+  const lines = statementLines(text);
+  assert.ok(!lines.some(l => l.includes('uniqueness')), 'nested gate_checks lines must be excluded');
+  assert.ok(!lines.some(l => l.startsWith('admitted_by')));
+  assert.ok(lines.some(l => l.includes('Statement')), 'the statement field itself must survive');
+});
+
+// --- parseManifest / replayExplains — pure -------------------------------
+
+test('parseManifest — reads mechanical, applies_to, and line_edits', () => {
+  const text = [
+    'mechanical: true',
+    'applies_to:',
+    '  - canon/elements/x/REQUIREMENT-1.yaml',
+    'line_edits:',
+    '  - from: "owner_role: ROLE-OLD-1"',
+    '    to: "owner_role: ROLE-NEW-1"',
+  ].join('\n');
+  const manifest = parseManifest(text);
+  assert.equal(manifest.mechanical, true);
+  assert.deepEqual(manifest.applies_to, ['canon/elements/x/REQUIREMENT-1.yaml']);
+  assert.deepEqual(manifest.line_edits, [{ from: 'owner_role: ROLE-OLD-1', to: 'owner_role: ROLE-NEW-1' }]);
+});
+
+test('replayExplains — positive: a fully declared edit reproduces the after-state', () => {
+  const before = ['name: "X"', 'owner_role: ROLE-OLD-1'];
+  const after = ['name: "X"', 'owner_role: ROLE-NEW-1'];
+  const edits = [{ from: 'owner_role: ROLE-OLD-1', to: 'owner_role: ROLE-NEW-1' }];
+  assert.equal(replayExplains(before, after, edits), true);
+});
+
+test('replayExplains — negative: an undeclared change is not explained (cannot self-grant)', () => {
+  const before = ['name: "X"', 'owner_role: ROLE-OLD-1'];
+  const after = ['name: "Y"', 'owner_role: ROLE-NEW-1']; // name changed too, not declared
+  const edits = [{ from: 'owner_role: ROLE-OLD-1', to: 'owner_role: ROLE-NEW-1' }];
+  assert.equal(replayExplains(before, after, edits), false);
+});
+
+// --- fixture-repository end-to-end -----------------------------------
+
+function writeYaml(dir, filename, lines) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, filename), lines.join('\n') + '\n', 'utf8');
+}
+
+test('checkAll — far-end change raises suspicion, reformat raises nothing, hatch cannot be self-granted', async (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'check-link-suspicion-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const run = (args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' });
+  run(['init', '-q']);
+  run(['config', 'user.email', 'fixture@example.com']);
+  run(['config', 'user.name', 'Fixture']);
+
+  const reqDir = join(root, 'canon', 'elements', '01_motivation', 'requirements');
+  const relDir = join(root, 'canon', 'relations');
+
+  writeYaml(reqDir, 'REQUIREMENT-CHANGED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-CHANGED-1', 'name: "Erase user data within 30 days"', 'zone: canon',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-REFORMATTED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-REFORMATTED-1', 'name: "Retain audit logs for 1 year"', 'zone: canon',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-MECHANICAL-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-MECHANICAL-1', 'name: "Route escalations to the owning role"',
+    'owner_role: ROLE-OLD-1', 'zone: canon',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-HATCH-REFUSED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-HATCH-REFUSED-1', 'name: "Route escalations to the owning role"',
+    'owner_role: ROLE-OLD-1', 'zone: canon',
+  ]);
+
+  writeYaml(relDir, 'REL-1.yaml', [
+    'notation: relation', 'id: REL-1', 'type: parent', 'from: CAPABILITY-X-1', 'to: REQUIREMENT-CHANGED-1', 'zone: canon',
+  ]);
+  writeYaml(relDir, 'REL-2.yaml', [
+    'notation: relation', 'id: REL-2', 'type: parent', 'from: CAPABILITY-X-1', 'to: REQUIREMENT-REFORMATTED-1', 'zone: canon',
+  ]);
+  writeYaml(relDir, 'REL-3.yaml', [
+    'notation: relation', 'id: REL-3', 'type: parent', 'from: CAPABILITY-X-1', 'to: REQUIREMENT-MECHANICAL-1', 'zone: canon',
+  ]);
+  writeYaml(relDir, 'REL-4.yaml', [
+    'notation: relation', 'id: REL-4', 'type: parent', 'from: CAPABILITY-X-1', 'to: REQUIREMENT-HATCH-REFUSED-1', 'zone: canon',
+  ]);
+
+  run(['add', '-A']);
+  run(['commit', '-q', '-m', 'c1: initial fixture']);
+
+  // c2: a real statement change, a reformat-only change, a fully-declared
+  // mechanical edit, and an edit that declares mechanical but goes further
+  // than what it declared.
+  writeYaml(reqDir, 'REQUIREMENT-CHANGED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-CHANGED-1', 'name: "Erase user data within 14 days"', 'zone: canon',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-REFORMATTED-1.yaml', [
+    '# reformatted only — same statement, different layout',
+    'zone: canon',
+    'name:   "Retain audit logs for 1 year"',
+    'id: REQUIREMENT-REFORMATTED-1',
+    'notation: requirement',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-MECHANICAL-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-MECHANICAL-1', 'name: "Route escalations to the owning role"',
+    'owner_role: ROLE-NEW-1', 'zone: canon',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-HATCH-REFUSED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-HATCH-REFUSED-1', 'name: "Route escalations to the new owning role"',
+    'owner_role: ROLE-NEW-1', 'zone: canon',
+  ]);
+  writeYaml(join(root, 'migrations', 'rename-role'), 'TRANSFORM.yaml', [
+    'mechanical: true',
+    'applies_to:',
+    '  - canon/elements/01_motivation/requirements/REQUIREMENT-MECHANICAL-1.yaml',
+    'line_edits:',
+    '  - from: "owner_role: ROLE-OLD-1"',
+    '    to: "owner_role: ROLE-NEW-1"',
+  ]);
+  writeYaml(join(root, 'migrations', 'rename-role-incomplete'), 'TRANSFORM.yaml', [
+    'mechanical: true',
+    'applies_to:',
+    '  - canon/elements/01_motivation/requirements/REQUIREMENT-HATCH-REFUSED-1.yaml',
+    'line_edits:',
+    '  - from: "owner_role: ROLE-OLD-1"',
+    '    to: "owner_role: ROLE-NEW-1"',
+  ]);
+
+  run(['add', '-A']);
+  run(['commit', '-q', '-m', 'c2: mixed edits']);
+
+  const findings = await checkAll(root);
+  const byTarget = Object.fromEntries(findings.map(f => [f.targetId, f]));
+
+  assert.ok(byTarget['REQUIREMENT-CHANGED-1'], 'a real statement change must raise suspicion');
+  assert.ok(!byTarget['REQUIREMENT-REFORMATTED-1'], 'a reformat-only change must raise nothing');
+  assert.ok(!byTarget['REQUIREMENT-MECHANICAL-1'], 'a fully-declared, independently-verified edit must raise nothing');
+  assert.ok(byTarget['REQUIREMENT-HATCH-REFUSED-1'], 'an edit that outruns its declared line_edits must still raise suspicion');
+  assert.equal(byTarget['REQUIREMENT-HATCH-REFUSED-1'].hatchRefused, true, 'the tool cannot self-grant the hatch by declaring mechanical: true alone');
+});
+
+test('checkAll — agreement lapse: an edit after agreement raises it, re-agreeing in the same commit does not', async (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'check-link-suspicion-agree-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const run = (args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' });
+  run(['init', '-q']);
+  run(['config', 'user.email', 'fixture@example.com']);
+  run(['config', 'user.name', 'Fixture']);
+
+  const reqDir = join(root, 'canon', 'elements', '01_motivation', 'requirements');
+
+  writeYaml(reqDir, 'REQUIREMENT-LAPSED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-LAPSED-1', 'name: "Original commitment"',
+    'agreement: agreed', 'agreed_by: "v.korobeinikov"', 'agreed_at: "2026-08-01"', 'zone: canon',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-RECONFIRMED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-RECONFIRMED-1', 'name: "Original commitment"',
+    'agreement: agreed', 'agreed_by: "v.korobeinikov"', 'agreed_at: "2026-08-01"', 'zone: canon',
+  ]);
+
+  run(['add', '-A']);
+  run(['commit', '-q', '-m', 'c1: both requirements agreed']);
+
+  // c2: LAPSED's statement changes but agreement lines are untouched — this
+  // is the condition §16.2's third row exists to catch.
+  writeYaml(reqDir, 'REQUIREMENT-LAPSED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-LAPSED-1', 'name: "Quietly rewritten commitment"',
+    'agreement: agreed', 'agreed_by: "v.korobeinikov"', 'agreed_at: "2026-08-01"', 'zone: canon',
+  ]);
+  // RECONFIRMED's statement changes too, but agreed_at is bumped in the same
+  // commit — a conscious re-agreement to the new statement.
+  writeYaml(reqDir, 'REQUIREMENT-RECONFIRMED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-RECONFIRMED-1', 'name: "Deliberately renegotiated commitment"',
+    'agreement: agreed', 'agreed_by: "v.korobeinikov"', 'agreed_at: "2026-08-05"', 'zone: canon',
+  ]);
+
+  run(['add', '-A']);
+  run(['commit', '-q', '-m', 'c2: one quiet rewrite, one re-agreement']);
+
+  const findings = await checkAll(root);
+  const byTarget = Object.fromEntries(findings.map(f => [f.targetId, f]));
+
+  assert.ok(byTarget['REQUIREMENT-LAPSED-1'], 'a statement change with no re-agreement must lapse');
+  assert.equal(byTarget['REQUIREMENT-LAPSED-1'].application, 'agreement-lapse');
+  assert.ok(!byTarget['REQUIREMENT-RECONFIRMED-1'], 'a statement change re-agreed in the same commit must not lapse');
+});


### PR DESCRIPTION
## Summary
- Adds CONTRACT.md §16: link suspicion is derived from git (never stored) over REL/ASSERTION/VERIFICATION/VALIDATION endpoints and agreement-carrying elements — content identity normalises away reformatting so only a genuine statement change raises it.
- Adds the mechanical-procedure hatch: a bulk migration can declare itself mechanical, but only a checker-replayed match against its declared `line_edits` suppresses suspicion — the declaration alone never does.
- Reference implementation + tests: `scripts/check-link-suspicion.mjs` / `scripts/check-link-suspicion.test.mjs`.
- Additive only — no schema change, no new required field, no existing validator rule touched.

## Test plan
- [x] `node --test scripts/check-link-suspicion.test.mjs` — 8/8 passing (content identity reformat-vs-change, manifest parsing/replay, fixture-repo suspicion/staleness/hatch-refusal, agreement-lapse)
- [x] `node scripts/check-notations.mjs` — clean
- [x] `node scripts/check-adl.mjs --base main` — clean