### PR TITLE
docs(notations): type: is a subtype, and hosts has no APPLICATION endpoint

### DIFF
--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -66,6 +66,8 @@ The complete set of canonical TYPE prefixes. Use exactly the listed form — abb
 
 Elements that get referenced across documents.
 
+**The catalogue TYPE is never carried by the `type:` field.** A TYPE in this registry is read from `notation:` plus the ID prefix ([ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §3). The `type:` field on an element file is a per-TYPE **subtype** value (`DRIVER`'s `external` / `internal`, `NODE`'s `cloud_instance` / `server` / …) — required where a TYPE defines a subtype vocabulary, meaningless as a TYPE lookup otherwise.
+
 | TYPE | What it is | Used by |
 |---|---|---|
 | `DRIVER` | strategic driver — external or internal | DGCA, FGA |

--- a/notations/elements/25-nodes.md
+++ b/notations/elements/25-nodes.md
@@ -18,7 +18,7 @@ Nodes are **zone primitives**: each is a single YAML file under `canon/elements/
 
 A `NODE` is an **infrastructure substrate** — the physical or virtual compute, network, or storage resource that hosts technology services. It is the *hardware or virtualisation layer*, not the software or service layer.
 
-> **ArchiMate note.** ArchiMate 3.2 §9.3.1 defines Node as "a computational resource upon which artefacts may be stored or deployed for execution." Transitrix maps this concept directly to `NODE`. Application-layer software (`APPLICATION`) is deployed *on* a NODE; platform-level services (`TECHNOLOGY_SERVICE`) are *hosted* by a NODE. The `hosts` relation ([17-relations.md](17-relations.md) §3) expresses this link.
+> **ArchiMate note.** ArchiMate 3.2 §9.3.1 defines Node as "a computational resource upon which artefacts may be stored or deployed for execution." Transitrix maps this concept directly to `NODE`. Platform-level services (`TECHNOLOGY_SERVICE`) are *hosted* by a NODE; the `hosts` relation ([17-relations.md](17-relations.md) §3) expresses that link and is closed to `NODE` → `TECHNOLOGY_SERVICE` — it has no `APPLICATION` endpoint. An application deployed on a node is modelled by giving the node's application-hosting surface its own `TECHNOLOGY_SERVICE` (e.g. `type: compute` or `type: container_platform`), then `APPLICATION` –`uses`→ `TECHNOLOGY_SERVICE` ←`hosts`– `NODE`, the same intermediary shape the rest of the technology layer already uses.
 
 It is **not**:
 


### PR DESCRIPTION
## What changed

Two documentation corrections surfaced by review:

- `IDS_AND_REFERENCES.md` §3.1 now states, at the TYPE registry itself, that the catalogue TYPE is carried by `notation:` + the ID prefix and that `type:` is a per-TYPE subtype value — never the catalogue TYPE. (`ELEMENT_PRIMITIVES.md` §3 already said this; the registry a reader lands on first did not.)
- `elements/25-nodes.md` §1 claimed the `hosts` relation covers an `APPLICATION` deployed on a `NODE`. It doesn't — `hosts` is closed to `NODE` → `TECHNOLOGY_SERVICE` per `vocabulary.yaml` and `17-relations.md` §3. Corrected the note and added the sanctioned modelling pattern (an intermediary `TECHNOLOGY_SERVICE`) next to it.

## How it is verified

`node scripts/check-notations.mjs` — clean.