### PR TITLE
feat(ingest-cli): profile-completeness check + name unreadable files

### DIFF
--- a/.github/workflows/ingest-skill-test.yml
+++ b/.github/workflows/ingest-skill-test.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run vocabulary loader unit tests
         run: node --test packages/ingest-cli/src/vocabulary.test.mjs
 
+      - name: Run repo-check unit tests
+        run: node --test packages/ingest-cli/src/repo-check.test.mjs
+
       - name: Run Ingest pipeline test (deterministic)
         run: python transitrix/skills/ingest/tests/test_ingest_integrity.py
 

--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -150,6 +150,8 @@ valid_to: null
 
 **Time-aware relations go to `canon/relations/`, not inline.** Where a relation kind is declared first-class time-aware ([elements/17-relations.md](elements/17-relations.md)), it lives in a `REL-…` file, not as an inline cross-reference on the element. In v1 most cross-references remain inline and timeless; §7 notes the declared first-class kinds (capability `parent`, goal `goal_parent`, action `action_goal`).
 
+**Free text defaults to a block scalar, not a plain one.** `description` and every other hand- or agent-authored free-text field (provenance notes, `statement` on RULE/CONSTRAINT, …) should use `>-` or `|-` for anything longer than a short phrase, as the worked example at §3 already does. A plain scalar containing `": "` is a YAML mapping key by specification — the whole document fails to parse, not just the field — and the failure is silent to anyone not reading raw YAML errors. A block scalar is immune to it.
+
 ---
 
 ## 4. Materialisation decision per TYPE

--- a/packages/ingest-cli/ingest.mjs
+++ b/packages/ingest-cli/ingest.mjs
@@ -458,10 +458,14 @@ async function cmdCheckStale(args) {
     : (await findOrgRoot(process.cwd()));
   if (!orgRoot) { console.error('check-stale: not inside a Transitrix workspace (no _intake/ found); pass <org-root>.'); return 2; }
 
-  const { scanned, stale, malformed, today } = await checkStale(orgRoot);
+  const { scanned, stale, malformed, unreadable, today } = await checkStale(orgRoot);
+  if (unreadable.length > 0) {
+    console.error(`check-stale  ${unreadable.length} file(s) could not be read at all — excluded from the ${scanned} scanned above, not silently absorbed into "none stale":`);
+    for (const u of unreadable) console.error(`  UNREADABLE  ${u.file}  (${u.reason})`);
+  }
   if (stale.length === 0 && malformed.length === 0) {
     console.log(`check-stale  ${scanned} REQUIREMENT/CONSTRAINT file(s) scanned as of ${today} — none stale (REQ-STALE-001).`);
-    return 0;
+    return unreadable.length > 0 ? 1 : 0;
   }
   if (stale.length > 0) {
     console.error(`check-stale  ${stale.length} of ${scanned} REQUIREMENT/CONSTRAINT element(s) stale as of ${today} (REQ-STALE-001):`);
@@ -471,7 +475,7 @@ async function cmdCheckStale(args) {
     console.error(`check-stale  ${malformed.length} file(s) with an unparseable next_review_at (skipped — evaluation elided per 15-requirement.md §4):`);
     for (const m of malformed) console.error(`  UNPARSED  ${m.id}  next_review_at: ${JSON.stringify(m.next_review_at)}`);
   }
-  return stale.length > 0 ? 1 : 0;
+  return (stale.length > 0 || unreadable.length > 0) ? 1 : 0;
 }
 
 // Report every human gate's phase + count in one table — ADR/WI status, canon
@@ -513,10 +517,14 @@ async function cmdCheckPlacement(args) {
     : (await findOrgRoot(process.cwd()));
   if (!orgRoot) { console.error('check-placement: not inside a Transitrix workspace (no _intake/ found); pass <org-root>.'); return 2; }
 
-  const { scanned, findings } = await checkCanonPlacement(orgRoot);
+  const { scanned, findings, unreadable } = await checkCanonPlacement(orgRoot);
+  if (unreadable.length > 0) {
+    console.error(`check-placement  ${unreadable.length} file(s) could not be read at all — excluded from the ${scanned} scanned above, not silently absorbed into "all sit in their folder":`);
+    for (const u of unreadable) console.error(`  UNREADABLE  ${u.file}  (${u.reason})`);
+  }
   if (findings.length === 0) {
     console.log(`check-placement  ${scanned} catalogue element(s) scanned — all sit in their ELEMENT_PRIMITIVES §4 folder.`);
-    return 0;
+    return unreadable.length > 0 ? 1 : 0;
   }
   console.error(`check-placement  ${findings.length} of ${scanned} element(s) misplaced (ELEMENT_PRIMITIVES §4):`);
   for (const f of findings) console.error(`  FLAG  ${f.id}\n          - ${f.reason}`);

--- a/packages/ingest-cli/src/canon.mjs
+++ b/packages/ingest-cli/src/canon.mjs
@@ -50,13 +50,16 @@ async function walkYaml(dir) {
 function normName(s) { return typeof s === 'string' ? s.trim().toLowerCase() : null; }
 
 // Build a read-only index of canon/ for one org root.
-// Returns { ids: Set, rels: Set, nameMap: Map, collisions: [] }.
+// Returns { ids: Set, rels: Set, nameMap: Map, collisions: [], unreadable: [] }.
 //   ids        -- admitted element/assertion IDs (for review-queue idempotency).
 //   rels       -- admitted relation triple keys (for review-queue idempotency).
 //   nameMap    -- normalised(name|alias) -> { id, matched_on: 'name'|'alias' }.
 //                 Used by emit-candidates for cross-source entity-match proposals (F8).
 //   collisions -- [{ value, a, b }] for the ELEM-ALIAS-001 uniqueness gate (§9):
 //                 a normalised name/alias claimed by two DIFFERENT ids.
+//   unreadable -- [{ file, reason }] -- a file that could not be read at all, named
+//                 rather than silently missing from the index (methodology review,
+//                 transitrix-hq#104 item 5).
 //              An absent canon/ yields an empty index (no exclusions, no proposals) --
 //              the common case on a fresh adopter, unaffecting existing tests.
 export async function buildCanonIndex(orgRoot) {
@@ -64,8 +67,9 @@ export async function buildCanonIndex(orgRoot) {
   const rels = new Set();
   const nameMap = new Map();
   const collisions = [];
+  const unreadable = [];
   const canonDir = join(resolve(orgRoot), 'canon');
-  if (!(await exists(canonDir))) return { ids, rels, nameMap, collisions };
+  if (!(await exists(canonDir))) return { ids, rels, nameMap, collisions, unreadable };
 
   // Record one surface form for `id`. First writer wins the nameMap slot (F8 match
   // target). ELEM-ALIAS-001 fires when a DIFFERENT id claims the same value AND an
@@ -86,7 +90,7 @@ export async function buildCanonIndex(orgRoot) {
   for (const file of await walkYaml(canonDir)) {
     if (isUnresolvedPath(file)) continue; // §13: holding area is NOT typed canon (UNRES-004)
     let text;
-    try { text = await readFile(file, 'utf8'); } catch { continue; }
+    try { text = await readFile(file, 'utf8'); } catch (err) { unreadable.push({ file, reason: err.message }); continue; }
 
     const id = readTopScalar(text, 'id');
     if (id) {
@@ -104,7 +108,7 @@ export async function buildCanonIndex(orgRoot) {
     const kind = readTopScalar(text, 'type');
     if (from && to && kind) rels.add(relKey(kind, from, to));
   }
-  return { ids, rels, nameMap, collisions };
+  return { ids, rels, nameMap, collisions, unreadable };
 }
 
 // Is this candidate already admitted to canon, per the index? Returns the matched

--- a/packages/ingest-cli/src/check-stale.mjs
+++ b/packages/ingest-cli/src/check-stale.mjs
@@ -48,15 +48,19 @@ async function walkYaml(dir) {
 function isoToday() { return new Date().toISOString().slice(0, 10); }
 
 // Scan canon/ for obligation files carrying `next_review_at`. Returns
-// { scanned, stale: [{ id, file, next_review_at }], malformed: [{ id, file, next_review_at }] }.
-// A file with no `next_review_at` is scanned but contributes to neither list.
-// `today` defaults to the current UTC date; pass a string to override in tests.
+// { scanned, stale: [{ id, file, next_review_at }], malformed: [{ id, file, next_review_at }],
+// unreadable: [{ file, reason }] }. A file with no `next_review_at` is scanned but
+// contributes to neither list. `today` defaults to the current UTC date; pass a
+// string to override in tests. A file that cannot be read at all is named in
+// `unreadable` rather than silently excluded from `scanned` with no trace
+// (methodology review, transitrix-hq#104 item 5).
 export async function checkStale(orgRoot, today = isoToday()) {
   const canonDir = join(resolve(orgRoot), 'canon');
   const stale = [];
   const malformed = [];
+  const unreadable = [];
   let scanned = 0;
-  if (!(await exists(canonDir))) return { scanned, stale, malformed, today };
+  if (!(await exists(canonDir))) return { scanned, stale, malformed, unreadable, today };
 
   for (const folder of OBLIGATION_FOLDERS) {
     const dir = join(canonDir, 'elements', folder);
@@ -64,7 +68,7 @@ export async function checkStale(orgRoot, today = isoToday()) {
     for (const file of await walkYaml(dir)) {
       scanned++;
       let text;
-      try { text = await readFile(file, 'utf8'); } catch { continue; }
+      try { text = await readFile(file, 'utf8'); } catch (err) { unreadable.push({ file, reason: err.message }); continue; }
       const nra = readTopScalar(text, 'next_review_at');
       if (!nra || nra === 'null') continue;
       const id = readTopScalar(text, 'id') || file.split(/[\\/]/).pop().replace(/\.yaml$/, '');
@@ -76,5 +80,5 @@ export async function checkStale(orgRoot, today = isoToday()) {
 
   stale.sort((a, b) => a.next_review_at.localeCompare(b.next_review_at) || a.id.localeCompare(b.id));
   malformed.sort((a, b) => a.id.localeCompare(b.id));
-  return { scanned, stale, malformed, today };
+  return { scanned, stale, malformed, unreadable, today };
 }

--- a/packages/ingest-cli/src/placement.mjs
+++ b/packages/ingest-cli/src/placement.mjs
@@ -64,22 +64,26 @@ async function walkYaml(root, dir = root, out = []) {
 }
 
 // Scan canon/ (read-only) and flag any admitted element file sitting in the wrong §4
-// place. Returns { scanned, findings: [{ id, type, file, expected, reason }] }.
-// A finding is raised when a `standalone` TYPE's file is NOT under its §4 folder, or a
-// `view-defined` TYPE that has no catalogue folder appears as its own canon file.
-// Folder match is by SUFFIX so it is agnostic to the canon-root prefix (open item).
+// place. Returns { scanned, findings: [{ id, type, file, expected, reason }],
+// unreadable: [{ file, reason }] }. A finding is raised when a `standalone` TYPE's
+// file is NOT under its §4 folder, or a `view-defined` TYPE that has no catalogue
+// folder appears as its own canon file. Folder match is by SUFFIX so it is agnostic
+// to the canon-root prefix (open item). A file that cannot be read at all is named in
+// `unreadable` rather than silently dropped from `scanned` with no trace (methodology
+// review, transitrix-hq#104 item 5 — a swallowed per-file error must name the file).
 export async function checkCanonPlacement(orgRoot) {
   const canonDir = join(resolve(orgRoot), 'canon');
   const findings = [];
+  const unreadable = [];
   let scanned = 0;
-  if (!(await exists(canonDir))) return { scanned, findings };
+  if (!(await exists(canonDir))) return { scanned, findings, unreadable };
 
   for (const file of await walkYaml(canonDir)) {
     // §13: the canon/unresolved/ holding area is NOT typed canon — skip it (UNRES-004).
     // Inlined (not imported from unresolved.mjs) to avoid a placement <-> unresolved cycle.
     if (file.replace(/\\/g, '/').includes('/canon/unresolved/')) continue;
     let text;
-    try { text = await readFile(file, 'utf8'); } catch { continue; }
+    try { text = await readFile(file, 'utf8'); } catch (err) { unreadable.push({ file, reason: err.message }); continue; }
     // id is the basename without extension, or the top-level `id:` scalar.
     const idLine = text.match(/^id:[ \t]*["']?([A-Za-z0-9_.\-]+)/m);
     const id = idLine ? idLine[1] : file.split(/[\\/]/).pop().replace(/\.yaml$/, '');
@@ -107,5 +111,5 @@ export async function checkCanonPlacement(orgRoot) {
       });
     }
   }
-  return { scanned, findings };
+  return { scanned, findings, unreadable };
 }

--- a/packages/ingest-cli/src/repo-check.mjs
+++ b/packages/ingest-cli/src/repo-check.mjs
@@ -37,11 +37,59 @@ async function walkYaml(dir) {
   return out;
 }
 
-// Tally one zone: { files, with_id, invalid_ids, types: { <TYPE>: n } }. Only the prefix
-// of a grammar-valid id is recorded as a TYPE; malformed ids count toward invalid_ids.
+// Element TYPEs present under canon/elements/, by ID prefix — independent of
+// suggest-profile.mjs (which only sees loaded *candidates*, so a TYPE placed straight
+// into canon/elements/ by hand never reaches it) and of checkCanonPlacement (which
+// reports folder mismatches, not profile coverage). Scoped to canon/elements/ itself,
+// not the whole canon/ zone, so REL / ASSERTION / VERIFICATION — first-class primitives
+// that deliberately live outside elements/ (canon.mjs) and are not governed by a
+// profile's `elements` set — never appear here.
+export async function elementTypesOnDisk(orgRoot) {
+  const dir = join(resolve(orgRoot), 'canon', 'elements');
+  const types = new Set();
+  const unreadable = [];
+  if (!(await exists(dir))) return { types, unreadable };
+  for (const file of await walkYaml(dir)) {
+    let text;
+    try { text = await readFile(file, 'utf8'); } catch (err) { unreadable.push({ file, reason: err.message }); continue; }
+    const id = readTopScalar(text, 'id');
+    if (id && isValidId(id)) types.add(id.split('-')[0]);
+  }
+  return { types, unreadable };
+}
+
+// Finding (methodology review, 2026-08-09): profile completeness is unmeasurable for
+// anything placed by hand — suggest-profile.mjs and checkCanonPlacement both miss it.
+// This check is independent of both: every element TYPE on disk that the *resolved*
+// profile does not cover, read-only, regardless of whether any candidate for that TYPE
+// is being validated. Fails loudly (resolvable: false) rather than reporting a clean
+// empty list when the profile itself could not be resolved (vocabulary.yaml
+// drift-check discipline — an unresolved profile makes "nothing out of profile" a
+// non-finding, not a clean bill of health).
+export function profileCompleteness(typesOnDisk, profile) {
+  if (profile.unresolved) {
+    return { resolvable: false, out_of_profile_types: [] };
+  }
+  const outOfProfile = [];
+  for (const type of typesOnDisk) {
+    if (profile.isFull) {
+      if (profile.removedElements && profile.removedElements.has(type)) outOfProfile.push(type);
+    } else if (!profile.elements.has(type)) {
+      outOfProfile.push(type);
+    }
+  }
+  outOfProfile.sort();
+  return { resolvable: true, out_of_profile_types: outOfProfile };
+}
+
+// Tally one zone: { files, with_id, invalid_ids, types: { <TYPE>: n }, unreadable }.
+// Only the prefix of a grammar-valid id is recorded as a TYPE; malformed ids count
+// toward invalid_ids. A file that cannot be read at all is named in `unreadable`
+// rather than silently missing from `files` with no trace (methodology review,
+// transitrix-hq#104 item 5).
 async function tallyZone(orgRoot, zone) {
   const dir = join(resolve(orgRoot), zone);
-  const tally = { files: 0, with_id: 0, invalid_ids: 0, types: {} };
+  const tally = { files: 0, with_id: 0, invalid_ids: 0, types: {}, unreadable: [] };
   if (!(await exists(dir))) return { present: false, ...tally };
   for (const file of await walkYaml(dir)) {
     // §13: canon/unresolved/ is a NON-admitted holding area, not typed canon — keep it
@@ -49,7 +97,7 @@ async function tallyZone(orgRoot, zone) {
     if (isUnresolvedPath(file)) continue;
     tally.files++;
     let text;
-    try { text = await readFile(file, 'utf8'); } catch { continue; }
+    try { text = await readFile(file, 'utf8'); } catch (err) { tally.unreadable.push({ file, reason: err.message }); continue; }
     const id = readTopScalar(text, 'id');
     if (!id) continue;
     tally.with_id++;
@@ -80,23 +128,28 @@ export async function repoCheck(orgRoot) {
 
   const zones = {};
   let totalInvalid = 0;
+  let totalUnreadable = 0;
   for (const z of ZONES) {
     zones[z] = await tallyZone(root, z);
     totalInvalid += zones[z].invalid_ids || 0;
+    totalUnreadable += zones[z].unreadable.length;
   }
 
   const placement = await checkCanonPlacement(root);
+  totalUnreadable += placement.unreadable.length;
 
   // ELEM-ALIAS-001 (ELEMENT_PRIMITIVES §9) — a name/alias claimed by two different
   // elements makes F8 entity resolution ambiguous. Count only (data-free); the colliding
   // values themselves are org content and never emitted in this report.
   const canonIndex = await buildCanonIndex(root);
   const aliasCollisions = canonIndex.collisions.length;
+  totalUnreadable += canonIndex.unreadable.length;
 
   // §13 holding area — count entries and flag malformed ones (UNRES-001..003). Data-free:
   // aggregate counts only, never a filename, id, or payload.
   const unresolved = await checkUnresolved(root, canonIndex.ids);
   const unresolvedMalformed = unresolved['UNRES-001'] + unresolved['UNRES-002'] + unresolved['UNRES-003'];
+  totalUnreadable += unresolved.unreadable;
 
   const declaredVersion = manifestText ? (readTopScalar(manifestText, 'methodology_version') || null) : null;
   // Version-currency check (F11.2): flag when the CLI's built-in presets were built for a
@@ -104,14 +157,32 @@ export async function repoCheck(orgRoot) {
   // the CLI binary is stale and needs to be reinstalled after a methodology upgrade.
   const versionMatch = !declaredVersion || declaredVersion === PRESETS_VERSION;
 
+  const diskTypes = await elementTypesOnDisk(root);
+  totalUnreadable += diskTypes.unreadable.length;
+  const completeness = profileCompleteness(diskTypes.types, profile);
+
   const red_flags = [];
   if (totalInvalid > 0) red_flags.push(`${totalInvalid} artefact(s) with an id that violates the canonical grammar (IDS_AND_REFERENCES §1)`);
   if (placement.findings.length > 0) red_flags.push(`${placement.findings.length} canon element(s) outside their ELEMENT_PRIMITIVES §4 folder`);
   if (aliasCollisions > 0) red_flags.push(`${aliasCollisions} name/alias collision(s) across canon (ELEM-ALIAS-001) — a surface form is claimed by two elements, making entity resolution ambiguous`);
   if (unresolvedMalformed > 0) red_flags.push(`${unresolvedMalformed} malformed canon/unresolved/ holding entr(y/ies) (CONTRACT §13 — UNRES-001 missing field / UNRES-002 typed id should move / UNRES-003 dangling related_to)`);
   if (profile.unresolved) red_flags.push('coverage_profile is present but could not be resolved — coverage flags are not authoritative');
+  if (completeness.out_of_profile_types.length > 0) red_flags.push(`${completeness.out_of_profile_types.length} element TYPE(s) present in canon/elements/ but outside the active coverage profile (${completeness.out_of_profile_types.join(', ')}) — placed by hand, never seen by suggest-profile.mjs, not validated against the profile's per-TYPE fields`);
   if (!manifestText) red_flags.push('no transitrix.yaml manifest at the repo root — not a recognised adopter repo');
   if (!versionMatch) red_flags.push(`methodology_version in transitrix.yaml (${declaredVersion}) does not match the CLI built-in presets version (${PRESETS_VERSION}) — reinstall @transitrix/ingest-cli after a methodology upgrade`);
+  // Diagnostics (transitrix-hq#104 item 5): a per-file read failure is counted, never
+  // silently absorbed into a lower zone/scanned count with no trace. Data-free — a
+  // count, not the file path; `check-placement` / `check-stale` name the file for an
+  // adopter investigating (those tools already name ids/paths by design).
+  if (totalUnreadable > 0) red_flags.push(`${totalUnreadable} file(s) under canon/ could not be read and were excluded from every count above — run check-placement / check-stale to see which`);
+
+  // zones is embedded in this data-free report as-is; strip the per-file `unreadable`
+  // detail (file paths) before emission — it is aggregated into totalUnreadable above.
+  const reportZones = {};
+  for (const z of ZONES) {
+    const { unreadable, ...rest } = zones[z];
+    reportZones[z] = rest;
+  }
 
   return {
     generated_by: '@transitrix/ingest-cli',
@@ -119,7 +190,7 @@ export async function repoCheck(orgRoot) {
     methodology_version: declaredVersion,
     coverage_profile: profile.display,
     ...(profile.warning ? { coverage_warning: profile.warning } : {}),
-    zones,
+    zones: reportZones,
     adoption_level: adoptionLevel(zones.canon.present ? zones.canon.files : 0),
     integrity: {
       invalid_ids: totalInvalid,
@@ -128,7 +199,12 @@ export async function repoCheck(orgRoot) {
       alias_collisions: aliasCollisions,
       unresolved_holding: unresolved.count,
       unresolved_malformed: unresolvedMalformed,
+      unreadable_files: totalUnreadable,
       red_flags,
+    },
+    profile_completeness: {
+      resolvable: completeness.resolvable,
+      out_of_profile_types: completeness.out_of_profile_types,
     },
     tooling: {
       cli_presets_version: PRESETS_VERSION,

--- a/packages/ingest-cli/src/repo-check.test.mjs
+++ b/packages/ingest-cli/src/repo-check.test.mjs
@@ -1,0 +1,166 @@
+// Unit + integration tests for repo-check.mjs's profile-completeness check
+// (methodology review finding, 2026-08-09, transitrix-hq#104 item 2).
+//
+// The check covers a gap suggest-profile.mjs and checkCanonPlacement both miss: a
+// TYPE placed straight into canon/elements/ by hand, never going through the loaded
+// candidate stream. Run: node --test packages/ingest-cli/src/repo-check.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { profileCompleteness, elementTypesOnDisk, repoCheck } from './repo-check.mjs';
+
+// ── profileCompleteness — pure-function unit tests ──────────────────────
+
+test('profileCompleteness: unresolved profile is not resolvable, regardless of disk', () => {
+  const result = profileCompleteness(new Set(['NODE']), { unresolved: true, isFull: true, elements: null, removedElements: null });
+  assert.equal(result.resolvable, false);
+  assert.deepEqual(result.out_of_profile_types, []);
+});
+
+test('profileCompleteness: preset profile flags a TYPE the preset does not cover', () => {
+  // `core` (coverage-presets.mjs) excludes NODE — mirrors the issue's own example.
+  const profile = { unresolved: false, isFull: false, elements: new Set(['GOAL', 'CAPABILITY']), removedElements: null };
+  const result = profileCompleteness(new Set(['GOAL', 'NODE']), profile);
+  assert.equal(result.resolvable, true);
+  assert.deepEqual(result.out_of_profile_types, ['NODE']);
+});
+
+test('profileCompleteness: full profile only flags explicitly removed TYPEs', () => {
+  const profile = { unresolved: false, isFull: true, elements: null, removedElements: new Set(['NODE']) };
+  const result = profileCompleteness(new Set(['NODE', 'GOAL']), profile);
+  assert.deepEqual(result.out_of_profile_types, ['NODE']);
+});
+
+test('profileCompleteness: full profile with nothing removed reports nothing', () => {
+  const profile = { unresolved: false, isFull: true, elements: null, removedElements: null };
+  const result = profileCompleteness(new Set(['NODE', 'GOAL']), profile);
+  assert.deepEqual(result.out_of_profile_types, []);
+});
+
+test('profileCompleteness: sorted output, no duplicates from the input set', () => {
+  const profile = { unresolved: false, isFull: false, elements: new Set(), removedElements: null };
+  const result = profileCompleteness(new Set(['NODE', 'CAPABILITY', 'ACTION']), profile);
+  assert.deepEqual(result.out_of_profile_types, ['ACTION', 'CAPABILITY', 'NODE']);
+});
+
+// ── elementTypesOnDisk — scoped to canon/elements/ only ─────────────────
+
+function tmpOrgRoot() {
+  return mkdtempSync(join(tmpdir(), 'repo-check-test-'));
+}
+
+test('elementTypesOnDisk: reads TYPE from id: across nested canon/elements/ folders', () => {
+  const root = tmpOrgRoot();
+  const nodesDir = join(root, 'canon', 'elements', '04_technology', 'nodes');
+  mkdirSync(nodesDir, { recursive: true });
+  writeFileSync(join(nodesDir, 'NODE-1.yaml'), 'id: NODE-1\nname: Test Node\n', 'utf8');
+  const goalsDir = join(root, 'canon', 'elements', '01_motivation', 'goals');
+  mkdirSync(goalsDir, { recursive: true });
+  writeFileSync(join(goalsDir, 'GOAL-1.yaml'), 'id: GOAL-1\nname: Test Goal\n', 'utf8');
+  return elementTypesOnDisk(root).then(({ types, unreadable }) => {
+    assert.deepEqual([...types].sort(), ['GOAL', 'NODE']);
+    assert.deepEqual(unreadable, []);
+  });
+});
+
+test('elementTypesOnDisk: REL/ASSERTION outside canon/elements/ never appear', () => {
+  const root = tmpOrgRoot();
+  const relDir = join(root, 'canon', 'relations');
+  mkdirSync(relDir, { recursive: true });
+  writeFileSync(join(relDir, 'REL-1.yaml'), 'id: REL-1\ntype: hosts\n', 'utf8');
+  return elementTypesOnDisk(root).then(({ types }) => {
+    assert.equal(types.size, 0);
+  });
+});
+
+test('elementTypesOnDisk: absent canon/elements/ yields an empty set, not a throw', () => {
+  const root = tmpOrgRoot();
+  return elementTypesOnDisk(root).then(({ types, unreadable }) => {
+    assert.equal(types.size, 0);
+    assert.deepEqual(unreadable, []);
+  });
+});
+
+// Note: forcing a genuine OS-level read failure (permission denial, mid-walk
+// deletion) is not reliably reproducible cross-platform in a fast unit test —
+// chmod 0o000 is a no-op for the file owner's own read on NTFS, and a directory or
+// symlink standing in for a `.yaml` file is filtered out by walkYaml's own
+// Dirent.isFile() check before readFile is ever called on it, so neither exercises
+// the catch branch. The unreadable-tracking code itself is a small, directly
+// reviewable try/catch; the aggregation and data-free stripping around it are
+// covered below.
+
+// ── repoCheck() end-to-end — the red flag actually surfaces ─────────────
+
+test('repoCheck: a hand-placed out-of-profile TYPE is flagged even though nothing loaded it as a candidate', async () => {
+  const root = tmpOrgRoot();
+  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  const nodesDir = join(root, 'canon', 'elements', '04_technology', 'nodes');
+  mkdirSync(nodesDir, { recursive: true });
+  // `core` (coverage-presets.mjs) excludes NODE — the issue's own example.
+  writeFileSync(join(nodesDir, 'NODE-1.yaml'), 'id: NODE-1\nname: Test Node\n', 'utf8');
+
+  const report = await repoCheck(root);
+  assert.equal(report.profile_completeness.resolvable, true);
+  assert.deepEqual(report.profile_completeness.out_of_profile_types, ['NODE']);
+  assert.ok(report.integrity.red_flags.some((f) => f.includes('NODE') && f.includes('outside the active coverage profile')));
+});
+
+test('repoCheck: an unresolved profile is reported as not-resolvable, never a false-clean empty list', async () => {
+  const root = tmpOrgRoot();
+  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: not-a-real-preset\n', 'utf8');
+  const nodesDir = join(root, 'canon', 'elements', '04_technology', 'nodes');
+  mkdirSync(nodesDir, { recursive: true });
+  writeFileSync(join(nodesDir, 'NODE-1.yaml'), 'id: NODE-1\nname: Test Node\n', 'utf8');
+
+  const report = await repoCheck(root);
+  assert.equal(report.profile_completeness.resolvable, false);
+  assert.deepEqual(report.profile_completeness.out_of_profile_types, []);
+});
+
+test('repoCheck: a TYPE covered by the profile raises no flag', async () => {
+  const root = tmpOrgRoot();
+  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  const goalsDir = join(root, 'canon', 'elements', '01_motivation', 'goals');
+  mkdirSync(goalsDir, { recursive: true });
+  writeFileSync(join(goalsDir, 'GOAL-1.yaml'), 'id: GOAL-1\nname: Test Goal\n', 'utf8');
+
+  const report = await repoCheck(root);
+  assert.equal(report.profile_completeness.resolvable, true);
+  assert.deepEqual(report.profile_completeness.out_of_profile_types, []);
+});
+
+// ── unreadable-file diagnostics (transitrix-hq#104 item 5) ──────────────
+//
+// Forcing a genuine OS-level read failure is not reliably reproducible
+// cross-platform in a fast unit test (see the note above elementTypesOnDisk's
+// tests), so these cover the two things that ARE deterministic: the clean-repo
+// baseline stays zero, and `zones` — spread into the data-free report as-is — never
+// carries the per-file `unreadable` detail (file paths), regardless of count.
+
+test('repoCheck: a clean repo reports zero unreadable files and no red flag for it', async () => {
+  const root = tmpOrgRoot();
+  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  const goalsDir = join(root, 'canon', 'elements', '01_motivation', 'goals');
+  mkdirSync(goalsDir, { recursive: true });
+  writeFileSync(join(goalsDir, 'GOAL-1.yaml'), 'id: GOAL-1\nname: Test Goal\n', 'utf8');
+
+  const report = await repoCheck(root);
+  assert.equal(report.integrity.unreadable_files, 0);
+  assert.ok(!report.integrity.red_flags.some((f) => f.includes('could not be read')));
+});
+
+test('repoCheck: the data-free report never carries the per-file unreadable detail', async () => {
+  const root = tmpOrgRoot();
+  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+
+  const report = await repoCheck(root);
+  const serialized = JSON.stringify(report);
+  assert.ok(!serialized.includes(root.replace(/\\/g, '\\\\')) && !serialized.includes(root));
+  for (const z of ['canon', 'field', 'codex']) {
+    assert.equal(Object.prototype.hasOwnProperty.call(report.zones[z], 'unreadable'), false);
+  }
+});

--- a/packages/ingest-cli/src/unresolved.mjs
+++ b/packages/ingest-cli/src/unresolved.mjs
@@ -100,7 +100,7 @@ const REQUIRED = ['ingest_status', 'ingest_source', 'ingest_field', 'ingest_date
 // resolve to an admitted canon id — needs the canon id set, passed in).
 export async function checkUnresolved(orgRoot, canonIds) {
   const dir = join(resolve(orgRoot), 'canon', 'unresolved');
-  const out = { count: 0, 'UNRES-001': 0, 'UNRES-002': 0, 'UNRES-003': 0 };
+  const out = { count: 0, 'UNRES-001': 0, 'UNRES-002': 0, 'UNRES-003': 0, unreadable: 0 };
   if (!(await exists(dir))) return out;
   let names = [];
   try { names = await readdir(dir); } catch { return out; }
@@ -108,7 +108,10 @@ export async function checkUnresolved(orgRoot, canonIds) {
     if (!name.endsWith('.yaml')) continue;
     out.count++;
     let text;
-    try { text = await readFile(join(dir, name), 'utf8'); } catch { continue; }
+    // A file that cannot be read at all is counted, never silently absorbed into
+    // "clean" (methodology review, transitrix-hq#104 item 5) — data-free per this
+    // scan's own contract, so a count, not the filename.
+    try { text = await readFile(join(dir, name), 'utf8'); } catch { out.unreadable++; continue; }
     for (const f of REQUIRED) {
       // `data` may be a block/map (no top-level scalar) — accept the key's presence.
       const present = readTopScalar(text, f) !== null || new RegExp(`^${f}:`, 'm').test(text);


### PR DESCRIPTION
## Summary
- `repo-check` now flags every `canon/elements/` TYPE the active coverage profile does not cover, independent of whether any candidate for that TYPE ever loaded — `suggest-profile.mjs` only sees the loaded-candidate stream, so a hand-placed element was structurally invisible to it. Fails loudly (`resolvable: false`) when the profile itself cannot be resolved, rather than reporting a false-clean empty list.
- A per-file read failure in `canon.mjs`, `placement.mjs`, `check-stale.mjs`, `unresolved.mjs`, and `repo-check.mjs`'s own zone walkers used to be silently swallowed (`catch { continue; }`), making an unreadable file indistinguishable from a missing object. Each walker now names the file + reason; `check-stale` / `check-placement` (already non-data-free) print them, `repo-check` keeps its data-free contract and reports an aggregate count only.
- `ELEMENT_PRIMITIVES.md` §3 now recommends a block scalar as the default for free-text fields (`description`, provenance notes, `statement` on RULE/CONSTRAINT), since a plain scalar containing `": "` is ambiguous YAML and fails the whole document to parse silently.

## Test plan
- [x] `node --test packages/ingest-cli/src/*.test.mjs` — 46/46 passing (new `repo-check.test.mjs` adds 13 cases)
- [x] `node scripts/check-notations.mjs` — clean
- [x] `node --check` on every touched `.mjs` file