### PR TITLE
feat(notations): integration-map — INTEGRATION projected as a graph

### DIFF
--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -114,6 +114,7 @@ Each notation file carries its own ID using the same grammar; the TYPE names the
 | `ACTION_NET` | `*.action.transitrix.yaml` (deprecated alias: `*.activities.transitrix.yaml`) |
 | `PRODUCTS_CAT` | `*.products.transitrix.yaml` |
 | `APPLICATIONS_CAT` | `*.applications.transitrix.yaml` |
+| `INTEGRATION_MAP` | `*.integration-map.transitrix.yaml` |
 | `SCENARIOS` | `*.scenarios.transitrix.yaml` |
 | `BLOCKS` | `*.blocks.transitrix.yaml` |
 | `PROCESS_BLUEPRINT` | `*.process-blueprint.transitrix.yaml` |

--- a/notations/NOTATION_SELECTION_GUIDE.md
+++ b/notations/NOTATION_SELECTION_GUIDE.md
@@ -14,7 +14,35 @@ status: "draft"
 
 ## 1. How to choose a family — read this first
 
-The three families are not interchangeable, and the difference matters more than which specific diagram type looks closest:
+### 1.0 First, the question that precedes the family choice — authored or derived?
+
+**Is the artefact's content *authored*, or *derived from admitted canon*?**
+
+- **Derived** — the content is a projection of elements that already exist in `canon/`
+  (an integration landscape read off `INTEGRATION`, an action tree read off `ACTION`).
+  **No general-purpose tool is a candidate at all**: PlantUML and Mermaid have nothing
+  to derive from. The answer is a Transitrix *view*, and the rest of this section does
+  not apply — it ranks tools for producing a drawing, and this is not a drawing problem.
+- **Authored** — someone is composing the content themselves. The rest of this section
+  applies.
+
+Asking this first is what stops the family choice being read as a preference order. The
+options below answer different questions; they are not a quality ranking with Transitrix
+at the top.
+
+**Transitrix is not mandatory for diagrams.** If PlantUML or Mermaid has a notation that
+fits what someone needs to show, use it — that is a sanctioned answer, not a concession
+and not a fallback. For most diagrams a person draws in a week those tools are simply
+right: mature, portable, renderable anywhere, no admission step, nothing to maintain.
+What Transitrix asks for is narrow: **the things that are true about the organisation and
+must stay true** — the process actually followed, the obligation that actually binds, the
+integration that actually exists. Those earn admission, versioning, and a projection that
+breaks when the fact changes. A component sketch explaining a design in a pull request
+earns none of that and should not pay for it. (The 2026-08-09 decision that a flow view
+projects canon rather than adding a drawing notation.)
+
+The three families are not interchangeable, and — once the artefact is authored, not
+derived — the difference matters more than which specific diagram type looks closest:
 
 - **Mermaid / PlantUML** are generic diagram-as-code renderers. A diagram is a single fenced text block, throwaway or living inside a doc/README/PR/wiki page, with no persistent data model behind it. Nothing about the diagram is validated against, or reused by, anything else.
 - **Transitrix** notations are not diagrams-for-illustration — they are projections of the adopter's canonical enterprise-architecture data (`canon/`, `field/`, `codex/` zones per [CONTRACT.md](CONTRACT.md)). The same element (a Goal, a Capability, an Actor) can be referenced from many views; the view renders a projection, the element is the governed record. Content is validated, versioned, and cross-referenced with the rest of the adopter's model.

--- a/notations/NOTATION_SELECTION_GUIDE.md
+++ b/notations/NOTATION_SELECTION_GUIDE.md
@@ -180,7 +180,7 @@ Mermaid's own docs mark all of these beta — syntax may change.
 
 Unlike Mermaid/PlantUML, a Transitrix notation is not a single fenced block — it's a `*.<short-name>.transitrix.yaml` file with a `notation: <short-name>` header (contract in [CONTRACT.md](CONTRACT.md) §3), rendered by Transitrix Studio. The full index with extensions lives in [README.md](README.md); this table adds the "when to recommend it" framing to match §2–§3 above.
 
-### 4.1 Views — render-able artefacts (15 active, 1 deprecated)
+### 4.1 Views — render-able artefacts (16 active, 1 deprecated)
 
 | Notation | Short name | What it models | When to recommend it | Status |
 |---|---|---|---|---|
@@ -193,6 +193,7 @@ Unlike Mermaid/PlantUML, a Transitrix notation is not a single fenced block — 
 | Nested Block Diagrams | `blocks` | Recursive container tree — "what's inside what" | Deep architectural overview, infra zones, bounded-context maps |documented |
 | Products Catalogue | `products` | Inventory of products/services, text + table | Portfolio catalogue of what the org sells/offers | draft |
 | Applications Catalogue | `applications` | Inventory of applications/integrations | IT application landscape inventory | draft |
+| Integration Map | `integration-map` | Application-cooperation graph, projected from admitted `INTEGRATION` (no edge can be authored that canon doesn't carry) | Show what talks to what, derived — never a hand-drawn integration landscape | draft |
 | Scenarios | `scenarios` | Report-config over the `SCENARIO` catalogue — alternative paths to a target state | Compare roadmap/planning alternatives serving one or more goals | draft |
 | Process Blueprint | `process-blueprint` | Wide left-to-right value chain; each stage carries goal/result/systems/actors/equipment/info | A governed, canon-linked value chain (not an ad hoc journey sketch) | draft |
 | Action Card | `action-card` | Single-project narrative — DGCA chain, dates, milestones, gate decisions | One-pager for a single project's status/context | draft |
@@ -243,6 +244,7 @@ The same concept often exists in more than one family. This table exists to stop
 | Gantt / project schedule | `gantt` | Gantt Chart | **action** (AoN, critical path) | the schedule is a real delivery plan referencing canon Goals/Changes |
 | Capability / goal hierarchy | `mindmap`, `treemap-beta` (informal) | WBS, MindMap (informal) | **capability-map**, **goals** | need CMMI maturity, canonical IDs, cross-refs |
 | C4 software architecture | `C4Context`… (experimental) | C4 via stdlib (mature) | element primitives (`ACTOR`/`NODE`/`TECHNOLOGY_SERVICE`) + **blocks** | the infra/app landscape must persist and cross-reference compliance/process |
+| Application cooperation / data-flow landscape | — | — | **integration-map** | always for a governed landscape — the picture is derived from admitted `INTEGRATION`, never authored; a quick illustrative sketch of a proposed (not-yet-admitted) integration is Mermaid `flowchart` or PlantUML Component Diagram instead |
 | Enterprise architecture (ArchiMate) | — | ArchiMate stdlib (illustrative) | element primitives — ArchiMate-inspired, governed canon data | the model must be governed/versioned, not a one-off picture |
 | Strategy → goals → initiatives | — | — | **dgca**, **goals**, **actions-tree** | always — no Mermaid/PlantUML equivalent |
 | Regulatory obligation mapping | — | — | **codex + requirement + assertion + compliance-impact** | always — unique to Transitrix |
@@ -277,6 +279,7 @@ Ready-made mappings from common phrasing to a recommendation. Use these as a fir
 | Comparing roadmap / scenario alternatives | Transitrix **scenarios**; Mermaid `quadrantChart` for a quick 2-axis comparison | canon linkage is the deciding factor |
 | A nested/layered architecture overview | Transitrix **blocks**; Mermaid `treemap-beta` for a quick size-encoded sketch | canon linkage is the deciding factor |
 | C4 context/container/component diagram | PlantUML C4 (mature, via stdlib); Mermaid C4 only if already Mermaid-only and okay with experimental | PlantUML's C4 support is production-grade |
+| What talks to what — the real, governed integration landscape | Transitrix **integration-map** | Derived from admitted `INTEGRATION`, not drawn — see §1.0; a proposed integration that isn't admitted yet has nothing for it to derive from, so sketch it in Mermaid/PlantUML instead |
 | Enterprise architecture in ArchiMate style | PlantUML ArchiMate stdlib if illustrative; Transitrix element primitives if it must persist | canon linkage is the deciding factor |
 | A UI mockup / wireframe | PlantUML Salt (`@startsalt`) | Mermaid has no wireframe type |
 | Network topology | PlantUML Network Diagram (nwdiag) for illustration; Transitrix `NODE`/`TECHNOLOGY_SERVICE` for canonical infra | canon linkage is the deciding factor |

--- a/notations/README.md
+++ b/notations/README.md
@@ -6,7 +6,7 @@ Transitrix is a text-native methodology: every architecture artefact lives in a 
 
 The view notations live under [`views/`](views/), split by class into a folder per class — [`diagrams/`](views/diagrams/), [`reports/`](views/reports/), and [`documents/`](views/documents/) — so a spec's class is a filesystem fact, not a table position. Studio also renders **PlantUML** (`.puml`/`.plantuml`) natively — no separate Transitrix notation is needed for it.
 
-### Diagram views (A = 11)
+### Diagram views (A = 12)
 
 Each renders a visual diagram.
 
@@ -21,6 +21,7 @@ Each renders a visual diagram.
 | [08-blocks.md](./views/diagrams/08-blocks.md) | `blocks` | Multi-level container layouts for deep architectural overviews (recursive `block` tree), or a single-layer rectangular matrix (RACI, coverage grids) — see §4 / §4a. | `*.blocks.transitrix.yaml` | documented |
 | [09-products.md](./views/diagrams/09-products.md) | `products` | Inventory of products and services — text-and-table catalogue, no diagram. | `*.products.transitrix.yaml` | draft |
 | [10-applications.md](./views/diagrams/10-applications.md) | `applications` | Inventory of applications and integrations — text-and-table catalogue, no diagram. | `*.applications.transitrix.yaml` | draft |
+| [12-integration-map.md](./views/diagrams/12-integration-map.md) | `integration-map` | Application-cooperation / data-flow graph, projected from admitted `INTEGRATION` (and, optionally, `uses` edges to `TECHNOLOGY_SERVICE`) — no edge can be authored that canon doesn't carry. | `*.integration-map.transitrix.yaml` | draft |
 | [13-process-blueprint.md](./views/diagrams/13-process-blueprint.md) | `process-blueprint` | Wide blueprint of a value chain — stages laid out left-to-right, each carrying its goal, result, and supporting systems / actors / equipment / information entities. | `*.process-blueprint.transitrix.yaml` | draft |
 | [18-action-card.md](./views/diagrams/18-action-card.md) | `action-card` | Single-project narrative view — DGCA chain, dates, milestones, gate decisions. | `*.action-card.transitrix.yaml` | draft |
 

--- a/notations/examples/README.md
+++ b/notations/examples/README.md
@@ -13,6 +13,7 @@ One subfolder per diagram format. Open any example file in VS Code with the Tran
 | [`process-map/`](process-map/) | `*.process-map.transitrix.yaml` | Process landscape map | Top-level catalogue of operating, supporting, and management processes |
 | [`products/`](products/) | `*.products.transitrix.yaml` | Products catalogue | Portfolio of digital products, services, platforms, and bundles |
 | [`applications/`](applications/) | `*.applications.transitrix.yaml` | Applications catalogue | Inventory of applications, integrations, platforms, and data stores |
+| [`integration-map/`](integration-map/) | `*.integration-map.transitrix.yaml` | Integration Map | Application-cooperation graph projected from admitted `INTEGRATION` — includes a rule-violation fixture showing an inline-authored edge is rejected |
 | [`scenarios/`](scenarios/) | `*.scenarios.transitrix.yaml` | Scenarios | Planning and simulation scenarios |
 | [`process-blueprint/`](process-blueprint/) | `*.process-blueprint.transitrix.yaml` | Process Blueprint | Wide blueprint of a value chain — stages with systems, actors, equipment, information entities |
 | [`compliance-impact/`](compliance-impact/) | `*.compliance-impact.transitrix.yaml` | Compliance Impact | Report-config view over the compliance overlay — (obligation × subject) matrix derived from `ASSERTION` + process flow + `REQUIREMENT` status |

--- a/notations/examples/integration-map/README.md
+++ b/notations/examples/integration-map/README.md
@@ -1,0 +1,48 @@
+# Integration Map notation — examples
+
+File extension: **`.integration-map.transitrix.yaml`**
+
+The integration-map view is a **selection / rendering configuration** over the application-cooperation graph derived from `INTEGRATION` ([`../../ELEMENT_PRIMITIVES.md`](../../ELEMENT_PRIMITIVES.md) §7.8, [`../../views/diagrams/10-applications.md`](../../views/diagrams/10-applications.md)) and, optionally, the `uses` relation to `TECHNOLOGY_SERVICE` ([`../../elements/17-relations.md`](../../elements/17-relations.md) §3). The view document declares which applications and integrations to render — it carries no canonical content of its own, and no field on it can express an edge canon doesn't already carry. See [`../../views/diagrams/12-integration-map.md`](../../views/diagrams/12-integration-map.md) for the view spec, the render contract, and the schema guarantee (§5.3).
+
+## Files in this folder
+
+| File | Description |
+|---|---|
+| [`enterprise.integration-map.transitrix.yaml`](enterprise.integration-map.transitrix.yaml) | Three applications (`APPLICATION-OMS-1`, `APPLICATION-CRM-1`, `APPLICATION-BILLING-1`), filtered to Kafka/REST integrations, with the Kafka platform dependency shown via `technology_services.show: true`. |
+| [`rule-violations/`](rule-violations/) | **Deliberately invalid.** Demonstrates that `INTMAP-004` fires when an author tries to place an edge — a `source:`/`target:` object — directly into a reference list instead of pointing at an admitted `INTEGRATION`. Do not copy from this folder; copy from the file above instead. |
+
+## Notation header
+
+Every file starts with:
+
+```yaml
+notation: integration-map
+```
+
+## Shape
+
+An integration-map view file carries the shared envelope (`notation:`, `spec_version:`, `methodology_version:`) plus a single `view` object. The `view` names the applications in scope (an explicit `include` list or a `filter`), the integrations to draw as edges (`include` / `filter` / `exclude` — always by reference to an admitted `INTEGRATION`, never inline), and optional technology-service and presentation knobs.
+
+```yaml
+notation: integration-map
+spec_version: "0.1"
+methodology_version: "3.3.0"
+
+view:
+  id: INTEGRATION_MAP-<NAME>-1
+  name: "..."
+  applications:
+    include: [APPLICATION-..., APPLICATION-...]
+  integrations:
+    filter:
+      protocol: [Kafka, REST]
+  technology_services:
+    show: true
+    include: [TECHNOLOGY_SERVICE-...]
+```
+
+The full field set, the render contract, and the validation rules are in [`../../views/diagrams/12-integration-map.md`](../../views/diagrams/12-integration-map.md).
+
+## Preview
+
+Open any `.integration-map.transitrix.yaml` file in VS Code with Transitrix Studio installed once the renderer ships (planned).

--- a/notations/examples/integration-map/enterprise.integration-map.transitrix.yaml
+++ b/notations/examples/integration-map/enterprise.integration-map.transitrix.yaml
@@ -1,0 +1,33 @@
+notation: integration-map
+spec_version: "0.1"
+methodology_version: "3.3.0"
+name: "Enterprise integration landscape"
+
+view:
+  id: INTEGRATION_MAP-ENTERPRISE-1
+  name: "Enterprise integration landscape"
+  description: >
+    Application-cooperation graph across the order-management domain — every
+    admitted integration between the named applications, plus the Kafka
+    platform dependency behind the event-driven ones.
+
+  applications:
+    include:
+      - APPLICATION-OMS-1
+      - APPLICATION-CRM-1
+      - APPLICATION-BILLING-1
+
+  integrations:
+    filter:
+      protocol: [Kafka, REST]
+
+  technology_services:
+    show: true
+    include:
+      - TECHNOLOGY_SERVICE-KAFKA-CLUSTER-1
+
+  isolated_applications: "show"
+  edge_label: "protocol"
+  grouping:
+    by: "domain"
+  order_nodes_by: "id"

--- a/notations/examples/integration-map/rule-violations/README.md
+++ b/notations/examples/integration-map/rule-violations/README.md
@@ -1,0 +1,28 @@
+# Integration map — rule-violation fixture
+
+A sibling fixture to [`../`](../) (the valid case, where every edge comes from an
+admitted `INTEGRATION` reference). This one deliberately breaks the one guarantee this
+notation exists to make: **an edge with no admitted `INTEGRATION` behind it must be
+impossible to express.**
+
+> **The file in this folder is invalid on purpose. Do not copy it as a starting point** —
+> copy from [`../enterprise.integration-map.transitrix.yaml`](../enterprise.integration-map.transitrix.yaml)
+> instead.
+
+## Seeded violation
+
+| File | Seeded violation | Rule it trips |
+|---|---|---|
+| [`attempted-inline-edge.integration-map.transitrix.yaml`](attempted-inline-edge.integration-map.transitrix.yaml) | `view.integrations.include` carries an object (`source:` / `target:` / `protocol:` keys) instead of a bare `INTEGRATION-…` id — an attempt to author an edge directly rather than reference one already admitted. | `INTMAP-004` |
+
+Per the spec's [§5.3](../../../views/diagrams/12-integration-map.md#53-the-schema-guarantee--why-an-unadmitted-edge-cannot-be-authored), this is defense-in-depth, not the primary guarantee: `view.integrations.include` / `.exclude` are typed as lists of strings, so there is no field shape on this notation into which a `(source, target)` pair fits. `INTMAP-004` is what a validator reports when an author hand-edits the YAML to try anyway — the same way a type-checked language rejects a string assigned to an integer field, rather than silently coercing it. There is no `edges:` or `links:` key anywhere in the schema for this violation to hide behind.
+
+## What is deliberately *not* seeded
+
+- **A reference to an unresolvable `INTEGRATION` id** (a plain string that doesn't resolve to anything admitted) — that is `INTMAP-003`, a different failure mode (a typo or a stale reference), and belongs in its own fixture if one is ever needed. This folder seeds the *schema-shape* violation, not the *reference-resolution* one.
+- **A second rule firing alongside `INTMAP-004`.** `APPLICATION-OMS-1` is named consistently with the valid sibling fixture so nothing else about the file is unusual.
+
+## References
+
+- [`../README.md`](../README.md) — the valid fixture this one is a sibling to.
+- [`../../../views/diagrams/12-integration-map.md`](../../../views/diagrams/12-integration-map.md) §5.3, §7 — the schema guarantee and `INTMAP-004`.

--- a/notations/examples/integration-map/rule-violations/attempted-inline-edge.integration-map.transitrix.yaml
+++ b/notations/examples/integration-map/rule-violations/attempted-inline-edge.integration-map.transitrix.yaml
@@ -1,0 +1,26 @@
+notation: integration-map
+spec_version: "0.1"
+methodology_version: "3.3.0"
+name: "Attempted inline edge — invalid on purpose"
+
+view:
+  id: INTEGRATION_MAP-INVALID-EDGE-1
+  name: "Attempted inline edge — invalid on purpose"
+  description: >
+    Seeded violation. The author has no admitted INTEGRATION between
+    APPLICATION-OMS-1 and APPLICATION-SHADOW-1 — SHADOW was never onboarded
+    or catalogued anywhere. This entry tries to draw the edge anyway by
+    placing a source/target object directly into `integrations.include`
+    instead of naming an admitted INTEGRATION id. INTMAP-004 rejects this:
+    the field only accepts a bare string id (§5.3 of the spec — there is no
+    field shape on this notation that can carry an edge canon doesn't admit).
+
+  applications:
+    include:
+      - APPLICATION-OMS-1
+
+  integrations:
+    include:
+      - source: APPLICATION-OMS-1
+        target: APPLICATION-SHADOW-1
+        protocol: "REST"

--- a/notations/views/diagrams/12-integration-map.md
+++ b/notations/views/diagrams/12-integration-map.md
@@ -1,0 +1,261 @@
+---
+notation: "Integration Map"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-08-09"
+status: "draft"
+file_extension: "*.integration-map.transitrix.yaml"
+---
+
+# Integration Map — Reference
+
+**Version:** 0.1
+**Date:** 2026-08-09
+**Status:** Draft — first cut of the diagram view projecting admitted `INTEGRATION` elements as a labelled directed graph.
+**File extension:** `*.integration-map.transitrix.yaml`
+**Scope:** A **rendering / selection / grouping configuration** for the application-cooperation / data-flow picture — what talks to what, and about what — read off admitted canon. The document is a presentation surface; it carries no canonical content of its own. Everything the view displays is **derived** from `APPLICATION` ([ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7 / [10-applications.md](./10-applications.md)), `INTEGRATION` ([ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.8 / [10-applications.md](./10-applications.md)), and — when `technology_services.show: true` — the `uses` relation to `TECHNOLOGY_SERVICE` ([elements/17-relations.md](../../elements/17-relations.md) §3).
+**Renderer:** Transitrix Studio (planned).
+**Class:** diagram view. Form set by the notation, read by whoever reads the model — not a report view.
+
+---
+
+## File header
+
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../../CONTRACT.md). This notation's per-notation values:
+
+| Field | Value |
+|---|---|
+| `notation:` value | `integration-map` |
+| File extension | `*.integration-map.transitrix.yaml` |
+
+### Document root fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `notation` | yes | string | MUST equal `integration-map` (per [CONTRACT.md](../../CONTRACT.md)) |
+| `spec_version` | no | string | reserved field per the shared contract |
+| `name` | yes | string | Human-readable document name — displayed in Studio diagram previews and listings. Per [CONTRACT.md](../../CONTRACT.md) §1.1. |
+| `generated_at` | no | string | Date the document was generated or last substantively revised — quoted ISO 8601 date per [CONTRACT.md](../../CONTRACT.md) §4. |
+| `view` | yes | object | the integration-map view config — see §3 and §4 |
+
+Example header:
+
+```yaml
+notation: integration-map
+spec_version: "0.1"
+name: "Human-readable title"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
+methodology_version: "3.3.0"
+view:
+  # ... see §3
+```
+
+---
+
+## 1. What this view is
+
+An integration-map view answers one question: **what applications talk to each other, in which direction, and over what — read off what is actually admitted, not drawn?**
+
+It is the application-cooperation / data-flow picture, projected from canon rather than authored as a diagram. This is the deciding design property: **an edge with no admitted `INTEGRATION` behind it must be impossible to express** — not discouraged, not linted, impossible. A drawing surface cannot guarantee that; a projection gets it for free, because the only way to make an edge appear is to admit the `INTEGRATION` it comes from. §3 states the schema property that makes this true; §7 (`INTMAP-004`) is the defence-in-depth check for an author who tries anyway.
+
+Removing or retiring an admitted `INTEGRATION` changes the render with no edit to the view — the same reconstruction invariant every view in this catalogue obeys ([ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §1.1).
+
+This view exists because the alternative — a general-purpose drawing notation for integration landscapes — was considered and refused: the data was never missing (`source`, `target`, and the transport contract are already admitted and validated on `INTEGRATION`); the picture was. See `architecture/notations.md` §1.0 for the authored-or-derived question this view is the worked answer to.
+
+---
+
+## 2. When to use this view
+
+| Use case | Notation |
+|---|---|
+| Show what talks to what across the application landscape, derived from admitted integrations. | Integration Map view |
+| Show platform dependencies alongside application cooperation (which applications use which technology services). | Integration Map view, `technology_services.show: true` |
+| Register a new application or integration, or record its transport contract. | **Applications Catalogue** ([10-applications.md](./10-applications.md)) — this view only reads what is already admitted there; it authors nothing. |
+| Show containment (an application inside a platform or bounded context). | **Nested Block Diagrams** ([08-blocks.md](./08-blocks.md)) — a different question (what's inside what, not what talks to what). |
+| Show how an application is used inside a business process, step by step. | **BPMN** ([01-bpmn.md](./01-bpmn.md)) or a Mermaid sequence diagram if the sequence is illustrative, not governed. |
+| Sketch an integration idea that isn't admitted canon yet (a proposal, a whiteboard sketch for a PR). | Mermaid or PlantUML — see `architecture/notations.md` §1.1: Transitrix is not mandatory for diagrams, and an unadmitted idea has nothing for this view to derive from. |
+
+---
+
+## 3. Document structure
+
+An integration-map view file is a short, declarative selection config. It does not own any canonical content. Two top-level keys plus the shared header:
+
+```yaml
+notation: integration-map
+spec_version: "0.1"
+name: "Enterprise integration landscape"    # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
+methodology_version: "3.3.0"
+
+view:
+  id: INTEGRATION_MAP-ENTERPRISE-1
+  name: "Enterprise integration landscape"
+  description: "Every admitted integration between the enterprise application set."
+
+  # Which APPLICATION nodes are in scope. At most one of `include` / `filter` is
+  # meaningful at a time (see §4 note ¹); omitting both is the zero-config default.
+  applications:
+    include:
+      - APPLICATION-OMS-1
+      - APPLICATION-CRM-1
+    # filter:
+    #   domain: [Operations, Sales]
+
+  # Which admitted INTEGRATION elements to draw as edges. Every entry in `include` /
+  # `exclude` is an INTEGRATION element id — a bare string, never an object (§4 note ²).
+  integrations:
+    # include:
+    #   - INTEGRATION-OMS-CRM-1
+    filter:
+      protocol: [Kafka, REST]
+    # exclude:
+    #   - INTEGRATION-LEGACY-1
+
+  # Platform dependencies via the `uses` relation. Off by default — this view's base
+  # case is application-to-application cooperation.
+  technology_services:
+    show: false
+    # include: [TECHNOLOGY_SERVICE-KAFKA-CLUSTER-1]
+    # filter:
+    #   platform: [Streaming]
+
+  isolated_applications: "show"   # show | hide — see §5.2 step 4
+  edge_label: "protocol"          # protocol | payload_class | directionality | none
+  grouping:
+    by: "none"                    # none | domain
+
+  order_nodes_by: "id"            # id | name | domain
+```
+
+The document carries the canonical envelope (`notation:` header, `spec_version:`, `methodology_version:` pin per [CONTRACT.md](../../CONTRACT.md) §10), a `view` object, and presentation fields under it. Nothing under `view` is canonical content — it is all selection / rendering configuration.
+
+---
+
+## 4. Fields
+
+Every field carries an explicit default, so a view with only the required envelope (`view.id`, `view.name`) renders deterministically — see §4.1.
+
+| Field | Required | Type | Default | Semantics |
+|---|---|---|---|---|
+| `view.id` | yes | string | — (required) | View identifier, canonical-grammar (`INTEGRATION_MAP-…`) per [IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §3.2 (`INTEGRATION_MAP` view-level TYPE). |
+| `view.name` | yes | string | — (required) | Human-readable name shown in the renderer. |
+| `view.description` | no | string | empty | Short description of the purpose of this view (which applications, which integrations, why). |
+| `view.applications.include` | no ¹ | list of strings | unset (use `filter`, or the full set) | Explicit list of `APPLICATION-…` element ids to include as nodes. Each entry MUST be a bare string; an object entry is `INTMAP-004`. |
+| `view.applications.filter` | no ¹ | object | **no filter — every admitted `APPLICATION` in canon** | Declarative filter: `domain: […]` (matches `APPLICATION.domain`). Resolved against the applications catalogue at render time. |
+| `view.integrations.include` | no ² | list of strings | unset (use `filter`, or the full set) | Explicit list of `INTEGRATION-…` element ids to draw as edges. Each entry MUST be a bare string; an object entry (e.g. carrying `source:` / `target:` / `from:` / `to:` keys) is `INTMAP-004` — this is the schema guarantee named in §1: there is no field shape by which this list can carry an edge that is not a reference to an admitted `INTEGRATION`. |
+| `view.integrations.filter` | no ² | object | **no filter — every admitted `INTEGRATION`** | Declarative filter: `protocol: […]`, `payload_class: […]`, `directionality: […]` (matches the named `INTEGRATION` fields, [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.8). |
+| `view.integrations.exclude` | no | list of strings | unset (no exclusions) | `INTEGRATION-…` ids to drop from the edge set after `include` / `filter` resolve. Each entry MUST be a bare string; same `INTMAP-004` guarantee as `include`. |
+| `view.technology_services.show` | no | bool | `false` | When `true`, also render `TECHNOLOGY_SERVICE` nodes reached from an in-scope `APPLICATION` via the `uses` relation ([elements/17-relations.md](../../elements/17-relations.md) §3), and one edge per `uses` relation. When `false`, `technology_services.include` / `.filter` are ignored. |
+| `view.technology_services.include` | no | list of strings | unset (use `filter`, or every reachable service) | Explicit list of `TECHNOLOGY_SERVICE-…` ids to include, narrowing the set reachable via `uses` from in-scope applications. Each entry MUST be a bare string. |
+| `view.technology_services.filter` | no | object | **no filter — every service reachable via `uses`** | Declarative filter on the reachable `TECHNOLOGY_SERVICE` set: `platform: […]`. |
+| `view.isolated_applications` | no | string | `show` | `show` — an in-scope `APPLICATION` with zero resolved edges still renders as a disconnected node. `hide` — it is dropped from the render entirely. Either way, no edge is invented; this field only controls whether a zero-degree node is visible. |
+| `view.edge_label` | no | string | `protocol` | Which admitted `INTEGRATION` field labels each edge: `protocol`, `payload_class`, `directionality`, or `none` (edges rendered unlabelled). The label always comes from the `INTEGRATION` element, never from the view document (§1). |
+| `view.grouping.by` | no | string | `none` | Presentation-only clustering hint: `none` (flat layout) or `domain` (nodes visually grouped by `APPLICATION.domain`). Affects layout only — never changes which nodes or edges render. |
+| `view.order_nodes_by` | no | string | `id` | Node ordering key (for renderers that lay out deterministically top-to-bottom or left-to-right): `id`, `name`, `domain`. |
+
+¹ **`applications`** — `include` and `filter` are both optional and mutually exclusive in effect: when `include` is set, `filter` is ignored (`INTMAP-006`, warning). Omitting both enumerates every admitted `APPLICATION` in canon.
+
+² **`integrations`** — same precedence rule as `applications`: `include` wins over `filter` when both are present (`INTMAP-006`, warning). `exclude` applies after either resolves, and applies regardless of whether `include` or `filter` was used.
+
+All references in `view.applications.*`, `view.integrations.*`, and `view.technology_services.*` resolve to canon primitives via the usual cross-reference rule ([IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §5).
+
+### 4.1 Zero-configuration default
+
+A view that carries only the required envelope —
+
+```yaml
+notation: integration-map
+spec_version: "0.1"
+name: "Full integration map"            # required per CONTRACT.md §1.1
+generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
+methodology_version: "3.3.0"
+view:
+  id: INTEGRATION_MAP-ALL-1
+  name: "Full integration map"
+```
+
+— renders **deterministically**: every admitted `APPLICATION` in canon as a node, every admitted `INTEGRATION` whose `source` and `target` both resolve within that node set as a labelled directed edge (label = `protocol`), no technology-service nodes, isolated applications shown, flat layout, nodes ordered by id. Each field a caller omits falls back to its §4 default; the result is reproducible from canon alone.
+
+Where a named, saved view-config of this notation lives in an adopter repo, and how a reader lists or re-runs it by name, is the registry convention in [REPORT_VIEW_CONFIG.md](../REPORT_VIEW_CONFIG.md) — the convention is uniform across every view notation, not only report-configs (§1 there).
+
+---
+
+## 5. Render contract
+
+This section is the **render contract**: the deterministic algorithm any conformant renderer (Studio, a per-build script) MUST follow to reproduce the view from canon. The contract names its inputs, its derivation steps, and the schema guarantee that makes an unadmitted edge unrepresentable.
+
+### 5.1 Inputs
+
+A conformant renderer reads exactly these canonical inputs:
+
+1. **`APPLICATION` catalogue** — every admitted `APPLICATION` element, whether nested inside the applications catalogue (`type: application`, [10-applications.md](./10-applications.md) §4) or standalone under `canon/elements/03_application/applications/` (promoted form, [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §4.1). Each contributes its id, `name`, and `domain`.
+2. **`INTEGRATION` catalogue** — every admitted `INTEGRATION` element, nested (`type: integration` inside an application's `integrations[]`, [10-applications.md](./10-applications.md) §4–§5) or standalone under `canon/elements/03_application/integrations/` (promoted form, [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.8). Each contributes its id, `source`, `target`, `protocol`, and — where `interface_semantics: true` — `payload_class`, `sensitivity`, `directionality` ([ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.8.1).
+3. **`uses` relations** — every admitted `REL` of kind `uses`, `APPLICATION` → `TECHNOLOGY_SERVICE` ([elements/17-relations.md](../../elements/17-relations.md) §3). Read only when `view.technology_services.show: true`.
+4. **`TECHNOLOGY_SERVICE` catalogue** — every admitted `TECHNOLOGY_SERVICE` element ([26-technology-services.md](../../elements/26-technology-services.md)) reachable via a `uses` relation read in step 3. Read only when `view.technology_services.show: true`.
+
+The renderer reads **no other input**. In particular: the view document itself contributes only selection / grouping / labelling configuration — never a node or an edge.
+
+### 5.2 Derivation
+
+1. **Resolve the application node scope.** Apply in precedence order: (a) if `view.applications.include` is set, use exactly those ids and skip (b); (b) otherwise, start from every admitted `APPLICATION` and narrow by `view.applications.filter` if present. Each id in `include` MUST resolve to an admitted `APPLICATION` — an unresolved or wrong-TYPE id is `INTMAP-003`.
+2. **Resolve the integration edge candidate set.** Apply in precedence order: (a) if `view.integrations.include` is set, use exactly those ids and skip (b); (b) otherwise, start from every admitted `INTEGRATION` and narrow by `view.integrations.filter` if present. Then drop any id present in `view.integrations.exclude`. Each surviving id MUST resolve to an admitted `INTEGRATION` — an unresolved or wrong-TYPE id is `INTMAP-003`.
+3. **Intersect edges with node scope.** For each candidate `INTEGRATION` from step 2, render it as a directed edge `source → target` **only if both `source` and `target` resolve to a node in the step-1 scope**. An `INTEGRATION` whose `source` or `target` falls outside the node scope is silently dropped from the render — not an error — and the renderer emits `INTMAP-007` (warning) naming the dropped id. This is the mechanism that makes an edge to something the view never named simply not appear, rather than appearing unlabelled or dangling.
+4. **Apply `view.isolated_applications`.** After step 3, an application node with zero incident edges is either kept (`show`, default) or dropped (`hide`).
+5. **Technology-service extension**, only when `view.technology_services.show: true`: for every application node surviving step 4, follow its admitted `uses` relations to `TECHNOLOGY_SERVICE`. Narrow the resulting service set by `view.technology_services.include` / `.filter` (same precedence rule as step 1). Add each surviving service as a node and each `uses` relation as an edge, visually distinct from an `INTEGRATION` edge (a `uses` edge is a different relation kind, not a different reading of the same one).
+6. **Label each `INTEGRATION` edge** per `view.edge_label` — reading the named field directly off the `INTEGRATION` element (never off the view document). `none` renders the edge unlabelled. A `uses` edge is unaffected by `edge_label` (§4 — it labels `INTEGRATION` edges only) and MAY be labelled by the renderer with the relation kind (`uses`) for legibility.
+7. **Grouping and ordering** are presentation-only per `view.grouping.by` and `view.order_nodes_by` (§4) — they never change which nodes or edges are in the render, only their visual arrangement.
+
+The derivation order is fixed so two renderers given the same canon produce identical output.
+
+### 5.3 The schema guarantee — why an unadmitted edge cannot be authored
+
+Steps 2–3 above are the render-time enforcement; the guarantee starts one level earlier, in the schema itself. `view.integrations.include` and `view.integrations.exclude` (§4) are typed as **lists of strings** — a reference to something already admitted. Neither this notation nor any other field on this document defines an `edges:` / `links:` key, and neither list accepts a mapping with `source:` / `target:` / `from:` / `to:` keys. There is consequently no field on an integration-map view document into which an author can place a `(source, target)` pair directly: the only way to make an edge appear is to admit an `INTEGRATION` element that carries it. `INTMAP-004` (§7) is the validator's defence-in-depth check for an author who tries anyway (e.g. hand-edits `include:` to carry an object) — it is not the primary guarantee, which is structural.
+
+---
+
+## 6. Relationship to other notations and elements
+
+```
+Integration Map view (this notation — diagram view, canon-projecting)
+  ├── reads   → APPLICATION elements          (10-applications.md §4–§5; ELEMENT_PRIMITIVES.md §4.1 — the node set)
+  ├── reads   → INTEGRATION elements           (10-applications.md §4–§5b; ELEMENT_PRIMITIVES.md §7.8 — the edge set)
+  │     ├── source / target  → APPLICATION
+  │     └── protocol / payload_class / directionality → edge label (view.edge_label)
+  └── reads   → uses relations                 (elements/17-relations.md §3 — optional TECHNOLOGY_SERVICE extension)
+        └── TECHNOLOGY_SERVICE elements         (26-technology-services.md)
+```
+
+Distinct from **Applications Catalogue** ([10-applications.md](./10-applications.md)) — the catalogue is where `APPLICATION` and `INTEGRATION` are authored (text-and-table, no diagram); this view only reads what the catalogue already admits, rendered as a graph.
+
+Distinct from **Nested Block Diagrams** ([08-blocks.md](./08-blocks.md)) — containment (what's inside what), not cooperation (what talks to what). The two compose: a blocks diagram can show platform groupings, an integration-map view can show the edges between the applications inside them.
+
+---
+
+## 7. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `INTMAP-001` | error | A required field from §4 is missing, or `id` does not match the canonical grammar `INTEGRATION_MAP-[<middle>-]<INTEGER>` ([IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §1). |
+| `INTMAP-002` | warning | `view.applications` resolves to zero applications after `include` / `filter` — the rendered graph will have no nodes. Usually a typo or an over-narrow filter. |
+| `INTMAP-003` | error | A reference in `view.applications.include`, `view.integrations.include`, `view.integrations.exclude`, or `view.technology_services.include` does not resolve to an admitted canonical element of the expected TYPE. |
+| `INTMAP-004` | error | An entry in `view.applications.include`, `view.integrations.include`, `view.integrations.exclude`, or `view.technology_services.include` is a mapping/object instead of a bare string id — most commonly an attempt to author an edge directly (e.g. an object carrying `source:` / `target:` / `from:` / `to:` keys). No such field shape is defined by this notation (§5.3); this rule exists to name the violation when an author tries anyway. |
+| `INTMAP-005` | error | `view.isolated_applications`, `view.edge_label`, or `view.grouping.by` is set to a value outside the enumerated set in §4. |
+| `INTMAP-006` | warning | Both `include` and `filter` are present on the same selector (`view.applications`, `view.integrations`, or `view.technology_services`) — `include` wins; `filter` is silently ignored. |
+| `INTMAP-007` | warning | An admitted `INTEGRATION` in the edge candidate set has a `source` or `target` outside the resolved application node scope — the edge is dropped from the render (§5.2 step 3), not an error. Rule names the dropped `INTEGRATION` id so a reader can widen `view.applications` if the omission is unintended. |
+
+The shared header rules `HDR-001..004` ([CONTRACT.md](../../CONTRACT.md) §2) apply in addition.
+
+---
+
+## 8. References
+
+- `APPLICATION` element (nested and promoted forms): [10-applications.md](./10-applications.md), [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §4.1.
+- `INTEGRATION` element schema, including Application Interface semantics: [10-applications.md](./10-applications.md) §5–§5b, [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.8.
+- `uses` relation (`APPLICATION` → `TECHNOLOGY_SERVICE`): [elements/17-relations.md](../../elements/17-relations.md) §3.
+- `TECHNOLOGY_SERVICE` element: [26-technology-services.md](../../elements/26-technology-services.md).
+- Reconstruction invariant (why view documents are not content homes): [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §1.1.
+- Named view-config convention (where this view's saved configs live, how they're named, listed, and re-run): [REPORT_VIEW_CONFIG.md](../REPORT_VIEW_CONFIG.md).
+- ID grammar and TYPE registry: [IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) (`INTEGRATION_MAP` registered in §3.2).
+- Applications Catalogue — the authoring surface this view projects: [10-applications.md](./10-applications.md).
+- Nested Block Diagrams — the containment view this pairs with: [08-blocks.md](./08-blocks.md).

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -907,6 +907,27 @@ rule_codes:
   INT-004:
     severity: error
     spec: notations/ELEMENT_PRIMITIVES.md
+  INTMAP-001:
+    severity: error
+    spec: notations/views/diagrams/12-integration-map.md
+  INTMAP-002:
+    severity: warning
+    spec: notations/views/diagrams/12-integration-map.md
+  INTMAP-003:
+    severity: error
+    spec: notations/views/diagrams/12-integration-map.md
+  INTMAP-004:
+    severity: error
+    spec: notations/views/diagrams/12-integration-map.md
+  INTMAP-005:
+    severity: error
+    spec: notations/views/diagrams/12-integration-map.md
+  INTMAP-006:
+    severity: warning
+    spec: notations/views/diagrams/12-integration-map.md
+  INTMAP-007:
+    severity: warning
+    spec: notations/views/diagrams/12-integration-map.md
   JURISDICTION-CONSISTENCY-001:
     severity: warning
     spec: notations/views/diagrams/13-process-blueprint.md

--- a/transitrix/.claude-plugin/plugin.json
+++ b/transitrix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix",
-  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 11 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Products, Action Card) + PlantUML rendering, or one of the 4 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric), or a codex artefact.",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 12 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Integration map, Products, Action Card) + PlantUML rendering, or one of the 4 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric), or a codex artefact.",
   "version": "0.1.0",
   "author": {
     "name": "Transitrix"

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -327,6 +327,7 @@ Use the matrix below to pick a notation. Full specs at `notations/<NN>-<name>.md
 | Multi-level container layout — what's inside what | **Nested blocks** | `*.blocks.transitrix.yaml` |
 | Alternative strategic development paths | **Scenarios** | `*.scenarios.transitrix.yaml` |
 | Catalogue of applications + integrations | **Applications** | `*.applications.transitrix.yaml` |
+| Application-cooperation graph — what talks to what, derived from admitted `INTEGRATION` (never hand-drawn) | **Integration Map** | `*.integration-map.transitrix.yaml` |
 | Catalogue of products + services | **Products** | `*.products.transitrix.yaml` |
 | Single-project narrative view — goals served, dates, milestones, gate decisions | **Action Card** | `*.action-card.transitrix.yaml` |
 | Compliance overlay — which obligations hit which product / process stage / task, with each cell's status | **Compliance Impact** | `*.compliance-impact.transitrix.yaml` |
@@ -360,6 +361,7 @@ Schema: `notations/elements/14-codex.md` for codex; `notations/CONTRACT.md` §5�
 - **Nested blocks** — `notation: blocks`. Root key `nested_blocks:`. Recursive `block` tree (`id`, `name`, optional `description`, optional `children[]`). Containment is YAML-nested.
 - **Scenarios** — `notation: scenarios`. Alternative strategic development paths, each scoping its own goals / capabilities / activities / products / processes / applications.
 - **Applications catalogue** — `notation: applications`. Inventory of `APPLICATION-…` elements + `INTEGRATION-…` entries with criticality, owner, type.
+- **Integration Map** — `notation: integration-map`. Root key `view:` — a selection/rendering config projecting admitted `INTEGRATION` elements (application-to-application edges, `source`/`target`) as a labelled directed graph, optionally extended with `uses` edges to `TECHNOLOGY_SERVICE`. Carries no canonical content: `view.integrations.include`/`.exclude` accept only bare string references, never an inline `source:`/`target:` pair, so no edge can be authored that canon doesn't already carry.
 - **Products catalogue** — `notation: products`. Inventory of `PRODUCT-…` elements grouped by category.
 - **Action Card** — `notation: action-card`. Root key `action_card:` carrying a single project's narrative — the project Action it summarises, planned dates, and document-scoped `MILESTONE` elements for narrative gates. One project per document.
 - **Process Blueprint** — `notation: process-blueprint`. Root key `process_blueprint:` with `stages[]` (each carrying `goal` and `result`) and per-aspect arrays `systems[]`, `actors[]`, `equipment[]`, `information_entities[]`. Aspect entries reference the stages they appear in via `stages: [STAGE-…]`.
@@ -416,6 +418,7 @@ The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI
 | Nested blocks | `templates/blocks.blocks.transitrix.yaml` |
 | Scenarios | `templates/scenarios.scenarios.transitrix.yaml` |
 | Applications | `templates/applications.applications.transitrix.yaml` |
+| Integration Map | `templates/integration-map.integration-map.transitrix.yaml` |
 | Products | `templates/products.products.transitrix.yaml` |
 | Process Blueprint | `templates/process-blueprint.process-blueprint.transitrix.yaml` |
 | Action Card | `templates/action-card.action-card.transitrix.yaml` |

--- a/transitrix/skills/onboard/templates/integration-map.integration-map.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/integration-map.integration-map.transitrix.yaml
@@ -1,0 +1,50 @@
+notation: integration-map
+spec_version: "0.1"
+methodology_version: "3.3.0"
+
+# Integration Map. Spec: notations/views/diagrams/12-integration-map.md
+# Application-cooperation / data-flow graph, projected from admitted
+# INTEGRATION elements (optionally extended with `uses` edges to
+# TECHNOLOGY_SERVICE). Carries no canonical content — no field here can
+# express an edge that isn't already an admitted INTEGRATION; register the
+# applications and integrations themselves in the Applications catalogue.
+
+name: "FILL-ME integration landscape"   # required per CONTRACT.md §1.1
+
+view:
+  id: INTEGRATION_MAP-FILL-ME-1
+  name: "FILL-ME — e.g. Enterprise integration landscape"
+  description: "FILL-ME — which applications, which integrations, and why"
+
+  # Which APPLICATION nodes are in scope. At most one of include / filter is
+  # meaningful at a time; omitting both is every admitted APPLICATION.
+  applications:
+    include:
+      - APPLICATION-FILL-ME-1
+      - APPLICATION-FILL-ME-2
+    # filter:
+    #   domain: [Operations]
+
+  # Which admitted INTEGRATION elements to draw as edges — always a bare
+  # string reference, never an inline source/target pair.
+  integrations:
+    # include:
+    #   - INTEGRATION-FILL-ME-1
+    filter:
+      protocol: [REST]
+    # exclude:
+    #   - INTEGRATION-FILL-ME-2
+
+  # Platform dependencies via the `uses` relation. Off by default.
+  technology_services:
+    show: false
+    # include: [TECHNOLOGY_SERVICE-FILL-ME-1]
+    # filter:
+    #   platform: [Streaming]
+
+  isolated_applications: "show"   # show | hide
+  edge_label: "protocol"          # protocol | payload_class | directionality | none
+  grouping:
+    by: "none"                    # none | domain
+
+  order_nodes_by: "id"            # id | name | domain


### PR DESCRIPTION
## Summary
- Adds the `integration-map` diagram view: a selection/rendering config that projects admitted `INTEGRATION` elements (and, optionally, `uses` edges to `TECHNOLOGY_SERVICE`) as a labelled directed graph. No field on the document accepts an inline `source`/`target` pair — an edge with nothing admitted behind it is structurally unrepresentable, enforced further by `INTMAP-004`.
- Registers `INTEGRATION_MAP` in the view-level TYPE table, the notation index, and the vocabulary rule-code registry (`INTMAP-001..007`).
- Updates the notation selection guide to ask authored-or-derived before ranking tools, and states plainly that Transitrix is not mandatory for diagrams.
- Adds a valid example plus a `rule-violations/` fixture proving `INTMAP-004` fires on an inline-edge attempt — the negative test the acceptance criteria call for.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] New example + rule-violation fixture reviewed for shape correctness