### PR TITLE
ci: wire check-notations unit tests into the doc-lint workflow

### DIFF
--- a/.github/workflows/notations-doc-lint.yml
+++ b/.github/workflows/notations-doc-lint.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run notations doc-lint
         run: node scripts/check-notations.mjs
+
+      - name: Run check-notations unit tests
+        run: node --test scripts/check-notations.test.mjs


### PR DESCRIPTION
Wires the existing `scripts/check-notations.test.mjs` unit tests (18 passing locally) into `.github/workflows/notations-doc-lint.yml` as a step after the doc-lint check. These tests existed and passed locally already; only the CI wiring was missing, blocked on a token permission gap that's now resolved.