### PR TITLE
docs: add throwaway fixture for auto-merge checklist verification

### DIFF
--- a/docs/_automerge-checklist-fixture.md
+++ b/docs/_automerge-checklist-fixture.md
@@ -1,0 +1,6 @@
+# Auto-merge checklist verification fixture
+
+This file exists only to give the "simple docs/chore PR auto-merge" checklist
+a real docs-only PR to evaluate during pre-merge verification of that
+workflow. The PR that adds it is expected to be closed without merging once
+a passing `WOULD MERGE` verdict has been captured from a dry run.


### PR DESCRIPTION
Adds a single small file under docs/ with no other changes, used to give the simple docs/chore PR auto-merge workflow a real positive case to evaluate during pre-merge dry-run verification. Will be closed without merging once verification is captured.