### PR TITLE
docs(changelog): 3.4.0 release notes + version pin bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [3.4.0] — 2026-08-09
+
+Bump category: **MINOR** — new notation spec file (diagram view), additive `ingest-cli` checks, and tooling/doc fixes only; no migration recipe required.
+
+### Added
+
+- **`integration-map` diagram view** (`notations/views/diagrams/12-integration-map.md`) — projects admitted `INTEGRATION` elements (and, optionally, `uses` edges to `TECHNOLOGY_SERVICE`) as a labelled directed graph. No field on the view document accepts an inline `source`/`target` pair — an edge with nothing admitted behind it is structurally unrepresentable, enforced by `INTMAP-004` and demonstrated by a rule-violations fixture. Registered in the view-level TYPE table, the notation index, and `vocabulary.yaml`'s rule codes. (#474)
+- **`ingest-cli repo-check` profile-completeness check** — flags every `canon/elements/` TYPE the active coverage profile does not cover, independent of whether any candidate for that TYPE ever loaded (previously invisible to `suggest-profile.mjs`, which only sees the loaded-candidate stream). Fails loudly (`resolvable: false`) when the profile itself cannot be resolved, instead of reporting a false-clean empty list. (#473)
+- **CI: shared simple docs/chore PR auto-merge check** — schedules the reusable workflow hosted at `transitrix/templates` against this repository's own open PRs, plus `workflow_dispatch` for a manual run. `DRY_RUN` defaults `true`. (#469)
+
+### Changed
+
+- **`NOTATION_SELECTION_GUIDE.md`** — authored-or-derived now comes before the general-purpose-tool ranking (content derived from admitted canon has no PlantUML/Mermaid candidate at all), and the guide states plainly that Transitrix is not mandatory for diagrams — a one-off sketch is a drawing, and PlantUML/Mermaid are the right tools for it. (#474)
+- **Declared `engines.node` floor raised `>=18` → `>=20`** across all six packages (`document-renderer`, `document-view-engine`, `decisions-cli`, `ingest-cli`, `reg-intel-cli`, `reqif-cli`) — CI already tests against Node 20 everywhere; the floor each manifest declared was a promise CI never tested. (#471)
+- **Getting Started Step 3** now scaffolds a `GOAL` element with `transitrix new goal` and completes hand-authored files with `validate --fix`, instead of walking the reader through admission-record/lifecycle fields by hand; no longer cites the envelope spec sections directly. (#468)
+
+### Fixed
+
+- **A per-file read failure in `ingest-cli`'s zone walkers** (`canon.mjs`, `placement.mjs`, `check-stale.mjs`, `unresolved.mjs`, `repo-check.mjs`) was silently swallowed, making an unreadable file indistinguishable from a missing object. Each walker now names the file and reason; `check-stale`/`check-placement` print them, `repo-check` keeps its data-free contract and reports an aggregate count only. (#473)
+- **`ELEMENT_PRIMITIVES.md` §3** now recommends a block scalar (`>-`/`|-`) as the default for free-text fields (`description`, provenance notes, `statement` on RULE/CONSTRAINT) — a plain scalar containing `": "` is ambiguous YAML and fails the whole document to parse, silently. (#473)
+- **`IDS_AND_REFERENCES.md` §3.1`** now states, at the TYPE registry itself, that `type:` is a per-TYPE subtype value, never the catalogue TYPE (the catalogue TYPE is carried by `notation:` + the ID prefix) — `ELEMENT_PRIMITIVES.md` §3 already said this; the registry a reader lands on first did not. (#472)
+- **`elements/25-nodes.md` §1** no longer claims `hosts` covers an `APPLICATION` deployed on a `NODE` — it doesn't. (#472)
+
+---
+
 ## [3.3.0] — 2026-08-08
 
 Bump category: **MINOR** — new notation spec file, additive document-view-engine rendering, and tooling/hygiene fixes only; no migration recipe required.

--- a/method/02-team-operations.md
+++ b/method/02-team-operations.md
@@ -146,7 +146,7 @@ Deliberately **not** one-file-per-record like ADR/WI: a single file, `operations
 ---
 ### FB-0002
 type: notation-gap
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 raised_by: modeler
 date: "2026-07-27"
 status: sent-upstream

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -880,7 +880,7 @@ Structural layout of a view document:
 ```yaml
 notation: dgca                # §1 — required header
 spec_version: "0.1"           # §1 — optional header
-methodology_version: "3.3.0"  # manifest-pinned methodology version
+methodology_version: "3.4.0"  # manifest-pinned methodology version
 name: "Retail strategy chain" # §1.1 — required document name
 
 view:                         # view identity block — id only; name lives at root per §1.1
@@ -961,7 +961,7 @@ views/
 ```yaml
 view_id: DGCA-RETAIL-1               # canonical ID of the view being captured
 generated_at: "2026-06-20T14:30:00Z" # ISO-8601 UTC timestamp — matches the file name
-methodology_version: "3.3.0"          # methodology version in use at generation time
+methodology_version: "3.4.0"          # methodology version in use at generation time
 # …notation-specific element list follows (format defined per notation spec)…
 ```
 

--- a/notations/COVERAGE_PROFILES.md
+++ b/notations/COVERAGE_PROFILES.md
@@ -24,7 +24,7 @@ A profile is declared at the repository root in `transitrix.yaml` under the `cov
 
 ```yaml
 transitrix: 1
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core         # short form — name a shipped preset
@@ -250,7 +250,7 @@ The shipped presets (`minimal`, `core`, `full`) are *re-defined per methodology 
 ```yaml
 # transitrix.yaml
 transitrix: 1
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 notations: [dgca, goals, activities, capability-map, applications]
 zones: [canon, field]
 # coverage_profile omitted → defaults to `full`

--- a/notations/CURRENT_VERSION.yaml
+++ b/notations/CURRENT_VERSION.yaml
@@ -5,4 +5,4 @@
 # placeholder allowlist in scripts/check-notations.mjs. Enforced by that
 # script's V1 check. See notations/CONTRACT.md §10 for the versioning and
 # compatibility policy this pin follows.
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -29,7 +29,7 @@ A worked example lives at `transitrix.yaml` in the [acme-corp reference repo](ht
 
 ```yaml
 transitrix: 1                       # manifest schema version (integer)
-methodology_version: "3.3.0"        # the methodology release this repo conforms to
+methodology_version: "3.4.0"        # the methodology release this repo conforms to
 notations: [dgca, goals, action, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md

--- a/notations/NOTATION_SELECTION_GUIDE.md
+++ b/notations/NOTATION_SELECTION_GUIDE.md
@@ -1,8 +1,8 @@
 ---
 title: "Notation Selection Guide — Mermaid, PlantUML, Transitrix"
-version: "0.1"
+version: "0.2"
 author: "Valerii Korobeinikov"
-last_updated: "2026-07-10"
+last_updated: "2026-08-09"
 status: "draft"
 ---
 

--- a/notations/PACKAGES.md
+++ b/notations/PACKAGES.md
@@ -20,7 +20,7 @@ A package is declared at the repository root in `transitrix.yaml` under the `pac
 
 ```yaml
 transitrix: 1
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core

--- a/notations/examples/compliance-impact/README.md
+++ b/notations/examples/compliance-impact/README.md
@@ -25,7 +25,7 @@ A compliance-impact view file carries the shared envelope (`notation:`, `spec_ve
 ```yaml
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: COMPLIANCE_IMPACT-<NAME>-1

--- a/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
+++ b/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 name: "Retail product — GDPR obligations"
 
 view:

--- a/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
+++ b/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 id: DGCA-DATA-RESIDENCY-1
 name: "EU data-residency DGCA chain"

--- a/notations/examples/dgca/startup.dgca.transitrix.yaml
+++ b/notations/examples/dgca/startup.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 id: DGCA-STARTUP-1
 name: "Product launch — strategy chain"

--- a/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 id: DGCA-STRATEGY-2026-DGA
 name: "Strategy 2026 — DGA view"

--- a/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 id: DGCA-STRAT-1
 name: "Strategy 2026 — DGCA chain"

--- a/notations/examples/integration-map/README.md
+++ b/notations/examples/integration-map/README.md
@@ -26,7 +26,7 @@ An integration-map view file carries the shared envelope (`notation:`, `spec_ver
 ```yaml
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: INTEGRATION_MAP-<NAME>-1

--- a/notations/examples/integration-map/enterprise.integration-map.transitrix.yaml
+++ b/notations/examples/integration-map/enterprise.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 name: "Enterprise integration landscape"
 
 view:

--- a/notations/examples/integration-map/rule-violations/attempted-inline-edge.integration-map.transitrix.yaml
+++ b/notations/examples/integration-map/rule-violations/attempted-inline-edge.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 name: "Attempted inline edge — invalid on purpose"
 
 view:

--- a/notations/examples/mrd/README.md
+++ b/notations/examples/mrd/README.md
@@ -34,7 +34,7 @@ An MRD view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: mrd
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: MRD-<NAME>-1

--- a/notations/examples/mrd/incident-status.mrd.transitrix.yaml
+++ b/notations/examples/mrd/incident-status.mrd.transitrix.yaml
@@ -2,7 +2,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Incident status communication — MRD"
 generated_at: "2026-08-04"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: MRD-INCIDENT-STATUS-1

--- a/notations/examples/packages/reqif-workflow/transitrix.yaml
+++ b/notations/examples/packages/reqif-workflow/transitrix.yaml
@@ -4,7 +4,7 @@
 # (packages/reqif-cli/tests/test_reqif_integrity.py Part B) stays unaffected
 # by content the XML converter does not carry (see this folder's README).
 transitrix: 1
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/packages/reqif/transitrix.yaml
+++ b/notations/examples/packages/reqif/transitrix.yaml
@@ -3,7 +3,7 @@
 # permitted cross-reference (Transitrix.CanonRef, reqif.md §3) something real
 # to cite, plus the reqif/ package folder itself.
 transitrix: 1
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/scenarios/README.md
+++ b/notations/examples/scenarios/README.md
@@ -26,7 +26,7 @@ A post-reclassification scenarios view file carries no canonical content. It dec
 ```yaml
 notation: scenarios
 spec_version: "0.3"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: SCENARIOS-2027-CUT-1

--- a/notations/examples/sdd/README.md
+++ b/notations/examples/sdd/README.md
@@ -35,7 +35,7 @@ An SDD view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: sdd
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: SDD-<NAME>-1

--- a/notations/examples/sdd/data-export.sdd.transitrix.yaml
+++ b/notations/examples/sdd/data-export.sdd.transitrix.yaml
@@ -2,7 +2,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Data export capability — SDD"
 generated_at: "2026-08-04"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: SDD-DATA-EXPORT-1

--- a/notations/examples/srs/README.md
+++ b/notations/examples/srs/README.md
@@ -33,7 +33,7 @@ An SRS view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: srs
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: SRS-<NAME>-1

--- a/notations/examples/srs/backup-power.srs.transitrix.yaml
+++ b/notations/examples/srs/backup-power.srs.transitrix.yaml
@@ -2,7 +2,7 @@ notation: srs
 spec_version: "0.1"
 name: "Backup-power controller — SRS"
 generated_at: "2026-08-04"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: SRS-BACKUP-POWER-1

--- a/notations/packages/reqif.md
+++ b/notations/packages/reqif.md
@@ -21,7 +21,7 @@ This is a package, not a core notation: nothing here changes `IDS_AND_REFERENCES
 
 ```yaml
 transitrix: 1
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 packages: [reqif]
 ```
 

--- a/notations/views/diagrams/02-dgca.md
+++ b/notations/views/diagrams/02-dgca.md
@@ -154,7 +154,7 @@ A DGCA document opens with a shared header block (`notation:`, `spec_version:`, 
 ```yaml
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 id: DGCA-LAUNCH-1
 name: "Product launch strategy chain"
 period: "2026"
@@ -188,7 +188,7 @@ notation: dgca
 spec_version: "0.1"
 id: DGCA-RETAIL-1
 name: "Retail strategy chain 2026"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view_config:
   goals:

--- a/notations/views/diagrams/04-goals.md
+++ b/notations/views/diagrams/04-goals.md
@@ -117,7 +117,7 @@ After goals are promoted to `canon/elements/01_motivation/goals/`, the view beco
 ```yaml
 notation: goals
 spec_version: "0.1"
-methodology_version: "3.3.0"          # required from v2.0 onward
+methodology_version: "3.4.0"          # required from v2.0 onward
 
 id: GOALS-STRAT-2026-1                 # required — GOALS-[<middle>-]<INTEGER>
 name: "Strategy 2026 — Goals Tree"    # required per CONTRACT.md §1.1

--- a/notations/views/diagrams/07-action.md
+++ b/notations/views/diagrams/07-action.md
@@ -128,7 +128,7 @@ After actions are promoted to `canon/elements/05_implementation/actions/`, the v
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "3.3.0"          # required from v2.0 onward
+methodology_version: "3.4.0"          # required from v2.0 onward
 
 id: ACTION_SCHED-PLATFORM-2026-1      # required — ACTION_SCHED-[<middle>-]<INTEGER>
 name: "Platform Launch 2026"          # required per CONTRACT.md §1.1
@@ -344,7 +344,7 @@ Both views are projections of the same underlying schedule. A document never "be
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 id: ACTION_SCHED-MINIMAL-1
 name: "Minimal schedule example"           # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                # optional per CONTRACT.md §4

--- a/notations/views/diagrams/12-integration-map.md
+++ b/notations/views/diagrams/12-integration-map.md
@@ -45,7 +45,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   # ... see §3
 ```
@@ -86,7 +86,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Enterprise integration landscape"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: INTEGRATION_MAP-ENTERPRISE-1
@@ -169,7 +169,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Full integration map"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   id: INTEGRATION_MAP-ALL-1
   name: "Full integration map"

--- a/notations/views/documents/29-mrd.md
+++ b/notations/views/documents/29-mrd.md
@@ -45,7 +45,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Incident status communication — MRD"   # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: MRD-INCIDENT-STATUS-1
@@ -168,7 +168,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Full MRD — all needs"           # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"             # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   id: MRD-ALL-1
   name: "Full MRD — all needs"

--- a/notations/views/documents/30-srs.md
+++ b/notations/views/documents/30-srs.md
@@ -45,7 +45,7 @@ notation: srs
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   # ... see §3
 ```
@@ -97,7 +97,7 @@ notation: srs
 spec_version: "0.1"
 name: "Backup-power controller — SRS"          # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                     # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: SRS-BACKUP-POWER-1
@@ -158,7 +158,7 @@ notation: srs
 spec_version: "0.1"
 name: "Full SRS — all software-tier requirements"    # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                           # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   id: SRS-ALL-1
   name: "Full SRS — all software-tier requirements"

--- a/notations/views/documents/31-sdd.md
+++ b/notations/views/documents/31-sdd.md
@@ -45,7 +45,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   # ... see §3
 ```
@@ -101,7 +101,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Data export capability — SDD"          # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: SDD-DATA-EXPORT-1
@@ -170,7 +170,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Full SDD — all design elements"   # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"               # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   id: SDD-ALL-1
   name: "Full SDD — all design elements"

--- a/notations/views/reports/11-scenarios.md
+++ b/notations/views/reports/11-scenarios.md
@@ -45,7 +45,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   # ... see §3
 ```
@@ -95,7 +95,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Optimistic vs Conservative — 2027 cut"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                       # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: SCENARIOS-<NAME>-1
@@ -152,7 +152,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "All scenarios"                   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   id: SCENARIOS-ALL-1
   name: "All scenarios"

--- a/notations/views/reports/21-compliance-impact.md
+++ b/notations/views/reports/21-compliance-impact.md
@@ -45,7 +45,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   # ... see §3
 ```
@@ -103,7 +103,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Retail product — GDPR obligations"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: COMPLIANCE_IMPACT-RETAIL-GDPR-1
@@ -190,7 +190,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Full compliance matrix"          # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   id: COMPLIANCE_IMPACT-ALL-1
   name: "Full compliance matrix"

--- a/notations/views/reports/22-coverage-metric.md
+++ b/notations/views/reports/22-coverage-metric.md
@@ -45,7 +45,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Retail product — regime coverage"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 view:
   id: COVERAGE_METRIC-RETAIL-1
@@ -199,7 +199,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Full coverage metric"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 view:
   id: COVERAGE_METRIC-ALL-1
   name: "Full coverage metric"

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -27,7 +27,7 @@
 # the ingest CLI needs to place and validate it.
 
 # Must equal notations/CURRENT_VERSION.yaml (enforced by check V1).
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 # ---------------------------------------------------------------------------
 # Element TYPE registry — ELEMENT_PRIMITIVES.md §4 (mode table) and §6 (layer

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -84,6 +84,8 @@ const VERSION_PIN_ALLOWLIST = new Set([
   'migrations/0.7-to-1.0/fixtures/after/canon/views/compliance-impact/retail.compliance-impact.transitrix.yaml',   // post-migration fixture
   'migrations/1.0-to-2.0/README.md',                    // documents the target version, not the current pin
   'migrations/3.1-to-4.0/README.md',                    // documents the target version, not the current pin
+  'migrations/3.1-to-4.0/fixtures/before/strategy.fga.transitrix.yaml',   // pre-migration fixture
+  'migrations/3.1-to-4.0/fixtures/after/strategy.dgca.transitrix.yaml',   // post-migration fixture
   'migrations/1.0-to-2.0/fixtures/after/canon/views/goals/strategy-2026.goals.transitrix.yaml',   // post-migration fixture
   'migrations/1.0-to-2.0/fixtures/after/canon/views/action/platform-launch.action.transitrix.yaml', // post-migration fixture
   'migrations/2.1-to-3.0/fixtures/before/canon/views/design-controls-trace-matrix/example.design-controls-trace-matrix.transitrix.yaml', // pre-migration fixture

--- a/transitrix/skills/feedback/SKILL.md
+++ b/transitrix/skills/feedback/SKILL.md
@@ -179,7 +179,7 @@ element"* — which passes.
    ---
    ### FB-0003
    type: notation-gap
-   methodology_version: "3.3.0"
+   methodology_version: "3.4.0"
    raised_by: Modeler
    date: "2026-07-28"
    status: open

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -158,7 +158,7 @@ The root `transitrix.yaml` pins which methodology release this repo conforms to 
 
 ```yaml
 transitrix: 1
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 notations: [dgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```

--- a/transitrix/skills/onboard/templates/action.action.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/action.action.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: action
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 # Action schedule — pure projection over standalone ACTION elements.
 # Spec: notations/views/diagrams/07-action.md (v2.0). No action data is authored inline.

--- a/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: coverage-metric
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 # Coverage Metric. Spec: notations/views/reports/22-coverage-metric.md
 # Report-config over the coverage read of canon (sibling of Compliance Impact).

--- a/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: goals
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 # Goals tree — pure projection over standalone GOAL elements.
 # Spec: notations/views/diagrams/04-goals.md (v2.0). No element data is authored inline.

--- a/transitrix/skills/onboard/templates/integration-map.integration-map.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/integration-map.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "3.3.0"
+methodology_version: "3.4.0"
 
 # Integration Map. Spec: notations/views/diagrams/12-integration-map.md
 # Application-cooperation / data-flow graph, projected from admitted


### PR DESCRIPTION
## What

Release prep for **3.4.0** (MINOR), per `RELEASING.md`'s per-release checklist:

1. Read every PR since `v3.3.0` (#468, #469, #471, #472, #473, #474), categorised each per the bump table — highest is #474 (new `integration-map` notation spec file) → **MINOR**.
2. Bumped `notations/CURRENT_VERSION.yaml` to `3.4.0` and every dependent `methodology_version` pin `check-notations.mjs`'s V1 check flagged (43 files). `node scripts/check-notations.mjs` clean after.
3. Two migration fixtures under `migrations/3.1-to-4.0/fixtures/` are before/after snapshots for a future MAJOR migration, not current-version trackers — allowlisted alongside the existing `0.7-to-1.0`/`1.0-to-2.0`/`2.1-to-3.0` fixture pairs (established convention), not bumped.
4. `NOTATION_SELECTION_GUIDE.md`'s own `version`/`last_updated` bumped (`0.1` → `0.2`) since #474 substantively edited it (authored-or-derived ordering, "Transitrix not mandatory" statement).
5. Changelog entry added, grouped Added/Changed/Fixed, referencing PR numbers.

No `MAJOR` change — no migration recipe needed.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean
- [x] Diff-reviewed a sample of the bumped pins (`notations/vocabulary.yaml`) — mechanical, single-line change only

Tag + GitHub Release + `acme-corp` companion pin bump follow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)