### PR TITLE
chore(packages): bump node engines floor from >=18 to >=20

### DIFF
--- a/packages/decisions-cli/package.json
+++ b/packages/decisions-cli/package.json
@@ -7,7 +7,7 @@
     "transitrix-decisions": "./decisions.mjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "decisions.mjs",

--- a/packages/document-renderer/package.json
+++ b/packages/document-renderer/package.json
@@ -4,7 +4,7 @@
   "description": "Parser for the .ttrs document-template format and its pass 1 deterministic resolver — resolves model-object references and derived figures with no agent present, leaving instruction slots for pass 2.",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "src/"

--- a/packages/document-view-engine/package.json
+++ b/packages/document-view-engine/package.json
@@ -4,7 +4,7 @@
   "description": "Skeleton-file parser and renderer for the document-view engine — turns a Markdown skeleton with {{ ... }} transclusion syntax into a header + body AST, resolves it against canon, and renders review/clean HTML. Layers over @transitrix/document-renderer for the notation's shared grammar (see README for current scope).",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "src/"

--- a/packages/ingest-cli/package.json
+++ b/packages/ingest-cli/package.json
@@ -7,7 +7,7 @@
     "transitrix-ingest": "./ingest.mjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "ingest.mjs",

--- a/packages/reg-intel-cli/package.json
+++ b/packages/reg-intel-cli/package.json
@@ -7,7 +7,7 @@
     "transitrix-reg-intel": "./reg-intel.mjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "reg-intel.mjs",

--- a/packages/reqif-cli/package.json
+++ b/packages/reqif-cli/package.json
@@ -7,7 +7,7 @@
     "transitrix-reqif": "./reqif.mjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "reqif.mjs",


### PR DESCRIPTION
## What

Bumps the declared `engines.node` floor in all six package manifests (`document-renderer`, `document-view-engine`, `decisions-cli`, `ingest-cli`, `reg-intel-cli`, `reqif-cli`) from `>=18` to `>=20`.

## Why

CI already runs every package's tests against Node 20 (`node-version: '20'`, pinned in 10 of 11 workflow files) — the `>=18` floor each manifest declared was a promise CI never actually tested. This closes the gap between the declared floor and the tested floor for this repo, mirroring the same fix already landed for transitrix-studio's one lagging manifest.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean
- [x] Diff scoped to exactly the six `package.json` files