### PR TITLE
feat(notations): add PDF output to the document-view engine

### DIFF
--- a/packages/document-view-engine/README.md
+++ b/packages/document-view-engine/README.md
@@ -9,7 +9,8 @@ their own repository.
 **Scope of this package today: syntax (§2), reference resolution (§3), derived-content
 evaluation, render profiles (§4) for `inline`/`each` content, `figure`/`figref`
 rendering, the `trace` coverage matrix, `view` rendering for the `blocks`
-notation, derivation share (§5), and telemetry (§6).** `parseSkeleton()` turns a skeleton file's text
+notation, derivation share (§5), telemetry (§6), and §7 output (print stylesheet, the
+print-engine seam, and page-geometry verification).** `parseSkeleton()` turns a skeleton file's text
 into a header object and a body AST. `resolveReference()` / `createResolver()`
 classify an id against canon into one of the four states below. `createEvaluator()`
 resolves `{{ ID.field }}` traversal, `{{# each ... }}` selection, and
@@ -22,7 +23,13 @@ derivation-share and illustrations lines. `view` renders a `blocks` notation
 other notation, or the `blocks` notation's `grid:` (matrix-subset) root, renders as a
 missing/failed illustration — those are later slices on this epic. `renderDocument()`
 also returns a §6 telemetry snapshot alongside the derivation-share numbers, in the
-same single pass. Not yet built: PDF output (§7) — a later layer on top of these.
+same single pass. `wrapDocument()` (`src/pdf-layout.mjs`) wraps a rendered `html`
+body in a standalone document carrying the §7 print stylesheet — page size, every
+`dv-*` class's print colour/border, and the `dv-fit-page` landscape-page rule;
+`convertToPdf()` runs it through a **caller-supplied** print engine and verifies the
+resulting page geometry (`src/pdf-geometry.mjs`). The engine itself is not bundled:
+it is a dependency this repo does not carry today, so it is a parameter — see the
+"PDF output" section below.
 
 ## Skeleton file shape
 
@@ -235,6 +242,61 @@ inline, field-ref, `figure`, `view`, and `figref` alike — so the tally covers 
 whole render, not only spans. `telemetry` is always returned, identically, regardless
 of `profile`; only the printed HTML differs between `review` and `clean`.
 
+## PDF output (§7)
+
+Three pieces, in the order the output actually happens: **declare** the page geometry,
+**convert** through a print engine, **verify** the geometry of what came back.
+
+### Declare — `src/pdf-layout.mjs`
+
+`wrapDocument(bodyHtml, { title })` wraps a `renderDocument()` body in a standalone
+`<html>` document carrying `buildStylesheet()`'s CSS: `@page { size: A4; margin:
+20mm; }` for the default portrait page, a named `@page landscape { size: A4 landscape;
+margin: 15mm; }` for a `dv-fit-page` illustration, and the print colour/border for
+every `dv-*` class `render.mjs` emits (§4's state colours, the four illustration
+border classes, the `dv-trace` table).
+
+### Convert — the engine is a parameter, not a dependency
+
+This package bundles no print engine. Turning HTML into PDF bytes needs a headless
+rendering engine, which is a dependency it does not carry today (`"dependencies": {}`
+— see `package.json`); which engine to adopt is an open architecture question, filed
+separately rather than decided inside this slice. So the engine is supplied by the
+caller:
+
+```js
+import { convertToPdf } from '@transitrix/document-view-engine/src/pdf-layout.mjs';
+
+const { pdf, geometry } = await convertToPdf(html, {
+  title: 'Design Description',
+  convert: (doc) => myPrintEngine.render(doc),   // HTML in, PDF bytes out
+});
+```
+
+Everything around the engine — wrap, convert, verify — is implemented and tested here,
+so adopting an engine later is supplying one function rather than writing this half.
+
+### Verify — `src/pdf-geometry.mjs`
+
+`verifyPageGeometry(pdfBytes)` reads every page's `/MediaBox` (honouring `/Rotate` and
+page-tree inheritance) and checks it is A4 in one of the two declared orientations —
+595 × 842 pt portrait, 842 × 595 pt landscape, ±1 pt. `convertToPdf` runs it by default
+and **throws** on a mismatch.
+
+The check is the point of §7, not decoration: an engine that ignores `@page { size:
+A4 }` falls back to its own default paper — 612 × 792 pt, US Letter — and produces a
+plausible-looking PDF whose last centimetres spill onto a second page every time. That
+case is reported by name ("US Letter — the page-size declaration was ignored"), not as
+a bare size mismatch. A PDF whose page objects cannot be read at all (compressed object
+streams) is also a failure, never a vacuous pass: an unverifiable page size is not a
+verified one.
+
+```js
+import { verifyPageGeometry } from '@transitrix/document-view-engine/src/pdf-geometry.mjs';
+
+const { ok, pages, problems } = verifyPageGeometry(pdfBytes);
+```
+
 ## Tests
 
 ```
@@ -245,4 +307,6 @@ node packages/document-view-engine/tests/test_blocks_view.mjs
 node packages/document-view-engine/tests/test_render.mjs
 node packages/document-view-engine/tests/test_derivation_share.mjs
 node packages/document-view-engine/tests/test_telemetry.mjs
+node packages/document-view-engine/tests/test_pdf_layout.mjs
+node packages/document-view-engine/tests/test_pdf_geometry.mjs
 ```

--- a/packages/document-view-engine/src/pdf-geometry.mjs
+++ b/packages/document-view-engine/src/pdf-geometry.mjs
@@ -1,0 +1,139 @@
+// Page-geometry verification (§7 "Output") — reads the page boxes back out of
+// a produced PDF and checks they are the size the stylesheet declared.
+//
+// Why this exists as its own module: §7's requirement is not "declare A4", it
+// is "verify the rendered PDF reports 595 × 842 pt", because a print engine
+// that ignores `@page { size: A4 }` silently falls back to its own default —
+// US Letter, 612 × 792 pt — and the last centimetres of every page spill onto
+// a second one. The declaration and the check are two different things, and
+// only the check catches the failure.
+//
+// This module reads bytes; it never produces them. It carries no dependency
+// and works against whatever engine eventually produces the PDF, which is why
+// it can land before that engine is chosen.
+
+const PT_TOLERANCE = 1;
+
+// A4 at 72 dpi. A conforming engine writes 595.276 × 841.89; the tolerance
+// above covers both that and an engine that rounds to whole points.
+export const A4_PORTRAIT_PT = { width: 595, height: 842 };
+export const A4_LANDSCAPE_PT = { width: 842, height: 595 };
+
+// The one wrong answer worth naming in words rather than reporting as a bare
+// mismatch — it is what "the declaration was ignored" looks like in practice.
+const US_LETTER_PT = { width: 612, height: 792 };
+
+const OBJECT_RE = /\b\d+\s+\d+\s+obj\b([\s\S]*?)\bendobj\b/g;
+const MEDIABOX_RE = /\/MediaBox\s*\[\s*(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s*\]/;
+const ROTATE_RE = /\/Rotate\s+(-?\d+)/;
+const PAGE_RE = /\/Type\s*\/Page(?![a-zA-Z])/;
+const PAGES_RE = /\/Type\s*\/Pages(?![a-zA-Z])/;
+
+function parseBox(body) {
+  const m = MEDIABOX_RE.exec(body);
+  if (!m) return null;
+  const [x1, y1, x2, y2] = m.slice(1, 5).map(Number);
+  if ([x1, y1, x2, y2].some((n) => !Number.isFinite(n))) return null;
+  return { width: Math.abs(x2 - x1), height: Math.abs(y2 - y1) };
+}
+
+// A landscape page can be written either way — a landscape MediaBox, or a
+// portrait MediaBox with `/Rotate 90`. Both measure 842 × 595 pt when the
+// reader opens them, so both must be accepted; only the rotated form needs
+// the axes swapped to say so.
+function applyRotation(box, rotate) {
+  if (rotate === null) return box;
+  const normalised = ((rotate % 360) + 360) % 360;
+  return normalised === 90 || normalised === 270
+    ? { width: box.height, height: box.width }
+    : box;
+}
+
+/**
+ * Reads every page's effective size, in points, out of a PDF.
+ *
+ * Works on PDFs whose page dictionaries are written as plain objects. A PDF
+ * that packs them into compressed object streams yields no page objects here;
+ * that is reported as a named failure by `verifyPageGeometry`, never as a
+ * silent pass — an unreadable PDF and a correctly sized one must not look
+ * alike to a build.
+ *
+ * @param {Uint8Array|Buffer|string} pdf
+ * @returns {{ pages: Array<{ width: number, height: number }> }}
+ */
+export function readPageGeometry(pdf) {
+  const text = typeof pdf === 'string' ? pdf : Buffer.from(pdf).toString('latin1');
+  const pages = [];
+  let inherited = null;
+
+  OBJECT_RE.lastIndex = 0;
+  let match;
+  const pageObjects = [];
+  while ((match = OBJECT_RE.exec(text)) !== null) {
+    const body = match[1];
+    if (PAGES_RE.test(body)) {
+      // A page-tree node. Its MediaBox is the inheritable default for any
+      // page below it that declares none of its own (PDF 32000-1, §7.7.3.4).
+      const box = parseBox(body);
+      if (box && inherited === null) inherited = box;
+      continue;
+    }
+    if (PAGE_RE.test(body)) pageObjects.push(body);
+  }
+
+  for (const body of pageObjects) {
+    const box = parseBox(body) ?? inherited;
+    if (!box) continue;
+    const rotateMatch = ROTATE_RE.exec(body);
+    pages.push(applyRotation(box, rotateMatch ? Number(rotateMatch[1]) : null));
+  }
+
+  return { pages };
+}
+
+function matches(box, expected) {
+  return Math.abs(box.width - expected.width) <= PT_TOLERANCE
+    && Math.abs(box.height - expected.height) <= PT_TOLERANCE;
+}
+
+function describe(box) {
+  const round = (n) => Math.round(n * 100) / 100;
+  const size = `${round(box.width)} × ${round(box.height)} pt`;
+  if (matches(box, US_LETTER_PT) || matches(box, { width: US_LETTER_PT.height, height: US_LETTER_PT.width })) {
+    return `${size} (US Letter) — the page-size declaration was ignored and the engine used its own default`;
+  }
+  return `${size} — neither A4 portrait (595 × 842 pt) nor A4 landscape (842 × 595 pt)`;
+}
+
+/**
+ * Checks every page of a produced PDF against §7's declared geometry.
+ *
+ * Both A4 orientations pass: a document mixing portrait body text with a
+ * landscape page for a wide illustration is exactly what §7 asks for, so
+ * "every page is portrait" is not the rule — "every page is one of the two
+ * declared sizes" is.
+ *
+ * @param {Uint8Array|Buffer|string} pdf
+ * @param {{ allow?: Array<{width:number,height:number}> }} [options]
+ * @returns {{ ok: boolean, pages: Array<{width:number,height:number}>, problems: string[] }}
+ */
+export function verifyPageGeometry(pdf, { allow = [A4_PORTRAIT_PT, A4_LANDSCAPE_PT] } = {}) {
+  const { pages } = readPageGeometry(pdf);
+  const problems = [];
+
+  if (pages.length === 0) {
+    problems.push(
+      'no page geometry could be read from this PDF — it declares no page objects, '
+      + 'or writes them into compressed object streams this reader does not open. '
+      + 'Treated as a failure: an unverifiable page size is not a verified one.',
+    );
+    return { ok: false, pages, problems };
+  }
+
+  pages.forEach((box, index) => {
+    if (allow.some((expected) => matches(box, expected))) return;
+    problems.push(`page ${index + 1} measures ${describe(box)}`);
+  });
+
+  return { ok: problems.length === 0, pages, problems };
+}

--- a/packages/document-view-engine/src/pdf-layout.mjs
+++ b/packages/document-view-engine/src/pdf-layout.mjs
@@ -1,0 +1,159 @@
+// Print layout (§7 "Output", page-size + stylesheet half) — wraps
+// renderDocument()'s HTML body in a standalone document a print engine can
+// turn into a PDF that measures 595 × 842 pt (A4 portrait) or 842 × 595 pt
+// (A4 landscape), and gives every class render.mjs already emits its visual
+// meaning: §4's colour + margin-mark pair for the four §3 states, and the
+// four illustration border classes.
+//
+// Scope of this module: the HTML + CSS layer, plus the seam a print engine
+// plugs into. It bundles no engine of its own — turning this document into
+// PDF bytes needs a rendering engine (headless browser or equivalent), which
+// is a dependency this repo does not carry today (every package here ships
+// with `"dependencies": {}`); which engine to add is an open architecture
+// question, filed separately rather than decided inside this slice. So the
+// engine is a parameter (`convertToPdf`'s `convert`), not an import: the
+// whole §7 path — declare, wrap, convert, verify the produced geometry — is
+// implemented and tested here, and adopting an engine later is supplying one
+// function rather than rewriting this half.
+//
+// `@page` is the only mechanism that fixes PDF page geometry independent of
+// whatever the print engine's own default paper size is — CSS Paged Media
+// Level 3, §2.2. A named page (`@page landscape { … }`) plus the `page`
+// property on an element (here, `.dv-fit-page`) is how a single document
+// mixes portrait body text with a landscape page for one wide illustration,
+// per §7's "a wide diagram gets a landscape page ... not a shrunken font."
+// `fit = page` is the skeleton author's own signal that an illustration
+// needs that treatment — `fit = width` (default) and `fit = none` both stay
+// in the portrait flow.
+
+import { verifyPageGeometry } from './pdf-geometry.mjs';
+
+const PAGE_CSS = `
+@page {
+  size: A4;
+  margin: 20mm;
+}
+
+@page landscape {
+  size: A4 landscape;
+  margin: 15mm;
+}
+`;
+
+// §4 review profile: colour is never the only channel. The flag glyph
+// (⚑U/⚑A/⚑V/⚑S, already emitted inline by render.mjs) is the margin-mark
+// channel — legible in black-and-white print — so this stylesheet only
+// needs to add the colour half.
+const STATE_CSS = `
+.dv-ok { color: #1a7f37; }
+.dv-suspect { color: #9a6700; }
+.dv-unresolved { color: #cf222e; }
+.dv-clean { color: #1f2328; }
+.dv-flag { font-size: 0.75em; }
+`;
+
+const ILLUSTRATION_CSS = `
+.dv-illus-view, .dv-illus-suspect, .dv-illus-manual, .dv-illus-missing {
+  border-width: 2px;
+  border-style: solid;
+  padding: 4mm;
+  margin: 4mm 0;
+}
+.dv-illus-view { border-color: #1a7f37; }
+.dv-illus-suspect { border-color: #9a6700; }
+.dv-illus-manual { border-color: #1f2328; }
+.dv-illus-missing { border-color: #cf222e; }
+
+.dv-fit-width { max-width: 100%; }
+.dv-fit-none { }
+.dv-fit-page {
+  page: landscape;
+  break-before: page;
+  break-after: page;
+  max-width: 100%;
+}
+
+/* §7 "Diagrams embed as SVG, not raster" — vector must stay selectable and
+   scale with its box rather than overflow it. */
+.dv-illus-view svg, .dv-illus-suspect svg, .dv-illus-missing svg {
+  max-width: 100%;
+  height: auto;
+}
+`;
+
+const TRACE_CSS = `
+.dv-trace { border-collapse: collapse; width: 100%; }
+.dv-trace th, .dv-trace td { border: 1px solid #1f2328; padding: 2mm; text-align: center; }
+.dv-trace-cell.dv-unresolved { color: #cf222e; }
+`;
+
+const MISC_CSS = `
+.dv-figref { font-weight: bold; }
+.dv-derivation-share, .dv-illustrations { font-size: 0.85em; color: #57606a; margin-top: 4mm; }
+`;
+
+export function buildStylesheet() {
+  return [PAGE_CSS, STATE_CSS, ILLUSTRATION_CSS, TRACE_CSS, MISC_CSS].join('\n');
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// Wraps a renderDocument() `html` body into a standalone document: full
+// `<html>`, the stylesheet above, and nothing else — no table of contents,
+// no layout chrome (the epic's own "no document layout ships").
+export function wrapDocument(bodyHtml, { title = 'Untitled' } = {}) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(title)}</title>
+<style>${buildStylesheet()}</style>
+</head>
+<body>
+${bodyHtml}
+</body>
+</html>
+`;
+}
+
+/**
+ * Wraps a rendered body, hands it to a supplied print engine, and verifies
+ * the geometry of what comes back (§7).
+ *
+ * The verification is not optional decoration: an engine that ignores
+ * `@page { size: A4 }` produces a plausible-looking PDF at its own default
+ * paper size, and nothing downstream notices until the last centimetres of
+ * every page have spilled onto a second one. So a size mismatch throws by
+ * name here rather than being returned for a caller to ignore.
+ *
+ * @param {string} bodyHtml - `renderDocument()`'s `html`.
+ * @param {object} options
+ * @param {(html: string) => Promise<Uint8Array>|Uint8Array} options.convert -
+ *   The print engine. Takes a standalone HTML document, returns PDF bytes.
+ * @param {string} [options.title]
+ * @param {boolean} [options.verify=true] - Skips the geometry check. Only for
+ *   a caller that has already verified the bytes by other means.
+ * @returns {Promise<{ html: string, pdf: Uint8Array, geometry: object|null }>}
+ */
+export async function convertToPdf(bodyHtml, { convert, title, verify = true } = {}) {
+  if (typeof convert !== 'function') {
+    throw new Error(
+      'convertToPdf: no print engine supplied. Pass `convert(html) => PDF bytes` — '
+      + 'this package deliberately bundles no rendering engine of its own.',
+    );
+  }
+  const html = wrapDocument(bodyHtml, title === undefined ? {} : { title });
+  const pdf = await convert(html);
+  if (!verify) return { html, pdf, geometry: null };
+
+  const geometry = verifyPageGeometry(pdf);
+  if (!geometry.ok) {
+    throw new Error(`convertToPdf: produced PDF fails §7 page geometry — ${geometry.problems.join('; ')}`);
+  }
+  return { html, pdf, geometry };
+}

--- a/packages/document-view-engine/tests/test_pdf_geometry.mjs
+++ b/packages/document-view-engine/tests/test_pdf_geometry.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Unit tests for src/pdf-geometry.mjs — reading page sizes back out of a
+// produced PDF and checking them against §7's declared geometry.
+//
+// The fixtures below are hand-written minimal PDFs rather than engine output:
+// the point of the check is what it does with bytes it is handed, and a
+// hand-written fixture is the only way to exercise the failing cases (US
+// Letter, an unreadable page tree) deterministically and with no engine
+// installed.
+//
+// Run: node packages/document-view-engine/tests/test_pdf_geometry.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import {
+  readPageGeometry,
+  verifyPageGeometry,
+  A4_PORTRAIT_PT,
+  A4_LANDSCAPE_PT,
+} from '../src/pdf-geometry.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+// Builds a minimal PDF body: one /Pages node plus one object per page spec.
+// `box` and `rotate` are per page; `inheritedBox` goes on the /Pages node.
+function pdf(pages, { inheritedBox = null } = {}) {
+  const kids = pages.map((_, i) => `${i + 3} 0 R`).join(' ');
+  const inherited = inheritedBox ? ` /MediaBox [${inheritedBox}]` : '';
+  const objects = [
+    `1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj`,
+    `2 0 obj << /Type /Pages /Count ${pages.length} /Kids [${kids}]${inherited} >> endobj`,
+    ...pages.map((p, i) => {
+      const box = p.box ? ` /MediaBox [${p.box}]` : '';
+      const rotate = p.rotate === undefined ? '' : ` /Rotate ${p.rotate}`;
+      return `${i + 3} 0 obj << /Type /Page /Parent 2 0 R${box}${rotate} >> endobj`;
+    }),
+  ];
+  return `%PDF-1.7\n${objects.join('\n')}\n%%EOF\n`;
+}
+
+const A4 = '0 0 595.276 841.89';
+const A4_LAND = '0 0 841.89 595.276';
+const LETTER = '0 0 612 792';
+
+function run() {
+  // ── readPageGeometry ─────────────────────────────────────────────────
+  const twoUp = readPageGeometry(pdf([{ box: A4 }, { box: A4 }]));
+  check(twoUp.pages.length === 2, 'reads one entry per page object');
+  check(Math.round(twoUp.pages[0].width) === 595 && Math.round(twoUp.pages[0].height) === 842,
+    'reads A4 portrait as 595 × 842 pt');
+
+  const landscape = readPageGeometry(pdf([{ box: A4_LAND }]));
+  check(Math.round(landscape.pages[0].width) === 842 && Math.round(landscape.pages[0].height) === 595,
+    'reads a landscape MediaBox as 842 × 595 pt');
+
+  // A landscape page written the other legal way: portrait box + /Rotate 90.
+  // It opens at 842 × 595, so it must read that way too.
+  const rotated = readPageGeometry(pdf([{ box: A4, rotate: 90 }]));
+  check(Math.round(rotated.pages[0].width) === 842 && Math.round(rotated.pages[0].height) === 595,
+    '/Rotate 90 on a portrait box reads as landscape');
+  const rotated270 = readPageGeometry(pdf([{ box: A4, rotate: 270 }]));
+  check(Math.round(rotated270.pages[0].width) === 842, '/Rotate 270 also swaps the axes');
+  const rotated180 = readPageGeometry(pdf([{ box: A4, rotate: 180 }]));
+  check(Math.round(rotated180.pages[0].width) === 595, '/Rotate 180 leaves the axes alone');
+
+  // MediaBox is inheritable — a page declaring none takes the page-tree
+  // node's. Missing that fallback would report zero pages on a perfectly
+  // ordinary PDF.
+  const inherited = readPageGeometry(pdf([{}], { inheritedBox: A4 }));
+  check(inherited.pages.length === 1, 'a page with no MediaBox of its own is still a page');
+  check(Math.round(inherited.pages[0].height) === 842, 'MediaBox is inherited from the page-tree node');
+
+  // A page's own box wins over the inherited one — that is how the single
+  // landscape page in an otherwise-portrait document is expressed.
+  const mixed = readPageGeometry(pdf([{}, { box: A4_LAND }], { inheritedBox: A4 }));
+  check(Math.round(mixed.pages[0].width) === 595 && Math.round(mixed.pages[1].width) === 842,
+    "a page's own MediaBox overrides the inherited one");
+
+  // /Type /Pages must not be mistaken for /Type /Page — the prefix match
+  // would otherwise count the tree node itself as a page.
+  check(readPageGeometry(pdf([{ box: A4 }])).pages.length === 1,
+    'the /Pages tree node is not counted as a page');
+
+  // ── verifyPageGeometry ───────────────────────────────────────────────
+  check(verifyPageGeometry(pdf([{ box: A4 }, { box: A4 }])).ok,
+    'an all-A4-portrait document passes');
+  check(verifyPageGeometry(pdf([{ box: A4 }, { box: A4_LAND }, { box: A4 }])).ok,
+    'a portrait document with one landscape page passes — §7 asks for exactly that');
+  check(verifyPageGeometry(pdf([{ box: A4, rotate: 90 }])).ok,
+    'a rotated landscape page passes');
+
+  // The failure §7 names outright.
+  const letter = verifyPageGeometry(pdf([{ box: LETTER }]));
+  check(!letter.ok, 'a US Letter page fails');
+  check(/US Letter/.test(letter.problems[0]), 'the US Letter failure is named as US Letter, not as a bare mismatch');
+  check(/declaration was ignored/.test(letter.problems[0]),
+    'the US Letter failure says what actually went wrong — the declaration was ignored');
+  check(/612/.test(letter.problems[0]) && /792/.test(letter.problems[0]),
+    'the failure reports the size it actually measured');
+
+  const oneBad = verifyPageGeometry(pdf([{ box: A4 }, { box: LETTER }, { box: A4 }]));
+  check(!oneBad.ok, 'one wrong page fails the whole document');
+  check(oneBad.problems.length === 1 && /page 2\b/.test(oneBad.problems[0]),
+    'the failure names which page, by 1-based number');
+
+  // An unreadable PDF must not look like a correct one.
+  const opaque = verifyPageGeometry('%PDF-1.7\n1 0 obj << /Type /Catalog >> endobj\n%%EOF\n');
+  check(!opaque.ok, 'a PDF with no readable page objects fails rather than passing vacuously');
+  check(/not a verified one/.test(opaque.problems[0]),
+    'the unreadable case says why it is a failure and not a pass');
+  check(verifyPageGeometry('').ok === false, 'empty input fails');
+
+  // Whole-point output from an engine that rounds must pass too.
+  check(verifyPageGeometry(pdf([{ box: '0 0 595 842' }])).ok, 'whole-point A4 passes within tolerance');
+  check(!verifyPageGeometry(pdf([{ box: '0 0 595 850' }])).ok, 'a size outside tolerance fails');
+
+  // A caller can narrow the allowed set — a portrait-only deliverable.
+  const narrowed = verifyPageGeometry(pdf([{ box: A4_LAND }]), { allow: [A4_PORTRAIT_PT] });
+  check(!narrowed.ok, 'a caller can require portrait only');
+  check(verifyPageGeometry(pdf([{ box: A4_LAND }]), { allow: [A4_LANDSCAPE_PT] }).ok,
+    'a caller can require landscape only');
+
+  // Bytes, not just strings — this is what an engine actually returns.
+  check(verifyPageGeometry(Buffer.from(pdf([{ box: A4 }]), 'latin1')).ok,
+    'accepts PDF bytes, not only a string');
+  check(verifyPageGeometry(new Uint8Array(Buffer.from(pdf([{ box: A4 }]), 'latin1'))).ok,
+    'accepts a Uint8Array');
+}
+
+run();
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('test_pdf_geometry: all checks passed.');

--- a/packages/document-view-engine/tests/test_pdf_layout.mjs
+++ b/packages/document-view-engine/tests/test_pdf_layout.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Unit tests for src/pdf-layout.mjs — the §7 print-layout stylesheet and
+// document wrapper (page-size declaration half; PDF conversion itself is a
+// separate, dependency-gated slice — see the module header).
+//
+// Run: node packages/document-view-engine/tests/test_pdf_layout.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { buildStylesheet, wrapDocument, convertToPdf } from '../src/pdf-layout.mjs';
+import { renderDocument } from '../src/render.mjs';
+
+// Stand-in print engines. No real one is bundled (see the module header), so
+// the seam is exercised with two stubs that differ in exactly the way that
+// matters: one reads the `@page` declaration out of the HTML it was handed and
+// honours it; the other ignores it and falls back to its own default paper.
+// That is the failure §7 exists to catch, and it is only reachable with a
+// stub — a conforming engine would never produce it.
+
+function minimalPdf(boxes) {
+  const objects = [
+    '1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj',
+    `2 0 obj << /Type /Pages /Count ${boxes.length} /Kids [${boxes.map((_, i) => `${i + 3} 0 R`).join(' ')}] >> endobj`,
+    ...boxes.map((box, i) => `${i + 3} 0 obj << /Type /Page /Parent 2 0 R /MediaBox [${box}] >> endobj`),
+  ];
+  return Buffer.from(`%PDF-1.7\n${objects.join('\n')}\n%%EOF\n`, 'latin1');
+}
+
+// Honours `@page { size: A4 }`, and gives any `.dv-fit-page` illustration the
+// landscape page the named `@page landscape` rule selects for it.
+function honouringEngine(html) {
+  if (!/@page\s*\{[^}]*size:\s*A4;/.test(html)) return minimalPdf(['0 0 612 792']);
+  // Matched on the class attribute, not the bare name — the stylesheet in the
+  // same document mentions the selector too, and that is not a page.
+  const landscapePages = (html.match(/class="[^"]*\bdv-fit-page\b/g) ?? []).length;
+  return minimalPdf(['0 0 595.276 841.89', ...Array(landscapePages).fill('0 0 841.89 595.276')]);
+}
+
+const ignoringEngine = () => minimalPdf(['0 0 612 792']);
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+async function run() {
+  const css = buildStylesheet();
+
+  // §7 "page size, declared, never inherited" — A4 in both orientations.
+  check(/@page\s*\{[^}]*size:\s*A4;/.test(css), 'default @page declares A4 portrait');
+  check(/@page\s*\{[^}]*margin:\s*20mm;/.test(css), 'default @page declares the 20mm margin');
+  check(/@page\s+landscape\s*\{[^}]*size:\s*A4 landscape;/.test(css), 'named landscape @page declares A4 landscape');
+  check(/@page\s+landscape\s*\{[^}]*margin:\s*15mm;/.test(css), 'named landscape @page declares the 15mm margin');
+
+  // `fit = page` is the only skeleton-level trigger for a landscape page —
+  // it must select the named page and force it onto its own page.
+  check(/\.dv-fit-page\s*\{[^}]*page:\s*landscape;/.test(css), 'dv-fit-page selects the named landscape page');
+  check(/\.dv-fit-page\s*\{[^}]*break-before:\s*page;/.test(css), 'dv-fit-page breaks before its own page');
+  check(/\.dv-fit-page\s*\{[^}]*break-after:\s*page;/.test(css), 'dv-fit-page breaks after its own page');
+
+  // Every class render.mjs actually emits must carry visual meaning here —
+  // an un-styled class is a §4/§7 gap (colour or border silently missing).
+  const mustStyle = [
+    '.dv-ok', '.dv-suspect', '.dv-unresolved', '.dv-clean', '.dv-flag',
+    '.dv-illus-view', '.dv-illus-suspect', '.dv-illus-manual', '.dv-illus-missing',
+    '.dv-fit-width', '.dv-fit-none', '.dv-fit-page',
+    '.dv-trace', '.dv-trace-cell', '.dv-figref',
+    '.dv-derivation-share', '.dv-illustrations',
+  ];
+  for (const selector of mustStyle) {
+    check(css.includes(selector), `stylesheet styles every class render.mjs emits: missing ${selector}`);
+  }
+
+  // §4 "colour is never the only channel" — the flag glyph is the margin
+  // mark, so a screen reader / b&w print still distinguishes state without
+  // colour; this only asserts the colour classes stay distinct from it.
+  check(!/\.dv-flag\s*\{[^}]*color:/.test(css), 'dv-flag carries no colour of its own — it is the non-colour channel');
+
+  // §7 "Diagrams embed as SVG ... vector survives print and zoom" — the
+  // illustration classes must not force a raster-style fixed box that would
+  // clip or distort the embedded <svg>.
+  check(/\.dv-illus-view svg[^{]*\{[^}]*max-width:\s*100%;/.test(css), 'embedded SVG scales within its illustration box rather than overflowing');
+
+  // ── wrapDocument ─────────────────────────────────────────────────────
+  const doc = wrapDocument('<p>hello</p>', { title: 'Design Description' });
+  check(doc.startsWith('<!DOCTYPE html>'), 'wrapDocument emits a standalone HTML document');
+  check(doc.includes('<title>Design Description</title>'), 'wrapDocument sets the document title');
+  check(doc.includes('<p>hello</p>'), 'wrapDocument carries the rendered body through unchanged');
+  check(doc.includes('<style>'), 'wrapDocument embeds the stylesheet');
+  check(doc.includes('@page'), 'wrapDocument\'s embedded stylesheet declares page size');
+
+  // No document layout ships with this deliverable — the wrapper must not
+  // invent a table of contents or any per-document chrome beyond the shell.
+  check(!/table of contents/i.test(doc), 'wrapDocument adds no table of contents (out of scope, per epic)');
+
+  const escaped = wrapDocument('<p>x</p>', { title: '<script>alert(1)</script>' });
+  check(!escaped.includes('<script>alert(1)</script>'), 'wrapDocument escapes an untrusted title rather than injecting it verbatim');
+  check(escaped.includes('&lt;script&gt;'), 'wrapDocument HTML-escapes the title');
+
+  const untitled = wrapDocument('<p>x</p>');
+  check(untitled.includes('<title>Untitled</title>'), 'wrapDocument defaults the title when none is given');
+
+  // ── convertToPdf ─────────────────────────────────────────────────────
+  {
+    const result = await convertToPdf('<p>body</p>', { convert: honouringEngine, title: 'T' });
+    check(result.html.includes('<title>T</title>'), 'convertToPdf wraps the body before handing it to the engine');
+    check(result.pdf.length > 0, 'convertToPdf returns the engine\'s bytes');
+    check(result.geometry.ok, 'convertToPdf verifies the produced geometry');
+    check(Math.round(result.geometry.pages[0].height) === 842, 'the produced page measures 595 × 842 pt');
+  }
+
+  // The whole reason the check exists: an engine that drops the declaration
+  // produces a plausible PDF at the wrong size, and must not pass silently.
+  {
+    let thrown = null;
+    await convertToPdf('<p>body</p>', { convert: ignoringEngine }).catch((e) => { thrown = e; });
+    check(thrown !== null, 'convertToPdf throws when the produced PDF is the wrong size');
+    check(/US Letter/.test(thrown?.message ?? ''), 'the throw names what the engine actually produced');
+  }
+
+  // `verify: false` is the only way past it, and has to be asked for.
+  {
+    const skipped = await convertToPdf('<p>body</p>', { convert: ignoringEngine, verify: false });
+    check(skipped.geometry === null, 'verify: false skips the check and says so by returning no geometry');
+  }
+
+  {
+    let thrown = null;
+    await convertToPdf('<p>body</p>', {}).catch((e) => { thrown = e; });
+    check(/no print engine supplied/.test(thrown?.message ?? ''),
+      'convertToPdf with no engine fails by name rather than by TypeError');
+  }
+
+  // ── End to end: renderDocument → wrap → engine → geometry ────────────
+  // Both profiles, since §4's two profiles must both reach PDF.
+  {
+    const ast = [
+      { type: 'text', value: '# Heading\n\n' },
+      { type: 'inline', id: 'A-1', fields: ['name'] },
+      { type: 'text', value: '\n\n' },
+      { type: 'view', path: 'nowhere.blocks.transitrix.yaml', fit: 'page' },
+    ];
+    const evaluator = {
+      async evaluateFieldPath() { return { id: 'A-1', state: 'ok', flag: null, content: 'value' }; },
+      async evaluateEach() { return []; },
+      async resolveReference() { return { state: 'ok' }; },
+    };
+
+    for (const profile of ['review', 'clean']) {
+      // eslint-disable-next-line no-await-in-loop -- two profiles, read in order
+      const { html } = await renderDocument(ast, evaluator, { profile });
+      // eslint-disable-next-line no-await-in-loop -- ditto
+      const out = await convertToPdf(html, { convert: honouringEngine, title: 'Doc' });
+      check(out.geometry.ok, `${profile}: a rendered document converts and verifies`);
+      check(out.geometry.pages.length === 2, `${profile}: the fit = page illustration gets a page of its own`);
+      check(Math.round(out.geometry.pages[1].width) === 842,
+        `${profile}: that page measures 842 × 595 pt — a wide diagram gets a landscape page, not a shrunken font`);
+    }
+  }
+}
+
+await run();
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('test_pdf_layout: all checks passed.');


### PR DESCRIPTION
Completes the document-view engine's output stage — declare the page geometry, convert through a print engine, verify the geometry of what came back.

## Declare — `src/pdf-layout.mjs`

`wrapDocument()` wraps a rendered body in a standalone HTML document carrying the print stylesheet: `@page { size: A4; margin: 20mm; }` as the default page, a named `@page landscape` a `fit = page` illustration selects (a wide diagram gets a landscape page, not a shrunken font), and the print colour or border for every `dv-*` class `render.mjs` emits. Colour is never the only channel — the flag glyph stays the non-colour margin mark, so the stylesheet adds no colour of its own to it.

## Convert — the engine is a parameter, not a dependency

`convertToPdf(html, { convert })` takes the print engine as a function. No rendering engine is bundled: every package here ships `"dependencies": {}`, and which engine to adopt is an open architecture question I have not decided inside this slice. Everything around it — wrap, convert, verify — is implemented and tested, so adopting an engine later is supplying one function rather than writing this half. Calling it with no engine fails by name, not by `TypeError`.

## Verify — `src/pdf-geometry.mjs`

`verifyPageGeometry()` reads each page's `/MediaBox` back out of the produced PDF — honouring `/Rotate` (a landscape page is legal either way) and page-tree inheritance — and checks it against the two declared orientations, ±1pt.

This is the point of the output stage rather than decoration: an engine that ignores the page-size declaration falls back to its own default paper and produces a plausible-looking PDF whose last centimetres spill onto a second page every time. That case is reported by name, not as a bare size mismatch. A PDF whose page objects cannot be read at all (compressed object streams) is a failure too, never a vacuous pass — an unverifiable page size is not a verified one.

## Tests

`tests/test_pdf_geometry.mjs` (new) exercises the reader against hand-written minimal PDFs — the only way to reach the failing cases deterministically with no engine installed. `tests/test_pdf_layout.mjs` covers the stylesheet, the wrapper, and an end-to-end pass from `renderDocument()` through two stub engines that differ in exactly the way that matters: one honours the declaration, one drops it. Both profiles. Full package suite green; `node scripts/check-notations.mjs` clean.

## Stacked

Based on `methodology/11-telemetry`, not `main`, per the stacked-PR exception — this depends on `render.mjs`, which is still unmerged. Please merge the earlier PRs in this chain first, in order, then this one.