### PR TITLE
feat(notations): add figure/figref and view as/fit to document-view engine parser

### DIFF
--- a/packages/document-view-engine/README.md
+++ b/packages/document-view-engine/README.md
@@ -39,7 +39,9 @@ Delimiters `{{ … }}`; `\{{` escapes a literal.
 | `{{# each TYPE where f = v and f2 != v2 order by f }} … {{/ each }}` | `{ type: 'each', entityType, where, orderBy, children }` |
 | `{{ .field }}` (inside an `each` body only) | `{ type: 'field-ref', fields }` |
 | `{{ trace from = A to = B via = rel }}` | `{ type: 'trace', from, to, via }` |
-| `{{ view <path> }}` | `{ type: 'view', path }` |
+| `{{ view <path> as = name fit = width\|page\|none }}` | `{ type: 'view', path, as, fit }` — `as`/`fit` optional, `fit` defaults to `width` |
+| `{{ figure <path> caption = "..." as = name }}` | `{ type: 'figure', path, caption, as }` — `caption`/`as` optional |
+| `{{ figref <name> }}` | `{ type: 'figref', name }` |
 
 `id` is validated against the canonical ID grammar
 ([`IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §1-2), including the

--- a/packages/document-view-engine/src/parse-skeleton.mjs
+++ b/packages/document-view-engine/src/parse-skeleton.mjs
@@ -145,6 +145,8 @@ function classify(rawContent, errors) {
 
   if (/^trace(\s|$)/.test(trimmed)) return parseTrace(trimmed, errors);
   if (/^view(\s|$)/.test(trimmed)) return parseView(trimmed, errors);
+  if (/^figure(\s|$)/.test(trimmed)) return parseFigure(trimmed, errors);
+  if (/^figref(\s|$)/.test(trimmed)) return parseFigref(trimmed, errors);
 
   if (/\s/.test(trimmed)) {
     errors.push({ message: `unrecognised directive "{{ ${trimmed} }}"` });
@@ -233,6 +235,30 @@ function parseKeyValuePairs(tokens, startIdx, errors, label) {
   return kv;
 }
 
+// `caption = "Device, front"` needs quote-aware tokenizing (a bare `.split(/\s+/)`
+// would split the caption itself) — figure is the one directive whose values carry
+// spaces, so only its key/value parsing goes through this path.
+function tokenizeRespectingQuotes(s) {
+  const tokens = [];
+  const re = /"([^"]*)"|(\S+)/g;
+  let m;
+  while ((m = re.exec(s)) !== null) tokens.push(m[1] !== undefined ? m[1] : m[2]);
+  return tokens;
+}
+
+function parseQuotedKeyValuePairs(rest, errors, label) {
+  return parseKeyValuePairs(tokenizeRespectingQuotes(rest), 0, errors, label);
+}
+
+// Splits "<path> key = value key2 = value2" into the leading bare path token (view/figure
+// share this shape: a whitespace-free path followed by key/value pairs) and the remainder.
+function splitPathAndRest(afterKeyword) {
+  const trimmed = afterKeyword.trim();
+  const m = /^(\S*)(?:\s+([\s\S]*))?$/.exec(trimmed);
+  if (!m) return { path: '', rest: '' };
+  return { path: m[1], rest: m[2] ?? '' };
+}
+
 function parseTrace(trimmed, errors) {
   const tokens = trimmed.split(/\s+/).filter(Boolean);
   const kv = parseKeyValuePairs(tokens, 1, errors, `"{{ ${trimmed} }}"`);
@@ -242,15 +268,41 @@ function parseTrace(trimmed, errors) {
   return { kind: 'trace', from: kv.from, to: kv.to, via: kv.via };
 }
 
+const VIEW_FIT_VALUES = ['width', 'page', 'none'];
+
 function parseView(trimmed, errors) {
-  const path = trimmed.slice(4).trim();
+  const { path, rest } = splitPathAndRest(trimmed.slice(4));
   if (!path) {
     errors.push({ message: `"{{ ${trimmed} }}": "view" requires a path` });
   }
-  if (/\s/.test(path)) {
-    errors.push({ message: `"{{ ${trimmed} }}": view path must not contain whitespace` });
+  const kv = parseQuotedKeyValuePairs(rest, errors, `"{{ ${trimmed} }}"`);
+  const fit = kv.fit ?? 'width';
+  if (!VIEW_FIT_VALUES.includes(fit)) {
+    errors.push({ message: `"{{ ${trimmed} }}": fit must be one of ${VIEW_FIT_VALUES.join('/')}, got "${fit}"` });
   }
-  return { kind: 'view', path };
+  return { kind: 'view', path, as: kv.as ?? null, fit };
+}
+
+function parseFigure(trimmed, errors) {
+  const { path, rest } = splitPathAndRest(trimmed.slice(6));
+  if (!path) {
+    errors.push({ message: `"{{ ${trimmed} }}": "figure" requires a path` });
+  }
+  const kv = parseQuotedKeyValuePairs(rest, errors, `"{{ ${trimmed} }}"`);
+  return { kind: 'figure', path, caption: kv.caption ?? null, as: kv.as ?? null };
+}
+
+function parseFigref(trimmed, errors) {
+  const rest = trimmed.slice(6).trim();
+  if (!rest) {
+    errors.push({ message: `"{{ ${trimmed} }}": "figref" requires a name` });
+    return { kind: 'figref', name: undefined };
+  }
+  const [name, ...extra] = rest.split(/\s+/);
+  if (extra.length > 0) {
+    errors.push({ message: `"{{ ${trimmed} }}": "figref" takes a single name, got "${rest}"` });
+  }
+  return { kind: 'figref', name };
 }
 
 // ── AST construction ────────────────────────────────────────────────────
@@ -282,7 +334,13 @@ function buildAst(tokens) {
         top.children.push({ type: 'trace', from: token.from, to: token.to, via: token.via });
         break;
       case 'view':
-        top.children.push({ type: 'view', path: token.path });
+        top.children.push({ type: 'view', path: token.path, as: token.as, fit: token.fit });
+        break;
+      case 'figure':
+        top.children.push({ type: 'figure', path: token.path, caption: token.caption, as: token.as });
+        break;
+      case 'figref':
+        top.children.push({ type: 'figref', name: token.name });
         break;
       case 'each-open': {
         const node = {

--- a/packages/document-view-engine/tests/test_parse_skeleton.mjs
+++ b/packages/document-view-engine/tests/test_parse_skeleton.mjs
@@ -156,12 +156,62 @@ function skeleton(body, headerExtra = '') {
 {
   const { ast, errors } = parseSkeleton(skeleton('{{ view path/to/view-file }}'));
   check(errors.length === 0, `view should parse clean: ${JSON.stringify(errors)}`);
-  checkEqual(ast, [{ type: 'view', path: 'path/to/view-file' }], 'view directive');
+  checkEqual(ast, [{ type: 'view', path: 'path/to/view-file', as: null, fit: 'width' }], 'view directive, fit defaults to width');
+}
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ view path/to/view-file as = fig-arch fit = page }}'));
+  check(errors.length === 0, `view with as/fit should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'view', path: 'path/to/view-file', as: 'fig-arch', fit: 'page' }], 'view directive with as/fit');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ view path/to/view-file fit = tall }}'));
+  check(errors.some((e) => /fit must be one of width\/page\/none/.test(e.message)), 'invalid fit value is flagged');
 }
 
 {
   const { errors } = parseSkeleton(skeleton('{{ view }}'));
   check(errors.some((e) => /requires a path/.test(e.message)), 'view with no path is flagged');
+}
+
+// ── Figure / figref (§2) ──────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ figure path/to/image.png caption = "Device, front" as = fig-device }}'));
+  check(errors.length === 0, `figure should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(
+    ast,
+    [{ type: 'figure', path: 'path/to/image.png', caption: 'Device, front', as: 'fig-device' }],
+    'figure directive with quoted caption',
+  );
+}
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ figure path/to/image.png }}'));
+  check(errors.length === 0, `bare figure should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'figure', path: 'path/to/image.png', caption: null, as: null }], 'figure with no caption/as');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ figure }}'));
+  check(errors.some((e) => /requires a path/.test(e.message)), 'figure with no path is flagged');
+}
+
+{
+  const { ast, errors } = parseSkeleton(skeleton('{{ figref fig-arch }}'));
+  check(errors.length === 0, `figref should parse clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'figref', name: 'fig-arch' }], 'figref directive');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ figref }}'));
+  check(errors.some((e) => /requires a name/.test(e.message)), 'figref with no name is flagged');
+}
+
+{
+  const { errors } = parseSkeleton(skeleton('{{ figref fig-arch fig-other }}'));
+  check(errors.some((e) => /takes a single name/.test(e.message)), 'figref with more than one name is flagged');
 }
 
 // ── Mixed text + directive ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The document-view engine epic's §2 syntax defines `figure`, `figref`, and `view`'s `as =` / `fit =` parameters, but the skeleton-file parser (first slice) only understood a bare `{{ view <path> }}`.
- Adds `{{ figure <path> caption = "..." as = name }}`, `{{ figref <name> }}`, and `view`'s `as =` / `fit =` (validated against `width` / `page` / `none`, defaulting to `width`).
- `caption` values can contain spaces (`"Device, front"`), so `figure`'s key/value parsing goes through a quote-aware tokenizer; `view`/`trace` keep the existing bare-token parser since their values never do.
- Completes §2 syntax coverage before the next layer (evaluation/render profiles) builds on this AST.

## Test plan

- [x] `node packages/document-view-engine/tests/test_parse_skeleton.mjs`
- [x] `node scripts/check-notations.mjs` — doc-lint clean
- [x] `node scripts/check-notations.test.mjs` — 18 checks pass