### PR TITLE
ci: wire check-notations unit tests into the doc-lint workflow

### DIFF
--- a/.github/workflows/notations-doc-lint.yml
+++ b/.github/workflows/notations-doc-lint.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run notations doc-lint
         run: node scripts/check-notations.mjs
+
+      - name: Run check-notations unit tests
+        run: node --test scripts/check-notations.test.mjs


### PR DESCRIPTION
Adds the `scripts/check-notations.test.mjs` unit tests to `.github/workflows/notations-doc-lint.yml` as a step after the doc-lint check, so they run on every pull request and push to `main`.

## Test plan

- [x] `node scripts/check-notations.test.mjs` — 18 checks pass
- [x] `node scripts/check-notations.mjs` — doc-lint clean
- [x] Workflow parses; the new step runs in the same job as the existing check
