### PR TITLE
feat(document-renderer): add the .ttrs template format and its pass 1 resolver

### DIFF
--- a/.github/workflows/document-renderer-test.yml
+++ b/.github/workflows/document-renderer-test.yml
@@ -1,0 +1,40 @@
+name: document-renderer test
+
+# Unit tests for @transitrix/document-renderer — the `.ttrs` document-template
+# parser and its pass 1 deterministic resolver. Deterministic, no API key and no
+# model: pass 1 runs with no agent present by design, so the whole suite is a
+# plain Node run.
+#
+# The pass-1 suite renders the committed worked template
+# (packages/document-renderer/tests/fixtures/product.mrd.ttrs) end-to-end against
+# its fixture repository, and covers the no-repository cases, the named failures,
+# and re-run byte-stability.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/document-renderer/**'
+      - 'notations/CONTRACT.md'
+      - '.github/workflows/document-renderer-test.yml'
+  workflow_dispatch:
+  schedule:
+    # Mondays 10:30 UTC — weekly safety net, offset from the other Monday crons.
+    - cron: '30 10 * * 1'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run template-parser tests
+        run: node packages/document-renderer/tests/test_parse_template.mjs
+
+      - name: Run pass-1 resolver tests
+        run: node packages/document-renderer/tests/test_pass1.mjs

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -69,6 +69,10 @@ Each notation has exactly one canonical file extension: `*.<short-name>.transitr
 
 No aliases are accepted: one notation has exactly one extension. The full per-notation mapping lives in [README.md](README.md).
 
+The canonical extension is `*.<short-name>.transitrix.yaml` **or** `*.<short-name>.ttrs`; which one a given notation takes is a property of that notation. A `.ttrs` document is prose with directives rather than a mapping, and its middle segment is the document kind (`product.mrd.ttrs`), so the extension/parent-folder rule applies to it unchanged. `.ttrs` replaces `*.<short-name>.transitrix.yaml` in full for the notation that takes it — it is never appended to it, and no notation carries both. "One notation, exactly one extension" is unchanged, and `HDR-003` continues to enforce it.
+
+The near-miss `.trs` is one keystroke away and is a different, widely used format. A file ending `.trs` where a document source is expected is reported as that near-miss by name, not as an unknown-file error.
+
 ---
 
 ## 4. Date format

--- a/notations/views/documents/DIRECTIVE_LANGUAGE.md
+++ b/notations/views/documents/DIRECTIVE_LANGUAGE.md
@@ -1,0 +1,295 @@
+---
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-08-07"
+status: "draft"
+---
+
+# Directive language — normative reference
+
+**Version:** 0.1
+**Date:** 2026-08-07
+**Status:** Draft — the single normative definition of the `{{ … }}` directive
+language shared by every document source in this class.
+**Applies to:** `.ttrs` document templates and document-view skeleton files.
+
+---
+
+## 0. What this document is, and what it is not
+
+This is **not a notation spec.** It defines no file schema, claims no
+`notation:` value, and registers nothing. It deliberately carries no top-level
+`notation:` header — a file in this folder without one is not a view spec and is
+not counted as one ([`check-notations.mjs`](../../../scripts/check-notations.mjs),
+check `C1`). That absence is the point being made, not an omission.
+
+What it defines is the **directive language**: the `{{ … }}` constructs that
+appear inside a document source. One language, defined once, here.
+
+Two implementations of that one language ship today —
+[`@transitrix/document-renderer`](../../../packages/document-renderer/README.md)
+(`.ttrs` templates, pass 1) and
+[`@transitrix/document-view-engine`](../../../packages/document-view-engine/README.md)
+(skeleton files, render profiles). **Two implementations of one notation is
+deliberate policy. Two specifications of one notation is drift** — the same
+drift the closed-vocabulary work was written against. Hence one spec, and a
+standing obligation on each implementation, §7.
+
+---
+
+## 1. Document *kinds* are not notations
+
+**A document view is a kind, never a notation of its own.**
+
+`MRD`, `SRS`, `SDD` and `SDS` name **kinds**. A kind is the middle segment of a
+document source's filename:
+
+    <basename>.<kind>.ttrs         e.g.  product.mrd.ttrs
+                                         platform.srs.ttrs
+                                         gateway.sdd.ttrs
+
+They are layouts over canon — a presentation surface, carrying no canonical
+content of their own. They are not members of the notation registry in that
+capacity, they do not each get a directive language of their own, and a new kind
+never means a new language.
+
+Stated plainly because the opposite reading is the available mistake: seeing
+[`29-mrd.md`](29-mrd.md), [`30-srs.md`](30-srs.md) and [`31-sdd.md`](31-sdd.md)
+sitting in this folder, one could conclude each defines a notation with its own
+syntax. It does not. Each defines a **layout** — which elements a document of
+that kind selects and how they are arranged. The syntax they are written in is
+this document's, shared and identical across all of them.
+
+**No registry surgery follows from this.** [`CONTRACT.md`](../../CONTRACT.md) §3
+(extension / content match) and the `E1` extension-and-parent-folder check are
+unaffected and unchanged. Those specs that do carry a `notation:` value keep it
+and stay counted; this document simply states what was already true.
+
+---
+
+## 2. Lexical rules
+
+Delimiters are `{{` and `}}`. Everything outside a directive is **fixed text**,
+copied through verbatim.
+
+| Rule | Definition |
+|---|---|
+| Escape | `\{{` renders a literal `{{`. **It is the only escape in the language.** There is no `\}}`; a `}}` outside a directive is ordinary text. |
+| Whitespace | Insignificant immediately inside the delimiters: `{{REQ-14}}` and `{{ REQ-14 }}` are the same directive. |
+| Nesting | **No directive nests inside another**, with the single exception of the block forms in §4, which contain fixed text and directives as their body. |
+
+### 2.1 Identifiers
+
+An `id` is validated against the canonical ID grammar
+([`IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md) §1):
+
+    <TYPE>-[<middle>-]<INTEGER>            REQ-14, CAP-1, BUSINESS_SERVICE-3
+
+**The `CAPABILITY` exception is part of this language, not just of the ID
+grammar.** A capability id embeds a V/H diagram address whose dots are part of
+the id ([`IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md) §2):
+
+    CAPABILITY-V<L1[.L2[.L3]]>
+    CAPABILITY-H<L1[.L2[.L3]]>
+
+A conforming parser **must** split the capability prefix off *before* reading a
+field path, or it will read `CAPABILITY-V1.2.3` as the id `CAPABILITY-V1` with
+the field path `2.3`. This is the pitfall a naive grammar gets wrong, and it is
+normative:
+
+| Directive | id | field path |
+|---|---|---|
+| `{{ CAPABILITY-V1.2.3 }}` | `CAPABILITY-V1.2.3` | — |
+| `{{ CAPABILITY-V1.2.3.name }}` | `CAPABILITY-V1.2.3` | `name` |
+| `{{ REQ-14.parent.title }}` | `REQ-14` | `parent.title` |
+
+---
+
+## 3. Inline constructs
+
+### 3.1 Inline reference
+
+    {{ <id> }}
+
+Substitutes the named object's display value. With no field path, an
+implementation resolves the first field the object carries from its own
+documented default order.
+
+### 3.2 Field path
+
+    {{ <id>.<field>[.<field>[.<field>]] }}
+
+Substitutes one field of the named object. A middle segment must itself name
+another object, which the resolver walks into.
+
+**Traversal is capped at depth 3.** A path of four or more segments is a
+failure, not a deeper walk. The cap is a language rule, not an implementation
+budget: a document that walks arbitrarily far into the model stops being a
+document and becomes a query.
+
+### 3.3 Row reference
+
+    {{ .<field> }}
+
+A field of the current row of the enclosing `each` block (§4.1). **Meaningful
+only inside one** — outside any `each`, there is nothing for it to resolve
+against, and it is a failure.
+
+### 3.4 Trace
+
+    {{ trace from = <TYPE> to = <TYPE> via = <relation> }}
+
+Renders the trace coverage between two element types along one relation. All
+three attributes are required.
+
+### 3.5 Figures
+
+| Form | Meaning |
+|---|---|
+| `{{ view <path> [as = <name>] [fit = width\|page\|none] }}` | **Derived** figure — a view authored in an existing view notation, rendered from the model. `fit` defaults to `width`. |
+| `{{ figure <path> [caption = "…"] [as = <name>] }}` | **Supplied** figure — an asset embedded as-is. Never generated. |
+| `{{ figref <name> }}` | Cross-reference to a figure declared earlier in the same document, by its `as` name. |
+
+Figures are numbered in document order. A `figref` naming no figure declared
+earlier in the document is a failure — forward references are not resolved.
+
+---
+
+## 4. Block constructs
+
+A block form opens with `{{# … }}` and closes with `{{/ … }}`. **There are
+exactly two.**
+
+### 4.1 `each`
+
+    {{# each <TYPE> [where <clause> [and <clause>]…] [order by <field>] }}
+      … body …
+    {{/ each }}
+
+Repeats its body once per selected element, binding each in turn as the current
+row for `{{ .field }}` (§3.3).
+
+The `where` clause is deliberately small, and the limits are normative rather
+than incidental:
+
+| Rule | Definition |
+|---|---|
+| Combination | **`and` only.** There is no `or`, and no parentheses. |
+| Operators | **`=` and `!=` only.** No ordering comparisons, no pattern matching, no membership. |
+| Right-hand side | **A literal only.** Never another field, never a nested directive. |
+
+A document template is not a query language, and the ceiling is set here on
+purpose: everything expressible in `where` is answerable by one pass over the
+element index, with no join planning and no evaluation order to reason about.
+
+`order by` takes a single field and is what makes a rendered document
+reproducible — without it, row order would follow the index's own order, which
+is not a guarantee any document should rest on.
+
+### 4.2 `instruct`
+
+    {{# instruct <slot-id> }}
+    question: …
+    inputs: …
+    sufficient: …
+    {{/ instruct }}
+
+An **instruction slot** — a section a deterministic pass cannot fill, carrying
+the instruction for whatever later pass does. `question:` and `sufficient:` are
+required; `inputs:` is optional and comma-separated.
+
+**A slot's body is opaque.** A parser scans from `{{# instruct … }}` straight to
+the matching `{{/ instruct }}` and keeps everything between as raw text. A
+`{{ REQ-14 }}` written inside a slot is **instruction prose, not a reference** —
+it is never resolved and never becomes a node of its own. This is the second
+rule a naive grammar gets wrong, and it is normative.
+
+A `<slot-id>` is lower-case letters, digits and hyphens, and **must be unique
+within a document** — it names that section wherever slots are recorded.
+
+---
+
+## 5. Reference states
+
+Resolving a reference yields exactly one state. Three concern canon; the fourth
+concerns configuration.
+
+| State | Flag | Meaning |
+|---|---|---|
+| ok | — | resolved, admitted, and inside its validity interval |
+| unresolved | `⚑U` | no object with that id exists |
+| not admitted | `⚑A` | the object exists, but its admission state is not active |
+| out of validity | `⚑V` | its `[valid_from, valid_to]` interval does not cover the render date |
+| no repository configured | — | the document cites canon, and none is configured |
+
+They are classified in that order: existence, then admission, then validity.
+
+**The states are kept distinct on purpose.** "You have no repository" and "your
+repository lacks this id" are different problems with different fixes, and
+folding the first into the second hides it.
+
+**The worst defect is not a missing reference.** It is a reference that resolves
+and renders as plainly correct text when the object behind it was never admitted
+or has stopped being valid — a reader has no way to see it. A non-ok state
+therefore never renders as its bare value.
+
+### 5.1 Suspicion (`⚑S`) — reported as not computed
+
+Link suspicion is **not** part of this language's MVP. Three standing reasons,
+none of them a schedule:
+
+1. It is out of scope by the rendered-documents decision.
+2. It is **computed from commit history**, not read from a file — a different
+   class of input from everything else here.
+3. [`CONTRACT.md`](../../CONTRACT.md) §16.2 scopes it to `REL` and claim
+   records, not to the element references a document cites.
+
+**It must nonetheless be reported as "not computed", never simply omitted.** A
+clean render and a render that never checked must not look alike. An
+implementation that silently leaves suspicion out of its output is
+non-conforming even when every other state is right.
+
+---
+
+## 6. Failure discipline
+
+| Requirement | Rule |
+|---|---|
+| Never silent | Every construct a document contains is either rendered or reported. Nothing is dropped. |
+| Never blank | A reference that does not render its value leaves a visible marker, not an empty string. |
+| Named by kind | Unknown or malformed syntax and **recognised-but-not-implemented** are different failures and must carry different codes. |
+
+The third row is the one that is easy to get wrong. A construct defined in this
+document but not implemented by the package reading it **fails by name —
+"recognised, not implemented in this pass"** — and never in the same bucket as a
+typo. Reporting a valid template as malformed syntax sends its author looking
+for a mistake they did not make.
+
+---
+
+## 7. What each implementation must state
+
+This language is defined once, here. **An implementation admits a subset of it.**
+
+Every package that reads a document source **must state, in its own README:**
+
+1. **What it admits** — the constructs of this document it implements.
+2. **What it defers** — the constructs it recognises and declines, and under
+   which failure code.
+
+Stating both is what keeps one language with two implementations from becoming
+two languages. A package that documents only what it supports leaves an author
+unable to tell "not in the language" from "not in this package" — and that
+ambiguity is where a second, accidental specification starts.
+
+---
+
+## 8. References
+
+- Extension / content match, and the date format: [`CONTRACT.md`](../../CONTRACT.md) §3, §4.
+- Link suspicion, content identity, and the mechanical-procedure hatch: [`CONTRACT.md`](../../CONTRACT.md) §16.
+- ID grammar and the `CAPABILITY` V/H exception: [`IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md) §1-2.
+- Document kinds shipped today: [`29-mrd.md`](29-mrd.md), [`30-srs.md`](30-srs.md), [`31-sdd.md`](31-sdd.md).
+- `.ttrs` templates and pass 1: [`@transitrix/document-renderer`](../../../packages/document-renderer/README.md).
+- Skeleton files, evaluation and render profiles: [`@transitrix/document-view-engine`](../../../packages/document-view-engine/README.md).
+- This class's index: [`README.md`](README.md).

--- a/notations/views/documents/README.md
+++ b/notations/views/documents/README.md
@@ -2,6 +2,20 @@
 
 Reserved for the document-view class — specs that render a standard document
 (MRD, SRS, SDD, …) from canon. See the 2026-07-30 rendered-documents architecture
-decision. The document-view engine's skeleton-file parser lives at
-[`packages/document-view-engine`](../../../packages/document-view-engine/README.md);
-reference resolution and rendering are follow-on work.
+decision.
+
+[`DIRECTIVE_LANGUAGE.md`](DIRECTIVE_LANGUAGE.md) is the **normative definition of
+the `{{ … }}` directive language** every document source in this class is written
+in — one language, defined once, shared by `.ttrs` templates and skeleton files
+alike. It is not a notation spec and carries no `notation:` header.
+
+The numbered specs beside it (`29-mrd.md`, `30-srs.md`, `31-sdd.md`) define
+document **kinds** — layouts over canon, named by the middle segment of a
+document source's filename. **A kind is never a notation of its own**; see
+[`DIRECTIVE_LANGUAGE.md`](DIRECTIVE_LANGUAGE.md) §1.
+
+Implementations: the `.ttrs` template parser and its pass-1 resolver live at
+[`packages/document-renderer`](../../../packages/document-renderer/README.md);
+the skeleton-file parser, evaluator and render profiles at
+[`packages/document-view-engine`](../../../packages/document-view-engine/README.md).
+Each states which subset of the language it admits and what it defers.

--- a/packages/document-renderer/README.md
+++ b/packages/document-renderer/README.md
@@ -1,0 +1,166 @@
+# @transitrix/document-renderer
+
+Parser for the **`.ttrs` document-template format**, and its **pass 1
+deterministic resolver** — the half of the document renderer that runs and is
+testable with no agent present.
+
+Pass 1 ships as a unit callable on its own, so pass 2 (instruction slots) and
+Studio's preview can both depend on it as a library rather than on the whole
+renderer.
+
+**Two invariants, stated outright:**
+
+- **It writes nothing into the model.** Every filesystem touch here is a read.
+- **It is re-run-stable.** Given unchanged inputs the Markdown is byte-identical —
+  no timestamps, no filesystem-order dependence, no counters that reset.
+
+## File naming
+
+    <basename>.<kind>.ttrs        e.g. product.mrd.ttrs
+
+The middle segment is the document kind, so the existing extension/parent-folder
+lint applies to it unchanged. `.ttrs` replaces `*.<short-name>.transitrix.yaml`
+in full for this artefact class — it is not appended to it
+([`CONTRACT.md` §3](../../notations/CONTRACT.md)).
+
+`.trs` is one keystroke away and is a different, widely used format. A file
+ending `.trs` where a document source is expected is reported as that near-miss
+by name, not as an unknown-file error — in `scripts/check-notations.mjs` (check
+`T1`) and here (`TTRS-013`).
+
+## Header
+
+YAML front matter. Four required fields, one optional:
+
+```yaml
+---
+document: Market Requirements Document   # required — the name its readers use
+kind: mrd                                # required — matches the filename's middle segment
+template_id: product.mrd                 # required — named in the run record
+template_version: "1.0"                  # required — named in the run record
+canon: ../canon                          # OPTIONAL — the repository
+---
+```
+
+**`canon:` is deliberately optional — the repository is an optional input.** A
+template naming no model object and no derived figure renders standalone, with no
+repository configured at all. That is a legitimate input, not a degraded one.
+
+## Slot kinds
+
+Delimiters `{{ … }}`; `\{{` escapes a literal `{{`. That is the only escape.
+
+| Kind | Form | AST node |
+|---|---|---|
+| Fixed text | anything outside `{{ … }}` | `{ type: 'text', value }` |
+| Model-object reference | `{{ REQ-14 }}` | `{ type: 'reference', id, fields: [] }` |
+| | `{{ REQ-14.text }}` | `{ type: 'reference', id, fields: ['text'] }` |
+| | `{{ REQ-14.parent.title }}` | traversal capped at depth 3 |
+| Figure — derived | `{{ view <path> as = name fit = width\|page\|none }}` | `{ type: 'view', path, as, fit }` — `fit` defaults to `width` |
+| Figure — supplied | `{{ figure <path> caption = "…" as = name }}` | `{ type: 'figure', path, caption, as }` |
+| Figure — reference | `{{ figref <name> }}` | `{ type: 'figref', name }` |
+| Instruction slot | `{{# instruct <slot-id> }} … {{/ instruct }}` | `{ type: 'instruct', slotId, question, inputs, sufficient, raw }` |
+
+**No slot kind nests inside another.** A model-object reference, a figure and a
+figref are each a single `{{ … }}` on one line and contain nothing but their own
+argument. An instruction slot is the one block form, and **its body is opaque**:
+the parser scans straight from `{{# instruct … }}` to the matching
+`{{/ instruct }}` and keeps everything between as raw text. A `{{ REQ-14 }}`
+written inside a slot is instruction prose, not a reference — it is never
+resolved, and never becomes its own node.
+
+`id` is validated against the canonical ID grammar
+([`IDS_AND_REFERENCES.md`](../../notations/IDS_AND_REFERENCES.md) §1-2),
+including the `CAPABILITY` V/H diagram-address exception — so `CAPABILITY-V1.2.3`
+keeps its own dots rather than having them read as a field path.
+
+### The instruction slot body
+
+Three keys, one per line. `question:` and `sufficient:` are required, `inputs:`
+is optional and comma-separated:
+
+```
+{{# instruct market-size }}
+question: How large is the addressable market, and how fast is it growing?
+inputs: CAP-1, REQ-14
+sufficient: A market size with a currency and a year, a growth rate, and the method for both.
+{{/ instruct }}
+```
+
+The slot id names that section in the run record, so **two slots may not share
+one** (`TTRS-003`).
+
+## What pass 1 does with each kind
+
+| Kind | Pass 1 |
+|---|---|
+| Fixed text | copied verbatim |
+| Model-object reference | resolved against the repository |
+| Figure — derived | source resolved and numbered; rasterising is the output layer's job, reached through the `rasterise` hook |
+| Figure — supplied | resolved and numbered; never generated |
+| Instruction slot | **left untouched** — copied through byte-for-byte, so the unfilled section is visible in the output and pass 2 finds it by the same syntax that put it there |
+
+## Usage
+
+```js
+import { runPass1 } from '@transitrix/document-renderer/src/pass1.mjs';
+
+const { ok, markdown, instructionSlots, figures, errors } = await runPass1({
+  text,                       // template source
+  templatePath,               // enables the filename/`kind:` check; bases figure paths
+  // repositoryRoot,          // optional override; omitted, the header's `canon:` is used,
+                              // resolved relative to the template. Pass null to force
+                              // the no-repository case.
+  // rasterise,               // optional hook: ({kind, source, name, number, fit}) => embedPath
+});
+```
+
+`instructionSlots` lists every slot in the template, in document order, each with
+its full instruction — that is what the run record names.
+
+The parser is available on its own when only syntax is wanted:
+
+```js
+import { parseTemplate } from '@transitrix/document-renderer/src/parse-template.mjs';
+
+const { header, ast, errors } = parseTemplate(text);
+```
+
+## Failure discipline
+
+An unresolvable reference **fails the run by name**. It never renders as empty
+text — the output carries a `«unresolved: …»` marker where it stood, and the run
+has already failed by the time anyone reads it.
+
+| Code | Meaning |
+|---|---|
+| `TTRS-001` | header: missing or malformed required field, or no front matter |
+| `TTRS-002` | syntax: unknown directive, malformed reference, unclosed slot, bad slot id, missing `question:`/`sufficient:` |
+| `TTRS-003` | two instruction slots share one id |
+| `TTRS-010` | a model-object reference does not resolve — no such id, or no such field path |
+| `TTRS-011` | the template references a model object or derived figure, but **no repository is configured** |
+| `TTRS-012` | a figure source does not exist, or a `figref` names no declared figure |
+| `TTRS-013` | the filename is not `<basename>.<kind>.ttrs`, or its kind disagrees with the header |
+
+**`TTRS-011` is deliberately distinct from `TTRS-010`.** "You have no repository
+configured" and "your repository does not contain this id" are different problems
+with different fixes, and folding the first into the second would hide it.
+
+Deleting an element the document cites produces `TTRS-010`, not a silent gap.
+
+## Tests
+
+```
+node packages/document-renderer/tests/test_parse_template.mjs
+node packages/document-renderer/tests/test_pass1.mjs
+```
+
+`tests/fixtures/product.mrd.ttrs` is a complete worked template — every slot kind,
+one instruction slot — rendered end-to-end against `tests/fixtures/canon/` by the
+pass-1 suite.
+
+## Scope
+
+Pass 1 only. Filling instruction slots, emitting the run record, and PDF output
+are the next layer and are not in this package. Nothing here calls a model, and
+nothing here may — rendering happens in the CLI, never the agent.

--- a/packages/document-renderer/README.md
+++ b/packages/document-renderer/README.md
@@ -12,7 +12,37 @@ renderer.
 
 - **It writes nothing into the model.** Every filesystem touch here is a read.
 - **It is re-run-stable.** Given unchanged inputs the Markdown is byte-identical —
-  no timestamps, no filesystem-order dependence, no counters that reset.
+  no timestamps, no filesystem-order dependence, no counters that reset. The
+  render date is one of those inputs: pin `renderDate` to keep runs on different
+  days identical.
+
+## What this package admits, and what it defers
+
+The `{{ … }}` directive language is defined **once**, normatively, in
+[`notations/views/documents/DIRECTIVE_LANGUAGE.md`](../../notations/views/documents/DIRECTIVE_LANGUAGE.md).
+This package implements a subset of it. Both halves are stated here because
+stating only the first leaves an author unable to tell "not in the language"
+from "not in this package".
+
+| Construct | This package |
+|---|---|
+| Fixed text, `\{{` escape | **admits** |
+| Inline reference `{{ REQ-14 }}` | **admits** |
+| Field path `{{ REQ-14.parent.title }}` (depth 3) | **admits** |
+| `{{ view … }}` / `{{ figure … }}` / `{{ figref … }}` | **admits** — resolved and numbered; rasterising is the output layer's, via the `rasterise` hook |
+| `{{# instruct … }} … {{/ instruct }}` | **admits** — parsed and copied through; filling one is pass 2's |
+| `{{# each … }} … {{/ each }}` | **defers** — `TTRS-004` |
+| `{{ trace … }}` | **defers** — `TTRS-004` |
+| `{{ .field }}` (row reference) | **defers** — `TTRS-004`, it belongs to `each` |
+| `⚑S` link suspicion | **not computed** — reported as such, never omitted |
+
+A deferred construct is **recognised, not implemented in this pass**. It fails by
+that name under its own code and is never reported as unknown syntax
+(`TTRS-002`) — telling an author their valid template is a typo sends them
+looking for a mistake they did not make.
+
+Document kinds — `mrd`, `srs`, `sdd`, `sds` — are **kinds, not notations**
+(`DIRECTIVE_LANGUAGE.md` §1). The kind is the middle segment of the filename.
 
 ## File naming
 
@@ -105,15 +135,23 @@ one** (`TTRS-003`).
 ```js
 import { runPass1 } from '@transitrix/document-renderer/src/pass1.mjs';
 
-const { ok, markdown, instructionSlots, figures, errors } = await runPass1({
+const {
+  ok, markdown, instructionSlots, figures, errors,
+  findings, states, suspicion,        // the four states, and why ⚑S is absent
+} = await runPass1({
   text,                       // template source
   templatePath,               // enables the filename/`kind:` check; bases figure paths
   // repositoryRoot,          // optional override; omitted, the header's `canon:` is used,
                               // resolved relative to the template. Pass null to force
                               // the no-repository case.
   // rasterise,               // optional hook: ({kind, source, name, number, fit}) => embedPath
+  // profile: 'strict',       // 'strict' (default) | 'review'
+  // renderDate: '2026-08-07',// validity is resolved at this date; defaults to today
 });
 ```
+
+`findings` lists every non-ok reference state in document order — `{ code, state,
+flag, id, file }` — whatever the profile. `states` counts them by state.
 
 `instructionSlots` lists every slot in the template, in document order, each with
 its full instruction — that is what the run record names.
@@ -135,18 +173,68 @@ has already failed by the time anyone reads it.
 | Code | Meaning |
 |---|---|
 | `TTRS-001` | header: missing or malformed required field, or no front matter |
-| `TTRS-002` | syntax: unknown directive, malformed reference, unclosed slot, bad slot id, missing `question:`/`sufficient:` |
+| `TTRS-002` | syntax: **unknown** directive, malformed reference, unclosed slot, bad slot id, missing `question:`/`sufficient:` |
 | `TTRS-003` | two instruction slots share one id |
-| `TTRS-010` | a model-object reference does not resolve — no such id, or no such field path |
+| `TTRS-004` | **recognised, not implemented in this pass** — `each`, `trace`, `{{ .field }}` |
+| `TTRS-010` | a model-object reference does not resolve — no such id, or no such field path (`⚑U`) |
 | `TTRS-011` | the template references a model object or derived figure, but **no repository is configured** |
 | `TTRS-012` | a figure source does not exist, or a `figref` names no declared figure |
 | `TTRS-013` | the filename is not `<basename>.<kind>.ttrs`, or its kind disagrees with the header |
+| `TTRS-014` | the object exists but is **not admitted** (`⚑A`) |
+| `TTRS-015` | the object is **out of validity** at the render date (`⚑V`) |
+
+**`TTRS-004` is deliberately distinct from `TTRS-002`.** A construct this pass
+recognises and declines is not a typo, and must not be reported as one.
 
 **`TTRS-011` is deliberately distinct from `TTRS-010`.** "You have no repository
 configured" and "your repository does not contain this id" are different problems
 with different fixes, and folding the first into the second would hide it.
 
 Deleting an element the document cites produces `TTRS-010`, not a silent gap.
+
+## The four reference states
+
+Every reference lands in exactly one state. The three canon-side ones are
+`@transitrix/document-view-engine`'s own (`⚑U` / `⚑A` / `⚑V`), reused rather
+than re-invented — one language must not grow two classifications of the same
+failure. The fourth is about configuration, not canon.
+
+| State | Flag | Code |
+|---|---|---|
+| `unresolved` | `⚑U` | `TTRS-010` |
+| `not-admitted` | `⚑A` | `TTRS-014` |
+| `out-of-validity` | `⚑V` | `TTRS-015` |
+| `no-repository` | — | `TTRS-011` |
+
+**The worst defect is not a missing reference** — it is one that resolves and
+renders as plainly correct text when the object behind it was never admitted or
+has stopped being valid. So a non-ok state never renders as its bare value.
+
+### Profiles
+
+| Profile | Behaviour |
+|---|---|
+| `strict` *(default)* | **fails on all four states**, naming the file, the id and the state |
+| `review` | renders each flagged value and reports every state in `findings`, without failing |
+
+These correspond to `@transitrix/document-view-engine`'s `clean` / `review`
+pair. `review` reports exactly what `strict` fails on.
+
+### Suspicion is reported as *not computed*
+
+`⚑S` link suspicion is not part of pass 1 — out of scope by the
+rendered-documents decision, derived from commit history rather than read from a
+file, and scoped by [`CONTRACT.md`](../../notations/CONTRACT.md) §16.2 to `REL`
+and claim records rather than the element references a template cites.
+
+Every result nonetheless carries a `suspicion` field saying so:
+
+```js
+{ computed: false, state: 'not-computed', reason: '…' }
+```
+
+**It is never simply omitted.** A clean render must be distinguishable from one
+that never checked.
 
 ## Tests
 

--- a/packages/document-renderer/package.json
+++ b/packages/document-renderer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@transitrix/document-renderer",
+  "version": "0.0.1",
+  "description": "Parser for the .ttrs document-template format and its pass 1 deterministic resolver — resolves model-object references and derived figures with no agent present, leaving instruction slots for pass 2.",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "src/"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Transitrix"
+  },
+  "repository": "https://github.com/transitrix/methodology",
+  "dependencies": {}
+}

--- a/packages/document-renderer/src/ids.mjs
+++ b/packages/document-renderer/src/ids.mjs
@@ -1,0 +1,15 @@
+// Canonical ID grammar (notations/IDS_AND_REFERENCES.md §1-2): `<TYPE>-[<middle>-]<INTEGER>`,
+// plus the CAPABILITY V/H diagram-address exception. Own copy by design — same posture
+// as decisions-cli's src/yaml.mjs: zero cross-package runtime dependency.
+
+const GENERAL_ID = /^[A-Z][A-Z0-9_]*(-[A-Za-z0-9]+)*-[1-9][0-9]*$/;
+const CAPABILITY_ID = /^CAPABILITY-[VH][1-9][0-9]*(\.[1-9][0-9]*){0,2}$/;
+
+export function isValidId(id) {
+  if (typeof id !== 'string' || id === '') return false;
+  return GENERAL_ID.test(id) || CAPABILITY_ID.test(id);
+}
+
+// A CAPABILITY id embeds its own dots (the V/H diagram address, IDS_AND_REFERENCES.md
+// §2) — split it off first so those dots aren't mistaken for a field path separator.
+export const CAPABILITY_PREFIX = /^(CAPABILITY-[VH][1-9][0-9]*(?:\.[1-9][0-9]*){0,2})(?:\.(.*))?$/;

--- a/packages/document-renderer/src/parse-template.mjs
+++ b/packages/document-renderer/src/parse-template.mjs
@@ -13,6 +13,19 @@
 // and a body AST. It resolves nothing against a repository and renders nothing —
 // that is pass1.mjs, built on top of this AST.
 //
+// The directive language is ONE language with more constructs than this pass
+// implements (DIRECTIVE_LANGUAGE.md, notations/views/documents/). Two failures
+// that look alike from a distance are kept apart on purpose:
+//
+//   TTRS-002  unknown or malformed syntax — not in the language at all
+//   TTRS-004  recognised, not implemented in this pass — `each`, `trace` and
+//             the `.field` row reference are defined constructs this parser
+//             names and declines, never silently drops and never reports as
+//             though the author mistyped something
+//
+// Folding the second into the first would tell an author their valid template
+// is a typo.
+//
 // Zero dependencies, own copy of the minimal bits it needs — same posture as
 // decisions-cli's src/yaml.mjs (no cross-package runtime dependency).
 
@@ -98,6 +111,14 @@ const INSTRUCT_OPEN = /^#\s*instruct(?:\s+([^\s}]+))?\s*$/;
 const INSTRUCT_CLOSE = '{{/ instruct }}';
 const INSTRUCT_CLOSE_RE = /\{\{\/\s*instruct\s*\}\}/;
 
+// `{{# each TYPE where … order by … }} … {{/ each }}` — a construct of the
+// language this pass does not implement. Scanned to its close and reported
+// once, so an author gets one honest "not implemented here" rather than a
+// cascade of syntax errors from the block's own contents.
+const EACH_OPEN = /^#\s*each(\s|$)/;
+const EACH_CLOSE = '{{/ each }}';
+const EACH_CLOSE_RE = /\{\{\/\s*each\s*\}\}/;
+
 function tokenize(body) {
   const tokens = [];
   const errors = [];
@@ -136,6 +157,26 @@ function tokenize(body) {
         const rawSource = body.slice(i, bodyEnd + closeMatch[0].length);
         tokens.push(parseInstruct(openMatch[1], body.slice(bodyStart, bodyEnd), rawSource, errors));
         i = bodyEnd + closeMatch[0].length;
+        continue;
+      }
+      if (EACH_OPEN.test(content.trim())) {
+        flushText();
+        const afterOpen = close + 2;
+        const eachClose = EACH_CLOSE_RE.exec(body.slice(afterOpen));
+        if (!eachClose) {
+          errors.push({
+            code: 'TTRS-004',
+            message: `"{{ ${content.trim()} }}" is recognised, not implemented in this pass — and it is never closed either (expected a matching "${EACH_CLOSE}")`,
+          });
+          i = body.length;
+          break;
+        }
+        errors.push({
+          code: 'TTRS-004',
+          message: `"{{ ${content.trim()} }}": the \`each\` block is a construct of the directive language that pass 1 does not implement — recognised, not implemented in this pass`,
+        });
+        tokens.push({ type: 'unimplemented', construct: 'each' });
+        i = afterOpen + eachClose.index + eachClose[0].length;
         continue;
       }
       flushText();
@@ -290,7 +331,7 @@ function classify(rawContent, errors) {
   if (trimmed.startsWith('#')) {
     errors.push({
       code: 'TTRS-002',
-      message: `unknown block directive "{{${trimmed}}}" — "{{# instruct <slot-id> }}" is the only block form`,
+      message: `unknown block directive "{{${trimmed}}}" — "{{# instruct <slot-id> }}" and "{{# each … }}" are the language's only block forms`,
     });
     return { type: 'error' };
   }
@@ -298,6 +339,26 @@ function classify(rawContent, errors) {
   if (/^view(\s|$)/.test(trimmed)) return parseView(trimmed, errors);
   if (/^figure(\s|$)/.test(trimmed)) return parseFigure(trimmed, errors);
   if (/^figref(\s|$)/.test(trimmed)) return parseFigref(trimmed, errors);
+
+  // Recognised constructs of the language that pass 1 declines by name.
+  if (/^trace(\s|$)/.test(trimmed)) {
+    errors.push({
+      code: 'TTRS-004',
+      message: `"{{ ${trimmed} }}": \`trace\` is a construct of the directive language that pass 1 does not implement — recognised, not implemented in this pass`,
+    });
+    return { type: 'unimplemented', construct: 'trace' };
+  }
+
+  // `{{ .field }}` — the row reference, meaningful only inside an `each` block.
+  // Reported as unimplemented rather than as a malformed id: it is in the
+  // language, and its own block form is what pass 1 does not implement.
+  if (trimmed.startsWith('.')) {
+    errors.push({
+      code: 'TTRS-004',
+      message: `"{{ ${trimmed} }}": a field reference belongs to an \`each\` block — recognised, not implemented in this pass`,
+    });
+    return { type: 'unimplemented', construct: 'field-ref' };
+  }
 
   if (/\s/.test(trimmed)) {
     errors.push({ code: 'TTRS-002', message: `unrecognised directive "{{ ${trimmed} }}"` });

--- a/packages/document-renderer/src/parse-template.mjs
+++ b/packages/document-renderer/src/parse-template.mjs
@@ -1,0 +1,350 @@
+// `.ttrs` document-template parser — syntax only.
+//
+// A `.ttrs` file is prose with directives, not a mapping. It carries a YAML
+// front-matter header and a body made of four slot kinds:
+//
+//   fixed text              anything outside `{{ … }}` — copied verbatim
+//   model-object reference  `{{ REQ-14 }}` / `{{ REQ-14.text }}`
+//   figure                  `{{ view … }}` (derived) / `{{ figure … }}` (supplied)
+//                           / `{{ figref … }}` (cross-reference)
+//   instruction slot        `{{# instruct <slot-id> }} … {{/ instruct }}`
+//
+// Scope of this module: syntax. It turns a template's text into a header object
+// and a body AST. It resolves nothing against a repository and renders nothing —
+// that is pass1.mjs, built on top of this AST.
+//
+// Zero dependencies, own copy of the minimal bits it needs — same posture as
+// decisions-cli's src/yaml.mjs (no cross-package runtime dependency).
+
+import { isValidId, CAPABILITY_PREFIX } from './ids.mjs';
+
+const FRONT_MATTER = /^---\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?([\s\S]*)$/;
+
+// `<basename>.<kind>.ttrs` — the middle segment is the document kind, so the
+// existing extension/parent-folder lint applies to it unchanged.
+const TEMPLATE_FILENAME = /^[^.]+\.([a-z0-9-]+)\.ttrs$/;
+
+const SLOT_ID = /^[a-z0-9][a-z0-9-]*$/;
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const REQUIRED_HEADER_FIELDS = ['document', 'kind', 'template_id', 'template_version'];
+
+// Returns the document kind declared by a `.ttrs` filename, or undefined when the
+// name is not of that shape. Exported so a caller can check it against the header's
+// `kind:` without re-deriving the pattern.
+export function templateKindFromFilename(name) {
+  const m = TEMPLATE_FILENAME.exec(String(name));
+  return m ? m[1] : undefined;
+}
+
+function cleanScalar(raw) {
+  let s = String(raw).trim();
+  const hash = s.indexOf(' #');
+  if (hash >= 0) s = s.slice(0, hash).trim();
+  if (s.startsWith('"') && s.endsWith('"') && s.length >= 2) {
+    try { return JSON.parse(s); } catch { return s.slice(1, -1); }
+  }
+  if (s.startsWith("'") && s.endsWith("'") && s.length >= 2) return s.slice(1, -1).replace(/''/g, "'");
+  return s;
+}
+
+// ── Header ───────────────────────────────────────────────────────────────
+// `canon:` is deliberately optional — the repository is an optional input. A
+// template naming no model object and no derived figure renders standalone.
+
+function parseHeader(headerText) {
+  const errors = [];
+  const fields = {};
+  for (const line of headerText.split(/\r?\n/)) {
+    if (line.trim() === '' || line.trim().startsWith('#')) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*):[ \t]*(.*)$/);
+    if (!m) continue;
+    fields[m[1]] = cleanScalar(m[2]);
+  }
+
+  for (const name of REQUIRED_HEADER_FIELDS) {
+    if (!fields[name]) {
+      errors.push({ code: 'TTRS-001', message: `header: \`${name}\` is required` });
+    }
+  }
+  if (fields.kind && !/^[a-z0-9-]+$/.test(fields.kind)) {
+    errors.push({
+      code: 'TTRS-001',
+      message: `header: \`kind\` must be lower-case letters, digits and hyphens, got "${fields.kind}"`,
+    });
+  }
+
+  return {
+    header: {
+      document: fields.document,
+      kind: fields.kind,
+      template_id: fields.template_id,
+      template_version: fields.template_version,
+      canon: fields.canon ?? null,
+    },
+    errors,
+  };
+}
+
+// ── Tokenizer ────────────────────────────────────────────────────────────
+// Walks the body, splitting it into literal-text runs and `{{ … }}` directives.
+// `\{{` is the one defined escape — renders as a literal `{{`.
+//
+// An instruction slot's body is opaque: on `{{# instruct … }}` the tokenizer
+// scans straight to the matching `{{/ instruct }}` and keeps everything between
+// as raw text. No slot kind nests inside another, by design.
+
+const INSTRUCT_OPEN = /^#\s*instruct(?:\s+([^\s}]+))?\s*$/;
+const INSTRUCT_CLOSE = '{{/ instruct }}';
+const INSTRUCT_CLOSE_RE = /\{\{\/\s*instruct\s*\}\}/;
+
+function tokenize(body) {
+  const tokens = [];
+  const errors = [];
+  let buf = '';
+  let i = 0;
+
+  const flushText = () => {
+    if (buf !== '') { tokens.push({ type: 'text', value: buf }); buf = ''; }
+  };
+
+  while (i < body.length) {
+    if (body.startsWith('\\{{', i)) { buf += '{{'; i += 3; continue; }
+    if (body.startsWith('{{', i)) {
+      const close = body.indexOf('}}', i + 2);
+      if (close === -1) {
+        errors.push({ code: 'TTRS-002', message: `unterminated "{{" at offset ${i} — no matching "}}"` });
+        i = body.length;
+        break;
+      }
+      const content = body.slice(i + 2, close);
+      const openMatch = INSTRUCT_OPEN.exec(content.trim());
+      if (openMatch) {
+        flushText();
+        const afterOpen = close + 2;
+        const closeMatch = INSTRUCT_CLOSE_RE.exec(body.slice(afterOpen));
+        if (!closeMatch) {
+          errors.push({
+            code: 'TTRS-002',
+            message: `instruction slot "${content.trim()}" is never closed — expected a matching "${INSTRUCT_CLOSE}"`,
+          });
+          i = body.length;
+          break;
+        }
+        const bodyStart = afterOpen;
+        const bodyEnd = afterOpen + closeMatch.index;
+        const rawSource = body.slice(i, bodyEnd + closeMatch[0].length);
+        tokens.push(parseInstruct(openMatch[1], body.slice(bodyStart, bodyEnd), rawSource, errors));
+        i = bodyEnd + closeMatch[0].length;
+        continue;
+      }
+      flushText();
+      tokens.push(classify(content, errors));
+      i = close + 2;
+      continue;
+    }
+    buf += body[i];
+    i++;
+  }
+  flushText();
+  return { tokens, errors };
+}
+
+// ── Instruction slot ─────────────────────────────────────────────────────
+// Pass 1 never fills one of these; it copies the slot through untouched so the
+// unresolved section is visible in the Markdown and pass 2 can find it. The
+// three body keys are the epic's shape: the question the section answers, the
+// inputs it may read, and what makes an answer sufficient.
+
+function parseInstruct(slotId, bodyText, rawSource, errors) {
+  const label = slotId ? `instruction slot "${slotId}"` : 'instruction slot';
+
+  if (!slotId) {
+    errors.push({ code: 'TTRS-002', message: '"{{# instruct … }}": missing slot id' });
+  } else if (!SLOT_ID.test(slotId)) {
+    errors.push({
+      code: 'TTRS-002',
+      message: `${label}: slot id must be lower-case letters, digits and hyphens`,
+    });
+  }
+
+  const fields = {};
+  for (const line of bodyText.split(/\r?\n/)) {
+    const m = line.match(/^\s*(question|inputs|sufficient):[ \t]*(.*)$/);
+    if (m) fields[m[1]] = m[2].trim();
+  }
+
+  if (!fields.question) {
+    errors.push({ code: 'TTRS-002', message: `${label}: \`question:\` is required` });
+  }
+  if (!fields.sufficient) {
+    errors.push({ code: 'TTRS-002', message: `${label}: \`sufficient:\` is required` });
+  }
+
+  const inputs = fields.inputs
+    ? fields.inputs.split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+
+  return {
+    type: 'instruct',
+    slotId,
+    question: fields.question,
+    inputs,
+    sufficient: fields.sufficient,
+    raw: rawSource,
+  };
+}
+
+// ── Model-object reference and figures ───────────────────────────────────
+
+function splitIdAndFields(trimmed) {
+  const capMatch = CAPABILITY_PREFIX.exec(trimmed);
+  if (capMatch) return { id: capMatch[1], fieldsRaw: capMatch[2] ?? '' };
+  const dot = trimmed.indexOf('.');
+  if (dot === -1) return { id: trimmed, fieldsRaw: '' };
+  return { id: trimmed.slice(0, dot), fieldsRaw: trimmed.slice(dot + 1) };
+}
+
+function splitFieldPath(raw, errors, context) {
+  const segments = raw.split('.').filter((s) => s !== '');
+  if (segments.length === 0) {
+    errors.push({ code: 'TTRS-002', message: `${context}: empty field path` });
+    return [];
+  }
+  if (segments.length > 3) {
+    errors.push({ code: 'TTRS-002', message: `${context}: field path "${raw}" exceeds max traversal depth 3` });
+  }
+  for (const seg of segments) {
+    if (!IDENTIFIER.test(seg)) {
+      errors.push({ code: 'TTRS-002', message: `${context}: "${seg}" in field path "${raw}" is not a valid field name` });
+    }
+  }
+  return segments;
+}
+
+// `key = value` attribute list, values optionally double-quoted.
+function parseAttrs(rest) {
+  const attrs = {};
+  const re = /([a-z_][a-z0-9_]*)\s*=\s*("(?:[^"\\]|\\.)*"|\S+)/gi;
+  let m;
+  while ((m = re.exec(rest)) !== null) {
+    let value = m[2];
+    if (value.startsWith('"')) {
+      try { value = JSON.parse(value); } catch { value = value.slice(1, -1); }
+    }
+    attrs[m[1]] = value;
+  }
+  return attrs;
+}
+
+// The leading path argument: everything before the first `key =` attribute.
+function splitPathAndAttrs(rest) {
+  const attrStart = rest.search(/[a-z_][a-z0-9_]*\s*=/i);
+  if (attrStart === -1) return { path: rest.trim(), attrRest: '' };
+  return { path: rest.slice(0, attrStart).trim(), attrRest: rest.slice(attrStart) };
+}
+
+const FIT_VALUES = new Set(['width', 'page', 'none']);
+
+function parseView(trimmed, errors) {
+  const { path, attrRest } = splitPathAndAttrs(trimmed.replace(/^view\s*/, ''));
+  const attrs = parseAttrs(attrRest);
+  if (!path) {
+    errors.push({ code: 'TTRS-002', message: `"{{ ${trimmed} }}": missing view source path` });
+  }
+  const fit = attrs.fit ?? 'width';
+  if (!FIT_VALUES.has(fit)) {
+    errors.push({ code: 'TTRS-002', message: `"{{ ${trimmed} }}": fit must be width, page or none — got "${fit}"` });
+  }
+  return { type: 'view', path, as: attrs.as ?? null, fit };
+}
+
+function parseFigure(trimmed, errors) {
+  const { path, attrRest } = splitPathAndAttrs(trimmed.replace(/^figure\s*/, ''));
+  const attrs = parseAttrs(attrRest);
+  if (!path) {
+    errors.push({ code: 'TTRS-002', message: `"{{ ${trimmed} }}": missing figure asset path` });
+  }
+  return { type: 'figure', path, caption: attrs.caption ?? null, as: attrs.as ?? null };
+}
+
+function parseFigref(trimmed, errors) {
+  const name = trimmed.replace(/^figref\s*/, '').trim();
+  if (!name) {
+    errors.push({ code: 'TTRS-002', message: `"{{ ${trimmed} }}": missing figure name` });
+  }
+  return { type: 'figref', name };
+}
+
+function classify(rawContent, errors) {
+  const trimmed = rawContent.trim();
+
+  if (trimmed.startsWith('/')) {
+    errors.push({
+      code: 'TTRS-002',
+      message: `unexpected closing directive "{{${trimmed}}}" — no block is open here`,
+    });
+    return { type: 'error' };
+  }
+
+  if (trimmed.startsWith('#')) {
+    errors.push({
+      code: 'TTRS-002',
+      message: `unknown block directive "{{${trimmed}}}" — "{{# instruct <slot-id> }}" is the only block form`,
+    });
+    return { type: 'error' };
+  }
+
+  if (/^view(\s|$)/.test(trimmed)) return parseView(trimmed, errors);
+  if (/^figure(\s|$)/.test(trimmed)) return parseFigure(trimmed, errors);
+  if (/^figref(\s|$)/.test(trimmed)) return parseFigref(trimmed, errors);
+
+  if (/\s/.test(trimmed)) {
+    errors.push({ code: 'TTRS-002', message: `unrecognised directive "{{ ${trimmed} }}"` });
+    return { type: 'error' };
+  }
+
+  const { id, fieldsRaw } = splitIdAndFields(trimmed);
+  if (!isValidId(id)) {
+    errors.push({
+      code: 'TTRS-002',
+      message: `model-object reference "{{ ${trimmed} }}": "${id}" is not a valid ID (IDS_AND_REFERENCES.md §1)`,
+    });
+  }
+  const fields = fieldsRaw === ''
+    ? []
+    : splitFieldPath(fieldsRaw, errors, `model-object reference "{{ ${trimmed} }}"`);
+  return { type: 'reference', id, fields };
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────
+
+export function parseTemplate(text) {
+  const errors = [];
+  const m = FRONT_MATTER.exec(String(text));
+  if (!m) {
+    return {
+      header: null,
+      ast: [],
+      errors: [{ code: 'TTRS-001', message: 'template has no `---` front-matter header' }],
+    };
+  }
+
+  const { header, errors: headerErrors } = parseHeader(m[1]);
+  errors.push(...headerErrors);
+
+  const { tokens, errors: bodyErrors } = tokenize(m[2]);
+  errors.push(...bodyErrors);
+
+  // A slot id names a section in the run record, so two slots may not share one.
+  const seen = new Set();
+  for (const node of tokens) {
+    if (node.type !== 'instruct' || !node.slotId) continue;
+    if (seen.has(node.slotId)) {
+      errors.push({ code: 'TTRS-003', message: `duplicate instruction slot id "${node.slotId}"` });
+    }
+    seen.add(node.slotId);
+  }
+
+  return { header, ast: tokens, errors };
+}

--- a/packages/document-renderer/src/pass1.mjs
+++ b/packages/document-renderer/src/pass1.mjs
@@ -1,0 +1,256 @@
+// Pass 1 — the deterministic half of the document renderer.
+//
+// Resolves every model-object reference and every derived figure in a `.ttrs`
+// template. Runs and is testable with NO agent present: nothing in this module
+// calls a model, and nothing in it may. Instruction slots are pass 2's job and
+// are copied through untouched, so an unfilled section is visible in the output
+// rather than silently blank.
+//
+// This module ships as a unit callable on its own, so pass 2 and Studio's
+// preview can both depend on it as a library rather than on the whole renderer.
+//
+// Two invariants worth stating outright:
+//
+//   * It writes nothing into the model. Every filesystem touch here is a read.
+//   * It is re-run-stable. Given unchanged inputs the Markdown is byte-identical —
+//     no timestamps, no filesystem-order dependence, no counters that reset.
+//
+// Failure discipline: an unresolvable reference FAILS the run by name. It never
+// renders as empty text. The distinct codes matter — a caller must be able to
+// tell "you have no repository configured" (TTRS-011) apart from "your
+// repository does not contain this id" (TTRS-010).
+
+import { existsSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';
+
+import { parseTemplate, templateKindFromFilename } from './parse-template.mjs';
+import { buildRepositoryIndex } from './repository.mjs';
+
+// Rendered in place of a reference the run could not resolve. The run has already
+// failed by the time this is visible; it exists so the failure is never a blank.
+const UNRESOLVED_MARKER = (id) => `«unresolved: ${id}»`;
+
+// Field consulted, in order, when a reference names no field path of its own.
+const DEFAULT_FIELDS = ['name', 'title', 'id'];
+
+function needsRepository(ast) {
+  return ast.some((node) => node.type === 'reference' || node.type === 'view');
+}
+
+function traverse(entry, fields, index) {
+  let current = entry;
+  for (let i = 0; i < fields.length; i++) {
+    const value = current.fields[fields[i]];
+    if (value === undefined) return undefined;
+    // A middle segment must name another object to keep walking into.
+    if (i < fields.length - 1) {
+      const next = index.get(value);
+      if (!next) return undefined;
+      current = next;
+      continue;
+    }
+    return value;
+  }
+  return undefined;
+}
+
+function renderReference(node, index, errors) {
+  const entry = index.get(node.id);
+  if (!entry) {
+    errors.push({
+      code: 'TTRS-010',
+      message: `model-object reference "${node.id}" does not resolve — no object with that id is in the repository`,
+    });
+    return UNRESOLVED_MARKER(node.id);
+  }
+
+  if (node.fields.length === 0) {
+    for (const name of DEFAULT_FIELDS) {
+      if (entry.fields[name] !== undefined) return entry.fields[name];
+    }
+    errors.push({
+      code: 'TTRS-010',
+      message: `model-object reference "${node.id}" resolves, but the object carries none of: ${DEFAULT_FIELDS.join(', ')}`,
+    });
+    return UNRESOLVED_MARKER(node.id);
+  }
+
+  const value = traverse(entry, node.fields, index);
+  if (value === undefined) {
+    const path = `${node.id}.${node.fields.join('.')}`;
+    errors.push({
+      code: 'TTRS-010',
+      message: `model-object reference "${path}" does not resolve — the field path is not present on that object`,
+    });
+    return UNRESOLVED_MARKER(path);
+  }
+  return value;
+}
+
+function resolveAssetPath(baseDir, path) {
+  if (!baseDir) return path;
+  return isAbsolute(path) ? path : resolvePath(join(baseDir, path));
+}
+
+// A derived figure (`{{ view … }}`) is authored as text in the existing view
+// notation; a supplied figure (`{{ figure … }}`) is an asset and is never
+// generated. Pass 1 resolves both to a stable, numbered embed. Turning a view
+// source into a raster is the output layer's job, reached through the optional
+// `rasterise` hook so this module stays free of any renderer dependency.
+function renderFigure(node, ctx, errors) {
+  const kind = node.type === 'view' ? 'view' : 'figure';
+  const abs = resolveAssetPath(ctx.baseDir, node.path);
+
+  if (!ctx.exists(abs)) {
+    errors.push({
+      code: 'TTRS-012',
+      message: `${kind} source "${node.path}" does not exist${ctx.baseDir ? ` (looked in ${ctx.baseDir})` : ''}`,
+    });
+    return UNRESOLVED_MARKER(node.path);
+  }
+
+  const number = ctx.figures.length + 1;
+  const name = node.as ?? `figure-${number}`;
+  const embedPath = ctx.rasterise
+    ? ctx.rasterise({ kind, source: abs, name, number, fit: node.fit ?? null })
+    : node.path;
+
+  ctx.figures.push({
+    number,
+    name,
+    kind,
+    source: node.path,
+    derived: kind === 'view',
+    fit: node.fit ?? null,
+    caption: node.caption ?? null,
+    embedPath,
+  });
+  ctx.figureNumbers.set(name, number);
+
+  const caption = node.caption ?? `Figure ${number}`;
+  return `![${caption}](${embedPath})`;
+}
+
+function renderFigref(node, ctx, errors) {
+  const number = ctx.figureNumbers.get(node.name);
+  if (number === undefined) {
+    errors.push({
+      code: 'TTRS-012',
+      message: `figref "${node.name}" names no figure declared earlier in this template`,
+    });
+    return UNRESOLVED_MARKER(node.name);
+  }
+  return `Figure ${number}`;
+}
+
+/**
+ * Run pass 1 over a `.ttrs` template.
+ *
+ * @param {object} options
+ * @param {string} options.text            template source
+ * @param {string} [options.templatePath]  path the source came from — enables the
+ *                                         filename/`kind:` cross-check and gives
+ *                                         figure paths a base directory
+ * @param {string} [options.repositoryRoot] canon root; overrides the header's `canon:`.
+ *                                          Pass `null` to force the no-repository case.
+ * @param {Function} [options.rasterise]   hook turning a resolved figure source into
+ *                                         the path to embed; omitted, the source path
+ *                                         is embedded as-is
+ * @returns {Promise<{ok, markdown, header, instructionSlots, figures, errors}>}
+ */
+export async function runPass1({ text, templatePath, repositoryRoot, rasterise } = {}) {
+  const { header, ast, errors } = parseTemplate(text);
+
+  if (header === null) {
+    return { ok: false, markdown: '', header: null, instructionSlots: [], figures: [], errors };
+  }
+
+  if (templatePath) {
+    const kindFromName = templateKindFromFilename(basename(templatePath));
+    if (kindFromName === undefined) {
+      errors.push({
+        code: 'TTRS-013',
+        message: `"${templatePath}" is not named <basename>.<kind>.ttrs`,
+      });
+    } else if (header.kind && kindFromName !== header.kind) {
+      errors.push({
+        code: 'TTRS-013',
+        message: `filename declares kind "${kindFromName}" but the header declares "${header.kind}"`,
+      });
+    }
+  }
+
+  // The repository is an optional input. Resolve which root we have, if any.
+  const explicit = repositoryRoot !== undefined;
+  let canonRoot = explicit ? repositoryRoot : header.canon;
+  if (canonRoot && !explicit && templatePath) {
+    canonRoot = resolvePath(join(dirname(templatePath), canonRoot));
+  }
+
+  if (!canonRoot && needsRepository(ast)) {
+    errors.push({
+      code: 'TTRS-011',
+      message: 'template references a model object but no repository is configured',
+    });
+  }
+
+  const index = await buildRepositoryIndex(canonRoot);
+
+  const ctx = {
+    baseDir: templatePath ? dirname(templatePath) : null,
+    exists: (p) => existsSync(p),
+    rasterise: rasterise ?? null,
+    figures: [],
+    figureNumbers: new Map(),
+  };
+
+  const instructionSlots = [];
+  const out = [];
+
+  for (const node of ast) {
+    switch (node.type) {
+      case 'text':
+        out.push(node.value);
+        break;
+      case 'reference':
+        out.push(canonRoot ? renderReference(node, index, errors) : UNRESOLVED_MARKER(node.id));
+        break;
+      case 'view':
+      case 'figure':
+        out.push(canonRoot || node.type === 'figure'
+          ? renderFigure(node, ctx, errors)
+          : UNRESOLVED_MARKER(node.path));
+        break;
+      case 'figref':
+        out.push(renderFigref(node, ctx, errors));
+        break;
+      case 'instruct':
+        // Pass 2's job. Copied through byte-for-byte — an unfilled section stays
+        // visible, and pass 2 finds it by the same syntax that put it here.
+        instructionSlots.push({
+          slotId: node.slotId,
+          question: node.question,
+          inputs: node.inputs,
+          sufficient: node.sufficient,
+        });
+        out.push(node.raw);
+        break;
+      default:
+        break; // a node the parser already reported on
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    markdown: out.join(''),
+    header,
+    instructionSlots,
+    figures: ctx.figures,
+    errors,
+  };
+}
+
+function basename(p) {
+  const parts = String(p).split(/[\\/]/);
+  return parts[parts.length - 1];
+}

--- a/packages/document-renderer/src/pass1.mjs
+++ b/packages/document-renderer/src/pass1.mjs
@@ -19,6 +19,27 @@
 // renders as empty text. The distinct codes matter — a caller must be able to
 // tell "you have no repository configured" (TTRS-011) apart from "your
 // repository does not contain this id" (TTRS-010).
+//
+// A reference lands in exactly one of FOUR distinguishable states. The three
+// canon-side ones are @transitrix/document-view-engine's own
+// (resolveReference()'s ⚑U / ⚑A / ⚑V), deliberately reused rather than
+// re-invented — one notation must not grow two classifications of the same
+// failure. The fourth is this pass's, and is about configuration, not canon:
+//
+//   unresolved         ⚑U  TTRS-010  no object with that id in the repository
+//   not-admitted       ⚑A  TTRS-014  it exists, but admission_state isn't active
+//   out-of-validity    ⚑V  TTRS-015  [valid_from, valid_to] misses the render date
+//   no-repository      —   TTRS-011  the template cites canon; none is configured
+//
+// The worst defect this guards against is not a missing reference — it is a
+// reference that resolves and renders as plainly correct text when the object
+// behind it was never admitted, or stopped being valid. So a non-ok state is
+// never rendered as its bare value.
+//
+// ⚑S (suspect) is NOT in this pass, and is reported as "not computed" rather
+// than omitted: a clean render has to be distinguishable from one that never
+// checked. Three standing reasons, none of them a time-box — see the
+// `suspicion` field of the result and DIRECTIVE_LANGUAGE.md.
 
 import { existsSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';
@@ -26,12 +47,53 @@ import { dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';
 import { parseTemplate, templateKindFromFilename } from './parse-template.mjs';
 import { buildRepositoryIndex } from './repository.mjs';
 
-// Rendered in place of a reference the run could not resolve. The run has already
-// failed by the time this is visible; it exists so the failure is never a blank.
+// Rendered in place of a reference that did not land in `ok`. The run has already
+// failed by the time this is visible; it exists so the failure is never a blank,
+// and never a value that reads as correct.
 const UNRESOLVED_MARKER = (id) => `«unresolved: ${id}»`;
+const STATE_MARKER = (state, id) => `«${STATES[state].label}: ${id}»`;
+
+// The one place a state's code, flag and wording live together.
+const STATES = {
+  unresolved: { code: 'TTRS-010', flag: '⚑U', label: 'unresolved' },
+  'not-admitted': { code: 'TTRS-014', flag: '⚑A', label: 'not admitted' },
+  'out-of-validity': { code: 'TTRS-015', flag: '⚑V', label: 'out of validity' },
+};
+
+// Why ⚑S is absent, carried in the result so a caller never has to guess
+// whether suspicion was clean or simply never run.
+const SUSPICION_NOT_COMPUTED = {
+  computed: false,
+  state: 'not-computed',
+  reason:
+    'link suspicion (⚑S) is not computed in pass 1: it is out of scope by the '
+    + 'rendered-documents decision, it is derived from commit history rather than '
+    + 'read from a file, and CONTRACT.md §16.2 scopes it to REL/claim records '
+    + 'rather than the element references a template cites.',
+};
 
 // Field consulted, in order, when a reference names no field path of its own.
 const DEFAULT_FIELDS = ['name', 'title', 'id'];
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function coversDate(validFrom, validTo, renderDate) {
+  if (validFrom === null || validFrom === undefined) return true; // nothing to check against
+  if (renderDate < validFrom) return false;
+  if (validTo !== null && validTo !== undefined && renderDate > validTo) return false;
+  return true;
+}
+
+// The §3 classification, in document-view-engine's order: existence, then
+// admission, then validity. Returns 'ok' when the object is usable.
+function classifyReference(entry, renderDate) {
+  if (!entry) return 'unresolved';
+  if (entry.admissionState !== 'active') return 'not-admitted';
+  if (!coversDate(entry.validFrom, entry.validTo, renderDate)) return 'out-of-validity';
+  return 'ok';
+}
 
 function needsRepository(ast) {
   return ast.some((node) => node.type === 'reference' || node.type === 'view');
@@ -54,37 +116,69 @@ function traverse(entry, fields, index) {
   return undefined;
 }
 
-function renderReference(node, index, errors) {
-  const entry = index.get(node.id);
-  if (!entry) {
-    errors.push({
-      code: 'TTRS-010',
-      message: `model-object reference "${node.id}" does not resolve — no object with that id is in the repository`,
+// Records one non-ok reference state: always as a finding, and — in the strict
+// profile — as an error that fails the run. The message names the file, the id
+// and the state, in that order, because that is the order someone fixing it
+// needs them in.
+function recordState(node, state, ctx) {
+  const { code, label, flag } = STATES[state];
+  ctx.findings.push({ code, state, flag, id: node.id, file: ctx.templateLabel });
+  ctx.states[state] = (ctx.states[state] ?? 0) + 1;
+  if (ctx.profile === 'strict') {
+    ctx.errors.push({
+      code,
+      message: `${ctx.templateLabel}: model-object reference "${node.id}" is ${label}`,
     });
-    return UNRESOLVED_MARKER(node.id);
+  }
+}
+
+function renderReference(node, index, ctx) {
+  const entry = index.get(node.id);
+  const state = classifyReference(entry, ctx.renderDate);
+
+  if (state !== 'ok') {
+    recordState(node, state, ctx);
+    // In review the value is shown WITH its flag, so a reader sees both what the
+    // template meant and that it is not usable. In strict it never renders as
+    // its bare value — a wrong-but-plausible render is the defect being guarded
+    // against, and it is worse than a visibly missing one.
+    if (ctx.profile === 'review' && entry) {
+      const value = readValue(node, entry, index);
+      if (value !== undefined) return `${value} ${STATES[state].flag}`;
+    }
+    return STATE_MARKER(state, node.id);
   }
 
+  ctx.states.ok = (ctx.states.ok ?? 0) + 1;
+
+  const value = readValue(node, entry, index);
+  if (value !== undefined) return value;
+
+  // The object is admitted and in validity; it is the field path that is absent.
+  const path = node.fields.length === 0
+    ? node.id
+    : `${node.id}.${node.fields.join('.')}`;
+  const detail = node.fields.length === 0
+    ? `resolves, but the object carries none of: ${DEFAULT_FIELDS.join(', ')}`
+    : 'does not resolve — the field path is not present on that object';
+  ctx.errors.push({
+    code: 'TTRS-010',
+    message: `${ctx.templateLabel}: model-object reference "${path}" ${detail}`,
+  });
+  return UNRESOLVED_MARKER(path);
+}
+
+// The value a reference substitutes: its own field path, or the first of the
+// default fields the object carries. `undefined` when neither is present.
+function readValue(node, entry, index) {
+  if (!entry) return undefined;
   if (node.fields.length === 0) {
     for (const name of DEFAULT_FIELDS) {
       if (entry.fields[name] !== undefined) return entry.fields[name];
     }
-    errors.push({
-      code: 'TTRS-010',
-      message: `model-object reference "${node.id}" resolves, but the object carries none of: ${DEFAULT_FIELDS.join(', ')}`,
-    });
-    return UNRESOLVED_MARKER(node.id);
+    return undefined;
   }
-
-  const value = traverse(entry, node.fields, index);
-  if (value === undefined) {
-    const path = `${node.id}.${node.fields.join('.')}`;
-    errors.push({
-      code: 'TTRS-010',
-      message: `model-object reference "${path}" does not resolve — the field path is not present on that object`,
-    });
-    return UNRESOLVED_MARKER(path);
-  }
-  return value;
+  return traverse(entry, node.fields, index);
 }
 
 function resolveAssetPath(baseDir, path) {
@@ -156,14 +250,40 @@ function renderFigref(node, ctx, errors) {
  * @param {Function} [options.rasterise]   hook turning a resolved figure source into
  *                                         the path to embed; omitted, the source path
  *                                         is embedded as-is
- * @returns {Promise<{ok, markdown, header, instructionSlots, figures, errors}>}
+ * @param {'strict'|'review'} [options.profile] `strict` (default) fails the run on
+ *                                         every non-ok reference state; `review`
+ *                                         renders each one flagged and does not fail.
+ *                                         Corresponds to @transitrix/document-view-engine's
+ *                                         `clean` / `review` pair.
+ * @param {string} [options.renderDate]    ISO date validity is resolved at; defaults to
+ *                                         today. Pin it to keep runs on different days
+ *                                         byte-identical — the date is an input.
+ * @returns {Promise<{ok, markdown, header, instructionSlots, figures, errors, findings, states, suspicion, profile, renderDate}>}
  */
-export async function runPass1({ text, templatePath, repositoryRoot, rasterise } = {}) {
+export async function runPass1({
+  text, templatePath, repositoryRoot, rasterise, profile = 'strict', renderDate,
+} = {}) {
+  if (profile !== 'strict' && profile !== 'review') {
+    throw new Error(`runPass1: profile must be "strict" or "review", got "${profile}"`);
+  }
+  const date = renderDate ?? todayIso();
   const { header, ast, errors } = parseTemplate(text);
 
-  if (header === null) {
-    return { ok: false, markdown: '', header: null, instructionSlots: [], figures: [], errors };
-  }
+  const emptyResult = (hdr) => ({
+    ok: false,
+    markdown: '',
+    header: hdr,
+    instructionSlots: [],
+    figures: [],
+    errors,
+    findings: [],
+    states: {},
+    suspicion: SUSPICION_NOT_COMPUTED,
+    profile,
+    renderDate: date,
+  });
+
+  if (header === null) return emptyResult(null);
 
   if (templatePath) {
     const kindFromName = templateKindFromFilename(basename(templatePath));
@@ -187,10 +307,15 @@ export async function runPass1({ text, templatePath, repositoryRoot, rasterise }
     canonRoot = resolvePath(join(dirname(templatePath), canonRoot));
   }
 
-  if (!canonRoot && needsRepository(ast)) {
+  // The fourth state, and the only one that is about configuration rather than
+  // canon. Named in the same breath as the other three so a caller reading the
+  // findings never has to look in two places for "why did nothing resolve".
+  const templateLabel = templatePath ? basename(templatePath) : '<template>';
+  const noRepository = !canonRoot && needsRepository(ast);
+  if (noRepository) {
     errors.push({
       code: 'TTRS-011',
-      message: 'template references a model object but no repository is configured',
+      message: `${templateLabel}: template references a model object but no repository is configured`,
     });
   }
 
@@ -202,6 +327,14 @@ export async function runPass1({ text, templatePath, repositoryRoot, rasterise }
     rasterise: rasterise ?? null,
     figures: [],
     figureNumbers: new Map(),
+    profile,
+    renderDate: date,
+    templateLabel,
+    errors,
+    findings: noRepository
+      ? [{ code: 'TTRS-011', state: 'no-repository', flag: null, id: null, file: templateLabel }]
+      : [],
+    states: noRepository ? { 'no-repository': 1 } : {},
   };
 
   const instructionSlots = [];
@@ -213,7 +346,9 @@ export async function runPass1({ text, templatePath, repositoryRoot, rasterise }
         out.push(node.value);
         break;
       case 'reference':
-        out.push(canonRoot ? renderReference(node, index, errors) : UNRESOLVED_MARKER(node.id));
+        // With no repository the run has already failed as TTRS-011; the id is
+        // still marked in the output rather than left blank.
+        out.push(canonRoot ? renderReference(node, index, ctx) : UNRESOLVED_MARKER(node.id));
         break;
       case 'view':
       case 'figure':
@@ -247,6 +382,14 @@ export async function runPass1({ text, templatePath, repositoryRoot, rasterise }
     instructionSlots,
     figures: ctx.figures,
     errors,
+    // Every non-ok reference state, in document order, whatever the profile —
+    // `review` reports exactly what `strict` fails on.
+    findings: ctx.findings,
+    states: ctx.states,
+    // Never omitted. "Clean" and "never checked" must not look alike.
+    suspicion: SUSPICION_NOT_COMPUTED,
+    profile,
+    renderDate: date,
   };
 }
 

--- a/packages/document-renderer/src/repository.mjs
+++ b/packages/document-renderer/src/repository.mjs
@@ -1,0 +1,94 @@
+// Repository index — the deterministic half of what pass 1 resolves against.
+//
+// A template's `canon:` header names a `canon/` directory. This module walks it
+// once into an id → object map so every reference in one render pass shares a
+// single index. Top-level scalars only: a model-object reference substitutes a
+// field's text, it does not traverse into nested structure.
+//
+// The repository is an OPTIONAL input. `buildRepositoryIndex(null)` is not an
+// error — it yields an empty index, and pass 1 decides whether the template
+// actually needed one.
+//
+// Own hand-rolled field extraction, no shared cross-package runtime import —
+// same convention as this repo's other packages.
+
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Record folders carrying ids alongside `elements/`. Kept in one place so a new
+// record kind is a one-line addition.
+const RECORD_DIRS = ['elements', 'relations', 'assertions', 'verifications', 'validations'];
+
+async function walkYaml(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  // Sort so an index built twice over unchanged inputs is byte-identical —
+  // readdir order is filesystem-dependent and must not leak into the output.
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  for (const entry of entries) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walkYaml(p)));
+    else if (entry.isFile() && entry.name.endsWith('.yaml')) out.push(p);
+  }
+  return out;
+}
+
+// Every top-level `key: scalar` in the document. Block scalars (`|`, `>`) are
+// folded to their content so `{{ REQ-14.text }}` picks up multi-line prose.
+export function topLevelFields(text) {
+  const fields = {};
+  const lines = String(text).split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^([A-Za-z_][A-Za-z0-9_]*):[ \t]*(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    const value = rawValue.trim();
+
+    if (value === '|' || value === '>' || value === '|-' || value === '>-') {
+      const block = [];
+      for (let j = i + 1; j < lines.length; j++) {
+        if (lines[j].trim() === '') { block.push(''); continue; }
+        if (!/^\s/.test(lines[j])) break;
+        block.push(lines[j].replace(/^\s+/, ''));
+      }
+      fields[key] = (value.startsWith('|') ? block.join('\n') : block.join(' ')).trim();
+      continue;
+    }
+    if (value === '') continue; // a nested mapping or sequence — not a scalar field
+    fields[key] = stripScalar(value);
+  }
+  return fields;
+}
+
+function stripScalar(value) {
+  let s = value;
+  const hash = s.indexOf(' #');
+  if (hash >= 0) s = s.slice(0, hash).trim();
+  if (s.startsWith('"') && s.endsWith('"') && s.length >= 2) {
+    try { return JSON.parse(s); } catch { return s.slice(1, -1); }
+  }
+  if (s.startsWith("'") && s.endsWith("'") && s.length >= 2) return s.slice(1, -1).replace(/''/g, "'");
+  return s;
+}
+
+// Walks `canonRoot` into an id → { fields } index. A null/undefined root yields an
+// empty index — the no-repository-configured case, which is legitimate input.
+export async function buildRepositoryIndex(canonRoot) {
+  const index = new Map();
+  if (!canonRoot) return index;
+
+  for (const dir of RECORD_DIRS) {
+    for (const file of await walkYaml(join(canonRoot, dir))) {
+      const text = await readFile(file, 'utf8');
+      const fields = topLevelFields(text);
+      if (!fields.id) continue;
+      index.set(fields.id, { fields });
+    }
+  }
+  return index;
+}

--- a/packages/document-renderer/src/repository.mjs
+++ b/packages/document-renderer/src/repository.mjs
@@ -76,8 +76,24 @@ function stripScalar(value) {
   return s;
 }
 
-// Walks `canonRoot` into an id → { fields } index. A null/undefined root yields an
+// A `valid_to:` of literal `null` means "no end" — an open interval, not the
+// string "null". Read as a scalar it arrives as text, so it is normalised here
+// rather than at every use site.
+function dateOrNull(value) {
+  if (value === undefined || value === '' || value === 'null' || value === '~') return null;
+  return value;
+}
+
+// Walks `canonRoot` into an id → entry index. A null/undefined root yields an
 // empty index — the no-repository-configured case, which is legitimate input.
+//
+// Each entry carries the fields a reference substitutes AND the three envelope
+// values the four-state classification is decided from. An object with no
+// `admission_state:` is `active`, matching @transitrix/document-view-engine's
+// buildCanonIndex(): absence is the ordinary case, not an unknown one.
+//
+// Proposed and rejected drafts are indexed, never skipped — telling "does not
+// exist" apart from "exists, not admitted" is the whole point of the split.
 export async function buildRepositoryIndex(canonRoot) {
   const index = new Map();
   if (!canonRoot) return index;
@@ -87,7 +103,12 @@ export async function buildRepositoryIndex(canonRoot) {
       const text = await readFile(file, 'utf8');
       const fields = topLevelFields(text);
       if (!fields.id) continue;
-      index.set(fields.id, { fields });
+      index.set(fields.id, {
+        fields,
+        admissionState: fields.admission_state ?? 'active',
+        validFrom: dateOrNull(fields.valid_from),
+        validTo: dateOrNull(fields.valid_to),
+      });
     }
   }
   return index;

--- a/packages/document-renderer/tests/fixtures/assets/rig.svg
+++ b/packages/document-renderer/tests/fixtures/assets/rig.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60" viewBox="0 0 120 60">
+  <rect x="1" y="1" width="118" height="58" fill="none" stroke="#333"/>
+  <text x="60" y="34" font-family="sans-serif" font-size="12" text-anchor="middle">test rig</text>
+</svg>

--- a/packages/document-renderer/tests/fixtures/canon/elements/CAP-1.yaml
+++ b/packages/document-renderer/tests/fixtures/canon/elements/CAP-1.yaml
@@ -1,0 +1,5 @@
+notation: capability
+id: CAP-1
+name: Batch release
+title: Batch release capability
+text: Releasing a manufactured batch to distribution.

--- a/packages/document-renderer/tests/fixtures/canon/elements/REQ-14.yaml
+++ b/packages/document-renderer/tests/fixtures/canon/elements/REQ-14.yaml
@@ -1,0 +1,10 @@
+notation: requirement
+id: REQ-14
+name: Operator confirms a batch before release
+title: Batch release confirmation
+parent: CAP-1
+text: |
+  The system shall require an authorised operator to confirm a batch
+  before it is released to distribution.
+level: system
+kind: functional

--- a/packages/document-renderer/tests/fixtures/diagrams/context.blocks.transitrix.yaml
+++ b/packages/document-renderer/tests/fixtures/diagrams/context.blocks.transitrix.yaml
@@ -1,0 +1,7 @@
+notation: blocks
+name: Batch release context
+nested_blocks:
+  - id: BLOCK-1
+    name: Manufacturing
+  - id: BLOCK-2
+    name: Distribution

--- a/packages/document-renderer/tests/fixtures/product.mrd.ttrs
+++ b/packages/document-renderer/tests/fixtures/product.mrd.ttrs
@@ -1,0 +1,30 @@
+---
+document: Market Requirements Document
+kind: mrd
+template_id: product.mrd
+template_version: "1.0"
+canon: canon
+---
+# {{ CAP-1.title }}
+
+## Scope
+
+This document covers {{ CAP-1.text }}
+
+## Requirements
+
+**{{ REQ-14 }}** — {{ REQ-14.text }}
+
+Its parent capability is {{ REQ-14.parent.name }}.
+
+{{ view diagrams/context.blocks.transitrix.yaml as = context fit = width }}
+
+{{ figref context }} shows where the capability sits.
+
+## Market
+
+{{# instruct market-size }}
+question: How large is the addressable market for this capability, and how fast is it growing?
+inputs: CAP-1, REQ-14
+sufficient: A market size with a currency and a year, a growth rate, and the method used to derive both.
+{{/ instruct }}

--- a/packages/document-renderer/tests/test_parse_template.mjs
+++ b/packages/document-renderer/tests/test_parse_template.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+// Unit tests for src/parse-template.mjs — every `.ttrs` slot kind, the header
+// rules (including `canon:` being optional), and the defined error cases.
+//
+// Run: node packages/document-renderer/tests/test_parse_template.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { parseTemplate, templateKindFromFilename } from '../src/parse-template.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+function deepEqual(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+function checkEqual(actual, expected, msg) {
+  if (!deepEqual(actual, expected)) {
+    _failures.push(`${msg}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`);
+  }
+}
+function hasCode(errors, code) { return errors.some((e) => e.code === code); }
+
+const HEADER = 'document: Market Requirements Document\nkind: mrd\ntemplate_id: product.mrd\ntemplate_version: "1.0"\n';
+
+function tpl(body, headerExtra = '') {
+  return `---\n${HEADER}${headerExtra}---\n${body}`;
+}
+
+// ── Header ───────────────────────────────────────────────────────────────
+
+{
+  const { header, errors } = parseTemplate(tpl(''));
+  check(errors.length === 0, `plain header should parse clean, got: ${JSON.stringify(errors)}`);
+  checkEqual(header, {
+    document: 'Market Requirements Document',
+    kind: 'mrd',
+    template_id: 'product.mrd',
+    template_version: '1.0',
+    canon: null,
+  }, 'header parses and `canon` defaults to null');
+}
+
+{
+  // The repository is an optional input — a header without `canon:` is legal.
+  const { header, errors } = parseTemplate(tpl('Plain prose only.'));
+  check(errors.length === 0, 'a template with no canon and no references parses clean');
+  check(header.canon === null, '`canon:` absent yields null, not an error');
+}
+
+{
+  const { header } = parseTemplate(tpl('', 'canon: ../canon\n'));
+  check(header.canon === '../canon', '`canon:` is read when present');
+}
+
+for (const field of ['document', 'kind', 'template_id', 'template_version']) {
+  const stripped = HEADER.split('\n').filter((l) => !l.startsWith(`${field}:`)).join('\n');
+  const { errors } = parseTemplate(`---\n${stripped}---\nbody`);
+  check(hasCode(errors, 'TTRS-001') && errors.some((e) => e.message.includes(field)),
+    `missing header field \`${field}\` is flagged TTRS-001`);
+}
+
+{
+  const { errors } = parseTemplate('no front matter here at all');
+  check(hasCode(errors, 'TTRS-001'), 'missing front matter is flagged');
+}
+
+{
+  const { errors } = parseTemplate(tpl('', '').replace('kind: mrd', 'kind: MRD'));
+  check(hasCode(errors, 'TTRS-001'), 'a non-lower-case `kind` is flagged');
+}
+
+// ── Filename / kind ──────────────────────────────────────────────────────
+
+check(templateKindFromFilename('product.mrd.ttrs') === 'mrd', 'kind is read off the filename');
+check(templateKindFromFilename('product.ttrs') === undefined, 'a missing kind segment is not a template name');
+check(templateKindFromFilename('product.mrd.trs') === undefined, 'the .trs near-miss is not a template name');
+
+// ── Fixed text ───────────────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseTemplate(tpl('Just prose, nothing else.'));
+  check(errors.length === 0, 'fixed text parses clean');
+  checkEqual(ast, [{ type: 'text', value: 'Just prose, nothing else.' }], 'fixed text is one verbatim run');
+}
+
+{
+  const { ast } = parseTemplate(tpl('An escaped \\{{ stays literal.'));
+  checkEqual(ast, [{ type: 'text', value: 'An escaped {{ stays literal.' }], '`\\{{` escapes a literal delimiter');
+}
+
+// ── Model-object reference ───────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseTemplate(tpl('{{ REQ-14 }}'));
+  check(errors.length === 0, `bare reference parses clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'reference', id: 'REQ-14', fields: [] }], 'bare reference');
+}
+
+{
+  const { ast } = parseTemplate(tpl('{{ REQ-14.text }}'));
+  checkEqual(ast, [{ type: 'reference', id: 'REQ-14', fields: ['text'] }], 'reference with a field');
+}
+
+{
+  const { ast } = parseTemplate(tpl('{{ REQ-14.parent.title }}'));
+  checkEqual(ast, [{ type: 'reference', id: 'REQ-14', fields: ['parent', 'title'] }], 'reference with a field path');
+}
+
+{
+  const { ast, errors } = parseTemplate(tpl('{{ CAPABILITY-V1.2.3 }}'));
+  check(errors.length === 0, `CAPABILITY diagram address parses clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'reference', id: 'CAPABILITY-V1.2.3', fields: [] }],
+    'a CAPABILITY id keeps its own dots — they are not a field path');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{ not-an-id }}'));
+  check(hasCode(errors, 'TTRS-002'), 'an invalid id is flagged');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{ REQ-14.a.b.c.d }}'));
+  check(errors.some((e) => /depth 3/.test(e.message)), 'field path deeper than 3 is flagged');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{ REQ-14'));
+  check(errors.some((e) => /unterminated/.test(e.message)), 'an unterminated directive is flagged');
+}
+
+// ── Figures ──────────────────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseTemplate(tpl('{{ view diagrams/context.blocks.transitrix.yaml }}'));
+  check(errors.length === 0, `view parses clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [{ type: 'view', path: 'diagrams/context.blocks.transitrix.yaml', as: null, fit: 'width' }],
+    'a derived figure defaults fit to width');
+}
+
+{
+  const { ast } = parseTemplate(tpl('{{ view d/c.yaml as = context fit = page }}'));
+  checkEqual(ast, [{ type: 'view', path: 'd/c.yaml', as: 'context', fit: 'page' }], 'view attributes are read');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{ view d/c.yaml fit = enormous }}'));
+  check(hasCode(errors, 'TTRS-002'), 'an unknown fit value is flagged');
+}
+
+{
+  const { ast } = parseTemplate(tpl('{{ figure assets/photo.png caption = "The rig" as = rig }}'));
+  checkEqual(ast, [{ type: 'figure', path: 'assets/photo.png', caption: 'The rig', as: 'rig' }],
+    'a supplied figure carries a quoted caption');
+}
+
+{
+  const { ast } = parseTemplate(tpl('{{ figref rig }}'));
+  checkEqual(ast, [{ type: 'figref', name: 'rig' }], 'figref names a figure');
+}
+
+// ── Instruction slot ─────────────────────────────────────────────────────
+
+{
+  const src = '{{# instruct market-size }}\nquestion: How large is the market?\ninputs: CAP-1, REQ-14\nsufficient: A number, a currency, a year and the method.\n{{/ instruct }}';
+  const { ast, errors } = parseTemplate(tpl(src));
+  check(errors.length === 0, `instruction slot parses clean: ${JSON.stringify(errors)}`);
+  check(ast.length === 1 && ast[0].type === 'instruct', 'the slot is one node');
+  check(ast[0].slotId === 'market-size', 'slot id is read');
+  check(ast[0].question === 'How large is the market?', 'question is read');
+  checkEqual(ast[0].inputs, ['CAP-1', 'REQ-14'], 'inputs are split on commas');
+  check(ast[0].sufficient === 'A number, a currency, a year and the method.', 'sufficient is read');
+  check(ast[0].raw === src, 'raw carries the slot verbatim, so pass 1 can copy it through');
+}
+
+{
+  const { ast, errors } = parseTemplate(tpl(
+    '{{# instruct only }}\nquestion: Q?\nsufficient: S.\n{{/ instruct }}'));
+  check(errors.length === 0, 'inputs are optional');
+  checkEqual(ast[0].inputs, [], 'absent inputs yield an empty list');
+}
+
+{
+  // The body is opaque: a `{{ … }}` inside a slot is instruction text, not a
+  // reference the parser resolves. This is what makes the four kinds non-nesting.
+  const { ast, errors } = parseTemplate(tpl(
+    '{{# instruct opaque }}\nquestion: Cite {{ REQ-14 }} in your answer.\nsufficient: S.\n{{/ instruct }}'));
+  check(errors.length === 0, `an opaque body parses clean: ${JSON.stringify(errors)}`);
+  check(ast.length === 1 && ast[0].type === 'instruct', 'nothing inside the slot becomes its own node');
+  check(ast[0].question === 'Cite {{ REQ-14 }} in your answer.', 'the inner delimiters stay literal text');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{# instruct nofin }}\nquestion: Q?\nsufficient: S.'));
+  check(errors.some((e) => /never closed/.test(e.message)), 'an unclosed slot is flagged');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{# instruct }}\nquestion: Q?\nsufficient: S.\n{{/ instruct }}'));
+  check(errors.some((e) => /missing slot id/.test(e.message)), 'a slot with no id is flagged');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{# instruct Bad_Id }}\nquestion: Q?\nsufficient: S.\n{{/ instruct }}'));
+  check(hasCode(errors, 'TTRS-002'), 'a malformed slot id is flagged');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{# instruct noq }}\nsufficient: S.\n{{/ instruct }}'));
+  check(errors.some((e) => /question.*required/.test(e.message)), 'a slot without a question is flagged');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{# instruct nosuf }}\nquestion: Q?\n{{/ instruct }}'));
+  check(errors.some((e) => /sufficient.*required/.test(e.message)), 'a slot without a sufficiency test is flagged');
+}
+
+{
+  const two = '{{# instruct dup }}\nquestion: Q?\nsufficient: S.\n{{/ instruct }}\n'
+    + '{{# instruct dup }}\nquestion: Q2?\nsufficient: S2.\n{{/ instruct }}';
+  const { errors } = parseTemplate(tpl(two));
+  check(hasCode(errors, 'TTRS-003'), 'two slots may not share one id — the run record names each slot');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{# each REQUIREMENT }}x{{/ each }}'));
+  check(hasCode(errors, 'TTRS-002'), 'instruct is the only block form');
+}
+
+// ── Mixed ────────────────────────────────────────────────────────────────
+
+{
+  const { ast, errors } = parseTemplate(tpl('Before {{ REQ-14 }} after.'));
+  check(errors.length === 0, `mixed text parses clean: ${JSON.stringify(errors)}`);
+  checkEqual(ast, [
+    { type: 'text', value: 'Before ' },
+    { type: 'reference', id: 'REQ-14', fields: [] },
+    { type: 'text', value: ' after.' },
+  ], 'literal runs interleave with directives');
+}
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('All parse-template checks passed.');

--- a/packages/document-renderer/tests/test_parse_template.mjs
+++ b/packages/document-renderer/tests/test_parse_template.mjs
@@ -218,9 +218,50 @@ check(templateKindFromFilename('product.mrd.trs') === undefined, 'the .trs near-
   check(hasCode(errors, 'TTRS-003'), 'two slots may not share one id — the run record names each slot');
 }
 
+// ── Recognised, not implemented in this pass (TTRS-004) ─────────────────
+// `each` and `trace` are constructs of the one directive language, not typos.
+// They must never be reported in the same bucket as malformed syntax, and must
+// never be dropped silently.
+
 {
   const { errors } = parseTemplate(tpl('{{# each REQUIREMENT }}x{{/ each }}'));
-  check(hasCode(errors, 'TTRS-002'), 'instruct is the only block form');
+  check(hasCode(errors, 'TTRS-004'), 'an `each` block is recognised, not implemented — not TTRS-002');
+  check(!hasCode(errors, 'TTRS-002'), 'an `each` block is never reported as unknown syntax');
+}
+
+{
+  const where = '{{# each REQUIREMENT where level = "system" and kind != "safety" order by id }}'
+    + '{{ .title }}{{/ each }}';
+  const { errors } = parseTemplate(tpl(where));
+  check(hasCode(errors, 'TTRS-004'), 'a full `each` with where/order by is recognised, not implemented');
+  check(!hasCode(errors, 'TTRS-002'),
+    "the block's contents raise no syntax errors of their own — it is consumed whole");
+  checkEqual(errors.filter((e) => e.code === 'TTRS-004').length, 1,
+    'one honest report per unimplemented block, not a cascade');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{ trace from = REQUIREMENT to = TEST via = verifies }}'));
+  check(hasCode(errors, 'TTRS-004'), '`trace` is recognised, not implemented — not TTRS-002');
+  check(!hasCode(errors, 'TTRS-002'), '`trace` is never reported as unknown syntax');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{ .title }}'));
+  check(hasCode(errors, 'TTRS-004'),
+    'a bare field reference belongs to `each` — recognised, not a malformed id');
+}
+
+{
+  const { errors } = parseTemplate(tpl('{{# each REQUIREMENT }}x'));
+  check(hasCode(errors, 'TTRS-004'), 'an unclosed `each` still reports as recognised-not-implemented');
+}
+
+{
+  // Still genuinely unknown syntax — the new code must not swallow this one.
+  const { errors } = parseTemplate(tpl('{{# repeat REQUIREMENT }}x{{/ repeat }}'));
+  check(hasCode(errors, 'TTRS-002'), 'an undefined block form is still TTRS-002');
+  check(!hasCode(errors, 'TTRS-004'), 'an undefined block form is not dressed up as unimplemented');
 }
 
 // ── Mixed ────────────────────────────────────────────────────────────────

--- a/packages/document-renderer/tests/test_pass1.mjs
+++ b/packages/document-renderer/tests/test_pass1.mjs
@@ -191,6 +191,141 @@ function tpl(body, headerExtra = '') {
   }
 }
 
+// ── The four distinguishable reference states ───────────────────────────
+//
+// unresolved / not-admitted / out-of-validity are @transitrix/document-view-
+// engine's own three (⚑U / ⚑A / ⚑V); no-repository-configured is the fourth,
+// about configuration rather than canon. The strict profile fails on all four
+// and names the file, the id and the state. The defect being guarded against
+// is not the missing reference — it is the one that renders as correct text
+// when the object behind it was never admitted, or has stopped being valid.
+
+async function withCanon(files, fn) {
+  const tmp = await mkdtemp(join(tmpdir(), 'ttrs-state-'));
+  try {
+    await mkdir(join(tmp, 'elements'), { recursive: true });
+    for (const [name, body] of Object.entries(files)) {
+      await writeFile(join(tmp, 'elements', name), body);
+    }
+    return await fn(tmp);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+const PROPOSED = 'id: REQ-20\nname: Draft requirement\nadmission_state: proposed\n';
+const RETIRED = 'id: REQ-21\nname: Retired requirement\nvalid_from: "2020-01-01"\nvalid_to: "2021-01-01"\n';
+const FUTURE = 'id: REQ-22\nname: Future requirement\nvalid_from: "2999-01-01"\n';
+const ACTIVE = 'id: REQ-23\nname: Active requirement\nvalid_from: "2020-01-01"\nvalid_to: null\n';
+
+await withCanon({ 'REQ-20.yaml': PROPOSED }, async (canon) => {
+  const result = await runPass1({
+    text: tpl('Cites {{ REQ-20 }}.'),
+    templatePath: TEMPLATE_PATH,
+    repositoryRoot: canon,
+    renderDate: '2026-08-07',
+  });
+  check(!result.ok, 'a not-admitted object fails the strict profile');
+  check(codes(result).includes('TTRS-014'), 'with its own code, not the unresolved one');
+  check(!codes(result).includes('TTRS-010'), 'not-admitted is not folded into unresolved');
+  check(result.findings[0].state === 'not-admitted', 'and is reported as that state');
+  check(result.findings[0].flag === '⚑A', "reusing document-view-engine's flag");
+  const msg = result.errors[0].message;
+  check(msg.includes('product.mrd.ttrs') && msg.includes('REQ-20') && msg.includes('not admitted'),
+    `the failure names file, id and state, got: ${msg}`);
+  check(!result.markdown.includes('Draft requirement'),
+    'and it never renders as its plain, plausible-looking value');
+});
+
+await withCanon({ 'REQ-21.yaml': RETIRED }, async (canon) => {
+  const result = await runPass1({
+    text: tpl('Cites {{ REQ-21 }}.'),
+    repositoryRoot: canon,
+    renderDate: '2026-08-07',
+  });
+  check(codes(result).includes('TTRS-015'), 'an object past its valid_to is out of validity');
+  check(result.findings[0].flag === '⚑V', 'flagged ⚑V');
+  check(!result.markdown.includes('Retired requirement'), 'and does not render as correct text');
+});
+
+await withCanon({ 'REQ-22.yaml': FUTURE }, async (canon) => {
+  const result = await runPass1({
+    text: tpl('Cites {{ REQ-22 }}.'),
+    repositoryRoot: canon,
+    renderDate: '2026-08-07',
+  });
+  check(codes(result).includes('TTRS-015'), 'an object not yet valid is out of validity too');
+});
+
+await withCanon({ 'REQ-23.yaml': ACTIVE }, async (canon) => {
+  const result = await runPass1({
+    text: tpl('Cites {{ REQ-23 }}.'),
+    repositoryRoot: canon,
+    renderDate: '2026-08-07',
+  });
+  check(result.ok, `an active object inside its validity resolves: ${JSON.stringify(result.errors)}`);
+  check(result.markdown.includes('Active requirement'), 'and renders its value');
+  check(result.states.ok === 1, 'counted as ok');
+});
+
+await withCanon({ 'REQ-23.yaml': ACTIVE }, async (canon) => {
+  // `valid_to: null` is an open interval, not the string "null".
+  const result = await runPass1({
+    text: tpl('{{ REQ-23 }}'),
+    repositoryRoot: canon,
+    renderDate: '2999-12-31',
+  });
+  check(result.ok, 'an open validity interval has no end');
+});
+
+// The fourth state is reported alongside the other three, not somewhere else.
+{
+  const result = await runPass1({
+    text: tpl('{{ REQ-14 }}'),
+    templatePath: TEMPLATE_PATH,
+    repositoryRoot: null,
+  });
+  check(result.findings.some((f) => f.state === 'no-repository'),
+    'no-repository-configured is one of the four reported states');
+  check(result.errors[0].message.includes('product.mrd.ttrs'),
+    'and names the file like the others');
+}
+
+// ── The review profile reports what strict fails on ─────────────────────
+
+await withCanon({ 'REQ-20.yaml': PROPOSED }, async (canon) => {
+  const result = await runPass1({
+    text: tpl('Cites {{ REQ-20 }}.'),
+    repositoryRoot: canon,
+    renderDate: '2026-08-07',
+    profile: 'review',
+  });
+  check(result.ok, `review does not fail on a flagged state: ${JSON.stringify(result.errors)}`);
+  check(result.findings.length === 1, 'but it still reports it');
+  check(result.findings[0].state === 'not-admitted', 'as the same state strict fails on');
+  check(result.markdown.includes('⚑A'), 'and the flag is visible in the output');
+});
+
+{
+  let threw = false;
+  try {
+    await runPass1({ text: tpl('x'), repositoryRoot: null, profile: 'nonsense' });
+  } catch { threw = true; }
+  check(threw, 'an unknown profile is rejected rather than silently treated as strict');
+}
+
+// ── Suspicion is "not computed", never simply absent ────────────────────
+// A clean render must be distinguishable from one that never checked.
+
+{
+  const result = await runPass1({ text: tpl('Prose only.'), repositoryRoot: null });
+  check(result.suspicion !== undefined, 'the result always carries a suspicion field');
+  check(result.suspicion.computed === false, 'pass 1 does not compute ⚑S');
+  check(result.suspicion.state === 'not-computed', 'and says so by name');
+  check(typeof result.suspicion.reason === 'string' && result.suspicion.reason.length > 0,
+    'with the standing reason, so absence is never mistaken for cleanliness');
+}
+
 // ── Criterion: re-running on unchanged inputs is byte-identical ──────────
 
 {

--- a/packages/document-renderer/tests/test_pass1.mjs
+++ b/packages/document-renderer/tests/test_pass1.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// Unit tests for src/pass1.mjs — the deterministic resolver, against the
+// acceptance criteria of the epic's pass-1 task:
+//
+//   * runs with a repository and no agent: references resolved, derived figures
+//     rendered, instruction slots left visibly unresolved;
+//   * runs with NO repository at all for a template that names none — succeeds;
+//   * a template that DOES name one with no repository configured fails by a
+//     distinct name (TTRS-011), not folded into unresolved-reference handling;
+//   * an unresolvable reference fails by name (TTRS-010), never renders empty;
+//   * deleting a cited element is a named failure, not a silent gap;
+//   * re-running on unchanged inputs is byte-identical.
+//
+// Run: node packages/document-renderer/tests/test_pass1.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { mkdtemp, mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runPass1 } from '../src/pass1.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, 'fixtures');
+const CANON = join(FIXTURES, 'canon');
+const TEMPLATE_PATH = join(FIXTURES, 'product.mrd.ttrs');
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+function deepEqual(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+function checkEqual(actual, expected, msg) {
+  if (!deepEqual(actual, expected)) {
+    _failures.push(`${msg}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`);
+  }
+}
+function codes(result) { return result.errors.map((e) => e.code); }
+
+const HEADER = 'document: Market Requirements Document\nkind: mrd\ntemplate_id: product.mrd\ntemplate_version: "1.0"\n';
+function tpl(body, headerExtra = '') {
+  return `---\n${HEADER}${headerExtra}---\n${body}`;
+}
+
+// ── Criterion: pass 1 runs against a repository with no agent available ──
+
+{
+  const body = [
+    '# Requirements',
+    '',
+    'The lead requirement is {{ REQ-14.title }}, owned by {{ CAP-1 }}.',
+    '',
+    '{{ view diagrams/context.blocks.transitrix.yaml as = context }}',
+    '',
+    'See {{ figref context }} above.',
+    '',
+    '{{# instruct market-size }}',
+    'question: How large is the addressable market?',
+    'inputs: CAP-1',
+    'sufficient: A number, a currency, a year and the method.',
+    '{{/ instruct }}',
+  ].join('\n');
+
+  const result = await runPass1({
+    text: tpl(body),
+    templatePath: TEMPLATE_PATH,
+    repositoryRoot: CANON,
+  });
+
+  check(result.ok, `full pass should succeed, got: ${JSON.stringify(result.errors)}`);
+  check(result.markdown.includes('Batch release confirmation'),
+    'a field reference resolves to that field');
+  check(result.markdown.includes('Batch release,') || result.markdown.includes('Batch release'),
+    'a bare reference resolves to the object name');
+  check(!result.markdown.includes('{{ REQ-14'), 'no reference syntax survives into the output');
+  check(result.markdown.includes('![Figure 1]'), 'a derived figure renders as an embed');
+  check(result.markdown.includes('See Figure 1 above.'), 'figref resolves to the figure number');
+
+  // Instruction slots are pass 2's job — untouched, and visibly so.
+  check(result.markdown.includes('{{# instruct market-size }}'),
+    'the instruction slot is left in the output verbatim');
+  check(result.markdown.includes('{{/ instruct }}'), 'including its closing directive');
+  check(result.instructionSlots.length === 1, 'the slot is reported for the run record');
+  checkEqual(result.instructionSlots[0], {
+    slotId: 'market-size',
+    question: 'How large is the addressable market?',
+    inputs: ['CAP-1'],
+    sufficient: 'A number, a currency, a year and the method.',
+  }, 'the reported slot carries its instruction in full');
+
+  check(result.figures.length === 1 && result.figures[0].derived === true,
+    'a `view` figure is recorded as derived from the model');
+}
+
+// ── Criterion: runs with no repository at all ────────────────────────────
+
+{
+  const result = await runPass1({
+    text: tpl('Plain prose, no model objects and no derived figures.'),
+    repositoryRoot: null,
+  });
+  check(result.ok, `no-repository template should succeed trivially, got: ${JSON.stringify(result.errors)}`);
+  check(result.markdown === 'Plain prose, no model objects and no derived figures.',
+    'fixed text is copied verbatim');
+}
+
+{
+  // A template with only an instruction slot still needs no repository.
+  const result = await runPass1({
+    text: tpl('{{# instruct scope }}\nquestion: Q?\nsufficient: S.\n{{/ instruct }}'),
+    repositoryRoot: null,
+  });
+  check(result.ok, 'an instruction-only template needs no repository');
+  check(result.instructionSlots.length === 1, 'and its slot is still reported');
+}
+
+{
+  // A supplied asset is not derived from the model, so it needs no repository either.
+  const result = await runPass1({
+    text: tpl('{{ figure assets/rig.svg caption = "The rig" as = rig }}'),
+    templatePath: TEMPLATE_PATH,
+    repositoryRoot: null,
+  });
+  check(result.ok, `a supplied figure needs no repository, got: ${JSON.stringify(result.errors)}`);
+  check(result.markdown === '![The rig](assets/rig.svg)', 'a supplied figure embeds its own caption');
+  check(result.figures[0].derived === false, 'and is recorded as not derived');
+}
+
+// ── Criterion: needs a repository, none configured — distinct failure ────
+
+{
+  const result = await runPass1({ text: tpl('{{ REQ-14 }}'), repositoryRoot: null });
+  check(!result.ok, 'a reference with no repository fails');
+  check(codes(result).includes('TTRS-011'),
+    `missing-repository is its own code, got: ${JSON.stringify(result.errors)}`);
+  check(!codes(result).includes('TTRS-010'),
+    'and is NOT folded into ordinary unresolved-reference handling');
+  check(result.markdown.includes('«unresolved: REQ-14»'), 'it never renders as empty text');
+}
+
+{
+  const result = await runPass1({
+    text: tpl('{{ view diagrams/context.blocks.transitrix.yaml }}'),
+    templatePath: TEMPLATE_PATH,
+    repositoryRoot: null,
+  });
+  check(codes(result).includes('TTRS-011'),
+    'a derived figure with no repository is the same distinct failure');
+}
+
+// ── Criterion: an unresolvable reference fails by name ───────────────────
+
+{
+  const result = await runPass1({ text: tpl('{{ REQ-999 }}'), repositoryRoot: CANON });
+  check(!result.ok, 'an unknown id fails the run');
+  check(codes(result).includes('TTRS-010'), 'with the unresolved-reference code');
+  check(result.errors[0].message.includes('REQ-999'), 'and names the reference');
+  check(result.markdown.includes('«unresolved: REQ-999»'), 'it never renders as empty text');
+}
+
+{
+  const result = await runPass1({ text: tpl('{{ REQ-14.nonesuch }}'), repositoryRoot: CANON });
+  check(codes(result).includes('TTRS-010'), 'an unknown field on a known object also fails');
+  check(result.errors[0].message.includes('REQ-14.nonesuch'), 'and names the full path');
+}
+
+{
+  const result = await runPass1({ text: tpl('{{ REQ-14.parent.name }}'), repositoryRoot: CANON });
+  check(result.ok, `a field path traverses to another object: ${JSON.stringify(result.errors)}`);
+  check(result.markdown === 'Batch release', 'and yields that object\'s field');
+}
+
+// ── Criterion: deleting a cited element is a named failure ───────────────
+
+{
+  const tmp = await mkdtemp(join(tmpdir(), 'ttrs-'));
+  try {
+    await mkdir(join(tmp, 'elements'), { recursive: true });
+    await writeFile(join(tmp, 'elements', 'REQ-14.yaml'), 'id: REQ-14\nname: Present for now\n');
+
+    const text = tpl('Cites {{ REQ-14 }}.');
+    const before = await runPass1({ text, repositoryRoot: tmp });
+    check(before.ok, `cited element present — run is clean: ${JSON.stringify(before.errors)}`);
+
+    await rm(join(tmp, 'elements', 'REQ-14.yaml'));
+    const after = await runPass1({ text, repositoryRoot: tmp });
+    check(!after.ok, 'deleting the cited element fails the run');
+    check(codes(after).includes('TTRS-010'), 'by name, not as a silent gap');
+    check(!after.markdown.includes('Cites .'), 'and the citation does not quietly vanish');
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+// ── Criterion: re-running on unchanged inputs is byte-identical ──────────
+
+{
+  const body = 'A {{ REQ-14.title }} and {{ CAP-1 }} and '
+    + '{{ view diagrams/context.blocks.transitrix.yaml as = ctx }} and {{ figref ctx }}.';
+  const opts = { text: tpl(body), templatePath: TEMPLATE_PATH, repositoryRoot: CANON };
+  const first = await runPass1(opts);
+  const second = await runPass1(opts);
+  check(first.ok && second.ok, 'both runs succeed');
+  check(first.markdown === second.markdown, 're-running on unchanged inputs is byte-identical');
+}
+
+// ── Figure sources and the rasterise hook ───────────────────────────────
+
+{
+  const result = await runPass1({
+    text: tpl('{{ view diagrams/missing.transitrix.yaml }}'),
+    templatePath: TEMPLATE_PATH,
+    repositoryRoot: CANON,
+  });
+  check(codes(result).includes('TTRS-012'), 'a figure source that does not exist fails by name');
+}
+
+{
+  const result = await runPass1({ text: tpl('{{ figref nobody }}'), repositoryRoot: null });
+  check(codes(result).includes('TTRS-012'), 'a figref naming no declared figure fails by name');
+}
+
+{
+  // Rasterisation is the output layer's job, reached through this hook — pass 1
+  // itself pulls in no renderer.
+  const seen = [];
+  const result = await runPass1({
+    text: tpl('{{ view diagrams/context.blocks.transitrix.yaml as = ctx }}'),
+    templatePath: TEMPLATE_PATH,
+    repositoryRoot: CANON,
+    rasterise: ({ kind, name, number }) => { seen.push({ kind, name, number }); return `build/${name}.png`; },
+  });
+  check(result.ok, `rasterise hook run is clean: ${JSON.stringify(result.errors)}`);
+  checkEqual(seen, [{ kind: 'view', name: 'ctx', number: 1 }], 'the hook is handed the resolved figure');
+  check(result.markdown === '![Figure 1](build/ctx.png)', 'and its return value is what gets embedded');
+}
+
+// ── The file-driven path: `canon:` resolved relative to the template ────
+
+{
+  // No `repositoryRoot` argument at all — the header's `canon:` is the repository,
+  // resolved relative to the template's own directory. This is the ordinary route.
+  const text = await readFile(TEMPLATE_PATH, 'utf8');
+  const result = await runPass1({ text, templatePath: TEMPLATE_PATH });
+
+  check(result.ok, `the committed example template renders clean: ${JSON.stringify(result.errors)}`);
+  check(result.header.canon === 'canon', 'the header carries the repository path');
+  check(result.markdown.startsWith('# Batch release capability'),
+    'the heading resolved from the model');
+  check(result.markdown.includes('authorised operator'), 'a block scalar resolves to its prose');
+  check(result.markdown.includes('Figure 1 shows where'), 'figref resolved');
+  check(result.instructionSlots.length === 1 && result.instructionSlots[0].slotId === 'market-size',
+    'the example exercises exactly one instruction slot');
+  check(result.markdown.includes('{{# instruct market-size }}'),
+    'which pass 1 leaves untouched');
+}
+
+// ── Filename / header kind cross-check ──────────────────────────────────
+
+{
+  const result = await runPass1({
+    text: tpl('x'),
+    templatePath: join(FIXTURES, 'product.srs.ttrs'),
+    repositoryRoot: null,
+  });
+  check(codes(result).includes('TTRS-013'), 'filename kind disagreeing with the header is flagged');
+}
+
+{
+  const result = await runPass1({
+    text: tpl('x'),
+    templatePath: join(FIXTURES, 'product.mrd.trs'),
+    repositoryRoot: null,
+  });
+  check(codes(result).includes('TTRS-013'), 'a .trs near-miss filename is not accepted as a template');
+}
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('All pass1 checks passed.');

--- a/packages/document-view-engine/README.md
+++ b/packages/document-view-engine/README.md
@@ -17,6 +17,34 @@ for `trace` / `view` / `figure` / `figref` (they render as inert pass-through
 markers today), derivation share (§5), telemetry (§6), and PDF output (§7) — later
 layers on top of these.
 
+## What this package admits, and what it defers
+
+The `{{ … }}` directive language is defined **once**, normatively, in
+[`notations/views/documents/DIRECTIVE_LANGUAGE.md`](../../notations/views/documents/DIRECTIVE_LANGUAGE.md).
+This package implements a subset of it. Both halves are stated here because
+stating only the first leaves an author unable to tell "not in the language"
+from "not in this package".
+
+| Construct | This package |
+|---|---|
+| Fixed text, `\{{` escape | **admits** |
+| Inline reference `{{ REQ-14 }}` | **admits** — parsed, resolved, rendered |
+| Field path `{{ REQ-14.parent.title }}` (depth 3) | **admits** |
+| `{{ .field }}` (row reference) | **admits** — bound to the enclosing `each` row |
+| `{{# each … }} … {{/ each }}` | **admits** — parsed, selected, rendered |
+| `{{ trace … }}` | **parses; defers** rendering — inert pass-through marker |
+| `{{ view … }}` / `{{ figure … }}` / `{{ figref … }}` | **parses; defers** rendering — inert pass-through markers |
+| `{{# instruct … }} … {{/ instruct }}` | **defers** — an instruction slot is `@transitrix/document-renderer`'s |
+| `⚑S` link suspicion | **admits** — computed for `REL`/claim records (see §3 below) |
+
+A deferred construct is **recognised, not implemented here** — never reported as
+unknown syntax. The two packages' subsets are complementary, not competing:
+this one owns `each` selection and rendering, the other owns `.ttrs` templates
+and instruction slots. They implement one language, not two.
+
+Document kinds — `mrd`, `srs`, `sdd`, `sds` — are **kinds, not notations**
+(`DIRECTIVE_LANGUAGE.md` §1).
+
 ## Skeleton file shape
 
 ```markdown

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -16,6 +16,9 @@
 //       value matches its file extension.
 //   L1  links — every relative Markdown link in notations/**/*.md resolves to
 //       an existing file (anchors and external URLs are skipped).
+//   T1  document sources — every `.ttrs` file is named <basename>.<kind>.ttrs,
+//       and no file ends `.trs` (the near-miss: one keystroke away, a different
+//       widely used format). Reported in words, not as an unknown-file error.
 //   V1  version — every concrete `methodology_version:` pin in the repo equals
 //       the single source of truth (notations/CURRENT_VERSION.yaml,
 //       per CONTRACT.md §10), except explicitly allowlisted placeholders.
@@ -450,6 +453,46 @@ async function checkPackageEnvelopeStatements(failures) {
   }
 }
 
+// T1: document-source file naming.
+//
+// `.trs` is one keystroke away from `.ttrs` and is a different, widely used
+// format. A file ending `.trs` where a document source is expected must be
+// reported as that near-miss in words — a bare "unknown file" would send the
+// author looking for the wrong problem (CONTRACT.md §3).
+//
+// Pure: takes the repo-relative paths, returns the findings. Exported for the
+// unit tests; the walk that feeds it lives in checkDocumentSources below.
+export function findDocumentSourceFailures(relPaths) {
+  const failures = [];
+  for (const rel of relPaths) {
+    const base = posix.basename(rel);
+
+    if (base.endsWith('.trs')) {
+      failures.push({
+        check: 'T1',
+        message: `${rel}: ends ".trs" — the document-source extension is ".ttrs" (".trs" is a different, widely used format, one keystroke away). Rename it, or move it out of the tree if it really is a .trs file.`,
+      });
+      continue;
+    }
+
+    if (!base.endsWith('.ttrs')) continue;
+
+    // `<basename>.<kind>.ttrs` — the middle segment is the document kind.
+    if (!/^[^.]+\.[a-z0-9-]+\.ttrs$/.test(base)) {
+      failures.push({
+        check: 'T1',
+        message: `${rel}: not named <basename>.<kind>.ttrs — the middle segment is the document kind (e.g. product.mrd.ttrs).`,
+      });
+    }
+  }
+  return failures;
+}
+
+async function checkDocumentSources(failures) {
+  const all = await walk(REPO_ROOT, null);
+  failures.push(...findDocumentSourceFailures(all.map(relPosix)));
+}
+
 // --- main ------------------------------------------------------------------
 
 async function main() {
@@ -463,6 +506,7 @@ async function main() {
     await checkNotationCounts(failures);
     await checkNoStandardIdentifiers(failures);
     await checkPackageEnvelopeStatements(failures);
+    await checkDocumentSources(failures);
   } catch (e) {
     console.error(`error: ${e.message}`);
     process.exit(2);

--- a/scripts/check-notations.test.mjs
+++ b/scripts/check-notations.test.mjs
@@ -12,6 +12,7 @@ import {
   parseStatedViewCounts,
   findStandardIdentifierEmissions,
   checkPackageEnvelopeStatement,
+  findDocumentSourceFailures,
   deriveDeprecationFailures,
 } from './check-notations.mjs';
 
@@ -170,5 +171,42 @@ test('deriveDeprecationFailures — negative: a non-deprecated spec without remo
     [{ name: '02-dgca.md', deprecated: false, removedIn: null }],
     'notations/views/diagrams'
   );
+  assert.deepEqual(failures, []);
+});
+
+test('findDocumentSourceFailures — positive: a canonical document source passes clean', () => {
+  const failures = findDocumentSourceFailures(['templates/product.mrd.ttrs']);
+  assert.deepEqual(failures, []);
+});
+
+test('findDocumentSourceFailures — negative: a .trs file is named as the near-miss, in words', () => {
+  const failures = findDocumentSourceFailures(['templates/product.mrd.trs']);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].check, 'T1');
+  // The point of the check: it must say ".ttrs" and say why ".trs" is wrong,
+  // rather than surfacing as an unrecognised-file error.
+  assert.match(failures[0].message, /\.ttrs/);
+  assert.match(failures[0].message, /one keystroke away/);
+});
+
+test('findDocumentSourceFailures — negative: a .ttrs file with no kind segment is flagged', () => {
+  const failures = findDocumentSourceFailures(['templates/product.ttrs']);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].check, 'T1');
+  assert.match(failures[0].message, /<basename>\.<kind>\.ttrs/);
+});
+
+test('findDocumentSourceFailures — negative: an upper-case kind segment is flagged', () => {
+  const failures = findDocumentSourceFailures(['templates/product.MRD.ttrs']);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].check, 'T1');
+});
+
+test('findDocumentSourceFailures — unrelated files are untouched', () => {
+  const failures = findDocumentSourceFailures([
+    'notations/CONTRACT.md',
+    'notations/examples/bpmn/order.bpmn.transitrix.yaml',
+    'packages/document-renderer/src/pass1.mjs',
+  ]);
   assert.deepEqual(failures, []);
 });


### PR DESCRIPTION
Adds `@transitrix/document-renderer` — the `.ttrs` document-template format and the deterministic half of the document renderer.

## The format

`.ttrs` is prose with directives, not a mapping. It reuses the `{{ … }}` delimiter family already established for skeleton files rather than introducing a second template language, and adds one block form for the instruction slot.

| Kind | Form |
|---|---|
| Fixed text | anything outside `{{ … }}`, copied verbatim |
| Model-object reference | `{{ REQ-14 }}` / `{{ REQ-14.text }}` / `{{ REQ-14.parent.title }}` (depth 3) |
| Figure — derived | `{{ view <path> as = name fit = width\|page\|none }}` |
| Figure — supplied | `{{ figure <path> caption = "…" as = name }}` |
| Figure — reference | `{{ figref <name> }}` |
| Instruction slot | `{{# instruct <slot-id> }} … {{/ instruct }}` |

**No slot kind nests inside another**, and an instruction slot's body is opaque — a `{{ … }}` written inside one is instruction prose, never a reference. `\{{` is the only escape. Naming is `<basename>.<kind>.ttrs`, the middle segment being the document kind, so the existing extension/parent-folder rule applies unchanged.

## Pass 1

Resolves every model-object reference and every derived figure, and **runs with no agent present** — nothing in it calls a model, and nothing in it may. Instruction slots are copied through byte-for-byte, so an unfilled section stays visible in the output and pass 2 finds it by the same syntax that put it there. Pass 1 ships as a unit callable on its own, so pass 2 and Studio's preview can depend on it as a library rather than on the whole renderer.

Two invariants held explicitly: it writes nothing into the model (every filesystem touch is a read), and it is re-run-stable (no timestamps, no filesystem-order dependence — the repository walk sorts).

## Failure discipline

An unresolvable reference **fails the run by name** and never renders as empty text; a `«unresolved: …»` marker stands where it was. Deleting a cited element is that same named failure, not a silent gap.

The repository is an **optional input**: a template naming no model object and no derived figure renders standalone with none configured. A template that *does* name one with no repository configured fails as `TTRS-011`, kept deliberately distinct from `TTRS-010` — "you have no repository configured" and "your repository does not contain this id" are different problems with different fixes, and folding the first into the second would hide it.

Full code table in the package README.

## Also in this change

- **`CONTRACT.md` §3** gains the clause: the canonical extension is `*.<short-name>.transitrix.yaml` **or** `*.<short-name>.ttrs`, which one a notation takes being a property of that notation. "One notation, exactly one extension" is unchanged and `HDR-003` continues to enforce it unmodified.
- **Doc-lint check `T1`** names the `.trs` near-miss in words — one keystroke away and a different, widely used format — rather than letting it surface as an unknown-file error. Verified end-to-end, not only in unit tests.
- **CI workflow** for the new package, since its tests would otherwise not run anywhere.

## Verification

- `node packages/document-renderer/tests/test_parse_template.mjs` — green
- `node packages/document-renderer/tests/test_pass1.mjs` — green; renders the committed worked template `tests/fixtures/product.mrd.ttrs` end-to-end against its fixture repository, and covers every acceptance criterion: no-agent run, no-repository run, the distinct missing-repository failure, unresolvable reference, deleted cited element, and re-run byte-stability
- `node --test scripts/check-notations.test.mjs` — 23/23
- `node scripts/check-notations.mjs` — clean
- `node scripts/check-workflow-scripts.mjs` — clean

Pass 2 (instruction slots), the run record, and PDF output are the next layer and are not in this change.