### PR TITLE
ci: schedule the shared simple docs/chore PR auto-merge check

### DIFF
--- a/.github/workflows/simple-pr-automerge.yml
+++ b/.github/workflows/simple-pr-automerge.yml
@@ -1,0 +1,28 @@
+name: Simple PR auto-merge
+
+# Runs the shared simple docs/chore PR auto-merge checklist (see the linked
+# workflow) against this repository's own open PRs. Roughly hourly, staggered
+# against the other repositories using the same workflow so they don't all
+# fire in the same minute. DRY_RUN defaults to true - flip it only via a
+# manual run with the input explicitly set to false.
+
+on:
+  schedule:
+    - cron: "7 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log only - no merge, no branch delete, no label change"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  simple-pr-automerge:
+    uses: transitrix/templates/.github/workflows/simple-pr-automerge.yml@main
+    with:
+      dry_run: ${{ inputs.dry_run != false }}


### PR DESCRIPTION
## What

Adds a small workflow that calls the shared "simple docs/chore PR auto-merge" reusable workflow (hosted at `transitrix/templates`, see that repository's own PR for the full checklist) against this repository's open PRs on a schedule, plus `workflow_dispatch` for a manual run.

`DRY_RUN` defaults to true - a scheduled run only logs `WOULD MERGE` / `WOULD FLAG (reason)` / `SKIP (reason)` per open PR and changes nothing. A human can later run this manually with `dry_run: false` to switch a given run to actually merging/labeling; nothing in this PR does that.

## Sequencing

This `uses:` the reusable workflow at `@main` in `transitrix/templates`, so it won't resolve until [transitrix/templates#4](https://github.com/transitrix/templates/pull/4) merges there first. Safe to merge this PR any time - it simply won't produce a working run until then.
