### PR TITLE
feat(notations): add derived-content evaluation and render profiles to document-view engine

### DIFF
--- a/packages/document-view-engine/README.md
+++ b/packages/document-view-engine/README.md
@@ -6,11 +6,16 @@ transclusion tags; the engine resolves them and emits a document. No document la
 ships with this package — a layout is authored by whoever needs that document, in
 their own repository.
 
-**Scope of this package today: syntax (§2) and reference resolution (§3).**
-`parseSkeleton()` turns a skeleton file's text into a header object and a body AST.
-`resolveReference()` / `createResolver()` classify an id against canon into one of
-the four states below. Neither renders — render profiles (§4), derivation share
-(§5), telemetry (§6), and PDF output (§7) are later layers built on top of these.
+**Scope of this package today: syntax (§2), reference resolution (§3), derived-content
+evaluation, and render profiles (§4) for `inline`/`each` content.** `parseSkeleton()`
+turns a skeleton file's text into a header object and a body AST. `resolveReference()`
+/ `createResolver()` classify an id against canon into one of the four states below.
+`createEvaluator()` resolves `{{ ID.field }}` traversal and `{{# each ... }}`
+selection against canon. `renderDocument()` walks the AST through an evaluator and
+emits HTML in the `review` or `clean` profile. Not yet built: evaluation/rendering
+for `trace` / `view` / `figure` / `figref` (they render as inert pass-through
+markers today), derivation share (§5), telemetry (§6), and PDF output (§7) — later
+layers on top of these.
 
 ## Skeleton file shape
 
@@ -87,9 +92,47 @@ An unresolvable endpoint on a `REL`/claim record is silent, not suspicious — t
 same posture `scripts/check-link-suspicion.mjs` takes (a validator's concern, e.g.
 `REL-002`, not this module's).
 
+## Evaluation and render profiles (§4)
+
+`createEvaluator(canonRoot)` builds on `createResolver()` to resolve the two
+derived-content forms `renderDocument()` needs:
+
+```js
+import { createEvaluator } from '@transitrix/document-view-engine/src/evaluate.mjs';
+
+const evaluator = await createEvaluator('/path/to/canon');
+const { state, flag, content } = await evaluator.evaluateFieldPath('REQ-014', ['parent', 'title'], { renderDate: '2026-08-06' });
+```
+
+`evaluateFieldPath(id, fields, opts)` re-runs §3's four-state classification at
+every traversal hop — a `parent` that is itself out of validity flags the whole
+expression, not just the id nearest the reader. `evaluateEach(node, opts)` selects
+every object of `node.entityType` whose §3 state resolves `ok`, applies `where`
+(AND-only) and `order by`, and returns the matching ids in order.
+
+`renderDocument(ast, evaluator, { profile, renderDate, failOn })` walks the AST and
+emits HTML:
+
+```js
+import { renderDocument } from '@transitrix/document-view-engine/src/render.mjs';
+
+const { html, failed, counts } = await renderDocument(ast, evaluator, { profile: 'review', renderDate: '2026-08-06' });
+```
+
+| Profile | Behaviour |
+|---|---|
+| `review` | Every span is coloured by its §3 state (`dv-ok` / `dv-suspect` / `dv-unresolved`); a non-default class also carries a flag glyph (`⚑S`/`⚑A`/`⚑V`/`⚑U`) as a second channel, never colour alone. |
+| `clean` | Everything renders as `dv-clean`, no flags, no counters. `failed` is `true` when a state in `failOn` occurred anywhere in the render (default: `unresolved`, `not-admitted`, `out-of-validity` — `suspect` warns only, per §4). |
+
+`trace` / `view` / `figure` / `figref` nodes render as HTML comments (`<!-- dv-view:
+not yet rendered (...) -->`) rather than throwing — a full-syntax skeleton still
+renders end to end, but those forms carry no content or classification yet.
+
 ## Tests
 
 ```
 node packages/document-view-engine/tests/test_parse_skeleton.mjs
 node packages/document-view-engine/tests/test_resolve_references.mjs
+node packages/document-view-engine/tests/test_evaluate.mjs
+node packages/document-view-engine/tests/test_render.mjs
 ```

--- a/packages/document-view-engine/package.json
+++ b/packages/document-view-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@transitrix/document-view-engine",
   "version": "0.0.1",
-  "description": "Skeleton-file parser for the document-view engine — turns a Markdown skeleton with {{ ... }} transclusion syntax into a header + body AST. Syntax only: no canon resolution, no rendering (see README for scope).",
+  "description": "Skeleton-file parser and renderer for the document-view engine — turns a Markdown skeleton with {{ ... }} transclusion syntax into a header + body AST, resolves it against canon, and renders review/clean HTML (see README for current scope).",
   "type": "module",
   "engines": {
     "node": ">=18"

--- a/packages/document-view-engine/src/evaluate.mjs
+++ b/packages/document-view-engine/src/evaluate.mjs
@@ -1,0 +1,155 @@
+// Evaluation — resolves a skeleton's derived content against canon (hub epic
+// "Document-view engine: skeleton transclusion, reference flags, render
+// profiles"). Given the AST from parse-skeleton.mjs and an index built by
+// resolve-references.mjs, this module answers two questions render.mjs (§4)
+// needs answered before it can colour anything:
+//
+//   - what text does `{{ ID.field }}` / `{{ ID.parent.title }}` actually
+//     render, and what §3 state does it carry (traversal along a reference
+//     field re-runs §3's four-state classification at each hop — a `parent`
+//     that itself is out of validity flags the whole chain, not just the leaf)
+//   - which objects does `{{# each TYPE where ... order by ... }}` select,
+//     and in what order
+//
+// Scope of this module: inline field access (with traversal, §2's "Inline"
+// table) and `each` selection (§2's "Selection"). It does NOT evaluate
+// `trace` / `view` / `figure` / `figref` — those need a matrix builder and an
+// illustration pipeline respectively, left as later layers (see this
+// package's README for what's still open on the epic).
+//
+// Zero dependencies, own copy of field extraction — same posture as
+// parse-skeleton.mjs / resolve-references.mjs / ids.mjs in this package.
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createResolver } from './resolve-references.mjs';
+import { isValidId } from './ids.mjs';
+
+// ── Generic scalar field extraction ─────────────────────────────────────
+// A canon element's own content fields (name/description/level/kind/...)
+// have no fixed schema this engine knows about — `.field` names whatever the
+// skeleton author asks for. Reads one top-level `key: value` scalar; a
+// nested mapping/list value (e.g. `gate_checks:` with indented children) has
+// no scalar on its own line and is reported as absent, not as its raw YAML.
+
+function extractField(text, name) {
+  const m = text.match(new RegExp(`^${name}:[ \\t]*(.*)$`, 'm'));
+  if (!m) return undefined;
+  let raw = m[1];
+  let inQuotes = false;
+  let cut = raw.length;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (ch === '"') inQuotes = !inQuotes;
+    else if (ch === '#' && !inQuotes) { cut = i; break; }
+  }
+  raw = raw.slice(0, cut).trim();
+  if (raw === '') return undefined;
+  if (raw === 'null') return null;
+  if (raw.startsWith('"') && raw.endsWith('"') && raw.length >= 2) {
+    try { return JSON.parse(raw); } catch { return raw.slice(1, -1); }
+  }
+  if (raw.startsWith("'") && raw.endsWith("'") && raw.length >= 2) return raw.slice(1, -1).replace(/''/g, "'");
+  return raw;
+}
+
+// TYPE is the id's leading run before its first hyphen (IDS_AND_REFERENCES.md
+// §1's grammar defines TYPE as `[A-Z][A-Z0-9_]*` — no hyphens inside it, so
+// splitting at the first hyphen is exact), except the CAPABILITY V/H address
+// form, whose id starts `CAPABILITY-V`/`CAPABILITY-H` — still type CAPABILITY.
+const CAPABILITY_PREFIX = /^CAPABILITY-[VH][1-9]/;
+
+export function typeOfId(id) {
+  if (CAPABILITY_PREFIX.test(id)) return 'CAPABILITY';
+  const dash = id.indexOf('-');
+  return dash === -1 ? id : id.slice(0, dash);
+}
+
+// ── Evaluator ────────────────────────────────────────────────────────────
+
+export async function createEvaluator(canonRoot) {
+  const { index, resolveReference } = await createResolver(canonRoot);
+  const orgRoot = join(canonRoot, '..');
+  const textCache = new Map();
+
+  async function textOf(entry) {
+    const abs = join(orgRoot, ...entry.orgRelPath.split('/'));
+    if (!textCache.has(abs)) {
+      textCache.set(abs, await readFile(abs, 'utf8').catch(() => ''));
+    }
+    return textCache.get(abs);
+  }
+
+  // Resolves `id` plus a `.field[.field...]` path against it. Every
+  // non-terminal segment must hold another id (§2: "traversal along
+  // reference fields") — each hop is re-classified through §3's four states,
+  // so a broken/expired/unadmitted link partway along the chain flags the
+  // whole expression, not just the id closest to the reader. The terminal
+  // segment's raw value is the rendered content.
+  //
+  // `fields.length === 0` is the bare-`{{ ID }}` form (§2's "whole object,
+  // default rendering for its type") — default per-type rendering is
+  // explicitly out of scope for this epic (each type's own spec owns it), so
+  // this evaluator has no formatting to apply; when the id itself resolves,
+  // it renders the id as a neutral placeholder rather than refusing to
+  // render at all.
+  async function evaluateFieldPath(id, fields, { renderDate } = {}) {
+    let current = await resolveReference(id, { renderDate });
+    if (current.state !== 'ok') return { id, state: current.state, flag: current.flag, content: null };
+    if (fields.length === 0) return { id, state: 'ok', flag: null, content: id };
+
+    let entry = index.get(id);
+    for (let i = 0; i < fields.length - 1; i++) {
+      const text = await textOf(entry);
+      const raw = extractField(text, fields[i]);
+      if (raw === undefined || typeof raw !== 'string' || !isValidId(raw)) {
+        return { id, state: 'unresolved', flag: '⚑U', content: null };
+      }
+      current = await resolveReference(raw, { renderDate });
+      if (current.state !== 'ok') return { id: raw, state: current.state, flag: current.flag, content: null };
+      entry = index.get(raw);
+    }
+
+    const text = await textOf(entry);
+    const raw = extractField(text, fields[fields.length - 1]);
+    return { id: current.id, state: 'ok', flag: null, content: raw === undefined || raw === null ? '' : String(raw) };
+  }
+
+  // Selects every object of `node.entityType`, applies `where` (AND-only,
+  // `=`/`!=` against a literal) and `order by`, per §2's "Selection" form.
+  // Only objects that resolve `ok` (admitted, in effect for `renderDate`)
+  // are selected — a listing renders the model as it stands at the render
+  // date, not draft/expired material; §3's flags still apply to any
+  // `.field` reference *within* a selected row (e.g. a row's own `.parent`
+  // can still be suspect), just not to row membership itself.
+  async function evaluateEach(node, { renderDate } = {}) {
+    const rows = [];
+    for (const [id, entry] of index) {
+      if (typeOfId(id) !== node.entityType) continue;
+      const state = await resolveReference(id, { renderDate });
+      if (state.state !== 'ok') continue;
+      const text = await textOf(entry);
+      let matches = true;
+      for (const clause of node.where) {
+        const value = extractField(text, clause.field);
+        const cmp = value === undefined || value === null ? '' : String(value);
+        if (clause.op === '=' && cmp !== clause.value) matches = false;
+        if (clause.op === '!=' && cmp === clause.value) matches = false;
+      }
+      if (matches) rows.push(id);
+    }
+    if (node.orderBy) {
+      const keyOf = async (id) => {
+        if (node.orderBy === 'id') return id;
+        const value = extractField(await textOf(index.get(id)), node.orderBy);
+        return value === undefined || value === null ? '' : String(value);
+      };
+      const keyed = await Promise.all(rows.map(async (id) => [id, await keyOf(id)]));
+      keyed.sort((a, b) => a[1].localeCompare(b[1]));
+      return keyed.map(([id]) => id);
+    }
+    return rows;
+  }
+
+  return { index, resolveReference, evaluateFieldPath, evaluateEach };
+}

--- a/packages/document-view-engine/src/render.mjs
+++ b/packages/document-view-engine/src/render.mjs
@@ -1,0 +1,130 @@
+// Render profiles (hub epic "Document-view engine: skeleton transclusion,
+// reference flags, render profiles", §4) — walks a skeleton's AST
+// (parse-skeleton.mjs) through an evaluator (evaluate.mjs) and emits HTML in
+// one of two profiles from the one evaluation pass:
+//
+//   review — every span is coloured by its §3 state, and colour is never the
+//            only channel: a non-default class also carries a flag glyph
+//            that doubles as the margin mark once this HTML feeds a print
+//            layout (§7, not built yet).
+//   clean  — everything renders black, no flags, no counters; the render
+//            fails (non-zero exit / `failed: true`) on any state in
+//            `failOn` (default: unresolved, not-admitted, out-of-validity —
+//            `suspect` warns only, per §4's "clean ... warns").
+//
+// Scope of this module: `inline` and `field-ref` (bound to an `each` row) —
+// the two derived-content forms evaluate.mjs resolves. `trace` / `view` /
+// `figure` / `figref` render as neutral pass-through placeholders so a
+// full-syntax skeleton still renders end-to-end without throwing; their
+// real rendering (a coverage matrix; an embedded model view or image, with
+// its own border-colour classes) is a later layer — see this package's
+// README for what's still open on the epic.
+
+const DEFAULT_FAIL_ON = ['unresolved', 'not-admitted', 'out-of-validity'];
+
+const STATE_INFO = {
+  ok: { color: 'ok', flag: null },
+  suspect: { color: 'suspect', flag: '⚑S' },
+  'not-admitted': { color: 'unresolved', flag: '⚑A' },
+  'out-of-validity': { color: 'unresolved', flag: '⚑V' },
+  unresolved: { color: 'unresolved', flag: '⚑U' },
+};
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function renderSpan(state, content, profile, counts) {
+  counts[state] = (counts[state] ?? 0) + 1;
+  if (profile === 'clean') {
+    return `<span class="dv-clean">${escapeHtml(content ?? '')}</span>`;
+  }
+  const info = STATE_INFO[state];
+  const flagHtml = info.flag ? `<sup class="dv-flag">${info.flag}</sup>` : '';
+  return `<span class="dv-${info.color}">${escapeHtml(content ?? '')}${flagHtml}</span>`;
+}
+
+async function renderNodes(nodes, evaluator, ctx, out) {
+  for (const node of nodes) {
+    // eslint-disable-next-line no-await-in-loop -- each node can depend on canon reads; order matters for figref numbering
+    await renderNode(node, evaluator, ctx, out);
+  }
+}
+
+async function renderNode(node, evaluator, ctx, out) {
+  switch (node.type) {
+    case 'text':
+      out.html.push(escapeHtml(node.value));
+      return;
+
+    case 'inline': {
+      const result = await evaluator.evaluateFieldPath(node.id, node.fields, ctx);
+      out.html.push(renderSpan(result.state, result.content, ctx.profile, out.counts));
+      if (result.state !== 'ok') out.failedStates.push(result.state);
+      return;
+    }
+
+    case 'field-ref': {
+      if (!ctx.currentRowId) {
+        // buildAst() already rejects a field-ref outside `each` — reachable
+        // only if a caller hands render() an AST that skipped that check.
+        out.html.push(renderSpan('unresolved', '', ctx.profile, out.counts));
+        out.failedStates.push('unresolved');
+        return;
+      }
+      const result = await evaluator.evaluateFieldPath(ctx.currentRowId, node.fields, ctx);
+      out.html.push(renderSpan(result.state, result.content, ctx.profile, out.counts));
+      if (result.state !== 'ok') out.failedStates.push(result.state);
+      return;
+    }
+
+    case 'each': {
+      const rowIds = await evaluator.evaluateEach(node, ctx);
+      for (const rowId of rowIds) {
+        // eslint-disable-next-line no-await-in-loop -- rows render in selection order
+        await renderNodes(node.children, evaluator, { ...ctx, currentRowId: rowId }, out);
+      }
+      return;
+    }
+
+    // Not evaluated yet (see module header) — pass through as an inert
+    // marker so a full-syntax skeleton still renders instead of throwing.
+    case 'trace':
+      out.html.push(`<!-- dv-trace: not yet rendered (from=${escapeHtml(node.from)} to=${escapeHtml(node.to)} via=${escapeHtml(node.via)}) -->`);
+      return;
+    case 'view':
+      out.html.push(`<!-- dv-view: not yet rendered (${escapeHtml(node.path)}) -->`);
+      return;
+    case 'figure':
+      out.html.push(`<!-- dv-figure: not yet rendered (${escapeHtml(node.path)}) -->`);
+      return;
+    case 'figref':
+      out.html.push(`<!-- dv-figref: not yet rendered (${escapeHtml(node.name)}) -->`);
+      return;
+
+    default:
+      throw new Error(`render: unknown AST node type "${node.type}"`);
+  }
+}
+
+// Renders `ast` (from parseSkeleton()) against `evaluator` (from
+// createEvaluator()) in the given profile. Returns:
+//   html         — the rendered document body (no page chrome — §7's layout
+//                  is a later layer)
+//   failed       — true iff `profile === 'clean'` and a state in `failOn`
+//                  occurred anywhere in the render
+//   counts       — { [state]: number } — how many spans landed in each §3
+//                  state, across the whole render
+export async function renderDocument(ast, evaluator, { profile = 'review', renderDate, failOn = DEFAULT_FAIL_ON } = {}) {
+  if (profile !== 'review' && profile !== 'clean') {
+    throw new Error(`render: profile must be "review" or "clean", got "${profile}"`);
+  }
+  const out = { html: [], counts: {}, failedStates: [] };
+  await renderNodes(ast, evaluator, { profile, renderDate }, out);
+
+  const failed = profile === 'clean' && out.failedStates.some((state) => failOn.includes(state));
+  return { html: out.html.join(''), failed, counts: out.counts };
+}

--- a/packages/document-view-engine/tests/test_evaluate.mjs
+++ b/packages/document-view-engine/tests/test_evaluate.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Unit + fixture tests for src/evaluate.mjs — the document-view engine's
+// derived-content evaluation: inline field access with traversal, and
+// `each` selection (§2's "Inline" and "Selection" forms).
+//
+// Run: node packages/document-view-engine/tests/test_evaluate.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createEvaluator, typeOfId } from '../src/evaluate.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+function checkEqual(actual, expected, msg) {
+  if (actual !== expected) {
+    _failures.push(`${msg}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// ── Pure ──────────────────────────────────────────────────────────────────
+
+checkEqual(typeOfId('REQUIREMENT-BACKUP-POWER-1'), 'REQUIREMENT', 'typeOfId splits at the first hyphen');
+checkEqual(typeOfId('TECHNOLOGY_SERVICE-1'), 'TECHNOLOGY_SERVICE', 'typeOfId keeps an underscore-joined TYPE intact');
+checkEqual(typeOfId('CAPABILITY-V1.2'), 'CAPABILITY', 'typeOfId recognises the CAPABILITY V/H diagram-address form');
+
+// ── Fixture — a small canon exercising traversal + selection ──────────────
+
+function writeYaml(dir, name, lines) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), lines.join('\n') + '\n', 'utf8');
+}
+
+async function run() {
+  const orgRoot = mkdtempSync(join(tmpdir(), 'evaluate-'));
+  const canonRoot = join(orgRoot, 'canon');
+  const reqDir = join(canonRoot, 'elements', '01_motivation', 'requirements');
+
+  writeYaml(reqDir, 'REQUIREMENT-PARENT-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-PARENT-1',
+    'name: "Parent requirement"', 'level: system', 'kind: functional',
+    'zone: canon', 'valid_from: "2020-01-01"', 'valid_to: null',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-CHILD-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-CHILD-1',
+    'name: "Child requirement"', 'parent: REQUIREMENT-PARENT-1',
+    'level: system', 'kind: functional',
+    'zone: canon', 'valid_from: "2020-01-01"', 'valid_to: null',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-BROKEN-PARENT-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-BROKEN-PARENT-1',
+    'name: "Points at nothing"', 'parent: REQUIREMENT-GHOST-1',
+    'level: system', 'kind: functional',
+    'zone: canon', 'valid_from: "2020-01-01"', 'valid_to: null',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-DRAFT-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-DRAFT-1',
+    'name: "Still a draft"', 'level: system', 'kind: functional',
+    'admission_state: proposed', 'zone: canon', 'valid_from: "2026-01-01"', 'valid_to: null',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-EXPIRED-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-EXPIRED-1',
+    'name: "Retired"', 'level: system', 'kind: functional',
+    'zone: canon', 'valid_from: "2020-01-01"', 'valid_to: "2021-01-01"',
+  ]);
+  writeYaml(reqDir, 'REQUIREMENT-HARDWARE-1.yaml', [
+    'notation: requirement', 'id: REQUIREMENT-HARDWARE-1',
+    'name: "Wrong kind for the each fixture"', 'level: system', 'kind: hardware',
+    'zone: canon', 'valid_from: "2020-01-01"', 'valid_to: null',
+  ]);
+
+  const evaluator = await createEvaluator(canonRoot);
+  const renderDate = '2026-08-06';
+
+  // ── Inline field access ──
+  {
+    const r = await evaluator.evaluateFieldPath('REQUIREMENT-PARENT-1', ['name'], { renderDate });
+    checkEqual(r.state, 'ok', 'a plain field access on an in-effect element resolves ok');
+    checkEqual(r.content, 'Parent requirement', 'the field value is unquoted and returned');
+  }
+  {
+    const r = await evaluator.evaluateFieldPath('REQUIREMENT-CHILD-1', [], { renderDate });
+    checkEqual(r.state, 'ok', 'a bare id (fields.length===0) resolves ok when the id itself resolves');
+    checkEqual(r.content, 'REQUIREMENT-CHILD-1', 'a bare id renders its own id as a neutral placeholder (no per-type default rendering, out of scope)');
+  }
+  {
+    const r = await evaluator.evaluateFieldPath('REQUIREMENT-CHILD-1', ['parent', 'name'], { renderDate });
+    checkEqual(r.state, 'ok', 'traversal through a reference field resolves ok when every hop resolves ok');
+    checkEqual(r.content, 'Parent requirement', 'traversal renders the terminal field on the final hop');
+  }
+  {
+    const r = await evaluator.evaluateFieldPath('REQUIREMENT-BROKEN-PARENT-1', ['parent', 'name'], { renderDate });
+    checkEqual(r.state, 'unresolved', 'a traversal hop pointing at a nonexistent id flags the whole chain unresolved');
+    checkEqual(r.flag, '⚑U', 'the unresolved flag glyph is ⚑U');
+  }
+  {
+    const r = await evaluator.evaluateFieldPath('REQUIREMENT-DOES-NOT-EXIST-1', ['name'], { renderDate });
+    checkEqual(r.state, 'unresolved', 'a nonexistent base id is unresolved');
+  }
+  {
+    const r = await evaluator.evaluateFieldPath('REQUIREMENT-DRAFT-1', ['name'], { renderDate });
+    checkEqual(r.state, 'not-admitted', 'a proposed draft is not-admitted, per §3');
+  }
+  {
+    const r = await evaluator.evaluateFieldPath('REQUIREMENT-EXPIRED-1', ['name'], { renderDate });
+    checkEqual(r.state, 'out-of-validity', 'a render date past valid_to is out-of-validity, per §3');
+  }
+  {
+    const r = await evaluator.evaluateFieldPath('REQUIREMENT-PARENT-1', ['nonexistent_field'], { renderDate });
+    checkEqual(r.state, 'ok', 'a missing terminal field is not a §3 state — the reference itself still resolves');
+    checkEqual(r.content, '', 'a missing terminal field renders empty content');
+  }
+
+  // ── Each selection ──
+  {
+    const rows = await evaluator.evaluateEach(
+      { entityType: 'REQUIREMENT', where: [{ field: 'level', op: '=', value: 'system' }, { field: 'kind', op: '=', value: 'functional' }], orderBy: 'id' },
+      { renderDate },
+    );
+    checkEqual(
+      JSON.stringify(rows),
+      JSON.stringify(['REQUIREMENT-BROKEN-PARENT-1', 'REQUIREMENT-CHILD-1', 'REQUIREMENT-PARENT-1']),
+      'each selects matching, admitted, in-effect rows, ordered by id — excludes wrong kind, draft, and expired',
+    );
+  }
+  {
+    const rows = await evaluator.evaluateEach(
+      { entityType: 'REQUIREMENT', where: [{ field: 'kind', op: '!=', value: 'functional' }], orderBy: null },
+      { renderDate },
+    );
+    checkEqual(JSON.stringify(rows), JSON.stringify(['REQUIREMENT-HARDWARE-1']), '"!=" excludes the matching value and selects the rest');
+  }
+
+  rmSync(orgRoot, { recursive: true, force: true });
+}
+
+await run();
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('test_evaluate: all checks passed.');

--- a/packages/document-view-engine/tests/test_render.mjs
+++ b/packages/document-view-engine/tests/test_render.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Unit + integration tests for src/render.mjs — render profiles (§4) applied
+// to the derived content evaluate.mjs resolves.
+//
+// Run: node packages/document-view-engine/tests/test_render.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { renderDocument } from '../src/render.mjs';
+import { parseSkeleton } from '../src/parse-skeleton.mjs';
+import { createEvaluator } from '../src/evaluate.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+function checkEqual(actual, expected, msg) {
+  if (actual !== expected) {
+    _failures.push(`${msg}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// ── Unit — a stub evaluator isolates render.mjs's own logic from canon I/O ─
+
+function stubEvaluator(byId, byRow) {
+  return {
+    async evaluateFieldPath(id, fields) {
+      const key = `${id}::${fields.join('.')}`;
+      return byId[key] ?? { id, state: 'unresolved', flag: '⚑U', content: null };
+    },
+    async evaluateEach() {
+      return Object.keys(byRow ?? {});
+    },
+  };
+}
+
+async function run() {
+  // ok, suspect, not-admitted, out-of-validity, unresolved — one inline each
+  {
+    const ast = [
+      { type: 'inline', id: 'A-1', fields: ['x'] },
+      { type: 'text', value: ' ' },
+      { type: 'inline', id: 'B-1', fields: ['x'] },
+      { type: 'text', value: ' ' },
+      { type: 'inline', id: 'C-1', fields: ['x'] },
+      { type: 'text', value: ' ' },
+      { type: 'inline', id: 'D-1', fields: ['x'] },
+      { type: 'text', value: ' ' },
+      { type: 'inline', id: 'E-1', fields: ['x'] },
+    ];
+    const evaluator = stubEvaluator({
+      'A-1::x': { id: 'A-1', state: 'ok', flag: null, content: 'clean value' },
+      'B-1::x': { id: 'B-1', state: 'suspect', flag: '⚑S', content: 'suspect value' },
+      'C-1::x': { id: 'C-1', state: 'not-admitted', flag: '⚑A', content: null },
+      'D-1::x': { id: 'D-1', state: 'out-of-validity', flag: '⚑V', content: null },
+      'E-1::x': { id: 'E-1', state: 'unresolved', flag: '⚑U', content: null },
+    });
+
+    const review = await renderDocument(ast, evaluator, { profile: 'review' });
+    check(review.html.includes('<span class="dv-ok">clean value</span>'), 'review: ok renders plain, no flag');
+    check(review.html.includes('<span class="dv-suspect">suspect value<sup class="dv-flag">⚑S</sup></span>'), 'review: suspect carries colour + margin-mark flag');
+    check(review.html.includes('<span class="dv-unresolved"><sup class="dv-flag">⚑A</sup></span>'), 'review: not-admitted renders red with ⚑A');
+    check(review.html.includes('<span class="dv-unresolved"><sup class="dv-flag">⚑V</sup></span>'), 'review: out-of-validity renders red with ⚑V');
+    check(review.html.includes('<span class="dv-unresolved"><sup class="dv-flag">⚑U</sup></span>'), 'review: unresolved renders red with ⚑U (flag glyph + margin mark)');
+    checkEqual(review.counts.ok, 1, 'review: counts tally by state (ok)');
+    checkEqual(review.counts.suspect, 1, 'review: counts tally by state (suspect)');
+
+    const clean = await renderDocument(ast, evaluator, { profile: 'clean' });
+    check(clean.html.includes('<span class="dv-clean">clean value</span>'), 'clean: content renders, no colour class name leaks the state');
+    check(!clean.html.includes('⚑'), 'clean: no flag glyphs anywhere');
+    check(clean.failed, 'clean: fails when unresolved/not-admitted/out-of-validity occurred (default failOn)');
+  }
+
+  // clean profile: suspect-only does not fail by default, but does with a custom failOn
+  {
+    const ast = [{ type: 'inline', id: 'B-1', fields: ['x'] }];
+    const evaluator = stubEvaluator({ 'B-1::x': { id: 'B-1', state: 'suspect', flag: '⚑S', content: 'v' } });
+    const defaultFailOn = await renderDocument(ast, evaluator, { profile: 'clean' });
+    check(!defaultFailOn.failed, 'clean: suspect alone warns, does not fail, under the default failOn set');
+    const customFailOn = await renderDocument(ast, evaluator, { profile: 'clean', failOn: ['suspect'] });
+    check(customFailOn.failed, 'clean: --fail-on can be configured to fail on suspect too');
+  }
+
+  // clean profile: an all-ok render exits clean
+  {
+    const ast = [{ type: 'inline', id: 'A-1', fields: ['x'] }];
+    const evaluator = stubEvaluator({ 'A-1::x': { id: 'A-1', state: 'ok', flag: null, content: 'v' } });
+    const clean = await renderDocument(ast, evaluator, { profile: 'clean' });
+    check(!clean.failed, 'clean: an all-ok render does not fail');
+  }
+
+  // each / field-ref
+  {
+    const ast = [{
+      type: 'each',
+      entityType: 'REQUIREMENT',
+      where: [],
+      orderBy: null,
+      children: [
+        { type: 'field-ref', fields: ['name'] },
+        { type: 'text', value: ';' },
+      ],
+    }];
+    const evaluator = {
+      async evaluateEach() { return ['ROW-1', 'ROW-2']; },
+      async evaluateFieldPath(id, fields) {
+        checkEqual(fields.join('.'), 'name', 'field-ref inside each passes its own field path through');
+        return { id, state: 'ok', flag: null, content: `${id}-name` };
+      },
+    };
+    const review = await renderDocument(ast, evaluator, { profile: 'review' });
+    checkEqual(review.html, '<span class="dv-ok">ROW-1-name</span>;<span class="dv-ok">ROW-2-name</span>;', 'each renders its children once per selected row, in order');
+  }
+
+  // a field-ref outside any each is unreachable via parseSkeleton (rejected
+  // at parse time) but render.mjs still degrades safely if handed one
+  {
+    const ast = [{ type: 'field-ref', fields: ['x'] }];
+    const evaluator = stubEvaluator({});
+    const clean = await renderDocument(ast, evaluator, { profile: 'clean' });
+    check(clean.failed, 'a field-ref with no current row renders unresolved rather than throwing');
+  }
+
+  // unknown profile value rejected
+  {
+    let threw = false;
+    try {
+      await renderDocument([], stubEvaluator({}), { profile: 'bogus' });
+    } catch {
+      threw = true;
+    }
+    check(threw, 'an unknown profile value is rejected rather than silently rendering something');
+  }
+
+  // ── Integration — real parseSkeleton + createEvaluator end to end ──
+  {
+    function writeYaml(dir, name, lines) {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, name), lines.join('\n') + '\n', 'utf8');
+    }
+    const orgRoot = mkdtempSync(join(tmpdir(), 'render-'));
+    const canonRoot = join(orgRoot, 'canon');
+    const reqDir = join(canonRoot, 'elements', '01_motivation', 'requirements');
+
+    writeYaml(reqDir, 'REQUIREMENT-ALPHA-1.yaml', [
+      'notation: requirement', 'id: REQUIREMENT-ALPHA-1', 'name: "Alpha"', 'level: system', 'kind: functional',
+      'zone: canon', 'valid_from: "2020-01-01"', 'valid_to: null',
+    ]);
+    writeYaml(reqDir, 'REQUIREMENT-BETA-1.yaml', [
+      'notation: requirement', 'id: REQUIREMENT-BETA-1', 'name: "Beta"', 'level: system', 'kind: functional',
+      'zone: canon', 'valid_from: "2020-01-01"', 'valid_to: null',
+    ]);
+
+    const skeletonText = [
+      '---',
+      'document: test doc',
+      'canon: ../canon',
+      '---',
+      '{{# each REQUIREMENT where level = system and kind = functional order by id }}',
+      '{{ .name }} - {{ REQUIREMENT-GHOST-1.name }}',
+      '{{/ each }}',
+    ].join('\n');
+
+    const { header, ast, errors } = parseSkeleton(skeletonText);
+    checkEqual(errors.length, 0, 'the integration skeleton parses cleanly');
+    checkEqual(header.canon, '../canon', 'header canon path parsed');
+
+    const evaluator = await createEvaluator(canonRoot);
+    const review = await renderDocument(ast, evaluator, { profile: 'review', renderDate: '2026-08-06' });
+    check(review.html.includes('<span class="dv-ok">Alpha</span>'), 'integration: real field access renders through the each loop');
+    check(review.html.includes('<span class="dv-ok">Beta</span>'), 'integration: both selected rows render, in id order');
+    check(review.html.includes('⚑U'), 'integration: the unresolved reference inside the loop still flags');
+
+    const clean = await renderDocument(ast, evaluator, { profile: 'clean', renderDate: '2026-08-06' });
+    check(clean.failed, 'integration: clean profile fails the build on the unresolved reference');
+
+    rmSync(orgRoot, { recursive: true, force: true });
+  }
+}
+
+await run();
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('test_render: all checks passed.');


### PR DESCRIPTION
## Summary
- Adds `createEvaluator()` — resolves `{{ ID.field }}` traversal (re-classifying §3's four states at every hop) and `{{# each ... }}` selection (filter + order by) against canon.
- Adds `renderDocument()` — walks the AST through an evaluator and emits HTML in the `review` (coloured, flagged) or `clean` (fails the build on a configurable state set) render profile, §4 of the epic.
- `trace` / `view` / `figure` / `figref` still render as inert pass-through markers; evaluating those, derivation share (§5), telemetry (§6), and PDF output (§7) remain open on the epic.

## Test plan
- [x] `node packages/document-view-engine/tests/test_evaluate.mjs`
- [x] `node packages/document-view-engine/tests/test_render.mjs`
- [x] `node packages/document-view-engine/tests/test_parse_skeleton.mjs` / `test_resolve_references.mjs` (unchanged, still green)
- [x] `node scripts/check-notations.mjs`