### PR TITLE
feat(notations): add document-view engine skeleton-file parser

### DIFF
--- a/notations/views/documents/README.md
+++ b/notations/views/documents/README.md
@@ -1,5 +1,7 @@
 # Document views
 
 Reserved for the document-view class — specs that render a standard document
-(MRD, SRS, SDD, …) from canon. Landing with the document-view engine; see the
-2026-07-30 rendered-documents architecture decision.
+(MRD, SRS, SDD, …) from canon. See the 2026-07-30 rendered-documents architecture
+decision. The document-view engine's skeleton-file parser lives at
+[`packages/document-view-engine`](../../../packages/document-view-engine/README.md);
+reference resolution and rendering are follow-on work.

--- a/packages/document-view-engine/README.md
+++ b/packages/document-view-engine/README.md
@@ -1,0 +1,64 @@
+# @transitrix/document-view-engine
+
+Parser for **skeleton files** — the Markdown-with-transclusion source format the
+document-view engine renders against canon. A skeleton carries structure and
+transclusion tags; the engine resolves them and emits a document. No document layout
+ships with this package — a layout is authored by whoever needs that document, in
+their own repository.
+
+**Scope of this package today: syntax only.** `parseSkeleton()` turns a skeleton
+file's text into a header object and a body AST. It does not resolve references
+against canon, does not compute reference-resolution state, and does not render.
+Those are later layers built on top of this AST.
+
+## Skeleton file shape
+
+```markdown
+---
+document: design description        # free text; the name its readers use
+canon: ../canon                     # root of the model this renders against
+profile: neutral                    # reserved; only `neutral` exists today
+---
+
+{{# each REQUIREMENT where level = system and kind = functional order by id }}
+### {{ .id }} — {{ .title }}
+
+{{ .text }}
+{{/ each }}
+```
+
+## Syntax
+
+Delimiters `{{ … }}`; `\{{` escapes a literal.
+
+| Form | AST node |
+|---|---|
+| `{{ REQ-14 }}` | `{ type: 'inline', id, fields: [] }` |
+| `{{ REQ-14.text }}` | `{ type: 'inline', id, fields: ['text'] }` |
+| `{{ REQ-14.parent.title }}` | `{ type: 'inline', id, fields: ['parent', 'title'] }` — traversal capped at depth 3 |
+| `{{# each TYPE where f = v and f2 != v2 order by f }} … {{/ each }}` | `{ type: 'each', entityType, where, orderBy, children }` |
+| `{{ .field }}` (inside an `each` body only) | `{ type: 'field-ref', fields }` |
+| `{{ trace from = A to = B via = rel }}` | `{ type: 'trace', from, to, via }` |
+| `{{ view <path> }}` | `{ type: 'view', path }` |
+
+`id` is validated against the canonical ID grammar
+([`IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §1-2), including the
+`CAPABILITY` V/H diagram-address exception. A `where` clause's comparison is `=` / `!=`
+against a literal, ANDed only — no other operator is expressible, by design.
+
+## Usage
+
+```js
+import { parseSkeleton } from '@transitrix/document-view-engine/src/parse-skeleton.mjs';
+
+const { header, ast, errors } = parseSkeleton(fileText);
+if (errors.length > 0) {
+  // each entry is { message } — surface all of them, not just the first
+}
+```
+
+## Tests
+
+```
+node packages/document-view-engine/tests/test_parse_skeleton.mjs
+```

--- a/packages/document-view-engine/package.json
+++ b/packages/document-view-engine/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@transitrix/document-view-engine",
+  "version": "0.0.1",
+  "description": "Skeleton-file parser for the document-view engine — turns a Markdown skeleton with {{ ... }} transclusion syntax into a header + body AST. Syntax only: no canon resolution, no rendering (see README for scope).",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "src/"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Transitrix"
+  },
+  "repository": "https://github.com/transitrix/methodology",
+  "dependencies": {}
+}

--- a/packages/document-view-engine/src/ids.mjs
+++ b/packages/document-view-engine/src/ids.mjs
@@ -1,0 +1,19 @@
+// Canonical ID grammar (notations/IDS_AND_REFERENCES.md §1-2): `<TYPE>-[<middle>-]<INTEGER>`,
+// plus the CAPABILITY V/H diagram-address exception. Own copy by design — same posture
+// as decisions-cli's src/yaml.mjs: zero cross-package runtime dependency.
+
+const GENERAL_ID = /^[A-Z][A-Z0-9_]*(-[A-Za-z0-9]+)*-[1-9][0-9]*$/;
+const CAPABILITY_ID = /^CAPABILITY-[VH][1-9][0-9]*(\.[1-9][0-9]*){0,2}$/;
+
+export function isValidId(id) {
+  if (typeof id !== 'string' || id === '') return false;
+  return GENERAL_ID.test(id) || CAPABILITY_ID.test(id);
+}
+
+// TYPE registry is open-ended (notations keep adding types) — a selection's entity
+// type is validated as an uppercase TYPE-shaped token, not against a closed list.
+const TYPE_NAME = /^[A-Z][A-Z0-9_]*$/;
+
+export function isValidTypeName(name) {
+  return typeof name === 'string' && TYPE_NAME.test(name);
+}

--- a/packages/document-view-engine/src/parse-skeleton.mjs
+++ b/packages/document-view-engine/src/parse-skeleton.mjs
@@ -1,0 +1,338 @@
+// Skeleton-file parser for the document-view engine (hub epic "Document-view engine:
+// skeleton transclusion, reference flags, render profiles", §1-2).
+//
+// Scope of this module: syntax only. It turns a skeleton file's text into a header
+// object and a body AST. It does NOT resolve references against canon, does not compute
+// the four reference-resolution states (§3), and does not render — those are the
+// engine's next layers, built on top of this AST.
+//
+// Zero dependencies, own copy of the minimal bits it needs — same posture as
+// decisions-cli's src/yaml.mjs (no cross-package runtime dependency).
+
+import { isValidId, isValidTypeName } from './ids.mjs';
+
+const FRONT_MATTER = /^---\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?([\s\S]*)$/;
+
+function cleanScalar(raw) {
+  let s = String(raw).trim();
+  const hash = s.indexOf(' #');
+  if (hash >= 0) s = s.slice(0, hash).trim();
+  if (s.startsWith('"') && s.endsWith('"') && s.length >= 2) {
+    try { return JSON.parse(s); } catch { return s.slice(1, -1); }
+  }
+  if (s.startsWith("'") && s.endsWith("'") && s.length >= 2) return s.slice(1, -1).replace(/''/g, "'");
+  return s;
+}
+
+// ── Header (§1) ──────────────────────────────────────────────────────────
+
+function parseHeader(headerText) {
+  const errors = [];
+  const fields = {};
+  for (const line of headerText.split(/\r?\n/)) {
+    if (line.trim() === '' || line.trim().startsWith('#')) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*):[ \t]*(.*)$/);
+    if (!m) continue;
+    fields[m[1]] = cleanScalar(m[2]);
+  }
+
+  const document = fields.document;
+  const canon = fields.canon;
+  let profile = fields.profile;
+
+  if (!document) errors.push({ message: 'header: `document` is required' });
+  if (!canon) errors.push({ message: 'header: `canon` is required' });
+  if (profile === undefined) {
+    profile = 'neutral';
+  } else if (profile !== 'neutral') {
+    errors.push({ message: `header: \`profile\` is reserved — only "neutral" exists today, got "${profile}"` });
+  }
+
+  return { header: { document, canon, profile }, errors };
+}
+
+// ── Tokenizer ────────────────────────────────────────────────────────────
+// Walks the raw body text, splitting it into literal-text runs and `{{ ... }}`
+// directives. `\{{` is the one defined escape (§2) — renders as a literal `{{`.
+
+function tokenize(body) {
+  const tokens = [];
+  const errors = [];
+  let buf = '';
+  let i = 0;
+
+  const flushText = () => {
+    if (buf !== '') { tokens.push({ kind: 'text', value: buf }); buf = ''; }
+  };
+
+  while (i < body.length) {
+    if (body.startsWith('\\{{', i)) { buf += '{{'; i += 3; continue; }
+    if (body.startsWith('{{', i)) {
+      flushText();
+      const close = body.indexOf('}}', i + 2);
+      if (close === -1) {
+        errors.push({ message: `tokenizer: unterminated "{{" at offset ${i} — no matching "}}"` });
+        i = body.length;
+        break;
+      }
+      const content = body.slice(i + 2, close);
+      tokens.push(classify(content, errors));
+      i = close + 2;
+      continue;
+    }
+    buf += body[i];
+    i++;
+  }
+  flushText();
+  return { tokens, errors };
+}
+
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// A CAPABILITY id embeds its own dots (the V/H diagram address, IDS_AND_REFERENCES.md
+// §2) — split it off first so those dots aren't mistaken for a field path separator.
+const CAPABILITY_PREFIX = /^(CAPABILITY-[VH][1-9][0-9]*(?:\.[1-9][0-9]*){0,2})(?:\.(.*))?$/;
+
+function splitIdAndFields(trimmed) {
+  const capMatch = CAPABILITY_PREFIX.exec(trimmed);
+  if (capMatch) return { id: capMatch[1], fieldsRaw: capMatch[2] ?? '' };
+  const dot = trimmed.indexOf('.');
+  if (dot === -1) return { id: trimmed, fieldsRaw: '' };
+  return { id: trimmed.slice(0, dot), fieldsRaw: trimmed.slice(dot + 1) };
+}
+
+function splitFieldPath(raw, errors, context) {
+  const segments = raw.split('.').filter((s) => s !== '');
+  if (segments.length === 0) {
+    errors.push({ message: `${context}: empty field path` });
+    return [];
+  }
+  if (segments.length > 3) {
+    errors.push({ message: `${context}: field path "${raw}" exceeds max traversal depth 3 (§2)` });
+  }
+  for (const seg of segments) {
+    if (!IDENTIFIER.test(seg)) {
+      errors.push({ message: `${context}: "${seg}" in field path "${raw}" is not a valid field name` });
+    }
+  }
+  return segments;
+}
+
+function classify(rawContent, errors) {
+  const trimmed = rawContent.trim();
+
+  if (trimmed.startsWith('#')) {
+    const rest = trimmed.slice(1).trim();
+    return parseEachOpen(rest, errors);
+  }
+
+  if (trimmed.startsWith('/')) {
+    const rest = trimmed.slice(1).trim();
+    if (rest !== 'each') {
+      errors.push({ message: `unknown closing directive "{{/${rest}}}" — only "{{/ each }}" is defined` });
+    }
+    return { kind: 'each-close' };
+  }
+
+  if (trimmed.startsWith('.')) {
+    if (/\s/.test(trimmed)) {
+      errors.push({ message: `malformed field reference "{{ ${trimmed} }}"` });
+      return { kind: 'error' };
+    }
+    const fields = splitFieldPath(trimmed.slice(1), errors, `field reference "{{ ${trimmed} }}"`);
+    return { kind: 'field-ref', fields };
+  }
+
+  if (/^trace(\s|$)/.test(trimmed)) return parseTrace(trimmed, errors);
+  if (/^view(\s|$)/.test(trimmed)) return parseView(trimmed, errors);
+
+  if (/\s/.test(trimmed)) {
+    errors.push({ message: `unrecognised directive "{{ ${trimmed} }}"` });
+    return { kind: 'error' };
+  }
+
+  const { id, fieldsRaw } = splitIdAndFields(trimmed);
+  if (!isValidId(id)) {
+    errors.push({ message: `inline reference "{{ ${trimmed} }}": "${id}" is not a valid ID (IDS_AND_REFERENCES.md §1)` });
+  }
+  let fields = [];
+  if (fieldsRaw !== '') {
+    fields = splitFieldPath(fieldsRaw, errors, `inline reference "{{ ${trimmed} }}"`);
+  }
+  return { kind: 'inline', id, fields };
+}
+
+function parseEachOpen(rest, errors) {
+  const tokens = rest.split(/\s+/).filter(Boolean);
+  if (tokens[0] !== 'each') {
+    errors.push({ message: `"{{# ${rest} }}" does not open with "each"` });
+    return { kind: 'each-open', entityType: undefined, where: [], orderBy: null };
+  }
+  const entityType = tokens[1];
+  if (!entityType) {
+    errors.push({ message: '"{{# each ... }}": missing entity type' });
+    return { kind: 'each-open', entityType: undefined, where: [], orderBy: null };
+  }
+  if (!isValidTypeName(entityType)) {
+    errors.push({ message: `"{{# each ${entityType} ... }}": "${entityType}" is not a valid TYPE name` });
+  }
+
+  let idx = 2;
+  const where = [];
+  if (tokens[idx] === 'where') {
+    idx++;
+    for (;;) {
+      const field = tokens[idx++];
+      const op = tokens[idx++];
+      const value = tokens[idx++];
+      if (field === undefined || op === undefined || value === undefined) {
+        errors.push({ message: `"{{# each ${entityType} where ... }}": incomplete comparison clause` });
+        break;
+      }
+      if (op !== '=' && op !== '!=') {
+        errors.push({ message: `"{{# each ${entityType} where ... }}": unsupported operator "${op}" — only "=" / "!=" (§2)` });
+      }
+      where.push({ field, op, value });
+      if (tokens[idx] === 'and') { idx++; continue; }
+      break;
+    }
+  }
+
+  let orderBy = null;
+  if (tokens[idx] === 'order') {
+    idx++;
+    if (tokens[idx] !== 'by') {
+      errors.push({ message: `"{{# each ${entityType} ... }}": expected "order by <field>"` });
+    } else {
+      idx++;
+      orderBy = tokens[idx++] ?? null;
+      if (!orderBy) errors.push({ message: `"{{# each ${entityType} ... }}": "order by" missing a field` });
+    }
+  }
+
+  if (idx < tokens.length) {
+    errors.push({ message: `"{{# each ${entityType} ... }}": unexpected trailing "${tokens.slice(idx).join(' ')}"` });
+  }
+
+  return { kind: 'each-open', entityType, where, orderBy };
+}
+
+function parseKeyValuePairs(tokens, startIdx, errors, label) {
+  const kv = {};
+  let idx = startIdx;
+  while (idx < tokens.length) {
+    const key = tokens[idx++];
+    const eq = tokens[idx++];
+    const value = tokens[idx++];
+    if (eq !== '=' || value === undefined) {
+      errors.push({ message: `${label}: malformed "${key ?? ''} ${eq ?? ''}" — expected "key = value"` });
+      break;
+    }
+    kv[key] = value;
+  }
+  return kv;
+}
+
+function parseTrace(trimmed, errors) {
+  const tokens = trimmed.split(/\s+/).filter(Boolean);
+  const kv = parseKeyValuePairs(tokens, 1, errors, `"{{ ${trimmed} }}"`);
+  for (const required of ['from', 'to', 'via']) {
+    if (!kv[required]) errors.push({ message: `"{{ ${trimmed} }}": missing required "${required}"` });
+  }
+  return { kind: 'trace', from: kv.from, to: kv.to, via: kv.via };
+}
+
+function parseView(trimmed, errors) {
+  const path = trimmed.slice(4).trim();
+  if (!path) {
+    errors.push({ message: `"{{ ${trimmed} }}": "view" requires a path` });
+  }
+  if (/\s/.test(path)) {
+    errors.push({ message: `"{{ ${trimmed} }}": view path must not contain whitespace` });
+  }
+  return { kind: 'view', path };
+}
+
+// ── AST construction ────────────────────────────────────────────────────
+// Pairs {{# each }} / {{/ each }} into nested nodes and rejects a `.field`
+// reference that appears outside any each block (nothing for it to resolve against).
+
+function buildAst(tokens) {
+  const errors = [];
+  const root = [];
+  const stack = [{ children: root, insideEach: false }];
+
+  for (const token of tokens) {
+    const top = stack[stack.length - 1];
+    switch (token.kind) {
+      case 'text':
+        top.children.push({ type: 'text', value: token.value });
+        break;
+      case 'inline':
+        top.children.push({ type: 'inline', id: token.id, fields: token.fields });
+        break;
+      case 'field-ref':
+        if (!top.insideEach) {
+          errors.push({ message: 'field reference ("{{ .field }}") used outside an {{# each }} block' });
+        } else {
+          top.children.push({ type: 'field-ref', fields: token.fields });
+        }
+        break;
+      case 'trace':
+        top.children.push({ type: 'trace', from: token.from, to: token.to, via: token.via });
+        break;
+      case 'view':
+        top.children.push({ type: 'view', path: token.path });
+        break;
+      case 'each-open': {
+        const node = {
+          type: 'each',
+          entityType: token.entityType,
+          where: token.where,
+          orderBy: token.orderBy,
+          children: [],
+        };
+        top.children.push(node);
+        stack.push({ children: node.children, insideEach: true });
+        break;
+      }
+      case 'each-close':
+        if (stack.length === 1) {
+          errors.push({ message: '"{{/ each }}" with no matching "{{# each }}"' });
+        } else {
+          stack.pop();
+        }
+        break;
+      case 'error':
+        break; // the classifying error was already recorded in errors
+      default:
+        errors.push({ message: `internal: unknown token kind "${token.kind}"` });
+    }
+  }
+
+  if (stack.length > 1) {
+    errors.push({ message: `${stack.length - 1} unclosed "{{# each }}" block(s) — missing "{{/ each }}"` });
+  }
+
+  return { ast: root, errors };
+}
+
+// ── Public entry point ──────────────────────────────────────────────────
+
+export function parseSkeleton(text) {
+  const fmMatch = FRONT_MATTER.exec(text);
+  if (!fmMatch) {
+    return {
+      header: { document: undefined, canon: undefined, profile: 'neutral' },
+      ast: [],
+      errors: [{ message: 'skeleton file must start with a YAML front-matter header (---\\n...\\n---)' }],
+    };
+  }
+
+  const [, headerText, body] = fmMatch;
+  const { header, errors: headerErrors } = parseHeader(headerText);
+  const { tokens, errors: tokenErrors } = tokenize(body);
+  const { ast, errors: astErrors } = buildAst(tokens);
+
+  return { header, ast, errors: [...headerErrors, ...tokenErrors, ...astErrors] };
+}

--- a/packages/document-view-engine/tests/test_parse_skeleton.mjs
+++ b/packages/document-view-engine/tests/test_parse_skeleton.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// Unit tests for src/parse-skeleton.mjs — every syntax form in the document-view
+// engine epic's §2, plus header validation (§1) and the defined error cases.
+//
+// Run: node packages/document-view-engine/tests/test_parse_skeleton.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { parseSkeleton } from '../src/parse-skeleton.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+function deepEqual(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+function checkEqual(actual, expected, msg) {
+  if (!deepEqual(actual, expected)) {
+    _failures.push(`${msg}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+function skeleton(body, headerExtra = '') {
+  return `---\ndocument: design description\ncanon: ../canon\n${headerExtra}---\n${body}`;
+}
+
+// ── Header (§1) ──────────────────────────────────────────────────────────
+
+{
+  const { header, errors } = parseSkeleton(skeleton(''));
+  check(errors.length === 0, `plain header should parse clean, got: ${JSON.stringify(errors)}`);
+  checkEqual(header, { document: 'design description', canon: '../canon', profile: 'neutral' }, 'header defaults profile to neutral');
+}
+
+{
+  const { errors } = parseSkeleton('---\ncanon: ../canon\n---\nbody');
+  check(errors.some((e) => /document.*required/.test(e.message)), 'missing document is flagged');
+}
+
+{
+  const { errors } = parseSkeleton('---\ndocument: x\n---\nbody');
+  check(errors.some((e) => /canon.*required/.test(e.message)), 'missing canon is flagged');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('', 'profile: srs-legacy\n'));
+  check(errors.some((e) => /profile.*reserved/.test(e.message)), 'non-neutral profile is flagged as reserved');
+}
+
+{
+  const { errors } = parseSkeleton('no front matter here at all');
+  check(errors.some((e) => /front-matter/.test(e.message)), 'missing front matter is flagged');
+}
+
+// ── Inline forms (§2) ────────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ REQ-14 }}'));
+  check(errors.length === 0, `bare id should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'inline', id: 'REQ-14', fields: [] }], 'bare {{ REQ-14 }}');
+}
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ REQ-14.text }}'));
+  check(errors.length === 0, `id.field should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'inline', id: 'REQ-14', fields: ['text'] }], '{{ REQ-14.text }}');
+}
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ REQ-14.parent.title }}'));
+  check(errors.length === 0, `traversal should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'inline', id: 'REQ-14', fields: ['parent', 'title'] }], '{{ REQ-14.parent.title }}');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ REQ-14.a.b.c.d }}'));
+  check(errors.some((e) => /max traversal depth 3/.test(e.message)), 'field path over depth 3 is flagged');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ not-an-id }}'));
+  check(errors.some((e) => /not a valid ID/.test(e.message)), 'malformed id is flagged');
+}
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ CAPABILITY-V1.2.3 }}'));
+  check(errors.length === 0, `capability id should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'inline', id: 'CAPABILITY-V1.2.3', fields: [] }], 'capability diagram-address id has no field path of its own');
+}
+
+// ── Escape (§2) ───────────────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('literal \\{{ not a directive }}'));
+  check(errors.length === 0, `escaped brace should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'text', value: 'literal {{ not a directive }}' }], '\\{{ escapes to a literal {{');
+}
+
+// ── Selection — {{# each }} (§2) ─────────────────────────────────────────
+
+{
+  const body = '{{# each REQUIREMENT where level = system and kind = functional order by id }}\n### {{ .id }} — {{ .title }}\n\n{{ .text }}\n{{/ each }}';
+  const { ast, errors } = parseSkeleton(skeleton(body));
+  check(errors.length === 0, `each block should parse clean: ${JSON.stringify(errors)}`);
+  check(ast.length === 1 && ast[0].type === 'each', 'produces one each node');
+  const node = ast[0];
+  checkEqual(node.entityType, 'REQUIREMENT', 'each entityType');
+  checkEqual(node.where, [
+    { field: 'level', op: '=', value: 'system' },
+    { field: 'kind', op: '=', value: 'functional' },
+  ], 'each where clauses, ANDed');
+  checkEqual(node.orderBy, 'id', 'each order by');
+  const fieldRefs = node.children.filter((c) => c.type === 'field-ref');
+  checkEqual(fieldRefs.map((f) => f.fields), [['id'], ['title'], ['text']], 'each body .field references resolve to current object');
+}
+
+{
+  // no where, no order by — both optional per §2
+  const { ast, errors } = parseSkeleton(skeleton('{{# each REQUIREMENT }}{{ .id }}{{/ each }}'));
+  check(errors.length === 0, `bare each should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast[0].where, [], 'bare each has no where clauses');
+  checkEqual(ast[0].orderBy, null, 'bare each has no order by');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ .id }}'));
+  check(errors.some((e) => /outside an .* each/.test(e.message)), '.field outside each is flagged');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{# each REQUIREMENT }}unclosed'));
+  check(errors.some((e) => /unclosed/.test(e.message)), 'unclosed each is flagged');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{/ each }}'));
+  check(errors.some((e) => /no matching/.test(e.message)), 'unmatched close is flagged');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{# each REQUIREMENT where level > system }}{{/ each }}'));
+  check(errors.some((e) => /unsupported operator/.test(e.message)), 'operator other than = / != is flagged');
+}
+
+// ── Trace matrix (§2) ─────────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ trace from = REQUIREMENT to = VERIFICATION via = verifies }}'));
+  check(errors.length === 0, `trace should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'trace', from: 'REQUIREMENT', to: 'VERIFICATION', via: 'verifies' }], 'trace directive');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ trace from = REQUIREMENT to = VERIFICATION }}'));
+  check(errors.some((e) => /missing required "via"/.test(e.message)), 'trace missing via is flagged');
+}
+
+// ── Embedded view (§2) ────────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ view path/to/view-file }}'));
+  check(errors.length === 0, `view should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'view', path: 'path/to/view-file' }], 'view directive');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ view }}'));
+  check(errors.some((e) => /requires a path/.test(e.message)), 'view with no path is flagged');
+}
+
+// ── Mixed text + directive ────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('Before {{ REQ-14 }} after.'));
+  check(errors.length === 0, `mixed text should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [
+    { type: 'text', value: 'Before ' },
+    { type: 'inline', id: 'REQ-14', fields: [] },
+    { type: 'text', value: ' after.' },
+  ], 'literal text runs interleave with directives');
+}
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('All parse-skeleton checks passed.');


### PR DESCRIPTION
## Summary

- First slice of the document-view engine: a new `@transitrix/document-view-engine` package whose `parseSkeleton()` turns a skeleton file's YAML header + `{{ ... }}` transclusion body into a header object and body AST.
- Covers every syntax form: bare/field/traversal inline references (depth capped at 3), the `{{# each TYPE where ... order by ... }}` selection block, `.field` references scoped to an `each` body, `trace`, `view`, and the `\{{` escape. IDs are validated against the canonical grammar (`IDS_AND_REFERENCES.md` §1-2, including the `CAPABILITY` V/H exception).
- Scope is syntax only, stated explicitly in the package README — canon resolution, the four reference-resolution states, render profiles, derivation share, telemetry, and PDF output are not part of this PR.

Zero runtime dependencies, following this repo's existing `packages/*` convention (own hand-rolled parsing, no shared cross-package runtime import).

**Not included:** the CI workflow file for this package (`.github/workflows/document-view-engine-test.yml`) — pushing `.github/workflows/**` changes is currently blocked by a known token-scope limitation on this repo. The workflow file exists locally and needs to be added by whoever has the right token scope; until then, run the test manually (see Test plan).

## Test plan

- [x] `node packages/document-view-engine/tests/test_parse_skeleton.mjs` — all checks pass
- [x] `node scripts/check-notations.mjs` — doc-lint clean
- [ ] Add `.github/workflows/document-view-engine-test.yml` once push access allows it