### PR TITLE
chore(release): bump methodology_version pin to 3.2.0

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,13 +23,14 @@ If a single release combines multiple kinds of change, the bump is the **highest
 For every release, in order:
 
 1. **Confirm the bump category.** Read every PR landed since the previous tag; categorise each change per the table above; pick the bump.
-2. **Update `methodology_version` in the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo's `transitrix.yaml`** to the new version, via a companion PR in that repo. acme-corp is the fixture adopter and tracks the latest released version.
-3. **Update each notation spec's `version:` frontmatter** if any spec changed in this release. (`spec_version` on individual files is informational — see CONTRACT §10.1 — so this step is bookkeeping for discoverability, not enforcement.)
-4. **Write release notes** describing what changed by category (`Added`, `Changed`, `Fixed`, `Removed`). Reference PR numbers.
-5. **For a `MAJOR` release** — ship a migration recipe under `migrations/<prev>-to-<this>/` (recipe format: see [`migrations/`](migrations/) and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10.4). The recipe is a precondition for the tag.
-6. **Tag** the release commit with `vX.Y.Z`.
-7. **Publish** the release notes as a GitHub Release on the tag.
-8. **Announce** the release (channel TBD with the maintainer).
+2. **Bump `notations/CURRENT_VERSION.yaml`** to the new version, in the same PR as the release notes. This is the manifest pin `scripts/check-notations.mjs`'s V1 check enforces every other concrete `methodology_version:` pin in this repo against — run `node scripts/check-notations.mjs` after bumping it and fix every pin the check flags (or add it to the script's allowlist if it is an intentional placeholder, e.g. a migration fixture pinned to a fixed source version). The tag is cut from a commit where this check is already clean — do not tag first and bump after.
+3. **Update `methodology_version` in the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo's `transitrix.yaml`** to the new version, via a companion PR in that repo. acme-corp is the fixture adopter and tracks the latest released version.
+4. **Update each notation spec's `version:` frontmatter** if any spec changed in this release. (`spec_version` on individual files is informational — see CONTRACT §10.1 — so this step is bookkeeping for discoverability, not enforcement.)
+5. **Write release notes** describing what changed by category (`Added`, `Changed`, `Fixed`, `Removed`). Reference PR numbers.
+6. **For a `MAJOR` release** — ship a migration recipe under `migrations/<prev>-to-<this>/` (recipe format: see [`migrations/`](migrations/) and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10.4). The recipe is a precondition for the tag.
+7. **Tag** the release commit with `vX.Y.Z`.
+8. **Publish** the release notes as a GitHub Release on the tag.
+9. **Announce** the release (channel TBD with the maintainer).
 
 ---
 

--- a/method/02-team-operations.md
+++ b/method/02-team-operations.md
@@ -146,7 +146,7 @@ Deliberately **not** one-file-per-record like ADR/WI: a single file, `operations
 ---
 ### FB-0002
 type: notation-gap
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 raised_by: modeler
 date: "2026-07-27"
 status: sent-upstream

--- a/migrations/3.1-to-4.0/fixtures/after/strategy.dgca.transitrix.yaml
+++ b/migrations/3.1-to-4.0/fixtures/after/strategy.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.3"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 id: FGA-STARTUP-1
 name: "Product launch — strategy chain"

--- a/migrations/3.1-to-4.0/fixtures/before/strategy.fga.transitrix.yaml
+++ b/migrations/3.1-to-4.0/fixtures/before/strategy.fga.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: fga
 spec_version: "0.3"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 id: FGA-STARTUP-1
 name: "Product launch — strategy chain"

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -876,7 +876,7 @@ Structural layout of a view document:
 ```yaml
 notation: dgca                # §1 — required header
 spec_version: "0.1"           # §1 — optional header
-methodology_version: "3.1.0"  # manifest-pinned methodology version
+methodology_version: "3.2.0"  # manifest-pinned methodology version
 name: "Retail strategy chain" # §1.1 — required document name
 
 view:                         # view identity block — id only; name lives at root per §1.1
@@ -957,7 +957,7 @@ views/
 ```yaml
 view_id: DGCA-RETAIL-1               # canonical ID of the view being captured
 generated_at: "2026-06-20T14:30:00Z" # ISO-8601 UTC timestamp — matches the file name
-methodology_version: "3.1.0"          # methodology version in use at generation time
+methodology_version: "3.2.0"          # methodology version in use at generation time
 # …notation-specific element list follows (format defined per notation spec)…
 ```
 

--- a/notations/COVERAGE_PROFILES.md
+++ b/notations/COVERAGE_PROFILES.md
@@ -24,7 +24,7 @@ A profile is declared at the repository root in `transitrix.yaml` under the `cov
 
 ```yaml
 transitrix: 1
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core         # short form — name a shipped preset
@@ -250,7 +250,7 @@ The shipped presets (`minimal`, `core`, `full`) are *re-defined per methodology 
 ```yaml
 # transitrix.yaml
 transitrix: 1
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 notations: [dgca, goals, activities, capability-map, applications]
 zones: [canon, field]
 # coverage_profile omitted → defaults to `full`

--- a/notations/CURRENT_VERSION.yaml
+++ b/notations/CURRENT_VERSION.yaml
@@ -5,4 +5,4 @@
 # placeholder allowlist in scripts/check-notations.mjs. Enforced by that
 # script's V1 check. See notations/CONTRACT.md §10 for the versioning and
 # compatibility policy this pin follows.
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -29,7 +29,7 @@ A worked example lives at `transitrix.yaml` in the [acme-corp reference repo](ht
 
 ```yaml
 transitrix: 1                       # manifest schema version (integer)
-methodology_version: "3.1.0"        # the methodology release this repo conforms to
+methodology_version: "3.2.0"        # the methodology release this repo conforms to
 notations: [dgca, goals, action, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md

--- a/notations/PACKAGES.md
+++ b/notations/PACKAGES.md
@@ -20,7 +20,7 @@ A package is declared at the repository root in `transitrix.yaml` under the `pac
 
 ```yaml
 transitrix: 1
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core

--- a/notations/examples/compliance-impact/README.md
+++ b/notations/examples/compliance-impact/README.md
@@ -25,7 +25,7 @@ A compliance-impact view file carries the shared envelope (`notation:`, `spec_ve
 ```yaml
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: COMPLIANCE_IMPACT-<NAME>-1

--- a/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
+++ b/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 name: "Retail product — GDPR obligations"
 
 view:

--- a/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
+++ b/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 id: DGCA-DATA-RESIDENCY-1
 name: "EU data-residency DGCA chain"

--- a/notations/examples/dgca/startup.dgca.transitrix.yaml
+++ b/notations/examples/dgca/startup.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 id: DGCA-STARTUP-1
 name: "Product launch — strategy chain"

--- a/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 id: DGCA-STRATEGY-2026-DGA
 name: "Strategy 2026 — DGA view"

--- a/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 id: DGCA-STRAT-1
 name: "Strategy 2026 — DGCA chain"

--- a/notations/examples/mrd/README.md
+++ b/notations/examples/mrd/README.md
@@ -34,7 +34,7 @@ An MRD view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: mrd
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: MRD-<NAME>-1

--- a/notations/examples/mrd/incident-status.mrd.transitrix.yaml
+++ b/notations/examples/mrd/incident-status.mrd.transitrix.yaml
@@ -2,7 +2,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Incident status communication — MRD"
 generated_at: "2026-08-04"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: MRD-INCIDENT-STATUS-1

--- a/notations/examples/packages/reqif-workflow/transitrix.yaml
+++ b/notations/examples/packages/reqif-workflow/transitrix.yaml
@@ -4,7 +4,7 @@
 # (packages/reqif-cli/tests/test_reqif_integrity.py Part B) stays unaffected
 # by content the XML converter does not carry (see this folder's README).
 transitrix: 1
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/packages/reqif/transitrix.yaml
+++ b/notations/examples/packages/reqif/transitrix.yaml
@@ -3,7 +3,7 @@
 # permitted cross-reference (Transitrix.CanonRef, reqif.md §3) something real
 # to cite, plus the reqif/ package folder itself.
 transitrix: 1
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/scenarios/README.md
+++ b/notations/examples/scenarios/README.md
@@ -26,7 +26,7 @@ A post-reclassification scenarios view file carries no canonical content. It dec
 ```yaml
 notation: scenarios
 spec_version: "0.3"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: SCENARIOS-2027-CUT-1

--- a/notations/examples/sdd/README.md
+++ b/notations/examples/sdd/README.md
@@ -35,7 +35,7 @@ An SDD view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: sdd
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: SDD-<NAME>-1

--- a/notations/examples/sdd/data-export.sdd.transitrix.yaml
+++ b/notations/examples/sdd/data-export.sdd.transitrix.yaml
@@ -2,7 +2,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Data export capability — SDD"
 generated_at: "2026-08-04"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: SDD-DATA-EXPORT-1

--- a/notations/examples/srs/README.md
+++ b/notations/examples/srs/README.md
@@ -33,7 +33,7 @@ An SRS view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: srs
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: SRS-<NAME>-1

--- a/notations/examples/srs/backup-power.srs.transitrix.yaml
+++ b/notations/examples/srs/backup-power.srs.transitrix.yaml
@@ -2,7 +2,7 @@ notation: srs
 spec_version: "0.1"
 name: "Backup-power controller — SRS"
 generated_at: "2026-08-04"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: SRS-BACKUP-POWER-1

--- a/notations/packages/reqif.md
+++ b/notations/packages/reqif.md
@@ -21,7 +21,7 @@ This is a package, not a core notation: nothing here changes `IDS_AND_REFERENCES
 
 ```yaml
 transitrix: 1
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 packages: [reqif]
 ```
 

--- a/notations/views/diagrams/02-dgca.md
+++ b/notations/views/diagrams/02-dgca.md
@@ -154,7 +154,7 @@ A DGCA document opens with a shared header block (`notation:`, `spec_version:`, 
 ```yaml
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 id: DGCA-LAUNCH-1
 name: "Product launch strategy chain"
 period: "2026"
@@ -188,7 +188,7 @@ notation: dgca
 spec_version: "0.1"
 id: DGCA-RETAIL-1
 name: "Retail strategy chain 2026"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view_config:
   goals:

--- a/notations/views/diagrams/04-goals.md
+++ b/notations/views/diagrams/04-goals.md
@@ -117,7 +117,7 @@ After goals are promoted to `canon/elements/01_motivation/goals/`, the view beco
 ```yaml
 notation: goals
 spec_version: "0.1"
-methodology_version: "3.1.0"          # required from v2.0 onward
+methodology_version: "3.2.0"          # required from v2.0 onward
 
 id: GOALS-STRAT-2026-1                 # required — GOALS-[<middle>-]<INTEGER>
 name: "Strategy 2026 — Goals Tree"    # required per CONTRACT.md §1.1

--- a/notations/views/diagrams/07-action.md
+++ b/notations/views/diagrams/07-action.md
@@ -128,7 +128,7 @@ After actions are promoted to `canon/elements/05_implementation/actions/`, the v
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "3.1.0"          # required from v2.0 onward
+methodology_version: "3.2.0"          # required from v2.0 onward
 
 id: ACTION_SCHED-PLATFORM-2026-1      # required — ACTION_SCHED-[<middle>-]<INTEGER>
 name: "Platform Launch 2026"          # required per CONTRACT.md §1.1
@@ -344,7 +344,7 @@ Both views are projections of the same underlying schedule. A document never "be
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 id: ACTION_SCHED-MINIMAL-1
 name: "Minimal schedule example"           # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                # optional per CONTRACT.md §4

--- a/notations/views/documents/29-mrd.md
+++ b/notations/views/documents/29-mrd.md
@@ -45,7 +45,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Incident status communication — MRD"   # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: MRD-INCIDENT-STATUS-1
@@ -168,7 +168,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Full MRD — all needs"           # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"             # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   id: MRD-ALL-1
   name: "Full MRD — all needs"

--- a/notations/views/documents/30-srs.md
+++ b/notations/views/documents/30-srs.md
@@ -45,7 +45,7 @@ notation: srs
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   # ... see §3
 ```
@@ -97,7 +97,7 @@ notation: srs
 spec_version: "0.1"
 name: "Backup-power controller — SRS"          # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                     # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: SRS-BACKUP-POWER-1
@@ -158,7 +158,7 @@ notation: srs
 spec_version: "0.1"
 name: "Full SRS — all software-tier requirements"    # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                           # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   id: SRS-ALL-1
   name: "Full SRS — all software-tier requirements"

--- a/notations/views/documents/31-sdd.md
+++ b/notations/views/documents/31-sdd.md
@@ -45,7 +45,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   # ... see §3
 ```
@@ -101,7 +101,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Data export capability — SDD"          # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: SDD-DATA-EXPORT-1
@@ -170,7 +170,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Full SDD — all design elements"   # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"               # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   id: SDD-ALL-1
   name: "Full SDD — all design elements"

--- a/notations/views/reports/11-scenarios.md
+++ b/notations/views/reports/11-scenarios.md
@@ -45,7 +45,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   # ... see §3
 ```
@@ -95,7 +95,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Optimistic vs Conservative — 2027 cut"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                       # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: SCENARIOS-<NAME>-1
@@ -152,7 +152,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "All scenarios"                   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   id: SCENARIOS-ALL-1
   name: "All scenarios"

--- a/notations/views/reports/21-compliance-impact.md
+++ b/notations/views/reports/21-compliance-impact.md
@@ -45,7 +45,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   # ... see §3
 ```
@@ -103,7 +103,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Retail product — GDPR obligations"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: COMPLIANCE_IMPACT-RETAIL-GDPR-1
@@ -190,7 +190,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Full compliance matrix"          # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   id: COMPLIANCE_IMPACT-ALL-1
   name: "Full compliance matrix"

--- a/notations/views/reports/22-coverage-metric.md
+++ b/notations/views/reports/22-coverage-metric.md
@@ -45,7 +45,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Retail product — regime coverage"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 view:
   id: COVERAGE_METRIC-RETAIL-1
@@ -199,7 +199,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Full coverage metric"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 view:
   id: COVERAGE_METRIC-ALL-1
   name: "Full coverage metric"

--- a/transitrix/skills/feedback/SKILL.md
+++ b/transitrix/skills/feedback/SKILL.md
@@ -179,7 +179,7 @@ element"* — which passes.
    ---
    ### FB-0003
    type: notation-gap
-   methodology_version: "3.1.0"
+   methodology_version: "3.2.0"
    raised_by: Modeler
    date: "2026-07-28"
    status: open

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -158,7 +158,7 @@ The root `transitrix.yaml` pins which methodology release this repo conforms to 
 
 ```yaml
 transitrix: 1
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 notations: [dgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```

--- a/transitrix/skills/onboard/templates/action.action.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/action.action.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: action
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 # Action schedule — pure projection over standalone ACTION elements.
 # Spec: notations/views/diagrams/07-action.md (v2.0). No action data is authored inline.

--- a/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: coverage-metric
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 # Coverage Metric. Spec: notations/views/reports/22-coverage-metric.md
 # Report-config over the coverage read of canon (sibling of Compliance Impact).

--- a/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: goals
 spec_version: "0.1"
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 # Goals tree — pure projection over standalone GOAL elements.
 # Spec: notations/views/diagrams/04-goals.md (v2.0). No element data is authored inline.


### PR DESCRIPTION
## Summary
- `v3.2.0` was tagged and its changelog published without bumping `notations/CURRENT_VERSION.yaml`, leaving the manifest pin — and every concrete `methodology_version` pin it governs — one release behind the published tag.
- Bumps the pin across the repo (CONTRACT.md, examples, view specs, onboarding templates, the two `3.1-to-4.0` migration fixtures) to `3.2.0`.
- Adds the missing step to `RELEASING.md`'s per-release checklist so a future release bumps this repo's own pin in the same PR as the changelog, before tagging, instead of after.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean (methodology_version pins consistent)