### PR TITLE
feat(notations): compute derivation share in the document-view engine

### DIFF
--- a/packages/document-view-engine/README.md
+++ b/packages/document-view-engine/README.md
@@ -9,7 +9,8 @@ their own repository.
 **Scope of this package today: syntax (§2), reference resolution (§3), derived-content
 evaluation, render profiles (§4) for `inline`/`each` content, `figure`/`figref`
 rendering, the `trace` coverage matrix, `view` rendering for the `blocks`
-notation, and derivation share (§5).** `parseSkeleton()` turns a skeleton file's text
+notation, derivation share (§5), telemetry (§6), and §7 output (print stylesheet, the
+print-engine seam, and page-geometry verification).** `parseSkeleton()` turns a skeleton file's text
 into a header object and a body AST. `resolveReference()` / `createResolver()`
 classify an id against canon into one of the four states below. `createEvaluator()`
 resolves `{{ ID.field }}` traversal, `{{# each ... }}` selection, and
@@ -20,8 +21,15 @@ point at them, the `trace` matrix as an HTML table, and — in `review` only —
 derivation-share and illustrations lines. `view` renders a `blocks` notation
 (nested-form) source file as inline SVG at render time (`src/blocks-view.mjs`); any
 other notation, or the `blocks` notation's `grid:` (matrix-subset) root, renders as a
-missing/failed illustration — those are later slices on this epic. Not yet built:
-telemetry (§6) and PDF output (§7) — later layers on top of these.
+missing/failed illustration — those are later slices on this epic. `renderDocument()`
+also returns a §6 telemetry snapshot alongside the derivation-share numbers, in the
+same single pass. `wrapDocument()` (`src/pdf-layout.mjs`) wraps a rendered `html`
+body in a standalone document carrying the §7 print stylesheet — page size, every
+`dv-*` class's print colour/border, and the `dv-fit-page` landscape-page rule;
+`convertToPdf()` runs it through a **caller-supplied** print engine and verifies the
+resulting page geometry (`src/pdf-geometry.mjs`). The engine itself is not bundled:
+it is a dependency this repo does not carry today, so it is a parameter — see the
+"PDF output" section below.
 
 ## Skeleton file shape
 
@@ -208,6 +216,87 @@ without the printed line. The printed lines themselves — `<div class="dv-deriv
 counters (§4). An empty document (no counted content at all) prints `n/a` rather
 than a `0%` that would misleadingly claim a share.
 
+## Telemetry (§6)
+
+`renderDocument()` also returns a `telemetry` snapshot (`src/telemetry.mjs`), built in
+the same single pass, of exactly what §6 asks for and nothing else: "which types,
+fields, relation kinds and matrix pairs were referenced and how often; counts of each
+failure state" — never section titles, heading text, prose, file names, or skeleton
+ordering, since any of those could be replayed back into a document's shape.
+
+```js
+const { telemetry } = await renderDocument(ast, evaluator, { profile: 'review' });
+// telemetry → {
+//   types:         { [TYPE]: count },              -- every inline/field-ref/each/trace type reference
+//   fields:        { ['TYPE.field(.field...)']: count },  -- every inline/field-ref field path, under its type
+//   relations:     { [via]: count },                -- every trace node's relation kind
+//   matrixPairs:   { ['from|to|via']: count },       -- every trace node's from/to/via triple
+//   failureStates: { [state]: count },              -- every §3 state other than 'ok', across the whole render
+// }
+```
+
+An `inline`/`field-ref`'s type comes from `evaluate.mjs`'s `typeOfId()` on the id it
+resolved against, not from the skeleton text itself. A failure state is recorded at
+every point this module already tracks one for the `clean` profile's `failOn` —
+inline, field-ref, `figure`, `view`, and `figref` alike — so the tally covers the
+whole render, not only spans. `telemetry` is always returned, identically, regardless
+of `profile`; only the printed HTML differs between `review` and `clean`.
+
+## PDF output (§7)
+
+Three pieces, in the order the output actually happens: **declare** the page geometry,
+**convert** through a print engine, **verify** the geometry of what came back.
+
+### Declare — `src/pdf-layout.mjs`
+
+`wrapDocument(bodyHtml, { title })` wraps a `renderDocument()` body in a standalone
+`<html>` document carrying `buildStylesheet()`'s CSS: `@page { size: A4; margin:
+20mm; }` for the default portrait page, a named `@page landscape { size: A4 landscape;
+margin: 15mm; }` for a `dv-fit-page` illustration, and the print colour/border for
+every `dv-*` class `render.mjs` emits (§4's state colours, the four illustration
+border classes, the `dv-trace` table).
+
+### Convert — the engine is a parameter, not a dependency
+
+This package bundles no print engine. Turning HTML into PDF bytes needs a headless
+rendering engine, which is a dependency it does not carry today (`"dependencies": {}`
+— see `package.json`); which engine to adopt is an open architecture question, filed
+separately rather than decided inside this slice. So the engine is supplied by the
+caller:
+
+```js
+import { convertToPdf } from '@transitrix/document-view-engine/src/pdf-layout.mjs';
+
+const { pdf, geometry } = await convertToPdf(html, {
+  title: 'Design Description',
+  convert: (doc) => myPrintEngine.render(doc),   // HTML in, PDF bytes out
+});
+```
+
+Everything around the engine — wrap, convert, verify — is implemented and tested here,
+so adopting an engine later is supplying one function rather than writing this half.
+
+### Verify — `src/pdf-geometry.mjs`
+
+`verifyPageGeometry(pdfBytes)` reads every page's `/MediaBox` (honouring `/Rotate` and
+page-tree inheritance) and checks it is A4 in one of the two declared orientations —
+595 × 842 pt portrait, 842 × 595 pt landscape, ±1 pt. `convertToPdf` runs it by default
+and **throws** on a mismatch.
+
+The check is the point of §7, not decoration: an engine that ignores `@page { size:
+A4 }` falls back to its own default paper — 612 × 792 pt, US Letter — and produces a
+plausible-looking PDF whose last centimetres spill onto a second page every time. That
+case is reported by name ("US Letter — the page-size declaration was ignored"), not as
+a bare size mismatch. A PDF whose page objects cannot be read at all (compressed object
+streams) is also a failure, never a vacuous pass: an unverifiable page size is not a
+verified one.
+
+```js
+import { verifyPageGeometry } from '@transitrix/document-view-engine/src/pdf-geometry.mjs';
+
+const { ok, pages, problems } = verifyPageGeometry(pdfBytes);
+```
+
 ## Tests
 
 ```
@@ -217,4 +306,7 @@ node packages/document-view-engine/tests/test_evaluate.mjs
 node packages/document-view-engine/tests/test_blocks_view.mjs
 node packages/document-view-engine/tests/test_render.mjs
 node packages/document-view-engine/tests/test_derivation_share.mjs
+node packages/document-view-engine/tests/test_telemetry.mjs
+node packages/document-view-engine/tests/test_pdf_layout.mjs
+node packages/document-view-engine/tests/test_pdf_geometry.mjs
 ```

--- a/packages/document-view-engine/README.md
+++ b/packages/document-view-engine/README.md
@@ -8,19 +8,20 @@ their own repository.
 
 **Scope of this package today: syntax (§2), reference resolution (§3), derived-content
 evaluation, render profiles (§4) for `inline`/`each` content, `figure`/`figref`
-rendering, the `trace` coverage matrix, and `view` rendering for the `blocks`
-notation.** `parseSkeleton()` turns a skeleton file's text into a header object and a
-body AST. `resolveReference()` / `createResolver()` classify an id against canon into
-one of the four states below. `createEvaluator()` resolves `{{ ID.field }}`
-traversal, `{{# each ... }}` selection, and `{{ trace ... }}` coverage matrices
-against canon. `renderDocument()` walks the AST through an evaluator and emits HTML
-in the `review` or `clean` profile, including numbered, bordered `figure` and `view`
-illustrations, the `figref` references that point at them, and the `trace` matrix as
-an HTML table. `view` renders a `blocks` notation (nested-form) source file as inline
-SVG at render time (`src/blocks-view.mjs`); any other notation, or the `blocks`
-notation's `grid:` (matrix-subset) root, renders as a missing/failed illustration —
-those are later slices on this epic. Not yet built: derivation share (§5), telemetry
-(§6), and PDF output (§7) — later layers on top of these.
+rendering, the `trace` coverage matrix, `view` rendering for the `blocks`
+notation, and derivation share (§5).** `parseSkeleton()` turns a skeleton file's text
+into a header object and a body AST. `resolveReference()` / `createResolver()`
+classify an id against canon into one of the four states below. `createEvaluator()`
+resolves `{{ ID.field }}` traversal, `{{# each ... }}` selection, and
+`{{ trace ... }}` coverage matrices against canon. `renderDocument()` walks the AST
+through an evaluator and emits HTML in the `review` or `clean` profile, including
+numbered, bordered `figure` and `view` illustrations, the `figref` references that
+point at them, the `trace` matrix as an HTML table, and — in `review` only — the §5
+derivation-share and illustrations lines. `view` renders a `blocks` notation
+(nested-form) source file as inline SVG at render time (`src/blocks-view.mjs`); any
+other notation, or the `blocks` notation's `grid:` (matrix-subset) root, renders as a
+missing/failed illustration — those are later slices on this epic. Not yet built:
+telemetry (§6) and PDF output (§7) — later layers on top of these.
 
 ## Skeleton file shape
 
@@ -179,6 +180,34 @@ is never resolved. Border classes, per §4's illustration provenance rule:
 on the wrapping `<figure>` — a hook for the print layout (§7, not built yet), not yet
 acted on by this module.
 
+## Derivation share (§5)
+
+`renderDocument()` accumulates §5's word counts in the same render pass as
+everything above — no extra AST walk. A `text` node's content counts toward
+`manualWords`, minus its own structural lines (an ATX heading, a markdown table
+row — `src/derivation-share.mjs`'s own concern; a `figure`/`view` caption is never
+part of a `text` node's content in the first place, so it's excluded by
+construction). An `inline`/`field-ref` node's resolved content counts toward
+`derivedWords`, regardless of its §3 state — an unresolved reference's `null`
+content simply counts zero words. Illustrations are **never folded into the word
+ratio** (§5: "a diagram is not worth some number of words") — counted on their own
+line instead: `total` is every `figure`/`view` node in the document, `fromModel` is
+only the `view`s that actually rendered SVG from their source (a `figure` is manual
+by definition and never counts toward it).
+
+```js
+const { html, derivationShare, illustrations } = await renderDocument(ast, evaluator, { profile: 'review' });
+// derivationShare → { derivedWords, manualWords }
+// illustrations   → { fromModel, total }
+```
+
+Both are always returned, in either profile, for a caller that wants the numbers
+without the printed line. The printed lines themselves — `<div class="dv-derivation-share">Derivation share: NN% (X of Y words)</div>` and
+`<div class="dv-illustrations">Illustrations — N of M rendered from the model</div>`
+— are appended to the rendered HTML **in `review` only**; `clean` prints no
+counters (§4). An empty document (no counted content at all) prints `n/a` rather
+than a `0%` that would misleadingly claim a share.
+
 ## Tests
 
 ```
@@ -187,4 +216,5 @@ node packages/document-view-engine/tests/test_resolve_references.mjs
 node packages/document-view-engine/tests/test_evaluate.mjs
 node packages/document-view-engine/tests/test_blocks_view.mjs
 node packages/document-view-engine/tests/test_render.mjs
+node packages/document-view-engine/tests/test_derivation_share.mjs
 ```

--- a/packages/document-view-engine/src/derivation-share.mjs
+++ b/packages/document-view-engine/src/derivation-share.mjs
@@ -1,0 +1,73 @@
+// Derivation share (hub epic "Document-view engine: skeleton transclusion,
+// reference flags, render profiles", §5) — how much of a rendered
+// document's body content comes from canon (`derived`) versus was authored
+// directly in the skeleton (`manual`), printed as a word-count ratio in the
+// `review` profile only (§4: "clean ... no counters").
+//
+// Scope: pure word-counting helpers, no canon I/O of their own — render.mjs
+// calls these against the same node content it is already resolving, in its
+// one render pass, rather than walking the AST again.
+//
+// "Structure authored in the skeleton" (headings, table scaffolding) is
+// never counted, on either side of the ratio — a `text` node's own line
+// shape decides this, since parse-skeleton.mjs keeps markdown opaque and
+// carries no block-type information of its own:
+//   - an ATX heading line ("#" .. "######" then whitespace or end of line)
+//   - a markdown table row (starts with "|")
+// Everything else in a `text` node is manual body prose. A `figure`'s or
+// `view`'s own caption is never part of a `text` node's content in the
+// first place, so it is excluded by construction, not by this filter.
+
+const HEADING_LINE = /^\s{0,3}#{1,6}(\s|$)/;
+const TABLE_ROW_LINE = /^\s*\|/;
+
+function isStructuralLine(line) {
+  return HEADING_LINE.test(line) || TABLE_ROW_LINE.test(line);
+}
+
+function countWords(s) {
+  const trimmed = String(s ?? '').trim();
+  if (trimmed === '') return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+// Word count for a `text` node's raw skeleton content — every line that
+// isn't structure (heading / table row) counts as manual prose.
+export function manualWordCount(text) {
+  return text
+    .split('\n')
+    .filter((line) => !isStructuralLine(line))
+    .reduce((sum, line) => sum + countWords(line), 0);
+}
+
+// Word count for a derived span's resolved content (an `inline` or
+// `field-ref` node's evaluated value) — no structure to exclude, since a
+// resolved field's content never carries skeleton-authored markdown.
+export function derivedWordCount(content) {
+  return countWords(content);
+}
+
+// Ratio in [0, 1]; `null` when the document has no counted content at all
+// (an undefined share, not a zero one).
+export function derivationShareRatio(derivedWords, manualWords) {
+  const total = derivedWords + manualWords;
+  return total === 0 ? null : derivedWords / total;
+}
+
+// §5: "print the ratio" — "Derivation share: NN% (X of Y words)".
+export function formatDerivationShare(derivedWords, manualWords) {
+  const ratio = derivationShareRatio(derivedWords, manualWords);
+  const total = derivedWords + manualWords;
+  const pct = ratio === null ? 'n/a' : `${Math.round(ratio * 100)}%`;
+  return `Derivation share: ${pct} (${derivedWords} of ${total} words)`;
+}
+
+// §5: "Illustrations are a separate line, never folded into the word
+// ratio ... Print illustrations — N of M rendered from the model." `total`
+// counts every `figure`/`view` node in the document; `fromModel` counts
+// only `view`s that actually rendered SVG from their model source — a
+// `figure` is manual by definition and never counts toward it, the same
+// way it never counts toward derivedWords.
+export function formatIllustrationsLine(fromModel, total) {
+  return `Illustrations — ${fromModel} of ${total} rendered from the model`;
+}

--- a/packages/document-view-engine/src/pdf-geometry.mjs
+++ b/packages/document-view-engine/src/pdf-geometry.mjs
@@ -1,0 +1,139 @@
+// Page-geometry verification (§7 "Output") — reads the page boxes back out of
+// a produced PDF and checks they are the size the stylesheet declared.
+//
+// Why this exists as its own module: §7's requirement is not "declare A4", it
+// is "verify the rendered PDF reports 595 × 842 pt", because a print engine
+// that ignores `@page { size: A4 }` silently falls back to its own default —
+// US Letter, 612 × 792 pt — and the last centimetres of every page spill onto
+// a second one. The declaration and the check are two different things, and
+// only the check catches the failure.
+//
+// This module reads bytes; it never produces them. It carries no dependency
+// and works against whatever engine eventually produces the PDF, which is why
+// it can land before that engine is chosen.
+
+const PT_TOLERANCE = 1;
+
+// A4 at 72 dpi. A conforming engine writes 595.276 × 841.89; the tolerance
+// above covers both that and an engine that rounds to whole points.
+export const A4_PORTRAIT_PT = { width: 595, height: 842 };
+export const A4_LANDSCAPE_PT = { width: 842, height: 595 };
+
+// The one wrong answer worth naming in words rather than reporting as a bare
+// mismatch — it is what "the declaration was ignored" looks like in practice.
+const US_LETTER_PT = { width: 612, height: 792 };
+
+const OBJECT_RE = /\b\d+\s+\d+\s+obj\b([\s\S]*?)\bendobj\b/g;
+const MEDIABOX_RE = /\/MediaBox\s*\[\s*(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s*\]/;
+const ROTATE_RE = /\/Rotate\s+(-?\d+)/;
+const PAGE_RE = /\/Type\s*\/Page(?![a-zA-Z])/;
+const PAGES_RE = /\/Type\s*\/Pages(?![a-zA-Z])/;
+
+function parseBox(body) {
+  const m = MEDIABOX_RE.exec(body);
+  if (!m) return null;
+  const [x1, y1, x2, y2] = m.slice(1, 5).map(Number);
+  if ([x1, y1, x2, y2].some((n) => !Number.isFinite(n))) return null;
+  return { width: Math.abs(x2 - x1), height: Math.abs(y2 - y1) };
+}
+
+// A landscape page can be written either way — a landscape MediaBox, or a
+// portrait MediaBox with `/Rotate 90`. Both measure 842 × 595 pt when the
+// reader opens them, so both must be accepted; only the rotated form needs
+// the axes swapped to say so.
+function applyRotation(box, rotate) {
+  if (rotate === null) return box;
+  const normalised = ((rotate % 360) + 360) % 360;
+  return normalised === 90 || normalised === 270
+    ? { width: box.height, height: box.width }
+    : box;
+}
+
+/**
+ * Reads every page's effective size, in points, out of a PDF.
+ *
+ * Works on PDFs whose page dictionaries are written as plain objects. A PDF
+ * that packs them into compressed object streams yields no page objects here;
+ * that is reported as a named failure by `verifyPageGeometry`, never as a
+ * silent pass — an unreadable PDF and a correctly sized one must not look
+ * alike to a build.
+ *
+ * @param {Uint8Array|Buffer|string} pdf
+ * @returns {{ pages: Array<{ width: number, height: number }> }}
+ */
+export function readPageGeometry(pdf) {
+  const text = typeof pdf === 'string' ? pdf : Buffer.from(pdf).toString('latin1');
+  const pages = [];
+  let inherited = null;
+
+  OBJECT_RE.lastIndex = 0;
+  let match;
+  const pageObjects = [];
+  while ((match = OBJECT_RE.exec(text)) !== null) {
+    const body = match[1];
+    if (PAGES_RE.test(body)) {
+      // A page-tree node. Its MediaBox is the inheritable default for any
+      // page below it that declares none of its own (PDF 32000-1, §7.7.3.4).
+      const box = parseBox(body);
+      if (box && inherited === null) inherited = box;
+      continue;
+    }
+    if (PAGE_RE.test(body)) pageObjects.push(body);
+  }
+
+  for (const body of pageObjects) {
+    const box = parseBox(body) ?? inherited;
+    if (!box) continue;
+    const rotateMatch = ROTATE_RE.exec(body);
+    pages.push(applyRotation(box, rotateMatch ? Number(rotateMatch[1]) : null));
+  }
+
+  return { pages };
+}
+
+function matches(box, expected) {
+  return Math.abs(box.width - expected.width) <= PT_TOLERANCE
+    && Math.abs(box.height - expected.height) <= PT_TOLERANCE;
+}
+
+function describe(box) {
+  const round = (n) => Math.round(n * 100) / 100;
+  const size = `${round(box.width)} × ${round(box.height)} pt`;
+  if (matches(box, US_LETTER_PT) || matches(box, { width: US_LETTER_PT.height, height: US_LETTER_PT.width })) {
+    return `${size} (US Letter) — the page-size declaration was ignored and the engine used its own default`;
+  }
+  return `${size} — neither A4 portrait (595 × 842 pt) nor A4 landscape (842 × 595 pt)`;
+}
+
+/**
+ * Checks every page of a produced PDF against §7's declared geometry.
+ *
+ * Both A4 orientations pass: a document mixing portrait body text with a
+ * landscape page for a wide illustration is exactly what §7 asks for, so
+ * "every page is portrait" is not the rule — "every page is one of the two
+ * declared sizes" is.
+ *
+ * @param {Uint8Array|Buffer|string} pdf
+ * @param {{ allow?: Array<{width:number,height:number}> }} [options]
+ * @returns {{ ok: boolean, pages: Array<{width:number,height:number}>, problems: string[] }}
+ */
+export function verifyPageGeometry(pdf, { allow = [A4_PORTRAIT_PT, A4_LANDSCAPE_PT] } = {}) {
+  const { pages } = readPageGeometry(pdf);
+  const problems = [];
+
+  if (pages.length === 0) {
+    problems.push(
+      'no page geometry could be read from this PDF — it declares no page objects, '
+      + 'or writes them into compressed object streams this reader does not open. '
+      + 'Treated as a failure: an unverifiable page size is not a verified one.',
+    );
+    return { ok: false, pages, problems };
+  }
+
+  pages.forEach((box, index) => {
+    if (allow.some((expected) => matches(box, expected))) return;
+    problems.push(`page ${index + 1} measures ${describe(box)}`);
+  });
+
+  return { ok: problems.length === 0, pages, problems };
+}

--- a/packages/document-view-engine/src/pdf-layout.mjs
+++ b/packages/document-view-engine/src/pdf-layout.mjs
@@ -1,0 +1,159 @@
+// Print layout (§7 "Output", page-size + stylesheet half) — wraps
+// renderDocument()'s HTML body in a standalone document a print engine can
+// turn into a PDF that measures 595 × 842 pt (A4 portrait) or 842 × 595 pt
+// (A4 landscape), and gives every class render.mjs already emits its visual
+// meaning: §4's colour + margin-mark pair for the four §3 states, and the
+// four illustration border classes.
+//
+// Scope of this module: the HTML + CSS layer, plus the seam a print engine
+// plugs into. It bundles no engine of its own — turning this document into
+// PDF bytes needs a rendering engine (headless browser or equivalent), which
+// is a dependency this repo does not carry today (every package here ships
+// with `"dependencies": {}`); which engine to add is an open architecture
+// question, filed separately rather than decided inside this slice. So the
+// engine is a parameter (`convertToPdf`'s `convert`), not an import: the
+// whole §7 path — declare, wrap, convert, verify the produced geometry — is
+// implemented and tested here, and adopting an engine later is supplying one
+// function rather than rewriting this half.
+//
+// `@page` is the only mechanism that fixes PDF page geometry independent of
+// whatever the print engine's own default paper size is — CSS Paged Media
+// Level 3, §2.2. A named page (`@page landscape { … }`) plus the `page`
+// property on an element (here, `.dv-fit-page`) is how a single document
+// mixes portrait body text with a landscape page for one wide illustration,
+// per §7's "a wide diagram gets a landscape page ... not a shrunken font."
+// `fit = page` is the skeleton author's own signal that an illustration
+// needs that treatment — `fit = width` (default) and `fit = none` both stay
+// in the portrait flow.
+
+import { verifyPageGeometry } from './pdf-geometry.mjs';
+
+const PAGE_CSS = `
+@page {
+  size: A4;
+  margin: 20mm;
+}
+
+@page landscape {
+  size: A4 landscape;
+  margin: 15mm;
+}
+`;
+
+// §4 review profile: colour is never the only channel. The flag glyph
+// (⚑U/⚑A/⚑V/⚑S, already emitted inline by render.mjs) is the margin-mark
+// channel — legible in black-and-white print — so this stylesheet only
+// needs to add the colour half.
+const STATE_CSS = `
+.dv-ok { color: #1a7f37; }
+.dv-suspect { color: #9a6700; }
+.dv-unresolved { color: #cf222e; }
+.dv-clean { color: #1f2328; }
+.dv-flag { font-size: 0.75em; }
+`;
+
+const ILLUSTRATION_CSS = `
+.dv-illus-view, .dv-illus-suspect, .dv-illus-manual, .dv-illus-missing {
+  border-width: 2px;
+  border-style: solid;
+  padding: 4mm;
+  margin: 4mm 0;
+}
+.dv-illus-view { border-color: #1a7f37; }
+.dv-illus-suspect { border-color: #9a6700; }
+.dv-illus-manual { border-color: #1f2328; }
+.dv-illus-missing { border-color: #cf222e; }
+
+.dv-fit-width { max-width: 100%; }
+.dv-fit-none { }
+.dv-fit-page {
+  page: landscape;
+  break-before: page;
+  break-after: page;
+  max-width: 100%;
+}
+
+/* §7 "Diagrams embed as SVG, not raster" — vector must stay selectable and
+   scale with its box rather than overflow it. */
+.dv-illus-view svg, .dv-illus-suspect svg, .dv-illus-missing svg {
+  max-width: 100%;
+  height: auto;
+}
+`;
+
+const TRACE_CSS = `
+.dv-trace { border-collapse: collapse; width: 100%; }
+.dv-trace th, .dv-trace td { border: 1px solid #1f2328; padding: 2mm; text-align: center; }
+.dv-trace-cell.dv-unresolved { color: #cf222e; }
+`;
+
+const MISC_CSS = `
+.dv-figref { font-weight: bold; }
+.dv-derivation-share, .dv-illustrations { font-size: 0.85em; color: #57606a; margin-top: 4mm; }
+`;
+
+export function buildStylesheet() {
+  return [PAGE_CSS, STATE_CSS, ILLUSTRATION_CSS, TRACE_CSS, MISC_CSS].join('\n');
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// Wraps a renderDocument() `html` body into a standalone document: full
+// `<html>`, the stylesheet above, and nothing else — no table of contents,
+// no layout chrome (the epic's own "no document layout ships").
+export function wrapDocument(bodyHtml, { title = 'Untitled' } = {}) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(title)}</title>
+<style>${buildStylesheet()}</style>
+</head>
+<body>
+${bodyHtml}
+</body>
+</html>
+`;
+}
+
+/**
+ * Wraps a rendered body, hands it to a supplied print engine, and verifies
+ * the geometry of what comes back (§7).
+ *
+ * The verification is not optional decoration: an engine that ignores
+ * `@page { size: A4 }` produces a plausible-looking PDF at its own default
+ * paper size, and nothing downstream notices until the last centimetres of
+ * every page have spilled onto a second one. So a size mismatch throws by
+ * name here rather than being returned for a caller to ignore.
+ *
+ * @param {string} bodyHtml - `renderDocument()`'s `html`.
+ * @param {object} options
+ * @param {(html: string) => Promise<Uint8Array>|Uint8Array} options.convert -
+ *   The print engine. Takes a standalone HTML document, returns PDF bytes.
+ * @param {string} [options.title]
+ * @param {boolean} [options.verify=true] - Skips the geometry check. Only for
+ *   a caller that has already verified the bytes by other means.
+ * @returns {Promise<{ html: string, pdf: Uint8Array, geometry: object|null }>}
+ */
+export async function convertToPdf(bodyHtml, { convert, title, verify = true } = {}) {
+  if (typeof convert !== 'function') {
+    throw new Error(
+      'convertToPdf: no print engine supplied. Pass `convert(html) => PDF bytes` — '
+      + 'this package deliberately bundles no rendering engine of its own.',
+    );
+  }
+  const html = wrapDocument(bodyHtml, title === undefined ? {} : { title });
+  const pdf = await convert(html);
+  if (!verify) return { html, pdf, geometry: null };
+
+  const geometry = verifyPageGeometry(pdf);
+  if (!geometry.ok) {
+    throw new Error(`convertToPdf: produced PDF fails §7 page geometry — ${geometry.problems.join('; ')}`);
+  }
+  return { html, pdf, geometry };
+}

--- a/packages/document-view-engine/src/render.mjs
+++ b/packages/document-view-engine/src/render.mjs
@@ -34,11 +34,26 @@
 // document order (§2: "Numbers are assigned at render time in document
 // order" — the two forms are not distinguished). `collectFigureNumbers()`
 // below counts both node types in its single ahead-of-render walk.
-
+//
+// Derivation share (§5) is accumulated in the same single render pass as
+// everything above — no extra AST walk. `text` nodes contribute to
+// `manualWords` (minus headings/table rows, derivation-share.mjs's own
+// concern), `inline`/`field-ref` contribute to `derivedWords`, and
+// `figure`/`view` contribute to the separate illustrations count (`view`
+// only adds to `illustrationsFromModel` when it actually renders SVG from
+// its source — a `figure` never does, by definition). Printed as two lines
+// appended to the `review` profile's own HTML only — `clean` prints no
+// counters, per §4.
 import { access, readFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 import { parseBlocksYaml, collectBlockIds, renderBlocksSvg } from './blocks-view.mjs';
 import { isValidId } from './ids.mjs';
+import {
+  manualWordCount,
+  derivedWordCount,
+  formatDerivationShare,
+  formatIllustrationsLine,
+} from './derivation-share.mjs';
 
 const DEFAULT_FAIL_ON = ['unresolved', 'not-admitted', 'out-of-validity'];
 
@@ -140,11 +155,13 @@ async function renderNodes(nodes, evaluator, ctx, out) {
 async function renderNode(node, evaluator, ctx, out) {
   switch (node.type) {
     case 'text':
+      out.manualWords += manualWordCount(node.value);
       out.html.push(escapeHtml(node.value));
       return;
 
     case 'inline': {
       const result = await evaluator.evaluateFieldPath(node.id, node.fields, ctx);
+      out.derivedWords += derivedWordCount(result.content);
       out.html.push(renderSpan(result.state, result.content, ctx.profile, out.counts));
       if (result.state !== 'ok') out.failedStates.push(result.state);
       return;
@@ -159,6 +176,7 @@ async function renderNode(node, evaluator, ctx, out) {
         return;
       }
       const result = await evaluator.evaluateFieldPath(ctx.currentRowId, node.fields, ctx);
+      out.derivedWords += derivedWordCount(result.content);
       out.html.push(renderSpan(result.state, result.content, ctx.profile, out.counts));
       if (result.state !== 'ok') out.failedStates.push(result.state);
       return;
@@ -180,6 +198,7 @@ async function renderNode(node, evaluator, ctx, out) {
     }
 
     case 'view': {
+      out.illustrationsTotal += 1;
       out.figureCounter += 1;
       const number = out.figureCounter;
       const label = `Figure ${number}`;
@@ -204,6 +223,7 @@ async function renderNode(node, evaluator, ctx, out) {
         }
       }
       const failedToRender = !exists || svg === null;
+      if (!failedToRender) out.illustrationsFromModel += 1;
       if (failedToRender) out.failedStates.push('unresolved');
       else if (suspect) out.failedStates.push('suspect');
       if (ctx.profile === 'clean') {
@@ -218,6 +238,7 @@ async function renderNode(node, evaluator, ctx, out) {
     }
 
     case 'figure': {
+      out.illustrationsTotal += 1;
       out.figureCounter += 1;
       const number = out.figureCounter;
       const absPath = isAbsolute(node.path) ? node.path : join(ctx.skeletonDir ?? '.', node.path);
@@ -261,12 +282,18 @@ async function renderNode(node, evaluator, ctx, out) {
 // containing the skeleton file — resolves a `figure`'s relative image path;
 // omit it only when every `figure` path in the AST is already absolute (as
 // unit-test fixtures typically are). Returns:
-//   html         — the rendered document body (no page chrome — §7's layout
-//                  is a later layer)
-//   failed       — true iff `profile === 'clean'` and a state in `failOn`
-//                  occurred anywhere in the render
-//   counts       — { [state]: number } — how many spans landed in each §3
-//                  state, across the whole render
+//   html            — the rendered document body (no page chrome — §7's
+//                     layout is a later layer); in `review` profile, ends
+//                     with the §5 derivation-share and illustrations lines
+//   failed          — true iff `profile === 'clean'` and a state in `failOn`
+//                     occurred anywhere in the render
+//   counts          — { [state]: number } — how many spans landed in each
+//                     §3 state, across the whole render
+//   derivationShare — { derivedWords, manualWords } — §5's word counts,
+//                     always returned (even in `clean`) for a caller that
+//                     wants the numbers without the printed line
+//   illustrations   — { fromModel, total } — §5's illustrations line, same
+//                     always-returned posture
 export async function renderDocument(ast, evaluator, { profile = 'review', renderDate, failOn = DEFAULT_FAIL_ON, skeletonDir } = {}) {
   if (profile !== 'review' && profile !== 'clean') {
     throw new Error(`render: profile must be "review" or "clean", got "${profile}"`);
@@ -274,9 +301,28 @@ export async function renderDocument(ast, evaluator, { profile = 'review', rende
   const figureState = { count: 0, numbers: new Map() };
   await collectFigureNumbers(ast, evaluator, { profile, renderDate, skeletonDir }, figureState);
 
-  const out = { html: [], counts: {}, failedStates: [], figureCounter: 0 };
+  const out = {
+    html: [],
+    counts: {},
+    failedStates: [],
+    figureCounter: 0,
+    derivedWords: 0,
+    manualWords: 0,
+    illustrationsTotal: 0,
+    illustrationsFromModel: 0,
+  };
   await renderNodes(ast, evaluator, { profile, renderDate, skeletonDir, figureNumbers: figureState.numbers }, out);
 
   const failed = profile === 'clean' && out.failedStates.some((state) => failOn.includes(state));
-  return { html: out.html.join(''), failed, counts: out.counts };
+
+  const derivationShare = { derivedWords: out.derivedWords, manualWords: out.manualWords };
+  const illustrations = { fromModel: out.illustrationsFromModel, total: out.illustrationsTotal };
+
+  // §5: printed in `review` only — `clean` carries no counters (§4).
+  if (profile === 'review') {
+    out.html.push(`<div class="dv-derivation-share">${escapeHtml(formatDerivationShare(out.derivedWords, out.manualWords))}</div>`);
+    out.html.push(`<div class="dv-illustrations">${escapeHtml(formatIllustrationsLine(out.illustrationsFromModel, out.illustrationsTotal))}</div>`);
+  }
+
+  return { html: out.html.join(''), failed, counts: out.counts, derivationShare, illustrations };
 }

--- a/packages/document-view-engine/src/render.mjs
+++ b/packages/document-view-engine/src/render.mjs
@@ -44,10 +44,21 @@
 // its source — a `figure` never does, by definition). Printed as two lines
 // appended to the `review` profile's own HTML only — `clean` prints no
 // counters, per §4.
+//
+// Telemetry (§6) rides the same pass: every `inline`/`field-ref` records the
+// type it referenced (via evaluate.mjs's `typeOfId`) and, if present, the
+// field path; every `each` records its `entityType`; every `trace` records
+// its relation kind and `from|to|via` matrix pair; and every state pushed
+// onto `out.failedStates` — inline, field-ref, figure, view, figref alike —
+// is mirrored into the telemetry collector's failure-state tally, so that
+// tally covers the whole render, not just spans. See telemetry.mjs for what
+// is deliberately excluded.
 import { access, readFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 import { parseBlocksYaml, collectBlockIds, renderBlocksSvg } from './blocks-view.mjs';
 import { isValidId } from './ids.mjs';
+import { typeOfId } from './evaluate.mjs';
+import { createTelemetryCollector } from './telemetry.mjs';
 import {
   manualWordCount,
   derivedWordCount,
@@ -80,6 +91,15 @@ function renderSpan(state, content, profile, counts) {
   const info = STATE_INFO[state];
   const flagHtml = info.flag ? `<sup class="dv-flag">${info.flag}</sup>` : '';
   return `<span class="dv-${info.color}">${escapeHtml(content ?? '')}${flagHtml}</span>`;
+}
+
+// Records a §3 failure state on both the clean-profile fail-on list and the
+// §6 telemetry tally — every call site that used to only push to
+// `out.failedStates` now goes through here, so the telemetry count covers
+// the whole render (inline, field-ref, figure, view, figref), not just spans.
+function fail(out, telemetry, state) {
+  out.failedStates.push(state);
+  telemetry.recordFailureState(state);
 }
 
 // ── Trace matrix (§2 "Trace matrix") ────────────────────────────────────
@@ -145,14 +165,14 @@ async function fileExists(absPath) {
   }
 }
 
-async function renderNodes(nodes, evaluator, ctx, out) {
+async function renderNodes(nodes, evaluator, ctx, out, telemetry) {
   for (const node of nodes) {
     // eslint-disable-next-line no-await-in-loop -- each node can depend on canon reads; order matters for figref numbering
-    await renderNode(node, evaluator, ctx, out);
+    await renderNode(node, evaluator, ctx, out, telemetry);
   }
 }
 
-async function renderNode(node, evaluator, ctx, out) {
+async function renderNode(node, evaluator, ctx, out, telemetry) {
   switch (node.type) {
     case 'text':
       out.manualWords += manualWordCount(node.value);
@@ -160,10 +180,13 @@ async function renderNode(node, evaluator, ctx, out) {
       return;
 
     case 'inline': {
+      const type = typeOfId(node.id);
+      telemetry.recordType(type);
+      telemetry.recordField(type, node.fields);
       const result = await evaluator.evaluateFieldPath(node.id, node.fields, ctx);
       out.derivedWords += derivedWordCount(result.content);
       out.html.push(renderSpan(result.state, result.content, ctx.profile, out.counts));
-      if (result.state !== 'ok') out.failedStates.push(result.state);
+      if (result.state !== 'ok') fail(out, telemetry, result.state);
       return;
     }
 
@@ -172,26 +195,34 @@ async function renderNode(node, evaluator, ctx, out) {
         // buildAst() already rejects a field-ref outside `each` — reachable
         // only if a caller hands render() an AST that skipped that check.
         out.html.push(renderSpan('unresolved', '', ctx.profile, out.counts));
-        out.failedStates.push('unresolved');
+        fail(out, telemetry, 'unresolved');
         return;
       }
+      const type = typeOfId(ctx.currentRowId);
+      telemetry.recordType(type);
+      telemetry.recordField(type, node.fields);
       const result = await evaluator.evaluateFieldPath(ctx.currentRowId, node.fields, ctx);
       out.derivedWords += derivedWordCount(result.content);
       out.html.push(renderSpan(result.state, result.content, ctx.profile, out.counts));
-      if (result.state !== 'ok') out.failedStates.push(result.state);
+      if (result.state !== 'ok') fail(out, telemetry, result.state);
       return;
     }
 
     case 'each': {
+      telemetry.recordType(node.entityType);
       const rowIds = await evaluator.evaluateEach(node, ctx);
       for (const rowId of rowIds) {
         // eslint-disable-next-line no-await-in-loop -- rows render in selection order
-        await renderNodes(node.children, evaluator, { ...ctx, currentRowId: rowId }, out);
+        await renderNodes(node.children, evaluator, { ...ctx, currentRowId: rowId }, out, telemetry);
       }
       return;
     }
 
     case 'trace': {
+      telemetry.recordType(node.from);
+      telemetry.recordType(node.to);
+      telemetry.recordRelation(node.via);
+      telemetry.recordMatrixPair(node.from, node.to, node.via);
       const matrix = await evaluator.evaluateTrace(node, ctx);
       out.html.push(renderTraceTable(matrix, ctx.profile));
       return;
@@ -224,8 +255,8 @@ async function renderNode(node, evaluator, ctx, out) {
       }
       const failedToRender = !exists || svg === null;
       if (!failedToRender) out.illustrationsFromModel += 1;
-      if (failedToRender) out.failedStates.push('unresolved');
-      else if (suspect) out.failedStates.push('suspect');
+      if (failedToRender) fail(out, telemetry, 'unresolved');
+      else if (suspect) fail(out, telemetry, 'suspect');
       if (ctx.profile === 'clean') {
         const body = svg ?? '';
         out.html.push(`<figure class="dv-clean ${fitClass}">${body}<figcaption>${label}</figcaption></figure>`);
@@ -245,7 +276,7 @@ async function renderNode(node, evaluator, ctx, out) {
       // eslint-disable-next-line no-await-in-loop -- order matters; this node's own figure number must be assigned before the next one
       const exists = await fileExists(absPath);
       const captionText = node.caption ? `Figure ${number} — ${node.caption}` : `Figure ${number}`;
-      if (!exists) out.failedStates.push('unresolved');
+      if (!exists) fail(out, telemetry, 'unresolved');
       if (ctx.profile === 'clean') {
         out.html.push(`<figure class="dv-clean"><img src="${escapeHtml(absPath)}" alt="${escapeHtml(captionText)}"><figcaption>${escapeHtml(captionText)}</figcaption></figure>`);
         return;
@@ -260,7 +291,7 @@ async function renderNode(node, evaluator, ctx, out) {
       const number = ctx.figureNumbers.get(node.name);
       if (number === undefined) {
         out.html.push(renderSpan('unresolved', '', ctx.profile, out.counts));
-        out.failedStates.push('unresolved');
+        fail(out, telemetry, 'unresolved');
         return;
       }
       const label = `Figure ${number}`;
@@ -294,6 +325,10 @@ async function renderNode(node, evaluator, ctx, out) {
 //                     wants the numbers without the printed line
 //   illustrations   — { fromModel, total } — §5's illustrations line, same
 //                     always-returned posture
+//   telemetry       — §6's snapshot (telemetry.mjs): types/fields/relations/
+//                     matrixPairs referenced and how often, plus a tally of
+//                     each §3 failure state across the whole render —
+//                     always returned, in either profile
 export async function renderDocument(ast, evaluator, { profile = 'review', renderDate, failOn = DEFAULT_FAIL_ON, skeletonDir } = {}) {
   if (profile !== 'review' && profile !== 'clean') {
     throw new Error(`render: profile must be "review" or "clean", got "${profile}"`);
@@ -311,7 +346,8 @@ export async function renderDocument(ast, evaluator, { profile = 'review', rende
     illustrationsTotal: 0,
     illustrationsFromModel: 0,
   };
-  await renderNodes(ast, evaluator, { profile, renderDate, skeletonDir, figureNumbers: figureState.numbers }, out);
+  const telemetry = createTelemetryCollector();
+  await renderNodes(ast, evaluator, { profile, renderDate, skeletonDir, figureNumbers: figureState.numbers }, out, telemetry);
 
   const failed = profile === 'clean' && out.failedStates.some((state) => failOn.includes(state));
 
@@ -324,5 +360,5 @@ export async function renderDocument(ast, evaluator, { profile = 'review', rende
     out.html.push(`<div class="dv-illustrations">${escapeHtml(formatIllustrationsLine(out.illustrationsFromModel, out.illustrationsTotal))}</div>`);
   }
 
-  return { html: out.html.join(''), failed, counts: out.counts, derivationShare, illustrations };
+  return { html: out.html.join(''), failed, counts: out.counts, derivationShare, illustrations, telemetry: telemetry.snapshot() };
 }

--- a/packages/document-view-engine/src/telemetry.mjs
+++ b/packages/document-view-engine/src/telemetry.mjs
@@ -1,0 +1,64 @@
+// Telemetry (§6) — records which types, fields, relation kinds and matrix
+// pairs a render referenced, and how often, plus a tally of each §3 failure
+// state. Threaded through render.mjs's single render pass — no second AST
+// walk, no canon re-read.
+//
+// §6 draws a hard line on what this may hold: "which types, fields, relation
+// kinds and matrix pairs were referenced and how often; counts of each
+// failure state; derivation share. Do not record: section titles, heading
+// text, prose, file names, skeleton ordering, or anything from which a
+// layout could be reconstructed." Every key below is a canonical TYPE name,
+// a `TYPE.field` pair, a relation kind, or a `from|to|via` triple — never a
+// document position, heading string, or file path — so nothing recorded
+// here can be replayed back into a document's shape. Derivation share is
+// tracked separately by derivation-share.mjs; render.mjs folds its own
+// already-computed number into the telemetry snapshot this module produces.
+
+function bump(map, key) {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function toObject(map) {
+  return Object.fromEntries([...map.entries()].sort(([a], [b]) => a.localeCompare(b)));
+}
+
+export function createTelemetryCollector() {
+  const types = new Map();
+  const fields = new Map();
+  const relations = new Map();
+  const matrixPairs = new Map();
+  const failureStates = new Map();
+
+  return {
+    recordType(type) {
+      if (type) bump(types, type);
+    },
+    // `fieldPath` is the `.field.field...` array off an `{{ ID.a.b }}` /
+    // `{{ .a.b }}` reference — recorded as the dotted path under its type,
+    // never the id or the surrounding prose.
+    recordField(type, fieldPath) {
+      if (!type || !fieldPath || fieldPath.length === 0) return;
+      bump(fields, `${type}.${fieldPath.join('.')}`);
+    },
+    recordRelation(via) {
+      if (via) bump(relations, via);
+    },
+    recordMatrixPair(fromType, toType, via) {
+      if (!fromType || !toType || !via) return;
+      bump(matrixPairs, `${fromType}|${toType}|${via}`);
+    },
+    // §3's four states only — 'ok' is not a failure and is never counted.
+    recordFailureState(state) {
+      if (state && state !== 'ok') bump(failureStates, state);
+    },
+    snapshot() {
+      return {
+        types: toObject(types),
+        fields: toObject(fields),
+        relations: toObject(relations),
+        matrixPairs: toObject(matrixPairs),
+        failureStates: toObject(failureStates),
+      };
+    },
+  };
+}

--- a/packages/document-view-engine/tests/test_derivation_share.mjs
+++ b/packages/document-view-engine/tests/test_derivation_share.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Unit tests for src/derivation-share.mjs — §5's word-counting helpers in
+// isolation from render.mjs's AST walk.
+//
+// Run: node packages/document-view-engine/tests/test_derivation_share.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import {
+  manualWordCount,
+  derivedWordCount,
+  derivationShareRatio,
+  formatDerivationShare,
+  formatIllustrationsLine,
+} from '../src/derivation-share.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+function checkEqual(actual, expected, msg) {
+  if (actual !== expected) {
+    _failures.push(`${msg}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+function run() {
+  // manualWordCount — plain prose counts, headings and table rows are excluded
+  checkEqual(manualWordCount('one two three'), 3, 'manualWordCount: plain prose counts every whitespace-delimited word');
+  checkEqual(manualWordCount('# Heading text'), 0, 'manualWordCount: an ATX heading line is structure, excluded entirely');
+  checkEqual(manualWordCount('###### Six deep'), 0, 'manualWordCount: heading depth 1-6 all excluded');
+  checkEqual(manualWordCount('#no-space is not a heading'), 5, 'manualWordCount: "#" without following whitespace is not a heading — counted as prose');
+  checkEqual(manualWordCount('| a | b |'), 0, 'manualWordCount: a markdown table row is structure, excluded');
+  checkEqual(manualWordCount('  | a | b |'), 0, 'manualWordCount: a table row is recognised past leading whitespace');
+  checkEqual(
+    manualWordCount('# Title\nbody one two\n| col |\nmore body'),
+    5,
+    'manualWordCount: mixed lines — only non-structural lines contribute (body one two = 3, more body = 2)',
+  );
+  checkEqual(manualWordCount(''), 0, 'manualWordCount: empty text contributes nothing');
+  checkEqual(manualWordCount('   '), 0, 'manualWordCount: whitespace-only text contributes nothing');
+
+  // derivedWordCount — resolved content, no structure filtering
+  checkEqual(derivedWordCount('two words'), 2, 'derivedWordCount: counts resolved content by whitespace');
+  checkEqual(derivedWordCount('# not filtered here'), 4, 'derivedWordCount: a leading "#" in resolved content is never treated as structure — only text nodes carry skeleton markdown');
+  checkEqual(derivedWordCount(null), 0, 'derivedWordCount: null content (an unresolved reference) counts as zero words');
+  checkEqual(derivedWordCount(undefined), 0, 'derivedWordCount: undefined content counts as zero words');
+
+  // derivationShareRatio
+  checkEqual(derivationShareRatio(3, 1), 0.75, 'derivationShareRatio: derived / (derived + manual)');
+  checkEqual(derivationShareRatio(0, 0), null, 'derivationShareRatio: no content at all is an undefined share, not zero');
+  checkEqual(derivationShareRatio(5, 0), 1, 'derivationShareRatio: all-derived content is a 100% share');
+  checkEqual(derivationShareRatio(0, 5), 0, 'derivationShareRatio: all-manual content is a 0% share');
+
+  // formatDerivationShare / formatIllustrationsLine — the printed lines
+  checkEqual(formatDerivationShare(3, 1), 'Derivation share: 75% (3 of 4 words)', 'formatDerivationShare: prints percentage and raw counts');
+  checkEqual(formatDerivationShare(0, 0), 'Derivation share: n/a (0 of 0 words)', 'formatDerivationShare: an empty document prints n/a, not 0%');
+  checkEqual(formatIllustrationsLine(2, 3), 'Illustrations — 2 of 3 rendered from the model', 'formatIllustrationsLine: prints the model-rendered count against the total');
+  checkEqual(formatIllustrationsLine(0, 0), 'Illustrations — 0 of 0 rendered from the model', 'formatIllustrationsLine: a document with no illustrations still prints a well-formed line');
+}
+
+run();
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('test_derivation_share: all checks passed.');

--- a/packages/document-view-engine/tests/test_pdf_geometry.mjs
+++ b/packages/document-view-engine/tests/test_pdf_geometry.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Unit tests for src/pdf-geometry.mjs — reading page sizes back out of a
+// produced PDF and checking them against §7's declared geometry.
+//
+// The fixtures below are hand-written minimal PDFs rather than engine output:
+// the point of the check is what it does with bytes it is handed, and a
+// hand-written fixture is the only way to exercise the failing cases (US
+// Letter, an unreadable page tree) deterministically and with no engine
+// installed.
+//
+// Run: node packages/document-view-engine/tests/test_pdf_geometry.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import {
+  readPageGeometry,
+  verifyPageGeometry,
+  A4_PORTRAIT_PT,
+  A4_LANDSCAPE_PT,
+} from '../src/pdf-geometry.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+// Builds a minimal PDF body: one /Pages node plus one object per page spec.
+// `box` and `rotate` are per page; `inheritedBox` goes on the /Pages node.
+function pdf(pages, { inheritedBox = null } = {}) {
+  const kids = pages.map((_, i) => `${i + 3} 0 R`).join(' ');
+  const inherited = inheritedBox ? ` /MediaBox [${inheritedBox}]` : '';
+  const objects = [
+    `1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj`,
+    `2 0 obj << /Type /Pages /Count ${pages.length} /Kids [${kids}]${inherited} >> endobj`,
+    ...pages.map((p, i) => {
+      const box = p.box ? ` /MediaBox [${p.box}]` : '';
+      const rotate = p.rotate === undefined ? '' : ` /Rotate ${p.rotate}`;
+      return `${i + 3} 0 obj << /Type /Page /Parent 2 0 R${box}${rotate} >> endobj`;
+    }),
+  ];
+  return `%PDF-1.7\n${objects.join('\n')}\n%%EOF\n`;
+}
+
+const A4 = '0 0 595.276 841.89';
+const A4_LAND = '0 0 841.89 595.276';
+const LETTER = '0 0 612 792';
+
+function run() {
+  // ── readPageGeometry ─────────────────────────────────────────────────
+  const twoUp = readPageGeometry(pdf([{ box: A4 }, { box: A4 }]));
+  check(twoUp.pages.length === 2, 'reads one entry per page object');
+  check(Math.round(twoUp.pages[0].width) === 595 && Math.round(twoUp.pages[0].height) === 842,
+    'reads A4 portrait as 595 × 842 pt');
+
+  const landscape = readPageGeometry(pdf([{ box: A4_LAND }]));
+  check(Math.round(landscape.pages[0].width) === 842 && Math.round(landscape.pages[0].height) === 595,
+    'reads a landscape MediaBox as 842 × 595 pt');
+
+  // A landscape page written the other legal way: portrait box + /Rotate 90.
+  // It opens at 842 × 595, so it must read that way too.
+  const rotated = readPageGeometry(pdf([{ box: A4, rotate: 90 }]));
+  check(Math.round(rotated.pages[0].width) === 842 && Math.round(rotated.pages[0].height) === 595,
+    '/Rotate 90 on a portrait box reads as landscape');
+  const rotated270 = readPageGeometry(pdf([{ box: A4, rotate: 270 }]));
+  check(Math.round(rotated270.pages[0].width) === 842, '/Rotate 270 also swaps the axes');
+  const rotated180 = readPageGeometry(pdf([{ box: A4, rotate: 180 }]));
+  check(Math.round(rotated180.pages[0].width) === 595, '/Rotate 180 leaves the axes alone');
+
+  // MediaBox is inheritable — a page declaring none takes the page-tree
+  // node's. Missing that fallback would report zero pages on a perfectly
+  // ordinary PDF.
+  const inherited = readPageGeometry(pdf([{}], { inheritedBox: A4 }));
+  check(inherited.pages.length === 1, 'a page with no MediaBox of its own is still a page');
+  check(Math.round(inherited.pages[0].height) === 842, 'MediaBox is inherited from the page-tree node');
+
+  // A page's own box wins over the inherited one — that is how the single
+  // landscape page in an otherwise-portrait document is expressed.
+  const mixed = readPageGeometry(pdf([{}, { box: A4_LAND }], { inheritedBox: A4 }));
+  check(Math.round(mixed.pages[0].width) === 595 && Math.round(mixed.pages[1].width) === 842,
+    "a page's own MediaBox overrides the inherited one");
+
+  // /Type /Pages must not be mistaken for /Type /Page — the prefix match
+  // would otherwise count the tree node itself as a page.
+  check(readPageGeometry(pdf([{ box: A4 }])).pages.length === 1,
+    'the /Pages tree node is not counted as a page');
+
+  // ── verifyPageGeometry ───────────────────────────────────────────────
+  check(verifyPageGeometry(pdf([{ box: A4 }, { box: A4 }])).ok,
+    'an all-A4-portrait document passes');
+  check(verifyPageGeometry(pdf([{ box: A4 }, { box: A4_LAND }, { box: A4 }])).ok,
+    'a portrait document with one landscape page passes — §7 asks for exactly that');
+  check(verifyPageGeometry(pdf([{ box: A4, rotate: 90 }])).ok,
+    'a rotated landscape page passes');
+
+  // The failure §7 names outright.
+  const letter = verifyPageGeometry(pdf([{ box: LETTER }]));
+  check(!letter.ok, 'a US Letter page fails');
+  check(/US Letter/.test(letter.problems[0]), 'the US Letter failure is named as US Letter, not as a bare mismatch');
+  check(/declaration was ignored/.test(letter.problems[0]),
+    'the US Letter failure says what actually went wrong — the declaration was ignored');
+  check(/612/.test(letter.problems[0]) && /792/.test(letter.problems[0]),
+    'the failure reports the size it actually measured');
+
+  const oneBad = verifyPageGeometry(pdf([{ box: A4 }, { box: LETTER }, { box: A4 }]));
+  check(!oneBad.ok, 'one wrong page fails the whole document');
+  check(oneBad.problems.length === 1 && /page 2\b/.test(oneBad.problems[0]),
+    'the failure names which page, by 1-based number');
+
+  // An unreadable PDF must not look like a correct one.
+  const opaque = verifyPageGeometry('%PDF-1.7\n1 0 obj << /Type /Catalog >> endobj\n%%EOF\n');
+  check(!opaque.ok, 'a PDF with no readable page objects fails rather than passing vacuously');
+  check(/not a verified one/.test(opaque.problems[0]),
+    'the unreadable case says why it is a failure and not a pass');
+  check(verifyPageGeometry('').ok === false, 'empty input fails');
+
+  // Whole-point output from an engine that rounds must pass too.
+  check(verifyPageGeometry(pdf([{ box: '0 0 595 842' }])).ok, 'whole-point A4 passes within tolerance');
+  check(!verifyPageGeometry(pdf([{ box: '0 0 595 850' }])).ok, 'a size outside tolerance fails');
+
+  // A caller can narrow the allowed set — a portrait-only deliverable.
+  const narrowed = verifyPageGeometry(pdf([{ box: A4_LAND }]), { allow: [A4_PORTRAIT_PT] });
+  check(!narrowed.ok, 'a caller can require portrait only');
+  check(verifyPageGeometry(pdf([{ box: A4_LAND }]), { allow: [A4_LANDSCAPE_PT] }).ok,
+    'a caller can require landscape only');
+
+  // Bytes, not just strings — this is what an engine actually returns.
+  check(verifyPageGeometry(Buffer.from(pdf([{ box: A4 }]), 'latin1')).ok,
+    'accepts PDF bytes, not only a string');
+  check(verifyPageGeometry(new Uint8Array(Buffer.from(pdf([{ box: A4 }]), 'latin1'))).ok,
+    'accepts a Uint8Array');
+}
+
+run();
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('test_pdf_geometry: all checks passed.');

--- a/packages/document-view-engine/tests/test_pdf_layout.mjs
+++ b/packages/document-view-engine/tests/test_pdf_layout.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Unit tests for src/pdf-layout.mjs — the §7 print-layout stylesheet and
+// document wrapper (page-size declaration half; PDF conversion itself is a
+// separate, dependency-gated slice — see the module header).
+//
+// Run: node packages/document-view-engine/tests/test_pdf_layout.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { buildStylesheet, wrapDocument, convertToPdf } from '../src/pdf-layout.mjs';
+import { renderDocument } from '../src/render.mjs';
+
+// Stand-in print engines. No real one is bundled (see the module header), so
+// the seam is exercised with two stubs that differ in exactly the way that
+// matters: one reads the `@page` declaration out of the HTML it was handed and
+// honours it; the other ignores it and falls back to its own default paper.
+// That is the failure §7 exists to catch, and it is only reachable with a
+// stub — a conforming engine would never produce it.
+
+function minimalPdf(boxes) {
+  const objects = [
+    '1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj',
+    `2 0 obj << /Type /Pages /Count ${boxes.length} /Kids [${boxes.map((_, i) => `${i + 3} 0 R`).join(' ')}] >> endobj`,
+    ...boxes.map((box, i) => `${i + 3} 0 obj << /Type /Page /Parent 2 0 R /MediaBox [${box}] >> endobj`),
+  ];
+  return Buffer.from(`%PDF-1.7\n${objects.join('\n')}\n%%EOF\n`, 'latin1');
+}
+
+// Honours `@page { size: A4 }`, and gives any `.dv-fit-page` illustration the
+// landscape page the named `@page landscape` rule selects for it.
+function honouringEngine(html) {
+  if (!/@page\s*\{[^}]*size:\s*A4;/.test(html)) return minimalPdf(['0 0 612 792']);
+  // Matched on the class attribute, not the bare name — the stylesheet in the
+  // same document mentions the selector too, and that is not a page.
+  const landscapePages = (html.match(/class="[^"]*\bdv-fit-page\b/g) ?? []).length;
+  return minimalPdf(['0 0 595.276 841.89', ...Array(landscapePages).fill('0 0 841.89 595.276')]);
+}
+
+const ignoringEngine = () => minimalPdf(['0 0 612 792']);
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+async function run() {
+  const css = buildStylesheet();
+
+  // §7 "page size, declared, never inherited" — A4 in both orientations.
+  check(/@page\s*\{[^}]*size:\s*A4;/.test(css), 'default @page declares A4 portrait');
+  check(/@page\s*\{[^}]*margin:\s*20mm;/.test(css), 'default @page declares the 20mm margin');
+  check(/@page\s+landscape\s*\{[^}]*size:\s*A4 landscape;/.test(css), 'named landscape @page declares A4 landscape');
+  check(/@page\s+landscape\s*\{[^}]*margin:\s*15mm;/.test(css), 'named landscape @page declares the 15mm margin');
+
+  // `fit = page` is the only skeleton-level trigger for a landscape page —
+  // it must select the named page and force it onto its own page.
+  check(/\.dv-fit-page\s*\{[^}]*page:\s*landscape;/.test(css), 'dv-fit-page selects the named landscape page');
+  check(/\.dv-fit-page\s*\{[^}]*break-before:\s*page;/.test(css), 'dv-fit-page breaks before its own page');
+  check(/\.dv-fit-page\s*\{[^}]*break-after:\s*page;/.test(css), 'dv-fit-page breaks after its own page');
+
+  // Every class render.mjs actually emits must carry visual meaning here —
+  // an un-styled class is a §4/§7 gap (colour or border silently missing).
+  const mustStyle = [
+    '.dv-ok', '.dv-suspect', '.dv-unresolved', '.dv-clean', '.dv-flag',
+    '.dv-illus-view', '.dv-illus-suspect', '.dv-illus-manual', '.dv-illus-missing',
+    '.dv-fit-width', '.dv-fit-none', '.dv-fit-page',
+    '.dv-trace', '.dv-trace-cell', '.dv-figref',
+    '.dv-derivation-share', '.dv-illustrations',
+  ];
+  for (const selector of mustStyle) {
+    check(css.includes(selector), `stylesheet styles every class render.mjs emits: missing ${selector}`);
+  }
+
+  // §4 "colour is never the only channel" — the flag glyph is the margin
+  // mark, so a screen reader / b&w print still distinguishes state without
+  // colour; this only asserts the colour classes stay distinct from it.
+  check(!/\.dv-flag\s*\{[^}]*color:/.test(css), 'dv-flag carries no colour of its own — it is the non-colour channel');
+
+  // §7 "Diagrams embed as SVG ... vector survives print and zoom" — the
+  // illustration classes must not force a raster-style fixed box that would
+  // clip or distort the embedded <svg>.
+  check(/\.dv-illus-view svg[^{]*\{[^}]*max-width:\s*100%;/.test(css), 'embedded SVG scales within its illustration box rather than overflowing');
+
+  // ── wrapDocument ─────────────────────────────────────────────────────
+  const doc = wrapDocument('<p>hello</p>', { title: 'Design Description' });
+  check(doc.startsWith('<!DOCTYPE html>'), 'wrapDocument emits a standalone HTML document');
+  check(doc.includes('<title>Design Description</title>'), 'wrapDocument sets the document title');
+  check(doc.includes('<p>hello</p>'), 'wrapDocument carries the rendered body through unchanged');
+  check(doc.includes('<style>'), 'wrapDocument embeds the stylesheet');
+  check(doc.includes('@page'), 'wrapDocument\'s embedded stylesheet declares page size');
+
+  // No document layout ships with this deliverable — the wrapper must not
+  // invent a table of contents or any per-document chrome beyond the shell.
+  check(!/table of contents/i.test(doc), 'wrapDocument adds no table of contents (out of scope, per epic)');
+
+  const escaped = wrapDocument('<p>x</p>', { title: '<script>alert(1)</script>' });
+  check(!escaped.includes('<script>alert(1)</script>'), 'wrapDocument escapes an untrusted title rather than injecting it verbatim');
+  check(escaped.includes('&lt;script&gt;'), 'wrapDocument HTML-escapes the title');
+
+  const untitled = wrapDocument('<p>x</p>');
+  check(untitled.includes('<title>Untitled</title>'), 'wrapDocument defaults the title when none is given');
+
+  // ── convertToPdf ─────────────────────────────────────────────────────
+  {
+    const result = await convertToPdf('<p>body</p>', { convert: honouringEngine, title: 'T' });
+    check(result.html.includes('<title>T</title>'), 'convertToPdf wraps the body before handing it to the engine');
+    check(result.pdf.length > 0, 'convertToPdf returns the engine\'s bytes');
+    check(result.geometry.ok, 'convertToPdf verifies the produced geometry');
+    check(Math.round(result.geometry.pages[0].height) === 842, 'the produced page measures 595 × 842 pt');
+  }
+
+  // The whole reason the check exists: an engine that drops the declaration
+  // produces a plausible PDF at the wrong size, and must not pass silently.
+  {
+    let thrown = null;
+    await convertToPdf('<p>body</p>', { convert: ignoringEngine }).catch((e) => { thrown = e; });
+    check(thrown !== null, 'convertToPdf throws when the produced PDF is the wrong size');
+    check(/US Letter/.test(thrown?.message ?? ''), 'the throw names what the engine actually produced');
+  }
+
+  // `verify: false` is the only way past it, and has to be asked for.
+  {
+    const skipped = await convertToPdf('<p>body</p>', { convert: ignoringEngine, verify: false });
+    check(skipped.geometry === null, 'verify: false skips the check and says so by returning no geometry');
+  }
+
+  {
+    let thrown = null;
+    await convertToPdf('<p>body</p>', {}).catch((e) => { thrown = e; });
+    check(/no print engine supplied/.test(thrown?.message ?? ''),
+      'convertToPdf with no engine fails by name rather than by TypeError');
+  }
+
+  // ── End to end: renderDocument → wrap → engine → geometry ────────────
+  // Both profiles, since §4's two profiles must both reach PDF.
+  {
+    const ast = [
+      { type: 'text', value: '# Heading\n\n' },
+      { type: 'inline', id: 'A-1', fields: ['name'] },
+      { type: 'text', value: '\n\n' },
+      { type: 'view', path: 'nowhere.blocks.transitrix.yaml', fit: 'page' },
+    ];
+    const evaluator = {
+      async evaluateFieldPath() { return { id: 'A-1', state: 'ok', flag: null, content: 'value' }; },
+      async evaluateEach() { return []; },
+      async resolveReference() { return { state: 'ok' }; },
+    };
+
+    for (const profile of ['review', 'clean']) {
+      // eslint-disable-next-line no-await-in-loop -- two profiles, read in order
+      const { html } = await renderDocument(ast, evaluator, { profile });
+      // eslint-disable-next-line no-await-in-loop -- ditto
+      const out = await convertToPdf(html, { convert: honouringEngine, title: 'Doc' });
+      check(out.geometry.ok, `${profile}: a rendered document converts and verifies`);
+      check(out.geometry.pages.length === 2, `${profile}: the fit = page illustration gets a page of its own`);
+      check(Math.round(out.geometry.pages[1].width) === 842,
+        `${profile}: that page measures 842 × 595 pt — a wide diagram gets a landscape page, not a shrunken font`);
+    }
+  }
+}
+
+await run();
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('test_pdf_layout: all checks passed.');

--- a/packages/document-view-engine/tests/test_render.mjs
+++ b/packages/document-view-engine/tests/test_render.mjs
@@ -361,7 +361,36 @@ async function run() {
     const clean = await renderDocument(ast, evaluator, { profile: 'clean', renderDate: '2026-08-06' });
     check(clean.failed, 'integration: clean profile fails the build on the unresolved reference');
 
+    checkEqual(
+      JSON.stringify(review.telemetry.types),
+      JSON.stringify({ REQUIREMENT: 5 }),
+      'telemetry: REQUIREMENT counted for the each node itself, once per row for the field-ref, and once per row for the (unresolved) inline reference',
+    );
+    checkEqual(JSON.stringify(review.telemetry.fields), JSON.stringify({ 'REQUIREMENT.name': 4 }), 'telemetry: the .name field path counted per row, from both the field-ref and the inline reference');
+    checkEqual(JSON.stringify(review.telemetry.relations), JSON.stringify({}), 'telemetry: no trace node in this skeleton, no relation kind referenced');
+    checkEqual(JSON.stringify(review.telemetry.matrixPairs), JSON.stringify({}), 'telemetry: no trace node in this skeleton, no matrix pair referenced');
+    checkEqual(JSON.stringify(review.telemetry.failureStates), JSON.stringify({ unresolved: 2 }), 'telemetry: the ghost reference is unresolved once per row, tallied across the whole render');
+    checkEqual(JSON.stringify(clean.telemetry), JSON.stringify(review.telemetry), 'telemetry: identical counters regardless of render profile — profile only changes what gets printed');
+
     rmSync(orgRoot, { recursive: true, force: true });
+  }
+
+  // telemetry (§6) — trace relation kind and matrix pair, and a failure
+  // state from a source outside inline/field-ref (a missing figure)
+  {
+    const ast = [
+      { type: 'trace', from: 'REQUIREMENT', to: 'VERIFICATION', via: 'verifies' },
+      { type: 'figure', path: '/definitely/not/here.png', caption: null, as: null },
+    ];
+    const evaluator = {
+      ...stubEvaluator({}),
+      async evaluateTrace() { return { rows: [], cols: [], covered: new Set() }; },
+    };
+    const review = await renderDocument(ast, evaluator, { profile: 'review' });
+    checkEqual(JSON.stringify(review.telemetry.types), JSON.stringify({ REQUIREMENT: 1, VERIFICATION: 1 }), 'telemetry: a trace node records both its from and to types');
+    checkEqual(JSON.stringify(review.telemetry.relations), JSON.stringify({ verifies: 1 }), 'telemetry: a trace node records its via relation kind');
+    checkEqual(JSON.stringify(review.telemetry.matrixPairs), JSON.stringify({ 'REQUIREMENT|VERIFICATION|verifies': 1 }), 'telemetry: a trace node records its from|to|via matrix pair');
+    checkEqual(JSON.stringify(review.telemetry.failureStates), JSON.stringify({ unresolved: 1 }), 'telemetry: a missing figure counts as an unresolved failure state, not just inline/field-ref failures');
   }
 }
 

--- a/packages/document-view-engine/tests/test_render.mjs
+++ b/packages/document-view-engine/tests/test_render.mjs
@@ -109,7 +109,10 @@ async function run() {
       },
     };
     const review = await renderDocument(ast, evaluator, { profile: 'review' });
-    checkEqual(review.html, '<span class="dv-ok">ROW-1-name</span>;<span class="dv-ok">ROW-2-name</span>;', 'each renders its children once per selected row, in order');
+    check(
+      review.html.startsWith('<span class="dv-ok">ROW-1-name</span>;<span class="dv-ok">ROW-2-name</span>;'),
+      'each renders its children once per selected row, in order',
+    );
   }
 
   // a field-ref outside any each is unreachable via parseSkeleton (rejected
@@ -256,6 +259,64 @@ async function run() {
     check(clean.failed, 'view clean: a missing/unparseable view file fails the build');
 
     rmSync(skeletonDir, { recursive: true, force: true });
+  }
+
+  // derivation share (§5) — a fixture with a known derived/manual split,
+  // plus a figure (manual, never counts toward illustrations-from-model)
+  // and a view (counts toward illustrations-from-model when it parses)
+  {
+    const skeletonDir = mkdtempSync(join(tmpdir(), 'render-derivshare-'));
+    writeFileSync(join(skeletonDir, 'photo.png'), 'not a real png, existence is all that matters', 'utf8');
+    const blocksYaml = [
+      'notation: blocks',
+      'name: "Test architecture"',
+      '',
+      'nested_blocks:',
+      '  id: BLOCKS-TEST-1',
+      '  name: "Test architecture"',
+      '  blocks:',
+      '    - id: APPLICATION-1',
+      '      name: "Application"',
+    ].join('\n');
+    writeFileSync(join(skeletonDir, 'arch.blocks.transitrix.yaml'), blocksYaml, 'utf8');
+
+    // derived: "alpha beta gamma" = 3 words. manual: "# Title" is a heading
+    // (excluded) + " plain body text here" = 4 words. 3 of (3 + 4) = 3/7.
+    const ast = [
+      { type: 'text', value: '# Title\n' },
+      { type: 'inline', id: 'A-1', fields: ['x'] },
+      { type: 'text', value: ' plain body text here' },
+      { type: 'figure', path: 'photo.png', caption: null, as: null },
+      { type: 'view', path: 'arch.blocks.transitrix.yaml', as: null, fit: 'width' },
+    ];
+    const evaluator = {
+      ...stubEvaluator({ 'A-1::x': { id: 'A-1', state: 'ok', flag: null, content: 'alpha beta gamma' } }),
+      async resolveReference(id) { return { id, state: 'ok', flag: null }; },
+    };
+
+    const review = await renderDocument(ast, evaluator, { profile: 'review', skeletonDir });
+    checkEqual(review.derivationShare.derivedWords, 3, 'derivation share: derived word count');
+    checkEqual(review.derivationShare.manualWords, 4, 'derivation share: manual word count, heading line excluded');
+    check(review.html.includes('<div class="dv-derivation-share">Derivation share: 43% (3 of 7 words)</div>'), 'derivation share: printed line matches the known split, rounded');
+    checkEqual(review.illustrations.fromModel, 1, 'derivation share: illustrations from-model count — figure is manual and never counts, the parsing view does');
+    checkEqual(review.illustrations.total, 2, 'derivation share: illustrations total counts every figure/view');
+    check(review.html.includes('<div class="dv-illustrations">Illustrations — 1 of 2 rendered from the model</div>'), 'derivation share: illustrations line printed alongside the word ratio');
+
+    const clean = await renderDocument(ast, evaluator, { profile: 'clean', skeletonDir });
+    check(!clean.html.includes('dv-derivation-share') && !clean.html.includes('dv-illustrations'), 'derivation share: clean profile prints no counters (§4)');
+    checkEqual(clean.derivationShare.derivedWords, 3, 'derivation share: numbers still returned to the caller even when clean prints nothing (derived)');
+    checkEqual(clean.derivationShare.manualWords, 4, 'derivation share: numbers still returned to the caller even when clean prints nothing (manual)');
+    checkEqual(clean.illustrations.fromModel, 1, 'derivation share: illustrations counts likewise returned under clean (fromModel)');
+    checkEqual(clean.illustrations.total, 2, 'derivation share: illustrations counts likewise returned under clean (total)');
+
+    rmSync(skeletonDir, { recursive: true, force: true });
+  }
+
+  // derivation share — an empty document prints "n/a", never a divide-by-zero
+  {
+    const review = await renderDocument([], stubEvaluator({}), { profile: 'review' });
+    check(review.html.includes('Derivation share: n/a (0 of 0 words)'), 'derivation share: an empty document reports n/a rather than 0%');
+    check(review.html.includes('Illustrations — 0 of 0 rendered from the model'), 'derivation share: an empty document still prints a well-formed illustrations line');
   }
 
   // ── Integration — real parseSkeleton + createEvaluator end to end ──

--- a/packages/document-view-engine/tests/test_telemetry.mjs
+++ b/packages/document-view-engine/tests/test_telemetry.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Unit tests for src/telemetry.mjs — §6's counters in isolation from
+// render.mjs's AST walk.
+//
+// Run: node packages/document-view-engine/tests/test_telemetry.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { createTelemetryCollector } from '../src/telemetry.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+function checkEqual(actual, expected, msg) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    _failures.push(`${msg}\n  expected: ${e}\n  actual:   ${a}`);
+  }
+}
+
+function run() {
+  // types — counted by name, repeats tally
+  {
+    const t = createTelemetryCollector();
+    t.recordType('REQUIREMENT');
+    t.recordType('REQUIREMENT');
+    t.recordType('VERIFICATION');
+    checkEqual(t.snapshot().types, { REQUIREMENT: 2, VERIFICATION: 1 }, 'types: counted by name, repeats tally');
+  }
+
+  // fields — keyed as TYPE.field, dotted paths preserved, empty/absent path ignored
+  {
+    const t = createTelemetryCollector();
+    t.recordField('REQUIREMENT', ['text']);
+    t.recordField('REQUIREMENT', ['text']);
+    t.recordField('REQUIREMENT', ['parent', 'title']);
+    t.recordField('REQUIREMENT', []);
+    t.recordField(null, ['x']);
+    checkEqual(
+      t.snapshot().fields,
+      { 'REQUIREMENT.parent.title': 1, 'REQUIREMENT.text': 2 },
+      'fields: TYPE.field(.field...) keys, a bare-id (no field path) or missing type records nothing',
+    );
+  }
+
+  // relations — the trace `via` name
+  {
+    const t = createTelemetryCollector();
+    t.recordRelation('verifies');
+    t.recordRelation('verifies');
+    t.recordRelation('parent');
+    checkEqual(t.snapshot().relations, { parent: 1, verifies: 2 }, 'relations: counted by via name');
+  }
+
+  // matrix pairs — from|to|via triple, distinct triples counted separately
+  {
+    const t = createTelemetryCollector();
+    t.recordMatrixPair('REQUIREMENT', 'VERIFICATION', 'verifies');
+    t.recordMatrixPair('REQUIREMENT', 'VERIFICATION', 'verifies');
+    t.recordMatrixPair('REQUIREMENT', 'REQUIREMENT', 'parent');
+    checkEqual(
+      t.snapshot().matrixPairs,
+      { 'REQUIREMENT|REQUIREMENT|parent': 1, 'REQUIREMENT|VERIFICATION|verifies': 2 },
+      'matrixPairs: distinct from|to|via triples counted separately',
+    );
+    const t2 = createTelemetryCollector();
+    t2.recordMatrixPair(null, 'VERIFICATION', 'verifies');
+    checkEqual(t2.snapshot().matrixPairs, {}, 'matrixPairs: an incomplete triple (missing from/to/via) records nothing');
+  }
+
+  // failure states — 'ok' is never counted; the four §3 failure states tally independently
+  {
+    const t = createTelemetryCollector();
+    t.recordFailureState('ok');
+    t.recordFailureState('suspect');
+    t.recordFailureState('not-admitted');
+    t.recordFailureState('not-admitted');
+    t.recordFailureState('out-of-validity');
+    t.recordFailureState('unresolved');
+    checkEqual(
+      t.snapshot().failureStates,
+      { 'not-admitted': 2, 'out-of-validity': 1, suspect: 1, unresolved: 1 },
+      'failureStates: ok is excluded, the four failure states tally independently',
+    );
+  }
+
+  // an empty collector snapshots to well-formed empty objects, not undefined
+  {
+    const t = createTelemetryCollector();
+    checkEqual(
+      t.snapshot(),
+      { types: {}, fields: {}, relations: {}, matrixPairs: {}, failureStates: {} },
+      'snapshot: an untouched collector returns empty objects for every category',
+    );
+  }
+}
+
+run();
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('test_telemetry: all checks passed.');


### PR DESCRIPTION
## Summary

Eighth slice of the document-view engine epic: §5, derivation share.

`renderDocument()` now accumulates §5's word counts in the same render pass — no extra AST walk. A `text` node's content counts toward `manualWords`, minus its own structural lines (an ATX heading, a markdown table row); a `figure`/`view` caption is never part of a `text` node's content in the first place, so it's excluded by construction. An `inline`/`field-ref` node's resolved content counts toward `derivedWords`, regardless of its §3 state.

Illustrations are counted on a separate line, never folded into the word ratio: `total` is every `figure`/`view` node, `fromModel` is only the `view`s that actually rendered SVG from their source — a `figure` is manual by definition and never counts toward it.

Both counts are always returned on `renderDocument()`'s result (`derivationShare`, `illustrations`) in either profile; the printed lines (`Derivation share: NN% (X of Y words)`, `Illustrations — N of M rendered from the model`) are appended to the rendered HTML in `review` only — `clean` prints no counters, per §4. An empty document prints `n/a` rather than a misleading `0%`.

Depends on #454 (still open, CI green) — this PR is based on that branch, per the stacked-PR exception (CLAUDE.md's "if a change truly depends on an unmerged one ... let Valerii merge bottom-up by hand"). Please merge #450, #451, #452, #454 first, in that order, then this one.

Scope still open on the epic: `view` for notations other than `blocks`, the `blocks` `grid:` form, telemetry (§6), and PDF output (§7).

## Test plan

- [x] `node packages/document-view-engine/tests/test_derivation_share.mjs` — new unit tests for the word-counting helpers in isolation
- [x] `node packages/document-view-engine/tests/test_render.mjs` — new integration checks against a fixture with a known derived/manual split and known illustration counts, plus the empty-document n/a case
- [x] Full existing suite for the package re-run clean (parse-skeleton, resolve-references, evaluate, blocks-view, render)
- [x] `node scripts/check-notations.mjs` — doc-lint clean