### PR TITLE
fix(notations): bump vocabulary.yaml version pin to 3.2.0

### DIFF
--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -29,7 +29,7 @@
 # the ingest CLI needs to place and validate it.
 
 # Must equal notations/CURRENT_VERSION.yaml (enforced by check V1).
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 # ---------------------------------------------------------------------------
 # Element TYPE registry — ELEMENT_PRIMITIVES.md §4 (mode table) and §6 (layer


### PR DESCRIPTION
Fixes a V1 check-notations.mjs finding on main: notations/vocabulary.yaml's methodology_version pin was left at 3.1.0 while notations/CURRENT_VERSION.yaml is 3.2.0. One-line mechanical fix.