### PR TITLE
docs(notations): elevate the directive language to a normative conformance document

### DIFF
--- a/.github/workflows/document-renderer-test.yml
+++ b/.github/workflows/document-renderer-test.yml
@@ -9,6 +9,13 @@ name: document-renderer test
 # (packages/document-renderer/tests/fixtures/product.mrd.ttrs) end-to-end against
 # its fixture repository, and covers the no-repository cases, the named failures,
 # and re-run byte-stability.
+#
+# The conformance suite diffs that render against the frozen
+# fixtures/product.mrd.expected.md — this package is the reference
+# implementation of notations/views/documents/DIRECTIVE_LANGUAGE.md, and the
+# frozen output is what an independent implementation checks itself against. It
+# never regenerates the fixture; a failure is a regression or a deliberate,
+# separately reviewed re-freeze.
 
 on:
   pull_request:
@@ -38,3 +45,6 @@ jobs:
 
       - name: Run pass-1 resolver tests
         run: node packages/document-renderer/tests/test_pass1.mjs
+
+      - name: Run conformance tests (frozen fixture)
+        run: node packages/document-renderer/tests/test_conformance.mjs

--- a/notations/views/documents/DIRECTIVE_LANGUAGE.md
+++ b/notations/views/documents/DIRECTIVE_LANGUAGE.md
@@ -1,15 +1,15 @@
 ---
-version: "0.1"
+version: "1.0"
 author: "Valerii Korobeinikov"
 last_updated: "2026-08-07"
-status: "draft"
+status: "stable"
 ---
 
-# Directive language — normative reference
+# Directive language — normative conformance document
 
-**Version:** 0.1
+**Version:** 1.0
 **Date:** 2026-08-07
-**Status:** Draft — the single normative definition of the `{{ … }}` directive
+**Status:** Stable — the single normative definition of the `{{ … }}` directive
 language shared by every document source in this class.
 **Applies to:** `.ttrs` document templates and document-view skeleton files.
 
@@ -26,14 +26,45 @@ check `C1`). That absence is the point being made, not an omission.
 What it defines is the **directive language**: the `{{ … }}` constructs that
 appear inside a document source. One language, defined once, here.
 
-Two implementations of that one language ship today —
-[`@transitrix/document-renderer`](../../../packages/document-renderer/README.md)
-(`.ttrs` templates, pass 1) and
+### 0.1 It states requirements on an implementation, not on ours
+
+**This document is a conformance contract.** It is written to be built against
+by someone who has never read this repository's code. Where it says *must*, it
+constrains **any** implementation of this language; nothing here describes what
+one particular parser happens to do today, and a reader should never need
+`pass1.mjs` open to know what conformance requires.
+
+That framing is the whole point, and it is recent. While the rendering engine
+was ours, a great deal could be settled in code and never written down. The
+moment someone else writes the engine, each of those settled-in-code details
+becomes a conformance contract. **A format with an unspecified failure
+discipline is a format every adopter implements differently** — and in a year
+`.ttrs` means different things to different people. So the failure discipline
+(§7), the reference states (§5) and the profile split (§6) are stated here as
+requirements, not left to be inferred.
+
+**A conformant implementation** is one that admits some subset of the constructs
+in §§2–4 and, for everything it admits, obeys §§5–7 in full. Admitting a subset
+is expected and legitimate (§8); getting §§5–7 wrong for what you do admit is
+not.
+
+### 0.2 The reference implementation
+
+[`@transitrix/document-renderer`](../../../packages/document-renderer/README.md)'s
+pass 1 is the **reference implementation** of this document — it exists to make
+the spec checkable, not as a product feature. Its committed conformance fixture
+(`tests/fixtures/product.mrd.ttrs` and the frozen
+`tests/fixtures/product.mrd.expected.md` beside it) is the output an independent
+implementation diffs against. Where this document and that implementation
+disagree, **this document wins** and the implementation has a bug.
+
+Two implementations of the language ship in this repository today — the
+reference one above, and
 [`@transitrix/document-view-engine`](../../../packages/document-view-engine/README.md)
 (skeleton files, render profiles). **Two implementations of one notation is
 deliberate policy. Two specifications of one notation is drift** — the same
 drift the closed-vocabulary work was written against. Hence one spec, and a
-standing obligation on each implementation, §7.
+standing obligation on each implementation, §8.
 
 ---
 
@@ -211,8 +242,16 @@ within a document** — it names that section wherever slots are recorded.
 
 ## 5. Reference states
 
-Resolving a reference yields exactly one state. Three concern canon; the fourth
-concerns configuration.
+Resolving a reference yields exactly one state. **The language names five non-ok
+states** — three concern canon, one concerns provenance, one concerns
+configuration.
+
+A conformant implementation **must keep every state it reports distinct from
+every other**; it may never merge two into one. Exactly two carve-outs exist,
+both narrow and both stated below: `⚑S` may be declined so long as the decline
+is reported (§5.1), and `no repository configured` cannot arise for a source
+whose repository is mandatory. Neither is licence to fold a state into its
+neighbour.
 
 | State | Flag | Meaning |
 |---|---|---|
@@ -220,38 +259,99 @@ concerns configuration.
 | unresolved | `⚑U` | no object with that id exists |
 | not admitted | `⚑A` | the object exists, but its admission state is not active |
 | out of validity | `⚑V` | its `[valid_from, valid_to]` interval does not cover the render date |
+| suspect | `⚑S` | the object resolves, but the link to it is under suspicion (§5.1) |
 | no repository configured | — | the document cites canon, and none is configured |
 
-They are classified in that order: existence, then admission, then validity.
+The canon-side three are classified in that order: existence, then admission,
+then validity. `⚑S` is orthogonal — it qualifies a reference that has already
+resolved, and is defined not here but by
+[`CONTRACT.md`](../../CONTRACT.md) §16, which this document **cites rather than
+restates**. There is one definition of suspicion, and it is not this one.
 
-**The states are kept distinct on purpose.** "You have no repository" and "your
-repository lacks this id" are different problems with different fixes, and
-folding the first into the second hides it.
+**Collapsing any two of these is non-conformance, not a simplification.** "You
+have no repository" and "your repository lacks this id" are different problems
+with different fixes, and folding the first into the second hides it. The same
+holds for every other pair: each state names a different thing for its reader to
+go and do.
+
+**The no-repository state is reachable only where the repository is optional.**
+In `.ttrs` it is: the header's `canon:` may be absent, and a template naming no
+model object and no derived figure renders standalone — a legitimate input, not
+a degraded one. The document-view engine's skeleton format requires its
+repository, so the state cannot arise there and an implementation of that format
+alone need not produce it. It is listed here because the language is one, and an
+implementation reading a source whose repository is optional **must** produce
+it.
 
 **The worst defect is not a missing reference.** It is a reference that resolves
 and renders as plainly correct text when the object behind it was never admitted
-or has stopped being valid — a reader has no way to see it. A non-ok state
-therefore never renders as its bare value.
+or has stopped being valid — a reader has no way to see it. **A non-ok state
+never renders as its bare value.**
 
-### 5.1 Suspicion (`⚑S`) — reported as not computed
+### 5.1 `⚑S` and the three-way requirement
 
-Link suspicion is **not** part of this language's MVP. Three standing reasons,
-none of them a schedule:
+`⚑S` is the one state an implementation may decline to compute, because it is a
+different class of input from everything else here: it is **derived from commit
+history**, not read from a file. Declining is permitted. **Being silent about
+declining is not.**
 
-1. It is out of scope by the rendered-documents decision.
-2. It is **computed from commit history**, not read from a file — a different
-   class of input from everything else here.
-3. [`CONTRACT.md`](../../CONTRACT.md) §16.2 scopes it to `REL` and claim
-   records, not to the element references a document cites.
+A conformant implementation must therefore be able to report **three distinct
+outcomes**, never two:
 
-**It must nonetheless be reported as "not computed", never simply omitted.** A
-clean render and a render that never checked must not look alike. An
-implementation that silently leaves suspicion out of its output is
-non-conforming even when every other state is right.
+| Outcome | Meaning |
+|---|---|
+| suspect | checked, and the link is under suspicion — `⚑S` |
+| not suspect | **checked, and clean** |
+| not computed | **never checked** — suspicion was not evaluated at all |
+
+The second and third are the pair that must not be allowed to look alike. A
+document that renders with no `⚑S` anywhere is making a claim; an implementation
+that never ran the check has made no claim at all, and must say so rather than
+produce output indistinguishable from a clean one. **An implementation that
+omits suspicion silently is non-conforming even when every other state is
+right** — it is the one failure mode that reads as success.
+
+Where an implementation reports "not computed" it should also say why, so a
+reader is not left to guess whether the omission is policy or a defect.
 
 ---
 
-## 6. Failure discipline
+## 6. Render profiles — the strict/lenient split
+
+**A conformant implementation must offer at least two render profiles**, and
+must name which one a given run used. This is a requirement on the
+implementation's interface, not an option:
+
+| Profile | Requirement |
+|---|---|
+| **strict** | **Fails the run** on every non-ok state of §5 the implementation computes. The output is not usable as a deliverable, and the implementation says so by exit status, not only in prose. |
+| **lenient** | **Does not fail.** Renders every reference it can, each non-ok one carrying its flag, and reports every state it found. |
+
+The names above are the roles, not required spelling — this repository's two
+implementations call the lenient profile `review`, and the strict one `strict`
+and `clean` respectively. What is normative is that **both roles exist and are
+selectable**, and that a rendered document can be traced to which was used.
+
+Two rules bind the pair together, and they are where a naive implementation goes
+wrong:
+
+1. **Lenient reports exactly what strict fails on.** Not a subset. The profiles
+   differ in consequence, never in what they detect — otherwise "it passed in
+   review" stops predicting anything about the strict run, and the lenient
+   profile becomes a way of not knowing.
+2. **Neither profile renders a non-ok reference as its bare value.** Lenient may
+   render the value *with* its flag, so a reader sees both what the template
+   meant and that it is not usable; strict renders a marker in its place. What
+   neither may do is emit text that reads as correct.
+
+The split exists because the two audiences are different. An author mid-draft
+needs to see the whole document with its gaps marked; a release pipeline needs a
+build that stops. Serving only the first ships wrong documents, and serving only
+the second makes the format unusable while a document is being written.
+
+---
+
+## 7. Failure discipline
 
 | Requirement | Rule |
 |---|---|
@@ -259,15 +359,34 @@ non-conforming even when every other state is right.
 | Never blank | A reference that does not render its value leaves a visible marker, not an empty string. |
 | Named by kind | Unknown or malformed syntax and **recognised-but-not-implemented** are different failures and must carry different codes. |
 
-The third row is the one that is easy to get wrong. A construct defined in this
-document but not implemented by the package reading it **fails by name —
-"recognised, not implemented in this pass"** — and never in the same bucket as a
-typo. Reporting a valid template as malformed syntax sends its author looking
-for a mistake they did not make.
+### 7.1 Not-implemented is a named failure, never an unknown one
+
+The third row is the one that is easy to get wrong, and it is normative.
+
+**A conformant implementation may leave any construct of this document
+unimplemented** — `each`, `trace`, `{{ .field }}`, or anything added to the
+language later. Admitting a subset is expected (§8). What it may not do is fail
+in either of the two ways that lose the distinction:
+
+- **Never silently.** A template using an unimplemented construct does not
+  render with that construct dropped or passed through as fixed text. It fails.
+- **Never as unknown syntax.** It fails **by its own name — "recognised, not
+  implemented"** — under a code distinct from the one used for a typo or a
+  malformed directive.
+
+The reason is the author on the other end. Reporting a valid template as
+malformed syntax sends someone looking for a mistake they did not make, in a
+file that is correct, against a specification that says the construct exists.
+The two messages are "this is not in the language" and "this is in the language
+and not in this tool" — and they lead to entirely different next actions.
+
+The reference implementation (§0.2) uses `TTRS-004` for this class and
+`TTRS-002` for unknown syntax; the codes themselves are that implementation's,
+but **having two distinct codes is the requirement**.
 
 ---
 
-## 7. What each implementation must state
+## 8. What each implementation must state
 
 This language is defined once, here. **An implementation admits a subset of it.**
 
@@ -284,12 +403,37 @@ ambiguity is where a second, accidental specification starts.
 
 ---
 
-## 8. References
+## 9. Conformance checklist
+
+An implementation claiming to read this language must satisfy all of the
+following. It is a summary of the requirements above, not a separate set of
+them; each row cites the section that binds.
+
+| # | Requirement | § |
+|---|---|---|
+| 1 | Splits the `CAPABILITY` V/H prefix off before reading a field path | §2.1 |
+| 2 | Caps field-path traversal at depth 3, and fails beyond it | §3.2 |
+| 3 | Treats an `instruct` body as opaque — no directive inside one is resolved | §4.2 |
+| 4 | Keeps every reference state it reports distinct — never merges two | §5 |
+| 5 | Never renders a non-ok reference as its bare value, in any profile | §5, §6 |
+| 6 | Reports suspicion three ways — suspect, not suspect, **not computed** | §5.1 |
+| 7 | Offers both a strict and a lenient profile, and names which a run used | §6 |
+| 8 | Detects the same states in both profiles; they differ only in consequence | §6 |
+| 9 | Fails a recognised-but-unimplemented construct **by name**, under a code distinct from unknown syntax | §7.1 |
+| 10 | States in its own README what it admits and what it defers | §8 |
+
+Rows 4, 6, 7 and 9 are the ones an implementation built from the reference
+code's behaviour alone would be most likely to miss, which is why each is
+written as a requirement above rather than left to be inferred.
+
+---
+
+## 10. References
 
 - Extension / content match, and the date format: [`CONTRACT.md`](../../CONTRACT.md) §3, §4.
 - Link suspicion, content identity, and the mechanical-procedure hatch: [`CONTRACT.md`](../../CONTRACT.md) §16.
 - ID grammar and the `CAPABILITY` V/H exception: [`IDS_AND_REFERENCES.md`](../../IDS_AND_REFERENCES.md) §1-2.
 - Document kinds shipped today: [`29-mrd.md`](29-mrd.md), [`30-srs.md`](30-srs.md), [`31-sdd.md`](31-sdd.md).
-- `.ttrs` templates and pass 1: [`@transitrix/document-renderer`](../../../packages/document-renderer/README.md).
+- The reference implementation and its conformance fixture: [`@transitrix/document-renderer`](../../../packages/document-renderer/README.md).
 - Skeleton files, evaluation and render profiles: [`@transitrix/document-view-engine`](../../../packages/document-view-engine/README.md).
 - This class's index: [`README.md`](README.md).

--- a/packages/document-renderer/README.md
+++ b/packages/document-renderer/README.md
@@ -1,8 +1,29 @@
 # @transitrix/document-renderer
 
-Parser for the **`.ttrs` document-template format**, and its **pass 1
-deterministic resolver** — the half of the document renderer that runs and is
-testable with no agent present.
+**The reference implementation of the `{{ … }}` directive language** — parser for
+the `.ttrs` document-template format and its pass 1 deterministic resolver,
+which runs and is testable with no agent present.
+
+## This is a reference implementation, not a product
+
+Its job is to make
+[`DIRECTIVE_LANGUAGE.md`](../../notations/views/documents/DIRECTIVE_LANGUAGE.md)
+**checkable** — a specification with nothing executable behind it drifts from
+what anyone actually builds. What this repository ships as a deliverable is the
+**format**; the rendering engine an adopter runs is delivery work, built against
+that spec rather than shipped from here.
+
+Two things follow, and both are deliberate:
+
+- **The spec outranks this code.** Where the two disagree, the specification is
+  right and this package has a bug. Nothing here is normative by virtue of
+  working; a behaviour not written down in `DIRECTIVE_LANGUAGE.md` is not a
+  behaviour anyone else is obliged to reproduce.
+- **The conformance fixture is the contract's test surface.**
+  [`tests/fixtures/product.mrd.expected.md`](tests/fixtures/product.mrd.expected.md)
+  is the frozen output of [`tests/fixtures/product.mrd.ttrs`](tests/fixtures/product.mrd.ttrs)
+  — the thing an independent implementation diffs its own output against. See
+  [Conformance fixture](#conformance-fixture).
 
 Pass 1 ships as a unit callable on its own, so pass 2 (instruction slots) and
 Studio's preview can both depend on it as a library rather than on the whole
@@ -137,7 +158,7 @@ import { runPass1 } from '@transitrix/document-renderer/src/pass1.mjs';
 
 const {
   ok, markdown, instructionSlots, figures, errors,
-  findings, states, suspicion,        // the four states, and why ⚑S is absent
+  findings, states, suspicion,        // the four computed states, and why ⚑S is not
 } = await runPass1({
   text,                       // template source
   templatePath,               // enables the filename/`kind:` check; bases figure paths
@@ -192,19 +213,26 @@ with different fixes, and folding the first into the second would hide it.
 
 Deleting an element the document cites produces `TTRS-010`, not a silent gap.
 
-## The four reference states
+## The five reference states
 
-Every reference lands in exactly one state. The three canon-side ones are
-`@transitrix/document-view-engine`'s own (`⚑U` / `⚑A` / `⚑V`), reused rather
-than re-invented — one language must not grow two classifications of the same
-failure. The fourth is about configuration, not canon.
+The language names **five** non-ok states
+([`DIRECTIVE_LANGUAGE.md`](../../notations/views/documents/DIRECTIVE_LANGUAGE.md) §5).
+This package computes four of them and reports the fifth as *not computed* —
+the one carve-out the language permits, and only because it reports the decline
+rather than staying silent about it. No two states are ever merged.
 
-| State | Flag | Code |
-|---|---|---|
-| `unresolved` | `⚑U` | `TTRS-010` |
-| `not-admitted` | `⚑A` | `TTRS-014` |
-| `out-of-validity` | `⚑V` | `TTRS-015` |
-| `no-repository` | — | `TTRS-011` |
+The three canon-side ones are `@transitrix/document-view-engine`'s own
+(`⚑U` / `⚑A` / `⚑V`), reused rather than re-invented — one language must not
+grow two classifications of the same failure. The fourth is about configuration,
+not canon.
+
+| State | Flag | Code | This package |
+|---|---|---|---|
+| `unresolved` | `⚑U` | `TTRS-010` | computed |
+| `not-admitted` | `⚑A` | `TTRS-014` | computed |
+| `out-of-validity` | `⚑V` | `TTRS-015` | computed |
+| `no-repository` | — | `TTRS-011` | computed |
+| `suspect` | `⚑S` | — | **not computed** — reported as such |
 
 **The worst defect is not a missing reference** — it is one that resolves and
 renders as plainly correct text when the object behind it was never admitted or
@@ -212,43 +240,91 @@ has stopped being valid. So a non-ok state never renders as its bare value.
 
 ### Profiles
 
-| Profile | Behaviour |
-|---|---|
-| `strict` *(default)* | **fails on all four states**, naming the file, the id and the state |
-| `review` | renders each flagged value and reports every state in `findings`, without failing |
+The language requires a strict and a lenient profile, both selectable, with the
+lenient one detecting exactly what the strict one fails on
+([`DIRECTIVE_LANGUAGE.md`](../../notations/views/documents/DIRECTIVE_LANGUAGE.md) §6).
+This package's pair:
+
+| Profile | Role | Behaviour |
+|---|---|---|
+| `strict` *(default)* | strict | **fails on all four computed states**, naming the file, the id and the state |
+| `review` | lenient | renders each flagged value and reports every state in `findings`, without failing |
 
 These correspond to `@transitrix/document-view-engine`'s `clean` / `review`
-pair. `review` reports exactly what `strict` fails on.
+pair. `review` reports exactly what `strict` fails on — the profiles differ in
+consequence, never in what they detect. Every result carries the `profile` it
+ran under, so a rendered document can be traced to which was used.
 
 ### Suspicion is reported as *not computed*
 
-`⚑S` link suspicion is not part of pass 1 — out of scope by the
+`⚑S` link suspicion is not computed by pass 1 — out of scope by the
 rendered-documents decision, derived from commit history rather than read from a
 file, and scoped by [`CONTRACT.md`](../../notations/CONTRACT.md) §16.2 to `REL`
 and claim records rather than the element references a template cites.
 
-Every result nonetheless carries a `suspicion` field saying so:
+Declining to compute it is permitted; **being silent about declining is not.**
+The language requires three distinguishable outcomes, not two — *suspect*,
+*checked and clean*, and *never checked*
+([`DIRECTIVE_LANGUAGE.md`](../../notations/views/documents/DIRECTIVE_LANGUAGE.md) §5.1).
+Every result therefore carries a `suspicion` field stating which, with its
+reason:
 
 ```js
 { computed: false, state: 'not-computed', reason: '…' }
 ```
 
 **It is never simply omitted.** A clean render must be distinguishable from one
-that never checked.
+that never checked — that is the one failure mode which reads as success.
 
 ## Tests
 
 ```
 node packages/document-renderer/tests/test_parse_template.mjs
 node packages/document-renderer/tests/test_pass1.mjs
+node packages/document-renderer/tests/test_conformance.mjs
 ```
 
 `tests/fixtures/product.mrd.ttrs` is a complete worked template — every slot kind,
 one instruction slot — rendered end-to-end against `tests/fixtures/canon/` by the
 pass-1 suite.
 
+## Conformance fixture
+
+`tests/fixtures/product.mrd.expected.md` is that template's rendered output,
+**generated once and committed as a frozen target**. It is the artefact an
+independent implementation of the language diffs its own output against, which
+is what makes the specification checkable rather than merely written down.
+
+`tests/test_conformance.mjs` asserts the current render matches it **byte for
+byte**, and additionally checks the requirements a second implementation is most
+likely to miss — the suspicion report, the profile naming, and that the lenient
+profile detects exactly what the strict one fails on.
+
+**It never regenerates the fixture, and must not be made to.** A golden file
+that rewrites itself records whatever the code does today and can therefore
+never catch a regression — the auto-update convenience is precisely the thing
+this fixture exists to refuse. A failure is one of two things:
+
+| | What it means | What to do |
+|---|---|---|
+| **Regression** | pass 1 stopped producing the specified output | fix the code; leave the fixture alone |
+| **Deliberate change** | the specified output changed on purpose in `DIRECTIVE_LANGUAGE.md` | re-freeze the fixture in its **own** commit, naming the spec change it follows, so a reviewer sees the output diff |
+
+If you cannot say which you are in, you are in the first.
+
+Determinism is pinned on both sides: the test passes an explicit `renderDate`
+(the render date is an input to validity resolution), and
+`tests/fixtures/.gitattributes` pins line endings to LF — pass 1 copies fixed
+text through verbatim, so a CRLF checkout would render CRLF and the byte
+comparison would hold on one platform only.
+
 ## Scope
 
 Pass 1 only. Filling instruction slots, emitting the run record, and PDF output
-are the next layer and are not in this package. Nothing here calls a model, and
-nothing here may — rendering happens in the CLI, never the agent.
+are not in this package. Nothing here calls a model, and nothing here may —
+rendering happens in the CLI, never the agent.
+
+`{{# instruct … }}` stays in the grammar and in the specification — a notation
+expresses the slot; who fills it is an implementation's property — but nothing
+here executes one. Pass 1 copies each slot through byte-for-byte so the unfilled
+section is visible in the output rather than silently blank.

--- a/packages/document-renderer/src/pass1.mjs
+++ b/packages/document-renderer/src/pass1.mjs
@@ -20,8 +20,9 @@
 // tell "you have no repository configured" (TTRS-011) apart from "your
 // repository does not contain this id" (TTRS-010).
 //
-// A reference lands in exactly one of FOUR distinguishable states. The three
-// canon-side ones are @transitrix/document-view-engine's own
+// The language names FIVE non-ok reference states (DIRECTIVE_LANGUAGE.md §5).
+// This pass computes four of them and reports the fifth (⚑S) as not computed.
+// The three canon-side ones are @transitrix/document-view-engine's own
 // (resolveReference()'s ⚑U / ⚑A / ⚑V), deliberately reused rather than
 // re-invented — one notation must not grow two classifications of the same
 // failure. The fourth is this pass's, and is about configuration, not canon:
@@ -36,10 +37,12 @@
 // behind it was never admitted, or stopped being valid. So a non-ok state is
 // never rendered as its bare value.
 //
-// ⚑S (suspect) is NOT in this pass, and is reported as "not computed" rather
-// than omitted: a clean render has to be distinguishable from one that never
-// checked. Three standing reasons, none of them a time-box — see the
-// `suspicion` field of the result and DIRECTIVE_LANGUAGE.md.
+// ⚑S (suspect) is NOT computed in this pass, and is reported as "not computed"
+// rather than omitted. DIRECTIVE_LANGUAGE.md §5.1 requires three distinguishable
+// outcomes and not two — suspect, checked-and-clean, and never-checked — because
+// a render that never checked must not look like one that came back clean. That
+// is the one failure mode which reads as success. Three standing reasons for
+// declining, none of them a time-box — see the `suspicion` field of the result.
 
 import { existsSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';

--- a/packages/document-renderer/tests/fixtures/.gitattributes
+++ b/packages/document-renderer/tests/fixtures/.gitattributes
@@ -1,0 +1,9 @@
+# The conformance fixture is compared byte-for-byte, so every input that feeds it
+# and the frozen output itself must check out identically on every platform.
+#
+# Without this, `core.autocrlf=true` on Windows checks the template out with CRLF
+# and Linux CI checks it out with LF — pass 1 copies fixed text through verbatim,
+# so the rendered Markdown differs by line ending alone and the comparison fails
+# on whichever platform did not generate the fixture. That would make the frozen
+# target frozen on one OS only, which is no target at all.
+* text eol=lf

--- a/packages/document-renderer/tests/fixtures/product.mrd.expected.md
+++ b/packages/document-renderer/tests/fixtures/product.mrd.expected.md
@@ -1,0 +1,24 @@
+# Batch release capability
+
+## Scope
+
+This document covers Releasing a manufactured batch to distribution.
+
+## Requirements
+
+**Operator confirms a batch before release** — The system shall require an authorised operator to confirm a batch
+before it is released to distribution.
+
+Its parent capability is Batch release.
+
+![Figure 1](diagrams/context.blocks.transitrix.yaml)
+
+Figure 1 shows where the capability sits.
+
+## Market
+
+{{# instruct market-size }}
+question: How large is the addressable market for this capability, and how fast is it growing?
+inputs: CAP-1, REQ-14
+sufficient: A market size with a currency and a year, a growth rate, and the method used to derive both.
+{{/ instruct }}

--- a/packages/document-renderer/tests/test_conformance.mjs
+++ b/packages/document-renderer/tests/test_conformance.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Conformance test — the frozen target.
+//
+// `fixtures/product.mrd.ttrs` is a worked template exercising every construct
+// this package admits; `fixtures/product.mrd.expected.md` is its rendered output,
+// generated ONCE by this package as the reference implementation of
+// notations/views/documents/DIRECTIVE_LANGUAGE.md and committed as the thing an
+// INDEPENDENT implementation diffs its own output against.
+//
+// ── Read this before "fixing" a failure ────────────────────────────────────
+//
+// This test NEVER regenerates the fixture. That is the entire point of it, not
+// an omission, and adding a --update flag or an auto-write-on-mismatch would
+// defeat it: a golden file that rewrites itself records whatever the code does
+// today and can therefore never detect a regression. It is a frozen target, not
+// a snapshot convenience.
+//
+// So a failure here means one of exactly two things, and they are not the same:
+//
+//   1. A REGRESSION in pass 1 — the reference implementation stopped producing
+//      the specified output. Fix the code. Do not touch the fixture.
+//   2. A DELIBERATE change to the specified output — the language or the
+//      rendering rules changed on purpose in DIRECTIVE_LANGUAGE.md. Then the
+//      fixture is re-frozen as its own reviewable act: regenerate it, and put
+//      the new bytes in a commit whose message says which spec change it
+//      follows. A reviewer must see the output diff.
+//
+// If you cannot say which of the two you are in, you are in (1).
+//
+// Determinism: every input is pinned. `renderDate` is passed explicitly (the
+// render date is an input to validity resolution, so an unpinned one makes the
+// output a function of the calendar), and fixtures/.gitattributes pins the
+// line endings — pass 1 copies fixed text through verbatim, so a CRLF checkout
+// would render CRLF and the byte comparison would hold on one OS only.
+//
+// Run: node packages/document-renderer/tests/test_conformance.mjs
+// Exit: 0 = matches; 1 = does not.
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runPass1 } from '../src/pass1.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, 'fixtures');
+const TEMPLATE_PATH = join(FIXTURES, 'product.mrd.ttrs');
+const EXPECTED_PATH = join(FIXTURES, 'product.mrd.expected.md');
+
+// The date the frozen fixture was rendered at. Changing it is a spec-level act,
+// not a test tweak — the fixture is only the frozen output at THIS date.
+const RENDER_DATE = '2026-08-07';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+// ── The fixture must exist, and a missing one is a failure, never a prompt ──
+
+let expected;
+try {
+  expected = await readFile(EXPECTED_PATH, 'utf8');
+} catch {
+  console.error(
+    `The conformance fixture is missing:\n  ${EXPECTED_PATH}\n\n`
+    + 'It is a committed artefact, not a generated one. Restore it from git\n'
+    + 'rather than regenerating it — a regenerated fixture silently adopts\n'
+    + "whatever the code does today, which is exactly what it exists to catch.\n",
+  );
+  process.exit(1);
+}
+
+check(!expected.includes('\r'),
+  'the frozen fixture contains a CR — it must be LF-only, or the comparison is platform-dependent');
+
+// ── Render, and compare byte for byte ───────────────────────────────────────
+
+const text = await readFile(TEMPLATE_PATH, 'utf8');
+const result = await runPass1({
+  text,
+  templatePath: TEMPLATE_PATH,
+  renderDate: RENDER_DATE,
+  profile: 'strict',
+});
+
+check(result.ok,
+  `the conformance template must render clean under the strict profile: ${JSON.stringify(result.errors)}`);
+
+if (result.markdown !== expected) {
+  const a = Buffer.from(result.markdown, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+
+  // Enough context to see WHAT diverged without dumping both documents.
+  const line = expected.slice(0, i).split('\n').length;
+  const window = (s) => JSON.stringify(s.slice(Math.max(0, i - 40), i + 40));
+
+  _failures.push(
+    'rendered output does not match the frozen conformance fixture\n'
+    + `  first difference at byte ${i} (line ${line})\n`
+    + `  expected around: ${window(expected)}\n`
+    + `  actual   around: ${window(result.markdown)}\n`
+    + `  actual length ${a.length}, expected length ${b.length}\n\n`
+    + '  This fixture is NOT auto-updated. See the header of this file: either\n'
+    + '  pass 1 regressed (fix the code), or the specified output changed on\n'
+    + '  purpose (re-freeze the fixture in its own reviewed commit).',
+  );
+}
+
+// ── The fixture is only a target if it exercises the constructs ─────────────
+//
+// A fixture that happened to render nothing interesting would still match
+// itself forever. These assert it keeps covering what it was chosen to cover.
+
+check(result.figures.length === 1 && result.figures[0].derived,
+  'the conformance template must exercise a derived figure');
+check(result.instructionSlots.length === 1,
+  'the conformance template must exercise an instruction slot');
+check(expected.includes('{{# instruct market-size }}'),
+  'the instruction slot must be copied through untouched — pass 1 does not fill it');
+check(expected.includes('Figure 1 shows where'),
+  'the conformance template must exercise a figref');
+check(expected.includes('before it is released to distribution.'),
+  'the conformance template must exercise a multi-line block scalar');
+check(expected.includes('Its parent capability is Batch release.'),
+  'the conformance template must exercise a field path that walks into another object');
+
+// ── Suspicion: reported, never omitted (DIRECTIVE_LANGUAGE.md §5.1) ─────────
+
+check(result.suspicion !== undefined && result.suspicion !== null,
+  'the result must carry a suspicion field — "never checked" must not look like "clean"');
+check(result.suspicion?.computed === false && result.suspicion?.state === 'not-computed',
+  'this implementation does not compute ⚑S, and must say so rather than stay silent');
+check(typeof result.suspicion?.reason === 'string' && result.suspicion.reason.length > 0,
+  'the not-computed report must carry its reason');
+
+// ── The profile is named on the result (DIRECTIVE_LANGUAGE.md §6) ───────────
+
+check(result.profile === 'strict',
+  'the result must name the profile it ran under, so a rendered document is traceable to it');
+
+// ── Lenient detects exactly what strict fails on (DIRECTIVE_LANGUAGE.md §6) ─
+//
+// On a clean template both are clean; the pair is exercised against a broken one
+// so the requirement is actually tested rather than trivially satisfied.
+
+{
+  const broken = text.replace('{{ CAP-1.title }}', '{{ CAP-404.title }}');
+  const strict = await runPass1({
+    text: broken, templatePath: TEMPLATE_PATH, renderDate: RENDER_DATE, profile: 'strict',
+  });
+  const lenient = await runPass1({
+    text: broken, templatePath: TEMPLATE_PATH, renderDate: RENDER_DATE, profile: 'review',
+  });
+
+  check(!strict.ok, 'strict must fail on an unresolved reference');
+  check(lenient.ok, 'lenient must not fail on the same template');
+
+  const states = (r) => r.findings.map((f) => `${f.state}:${f.id}`).join(',');
+  check(states(strict) === states(lenient) && states(strict).length > 0,
+    'lenient must detect exactly what strict fails on — the profiles differ in '
+    + `consequence, not in detection (strict: "${states(strict)}", lenient: "${states(lenient)}")`);
+
+  check(!lenient.markdown.includes('CAP-404.title')
+    && !/^# \s*$/m.test(lenient.markdown),
+    'lenient must not render a non-ok reference as its bare value, and must not render it blank');
+}
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} conformance check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('Conformance fixture matches; all conformance checks passed.');


### PR DESCRIPTION
## Why

The rendering engine is no longer ours to ship — methodology ships the **format**, and an adopter builds the engine as delivery work. That inverts what the specification has to carry: while the engine was ours, a great deal could be settled in code and never written down. The moment someone else writes one, each of those becomes a conformance contract. A format with an unspecified failure discipline is a format every adopter implements differently, and in a year `.ttrs` means different things to different people.

## What changed

**`DIRECTIVE_LANGUAGE.md` — reframed from description to requirement**, and moved to `status: stable` / `version: 1.0`.

- **§0.1 defines conformance.** An external reader can now build a second implementation without opening `pass1.mjs`. Where spec and code disagree, the spec wins and the code has a bug.
- **Five reference states, not four.** The §5 table gains `⚑S`. The two narrow carve-outs are named explicitly, so "must not merge two states" and "may decline to compute one" no longer contradict each other. `⚑S` is *cited* to `CONTRACT.md` §16, not restated — one definition of suspicion, and it isn't this one.
- **§5.1 — suspicion is a three-way requirement.** *suspect*, *checked-and-clean*, and *never-checked* must be mutually distinguishable. A render that never checked must not look like one that came back clean; that is the one failure mode which reads as success.
- **§6 — the strict/lenient profile split is normative**, including the rule that binds the pair: lenient detects **exactly** what strict fails on. Otherwise "it passed in review" stops predicting the strict run and the lenient profile becomes a way of not knowing.
- **§7.1 — not-implemented is a named failure by requirement.** An implementation may leave any construct unimplemented, but must fail by name — never as unknown syntax, never silently.
- **§9 — a conformance checklist**, flagging the four rows an implementation built from the reference code's behaviour alone would most likely miss.

**`@transitrix/document-renderer` is the reference implementation, not a product.** Its job is making the spec checkable. README says so plainly.

**The conformance fixture is the part with teeth.** `tests/fixtures/product.mrd.expected.md` is the worked template's output, generated once and committed frozen — the artefact an independent implementation diffs against. `tests/test_conformance.mjs` asserts a byte-for-byte match and **never regenerates it**: a golden file that rewrites itself records whatever the code does today and can therefore never catch a regression. On failure it prints the first differing byte and states which of the two possible causes the reader is in.

## One thing found on the way

The frozen fixture would have been frozen on **one OS only**. There is no `.gitattributes` and `core.autocrlf=true` on Windows, so the template checks out CRLF here and LF on Linux CI; pass 1 copies fixed text through verbatim, so the byte comparison would have failed on whichever platform did not generate the fixture. Line endings are now pinned to LF across the fixture tree.

## Judgement call worth a look

I moved the spec to `status: "stable"` (from `draft`) and `version: "1.0"`. A document labelled *draft* does not carry a conformance contract someone else builds against, and the frozen fixture is what makes the claim checkable. The sibling kind specs (`29-mrd`, `30-srs`, `31-sdd`) stay `draft` deliberately — the *language* is frozen, the *kinds* are not. Easy to revert if you disagree.

## Verification

```
node scripts/check-notations.mjs                              # clean, 18 view notations
node packages/document-renderer/tests/test_parse_template.mjs # pass
node packages/document-renderer/tests/test_pass1.mjs          # pass
node packages/document-renderer/tests/test_conformance.mjs    # pass
```

The conformance test was also verified to **fail** correctly: perturbing one word in the fixture produced a byte-offset diff and exit 1, with no self-healing. The new suite is wired into the `document-renderer test` workflow.

Nothing that renders is in scope — PDF, editor preview, agent-filled slots are parked. `{{# instruct }}` stays in the grammar and the spec; nothing here executes it.
