### PR TITLE
feat(catalogue): four integration levels + additive binding envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ New to the ideas behind it? Read **[`method/01-methodology.md`](method/01-method
 - **[`notations/views/documents/DIRECTIVE_LANGUAGE.md`](notations/views/documents/DIRECTIVE_LANGUAGE.md)** — the `.ttrs` document source format: one directive language shared by every document kind (`mrd`, `srs`, `sdd`, `sds`, …, the middle segment of `<basename>.<kind>.ttrs`). Canonical public explanation: [transitrix.com/ttrs](https://transitrix.com/ttrs/).
 - **[`method/00-glossary.md`](method/00-glossary.md)** — standardised terminology.
 - **[`method/03-architecture-decision-log.md`](method/03-architecture-decision-log.md)** — architecture decision records per repo and the harvested enterprise log across repos; §10 is the setup path, from an empty folder to a scheduled harvest.
+- **[`method/05-catalogue-integration.md`](method/05-catalogue-integration.md)** — the four separately-enabled levels (decisions / vocabulary / recognition / promotion) at which a project repository integrates with a central catalogue repository, and the ownership rule they share.
 - **[`transitrix/templates`](https://github.com/transitrix/templates)** — forkable starter templates (RACI, …): fork, edit for your own organisation, validate.
 
 Process & releases:

--- a/method/03-architecture-decision-log.md
+++ b/method/03-architecture-decision-log.md
@@ -139,9 +139,9 @@ A dependency-free doc-lint, companion to `check-notations.mjs`, run in CI on eve
 
 Exit codes match the repo convention: `0` clean, `1` findings, `2` script error.
 
-## 9. Out of scope here — reference-catalog distribution (phase 2)
+## 9. Reference-catalog distribution — the down-flow
 
-The *down* flow — the central architecture repo publishing versioned object catalogs (the TOGAF *Standards Information Base*) that project repos pin and consume — is a separate component, deliberately not in this release. It will reuse the same principles (explicit version pins, "supersede with a new version, don't edit in place") and will close the loop with this log: a repo bumping its catalog-version pin is itself an architecturally-significant decision → it emits an `author: agent` ADR here. Until then, the ADL stands on its own as the up-flow.
+The *down* flow — the central architecture repo publishing versioned object catalogs (the TOGAF *Standards Information Base*) that project repos pin and consume — is a separate component from the ADL. It is specified as a ladder of four separately-enabled levels, this ADL mechanism being the first of them, in [`05-catalogue-integration.md`](05-catalogue-integration.md). It reuses this log's own principles (explicit version pins, "supersede with a new version, don't edit in place") and closes the loop with it: a repo bumping its catalog-version pin is itself an architecturally-significant decision → it emits an `author: agent` ADR here. The ADL stands on its own as the up-flow regardless of which, if any, of the later levels a repository adopts.
 
 The *propagation mechanism* the down-flow will reuse — versioned transport, the named upgrade operation, and the agent ratification contract — is specified in [`04-methodology-update-propagation.md`](04-methodology-update-propagation.md). The reference-catalog layer is the next consumer of that mechanism.
 

--- a/method/04-methodology-update-propagation.md
+++ b/method/04-methodology-update-propagation.md
@@ -75,7 +75,7 @@ The worst an unattended agent can do, then, is leave a *proposed* upgrade for hu
 
 ## 6. Reference-catalog distribution — same pattern, separate component
 
-The architecture-decision-log forward-references ([`03-architecture-decision-log.md`](03-architecture-decision-log.md) §9) a future *down-flow*: a per-organization architecture repository publishing versioned reference catalogs (the TOGAF *Standards Information Base*) that project repositories pin and consume. That distribution layer is intentionally not designed here — but it will reuse this mechanism unchanged:
+The architecture-decision-log forward-references ([`03-architecture-decision-log.md`](03-architecture-decision-log.md) §9) a *down-flow*: a per-organization architecture repository publishing versioned reference catalogs (the TOGAF *Standards Information Base*) that project repositories pin and consume. That distribution layer is specified as **L1 — vocabulary** of the integration ladder in [`05-catalogue-integration.md`](05-catalogue-integration.md) §2, and reuses this mechanism unchanged:
 
 - The catalog source becomes the organization's architecture repository (not this one).
 - The version slot is a catalog-specific field on the consuming project's manifest.

--- a/method/05-catalogue-integration.md
+++ b/method/05-catalogue-integration.md
@@ -1,0 +1,56 @@
+---
+title: Catalogue integration levels — joining a network around a central catalogue
+status: draft
+last_reviewed: 2026-08-10
+audience: public
+license: MIT
+tags: [transitrix, methodology, operations, catalogue, federation, governance]
+---
+
+# Catalogue integration levels — joining a network around a central catalogue
+
+> How a project repository relates to a **central repository** holding a shared catalogue — a per-organisation architecture repository, or any repository other project repositories treat as authoritative for a set of elements. One repository modelling on its own needs none of this; it applies once a second repository's canon should be able to recognise the first's.
+
+This document names the **ownership rule** every level below assumes, and the **four levels** at which a project repository can integrate with a central one. Each level is separately enabled and useful on its own — a repository may stop at any level, and stopping is not a partial or broken state.
+
+## 1. The ownership rule
+
+**Exactly one repository owns each element.** For an element the central repository has admitted, the central repository owns it — its canonical `id`, its `name`, its content — and every other repository's relationship to it is by reference, never by copy. For an element only a project repository has admitted, that project repository owns it, exactly as it always has; nothing below changes what an unfederated repository does today.
+
+Ownership is not renamed by binding. A project repository's locally authored element keeps its own `id` for as long as the repository exists — binding to a central element (§3) adds a fact about the element, it never substitutes the central element's identity for the local one. **No tool ever rewrites a local `id`.**
+
+## 2. The four levels
+
+| Level | What a project repository does | Specified |
+|---|---|---|
+| **L0 — decisions** | Already shipped. Nothing below is required to be here. | The two-layer decision mechanism — per-repo decision records, harvested into a central log, propose-never-auto-merge, no two-way sync — is [`03-architecture-decision-log.md`](03-architecture-decision-log.md) in full. |
+| **L1 — vocabulary** | Pins the published central catalogue in its own manifest; a CI step reports terminology divergence against the pin. Report only — it never edits. | Catalogue publication format and the pin are specified where the catalogue-publishing mechanism lands. |
+| **L2 — recognition** | A locally authored object is matched against the pinned catalogue; a match is **proposed** as a binding, staged for review. It never writes a binding into admitted canon on its own. | The binding envelope this proposal fills in, once accepted, is §3 below. |
+| **L3 — promotion** | A local object is proposed for import into the central repository, carrying its own id as `origin` once admitted; the binding this returns to the project repository is applied through the same review gate as L2. | Same envelope, §3 below — `origin` is the central-side half of the binding L2 proposes locally. |
+
+A repository at **L0 alone** — no pin, no bound element, nothing beyond decision records — is a complete, valid state: it takes no new field and needs nothing else in this document. Each later level is opt-in and additive to the ones before it; nothing in this document requires a repository to advance past the level it has a use for.
+
+## 3. The envelope — additive binding
+
+Two optional fields carry a binding between a project repository's element and a central repository's element. Neither is required by any TYPE's schema; both are documented once, here, rather than per-notation.
+
+| Field | Where it appears | Semantics |
+|---|---|---|
+| `canon_id` | optional, on a `standalone` element in a **project** repository | Names the central element this element is bound to. Present only once a binding has been accepted (L2/L3, §2) — never authored ahead of that. |
+| `origin` | optional, on an element admitted in the **central** repository | Names the source project repository and the local `id` the element was promoted from (L3, §2). |
+
+Both fields are facts *about* an element, recorded alongside it — not a rename, not a merge, not a second copy. **Rendering rule:** a repository's own views always display its own `id`; the binding is metadata about the element, not its identity at home.
+
+## 4. Constraints that hold at every level
+
+- **Additive and backwards-compatible.** A repository that adopts none of this validates exactly as it did before this document existed. Any change here is a `MINOR` bump ([CONTRACT.md](../notations/CONTRACT.md) §10.2).
+- **Propose, never auto-merge**, at every level — L1 reports, L2 proposes, L3 emits a proposal for a human admission gate. Nothing at any level writes admitted canon unattended.
+- **No two-way sync**, at any level — the same discipline [`03-architecture-decision-log.md`](03-architecture-decision-log.md) §1 already states for decisions applies unchanged to elements: the central repository never edits a project repository's records, and a project repository never writes into the central repository.
+- **No agent writes across a repository boundary.** An agent working a project repository may propose a promotion; it may never write into the central repository. This is the authorship limit [`03-architecture-decision-log.md`](03-architecture-decision-log.md) §6 already places on ADRs, generalised to elements.
+- **Levels are separable in the tooling**, not merely in this document — each is built, and useful, independently of the ones after it.
+
+## 5. References
+
+- [`03-architecture-decision-log.md`](03-architecture-decision-log.md) — L0, in full; the propose-never-auto-merge and no-two-way-sync disciplines this document generalises.
+- [`04-methodology-update-propagation.md`](04-methodology-update-propagation.md) §6 — the transport pattern (versioned release, explicit pin, named operation) L1's catalogue pin reuses.
+- [`notations/CONTRACT.md`](../notations/CONTRACT.md) §17 — the binding envelope's field shapes and validation rules.

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -2,7 +2,7 @@
 
 All Transitrix notations share the same file-header contract: the same required field, the same reserved field, the same validator rules, and the same extension/content match guarantee. This document defines those shared rules once. Each notation spec links here and lists only its per-notation values (the `notation:` short name and the file extension).
 
-This document also defines four organisation-level contracts shared across all notations: the **zone model** (§5), the **admission record** (§6), the **primitive lifecycle** (§7), and the **versioned-attribute sidecar** (§9) — the four shared shapes every organisation artefact may carry. §8 aggregates the validation rules of the compliance and verification domain (REQUIREMENT + ASSERTION + VERIFICATION) for discoverability — the per-notation specs remain authoritative for the rule definitions themselves — and §8.1 covers risk modelling — the dedicated `RISK` element type, and the ArchiMate Risk and Security Overlay mapping onto core motivation primitives as an alternative. §10 sets the **versioning and compatibility policy** for the methodology itself — what kind of change each SemVer bump may carry, and what adopters can rely on across releases. §12 defines the **extensions bag** (`extensions:` — the open attribute escape hatch on every entity) and §13 the **unresolved holding area** (`canon/unresolved/` — where ingestion parks an object it cannot yet type); together they are the zero-information-loss contract the ingest pipeline relies on. §14 defines the **view-config contract** — the presentation layer of a view document — and §14.5 the **rendered snapshot format** — the committed output artefact produced by each CLI Capture run. §15 defines the **domain vocabulary** separating the project-domain `Action` from the process-domain `Activity`.
+This document also defines four organisation-level contracts shared across all notations: the **zone model** (§5), the **admission record** (§6), the **primitive lifecycle** (§7), and the **versioned-attribute sidecar** (§9) — the four shared shapes every organisation artefact may carry. §8 aggregates the validation rules of the compliance and verification domain (REQUIREMENT + ASSERTION + VERIFICATION) for discoverability — the per-notation specs remain authoritative for the rule definitions themselves — and §8.1 covers risk modelling — the dedicated `RISK` element type, and the ArchiMate Risk and Security Overlay mapping onto core motivation primitives as an alternative. §10 sets the **versioning and compatibility policy** for the methodology itself — what kind of change each SemVer bump may carry, and what adopters can rely on across releases. §12 defines the **extensions bag** (`extensions:` — the open attribute escape hatch on every entity) and §13 the **unresolved holding area** (`canon/unresolved/` — where ingestion parks an object it cannot yet type); together they are the zero-information-loss contract the ingest pipeline relies on. §14 defines the **view-config contract** — the presentation layer of a view document — and §14.5 the **rendered snapshot format** — the committed output artefact produced by each CLI Capture run. §15 defines the **domain vocabulary** separating the project-domain `Action` from the process-domain `Activity`. §17 defines the **binding envelope** (`canon_id` / `origin`) that relates a project repository's element to a central repository's, additive to every other section here.
 
 A change to the rules below applies to all notations simultaneously — they should be edited here, not duplicated into each spec.
 
@@ -1091,3 +1091,36 @@ This is the property that makes the hatch a checker-verified exemption rather th
 `MECH-001` is informational, not a build-breaking error: refusal does not fail validation, it only means §16.2's suspicion computation proceeds without the exemption. A reference implementation lives in [`scripts/check-link-suspicion.mjs`](../scripts/check-link-suspicion.mjs), alongside §16.1 and §16.2.
 
 **Additive.** Nothing in this section changes an existing schema, adds a required field to any TYPE, or alters an existing validation rule. A repository that declares no `migrations/*/TRANSFORM.yaml` manifest and never inspects link suspicion validates exactly as it did before this section existed.
+
+## 17. Binding envelope — `canon_id` and `origin`
+
+A project repository's element and a central repository's element are related by an optional, additive binding, not by a copy or a rename. The levels this binding is proposed and accepted at, the ownership rule it depends on, and the repository-boundary constraints it obeys are specified in [`method/05-catalogue-integration.md`](../method/05-catalogue-integration.md); this section defines the fields themselves and the rules a binding must satisfy.
+
+### 17.1 Fields
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `canon_id` | no | string | On a `standalone` element in a **project** repository: the id of the central element this element is bound to, resolved against the repository's pinned catalogue. Absent by default — present only once a binding has been accepted, never authored ahead of acceptance. |
+| `origin` | no | map | On an element admitted in the **central** repository: `{ repository: <slug>, id: <the local id it was promoted from> }` — where the element came from. Absent for an element the central repository authored itself. |
+
+Both fields are facts recorded *alongside* an element's own envelope (§3) — neither is a required field on any TYPE, and neither substitutes for `id`. **No tool ever rewrites a local `id`** in order to add or remove a binding.
+
+### 17.2 Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `BIND-001` | error | `canon_id` is present but does not resolve to any element in the repository's pinned catalogue. |
+| `BIND-002` | error | `canon_id` resolves, but the resolved central element's TYPE differs from this element's own TYPE. |
+| `BIND-003` | error | Two or more elements in the same catalogue carry the same `canon_id` — a central element cannot be the binding target of more than one local element. A **cross-catalogue** gate, requiring a full catalogue scan. |
+| `BIND-004` | error | `canon_id` is present but the repository has no catalogue pin configured — a binding without a pin. |
+| `BIND-005` | error | `origin` is present on an element that is not itself admitted in the central repository — `origin` records provenance for a central element, it is not a project-repository field. |
+
+### 17.3 Rendering rule
+
+A repository's own views always display its own `id` — a binding is metadata about an element, never a substitute for its identity at home. A rendered view never resolves `canon_id` in place of the id it is displaying.
+
+### 17.4 Out of scope here
+
+- **The catalogue itself** — its publication format, the pin field's shape and location in a consuming repository's manifest, and the version-match rule a pin resolves under — is specified where the catalogue-publishing mechanism lands, not here. `BIND-001` and `BIND-004` above assume that mechanism exists; they do not define it.
+- **How a binding is proposed** — the matching, staging, and review-queue mechanics of recognition and promotion (L2 / L3, [`method/05-catalogue-integration.md`](../method/05-catalogue-integration.md) §2) — is separate from the envelope shape and rules a binding must satisfy once accepted, which is all this section defines.
+- **`TERM` and other TYPE-specific catalogue content** are out of scope here; this section's fields and rules apply to any `standalone` element regardless of TYPE.

--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -1051,7 +1051,7 @@ No view inline shape: `RELEASE` is standalone-only, like `RISK` and `NEED` — i
 
 ## 9. Validation rules
 
-Element-primitive-specific rules. The shared header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2), lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3), and sidecar (`VERSIONED-001..005`, [CONTRACT.md](CONTRACT.md) §9.3) rules apply to element files in addition to these. `CONSTRAINT` and `NEED` additionally carry the agreement-axis rules (`AGREE-001..003`, [CONTRACT.md](CONTRACT.md) §6.3.1) — the REQUIREMENT-side counterpart is in [elements/15-requirement.md](elements/15-requirement.md) §4.
+Element-primitive-specific rules. The shared header (`HDR-001..004`, [CONTRACT.md](CONTRACT.md) §2), lifecycle (`LIFECYCLE-001..004`, [CONTRACT.md](CONTRACT.md) §7.3), sidecar (`VERSIONED-001..005`, [CONTRACT.md](CONTRACT.md) §9.3), and binding-envelope (`BIND-001..005`, [CONTRACT.md](CONTRACT.md) §17.2) rules apply to element files in addition to these. `CONSTRAINT` and `NEED` additionally carry the agreement-axis rules (`AGREE-001..003`, [CONTRACT.md](CONTRACT.md) §6.3.1) — the REQUIREMENT-side counterpart is in [elements/15-requirement.md](elements/15-requirement.md) §4.
 
 | Rule | Severity | Description |
 |---|---|---|

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -604,6 +604,21 @@ rule_codes:
   ATREE-007:
     severity: error
     spec: notations/views/reports/23-actions-tree.md
+  BIND-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  BIND-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  BIND-003:
+    severity: error
+    spec: notations/CONTRACT.md
+  BIND-004:
+    severity: error
+    spec: notations/CONTRACT.md
+  BIND-005:
+    severity: error
+    spec: notations/CONTRACT.md
   BL-001:
     severity: error
     spec: notations/views/diagrams/08-blocks.md


### PR DESCRIPTION
## Summary
- Specifies the ownership rule and the four separately-enabled levels (decisions / vocabulary / recognition / promotion) at which a project repository joins a network around a central catalogue repository — new `method/05-catalogue-integration.md`.
- Retargets the two forward references (decision-log §9, propagation §6) that previously deferred this to "not designed here".
- Adds the additive binding envelope (`canon_id` / `origin`) and its validation rules (`BIND-001..005`) to `notations/CONTRACT.md` §17, registered in `notations/vocabulary.yaml`.

Scoped to deliverables 1+2 of THQ-112 (source task: THQ-116). Catalogue publication, `TERM`, and the L2/L3 command surface are separate tasks and are out of scope here.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean
- [x] `node --test scripts/check-notations.test.mjs` — 54/54 pass
- [x] Internal markdown links in the touched files resolve