### PR TITLE
docs(readme): add .ttrs document source format section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ New to the ideas behind it? Read **[`method/01-methodology.md`](method/01-method
 - **[`patterns/implementation-tiers.md`](patterns/implementation-tiers.md)** — two implementation tiers (Simple / Full): what belongs in each, where the boundary sits, and how the upgrade path works.
 - **[`method/01-methodology.md`](method/01-methodology.md)** — the methodology overview: model, principles, zones, change lifecycle.
 - **[`notations/README.md`](notations/README.md)** — the canonical notation index; [`notations/CONTRACT.md`](notations/CONTRACT.md) and the per-notation specs are the authoritative source for the model in detail.
+- **[`notations/views/documents/DIRECTIVE_LANGUAGE.md`](notations/views/documents/DIRECTIVE_LANGUAGE.md)** — the `.ttrs` document source format: one directive language shared by every document kind (`mrd`, `srs`, `sdd`, `sds`, …, the middle segment of `<basename>.<kind>.ttrs`). Canonical public explanation: [transitrix.com/ttrs](https://transitrix.com/ttrs/).
 - **[`method/00-glossary.md`](method/00-glossary.md)** — standardised terminology.
 - **[`method/03-architecture-decision-log.md`](method/03-architecture-decision-log.md)** — architecture decision records per repo and the harvested enterprise log across repos; §10 is the setup path, from an empty folder to a scheduled harvest.
 - **[`transitrix/templates`](https://github.com/transitrix/templates)** — forkable starter templates (RACI, …): fork, edit for your own organisation, validate.

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -29,7 +29,7 @@
 # the ingest CLI needs to place and validate it.
 
 # Must equal notations/CURRENT_VERSION.yaml (enforced by check V1).
-methodology_version: "3.1.0"
+methodology_version: "3.2.0"
 
 # ---------------------------------------------------------------------------
 # Element TYPE registry — ELEMENT_PRIMITIVES.md §4 (mode table) and §6 (layer


### PR DESCRIPTION
## Summary
- Names the `.ttrs` document source format and its extension in the README's Documentation list.
- Links the normative directive-language spec (`notations/views/documents/DIRECTIVE_LANGUAGE.md`) and the canonical public page.

## Test plan
- [x] `node scripts/check-notations.mjs` — pre-existing unrelated finding only (vocabulary.yaml version pin, already covered by another open PR).
- [x] Both links verified to resolve.