### PR TITLE
feat(notations): TERM element type + generated glossary report view

### DIFF
--- a/.github/workflows/ingest-skill-test.yml
+++ b/.github/workflows/ingest-skill-test.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run repo-check unit tests
         run: node --test packages/ingest-cli/src/repo-check.test.mjs
 
+      - name: Run canon-index unit tests
+        run: node --test packages/ingest-cli/src/canon.test.mjs
+
       - name: Run Ingest pipeline test (deterministic)
         run: python transitrix/skills/ingest/tests/test_ingest_integrity.py
 

--- a/method/00-glossary.md
+++ b/method/00-glossary.md
@@ -106,6 +106,7 @@ Transitrix is grounded in ArchiMate 3.2 but uses deliberately simplified or doma
 | `ACTION` | Work Package | Broader than a single work package — covers initiatives, programmes, projects, and tasks. **Deprecated alias:** `ACTIVITY` (accepted with a warning until the 1.0 cut). |
 | `BUSINESS_OBJECT` | Business Object | Renamed from `INFORMATION_ENTITY` for ArchiMate alignment; `INFORMATION_ENTITY` is a deprecated alias. |
 | `ACTOR` | Business Actor | A single active-structure identity type (`person` \| `business_unit` \| `system`) replacing the former separate `UNIT` / `EMPLOYEE` TYPEs. |
+| `TERM` | Meaning | "Term" is more accessible than ArchiMate's "Meaning" for a business-vocabulary entry (name + definition, no modelled behaviour). |
 
 Everything else in the registry (`GOAL`, `DRIVER`, `CONSTRAINT`, `REQUIREMENT`, `STAKEHOLDER`, `ASSESSMENT`, `EQUIPMENT`, `ROLE`, `PROCESS`, `CAPABILITY`, `APPLICATION`, `NODE`, `TECHNOLOGY_SERVICE`, `BUSINESS_SERVICE`, `LOCATION`, …) uses the ArchiMate term directly or a name aligned with it — no divergence to record.
 

--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -63,6 +63,7 @@ canon/
       locations/      LOCATION-*.yaml         # elements/21-locations.md — physical/virtual places
       rules/          RULE-*.yaml             # worked-example precedent
       registries/     REGISTRY-*.yaml         # §7.19 — org-authored operating config; rows inline, promotable
+      terms/          TERM-*.yaml             # §7.30 — business-layer vocabulary entry; name+aliases+description only
     03_application/
       applications/   APPLICATION-*.yaml
       integrations/   INTEGRATION-*.yaml      # promotable; nested-in-view in v1 (§4)
@@ -190,6 +191,7 @@ The mode table. For each registry element TYPE: its mode (§1), its `notation` s
 | `TECHNOLOGY_SERVICE` | standalone | `technology-service` | technology | `04_technology/services/` | §7.25 + [elements/26-technology-services.md](elements/26-technology-services.md) |
 | `BUSINESS_OBJECT` | standalone | `business-object` | business | `02_business/business-objects/` | §7.15 |
 | `EQUIPMENT` | standalone | `equipment` | technology | `04_technology/equipment/` | §7.14 |
+| `TERM` | standalone | `term` | business | `02_business/terms/` | §7.30 (no dedicated spec) |
 
 ### 4.1 Why these assignments
 
@@ -209,6 +211,7 @@ The mode table. For each registry element TYPE: its mode (§1), its `notation` s
 - **`SCENARIO` is `standalone`, as the path the architect plans.** A scenario is *the path*, not the destination — an ordered set of steps (`ACTIVITY` / `CHANGE`) that moves the enterprise to one `TARGET_STATE` in service of one or more `GOAL`s (ArchiMate **Course of Action** realised by Work Packages + Gaps). It is what an architect *varies* alongside the `TARGET_STATE` when offering customer solution options — multiple paths may reach the same end-state. That makes it a first-class addressable element, not an inline fragment of a view. The earlier `view-defined` placement (a "scenario document" that scoped its own goals/capabilities/activities/etc.) conflated the path with the things it sequences and the things its end-state contains; the reclassification splits them: `TARGET_STATE` owns structural composition (§7.17), `SCENARIO` owns the ordered steps (§7.18). Scenario references — `pursues` goal list, `arrives_at` target-state ref, ordered `steps` — are **inline (B2)**; the only first-class REL in the planning model is `target_state_satisfies_goal` (declared on `TARGET_STATE`, §7.17).
 - **`RELEASE` is `standalone`, as the anchor a claim attaches to instead of a whole subject.** A `RELEASE` is a dated/versioned state of a `PRODUCT` or `APPLICATION` — not an ArchiMate concept (no counterpart in ArchiMate 3.x; vocabulary rule, 2026-07-30 decision, same basis as `RISK`/`METRIC`). It exists so a `REQUIREMENT` obligation (`required_for`) and an `ASSERTION`/`VERIFICATION` compliance claim can name *which shipped state* they concern, rather than the subject as a whole — a claim that was true of v2.3 and false of v2.4 needs a place to record that distinction. Referenced from at least two directions (the obligation side and the claim side), so it needs its own admission record and lifecycle like `RISK`/`NEED`, not an inline fragment of either. **Authoring is deliberately conservative**: a `RELEASE` is catalogued only when something references it — the same restraint as the `STEP` promotion rule (§7.20; §1) — so importing a vendor's entire version history is never required or implied; only the releases a claim or obligation actually needs to distinguish are ever materialised. Implementation layer (`05_implementation/`) matches its grain: it is a state of the thing being changed, not the change itself (`CHANGE`) or the work that produces it (`ACTION`).
 - **`NODE` and `TECHNOLOGY_SERVICE` are `standalone`, as first-class infrastructure elements.** Infrastructure nodes and the platform services they expose are shared references: many applications may consume the same `TECHNOLOGY_SERVICE`, and many nodes may co-host it. Making them standalone catalogue elements lets the application layer reference `TECHNOLOGY_SERVICE-…` IDs without repeating connectivity details, and lets the infrastructure team manage node lifecycle independently of the applications built on top. They belong in `04_technology/` (ArchiMate Technology layer) — distinct from `03_application/` (software) and `02_business/` (organisational behaviour). The `hosts` and `uses` relation kinds ([elements/17-relations.md](elements/17-relations.md) §3) are the cross-layer links.
+- **`TERM` is `standalone`, as the naming-only vocabulary entry.** A `TERM` carries industry vocabulary, an abbreviation, or a word used in a particular sense — a *name and a definition*, and nothing else (no relations, no per-TYPE fields beyond the shared envelope). It is not a modelled object: a concept that already has its own element (a `BUSINESS_OBJECT`, a `CAPABILITY`, …) is defined by that element's own `description`, not restated as a `TERM` — the boundary is enforced at admission by extending the `ELEM-ALIAS-001` cross-catalogue name/alias scan to also treat a `TERM`'s own `name` as a match surface (§9), rather than only its `aliases[]` as every other TYPE does. Business layer (`02_business/`) matches its grain: vocabulary is a fact about how the organisation talks about itself, not its intent (`01_motivation`) or how it executes. Standalone rather than view-defined because the whole point is a shared, addressable catalogue entry — the generated glossary (`views/reports/32-glossary.md`) is a pure projection over it and every other TYPE's `name`/`aliases`/`description`, never an authoring surface.
 - **`EQUIPMENT` and `BUSINESS_OBJECT` are `standalone`, promoted from `view-defined` (ADR 2026-06-08).** Both were originally Process Blueprint document-local TYPEs; the ADR promoted them to first-class catalogued elements — `EQUIPMENT` as the first `04_technology` TYPE (§7.14), `BUSINESS_OBJECT` (renamed from `INFORMATION_ENTITY` for ArchiMate alignment) at `02_business` (§7.15). `INFORMATION_ENTITY` is a deprecated one-release alias for `BUSINESS_OBJECT` (`BOBJ-D001`); it carries no row of its own in §4, matching how other deprecated aliases (`FACTOR`, `ACTIVITY`) are omitted from this table.
 
 ### 4.2 `view-defined` is inline-content convenience, never a content home of last resort
@@ -255,7 +258,7 @@ canon/elements/<NN>_<layer>/<plural-type>/<ID>.yaml
 | `NN_layer` folder | ArchiMate layer | Element TYPEs placed here |
 |---|---|---|
 | `01_motivation/` | Motivation | `DRIVER` (`factors/`), `GOAL` (`goals/`), `CONSTRAINT` (`constraints/`), `REQUIREMENT` (`requirements/`), `STAKEHOLDER` (`stakeholders/`), `ASSESSMENT` (`assessments/`), `RISK` (`risks/`), `METRIC` (`metrics/`), `NEED` (`needs/`) |
-| `02_business/` | Business | `CAPABILITY` (`capabilities/`), `PROCESS` (`processes/`), `STEP` (`steps/`, when promoted), `PRODUCT` (`products/`), `ROLE` (`roles/`), `ACTOR` (`actors/`), `LOCATION` (`locations/`), `BUSINESS_SERVICE` (`business-services/`), `RULE` (`rules/`), `REGISTRY` (`registries/`) |
+| `02_business/` | Business | `CAPABILITY` (`capabilities/`), `PROCESS` (`processes/`), `STEP` (`steps/`, when promoted), `PRODUCT` (`products/`), `ROLE` (`roles/`), `ACTOR` (`actors/`), `LOCATION` (`locations/`), `BUSINESS_SERVICE` (`business-services/`), `RULE` (`rules/`), `REGISTRY` (`registries/`), `BUSINESS_OBJECT` (`business-objects/`), `TERM` (`terms/`) |
 | `03_application/` | Application | `APPLICATION` (`applications/`), `INTEGRATION` (`integrations/`, when promoted) |
 | `04_technology/` | Technology | `EQUIPMENT` (`equipment/` — ADR 2026-06-08), `NODE` (`nodes/`), `TECHNOLOGY_SERVICE` (`services/`) |
 | `05_implementation/` | Implementation & Migration | `ACTION` (`actions/`), `CHANGE` (`changes/`), `TARGET_STATE` (`target-states/`), `SCENARIO` (`scenarios/`), `MILESTONE` (`milestones/` — see 6.2), `RELEASE` (`releases/` — §7.29) |
@@ -1038,6 +1041,47 @@ valid_to: null
 
 No view inline shape: `RELEASE` is standalone-only, like `RISK` and `NEED` — it is not authored inline inside any view document.
 
+### 7.30 `TERM` — `02_business/terms/`
+
+A `TERM` is business-layer vocabulary — an ArchiMate **Meaning** (the knowledge or expertise present in an interpretation of a concept within a particular context). It carries industry vocabulary, an abbreviation, or a word used in a particular sense: a name and a definition, and nothing else. It is the ordinary standalone envelope (§3) with **no per-TYPE fields of its own** — `aliases[]` for surface forms, `description` as the definition, `derived_from` to cite the standard the definition is drawn from, the admission record, and the lifecycle. No subtype vocabulary (`type` is omitted).
+
+**Boundary, written as sharply as the schema.** A `TERM` is not how an already-modelled concept gets its name recorded twice. A concept that is an enterprise object — a `BUSINESS_OBJECT`, a `CAPABILITY`, a `PRODUCT`, any element with its own catalogue record — is defined by that element's own `description`; a `TERM` restating it is an error. This is enforced at admission, not left to authoring discipline: a `TERM`'s own `name` is folded into the `ELEM-ALIAS-001` cross-catalogue name/alias scan (§9) as if it were an alias, so a `TERM` named identically to any other element's `name` or `aliases[]` entry anywhere in the catalogue fails uniqueness — the same gate every other TYPE's `aliases[]` already goes through, extended to `TERM`'s `name` specifically because naming *is* what a TERM is for.
+
+**Citing an external standard.** A term taken from an external standard (a regulator's defined-terms section, an industry glossary) cites the codex artefact it was drawn from via `derived_from` instead of restating the standard's own text as the definition. Where `derived_from` is present on a `TERM`, every entry MUST resolve to an admitted `LAW`, `REGULATION`, `POLICY`, or `INTERNAL_STANDARD` codex artefact (`TERM-002`) — the same restriction [elements/15-requirement.md](elements/15-requirement.md) §4 applies to `REQUIREMENT.derived_from` (`REQ-003`), for the same reason: a definitional citation names a source of authority, not a piece of Field evidence.
+
+```yaml
+# canon/elements/02_business/terms/TERM-DATA-RESIDENCY-1.yaml
+notation: term
+id: TERM-DATA-RESIDENCY-1
+name: "Data residency"
+aliases:
+  - "Data localisation"
+description: >
+  The requirement that data about a jurisdiction's residents be stored and
+  processed within that jurisdiction's borders, as defined by the cited
+  regulation.
+
+derived_from:
+  - REGULATION-GDPR-2016-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-08-10"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-08-10"
+valid_to: null
+```
+
+**The glossary.** `TERM` is one of two provenances a generated glossary draws from — the other being every other TYPE's own `name` / `aliases[]` / `description`. The glossary itself is a report-class view, never an authoring surface: [views/reports/32-glossary.md](./views/reports/32-glossary.md).
+
+No view inline shape: like `RELEASE`, `RISK`, and `NEED`, `TERM` is standalone-only — it is never authored inline inside a view document.
+
 ---
 
 ## 8. Alignment with the ID grammar and TYPE registry
@@ -1063,7 +1107,7 @@ Element-primitive-specific rules. The shared header (`HDR-001..004`, [CONTRACT.m
 | `BOBJ-001` | error | A `BUSINESS_OBJECT` element file is not located under its mandated `canon/elements/02_business/business-objects/` folder (§4). |
 | `BOBJ-D001` | warning | An element candidate carries `element_type: INFORMATION_ENTITY` or an `INFORMATION_ENTITY-…` id prefix — the deprecated alias for `BUSINESS_OBJECT`. The validator flags it and continues; hard error in the following release. Rename `element_type` to `BUSINESS_OBJECT`, update the id prefix, and rename `information_entities[]` → `business_objects[]` in blueprints. |
 | `ELEM-005` | warning | A `standalone` element carries inline a field declared `time_varying` (§7) or a cross-reference of a kind declared first-class time-aware ([elements/17](elements/17-relations.md)) — it belongs in the sidecar (`VERSIONED-004`) or a `REL-…` file (`REL-004`) respectively. Surfaced here for discoverability; the authoritative codes are `VERSIONED-004` / `REL-004`. |
-| `ELEM-ALIAS-001` | error | An element's `aliases[]` entry collides (case-insensitively, trimmed) with another element's `name` or another element's `aliases[]` entry in the same `canon/` catalogue. A **cross-catalogue** gate — distinct from the per-file `ELEM-*` checks above, it requires scanning the whole catalogue. Ambiguous surface forms make F8 cross-source entity resolution unreliable, so a collision is a hard error at canon admission. A value shared with the element's *own* `name`/aliases is not a collision. (Per the element-aliases architecture decision; §3 `aliases` field.) |
+| `ELEM-ALIAS-001` | error | An element's `aliases[]` entry collides (case-insensitively, trimmed) with another element's `name` or another element's `aliases[]` entry in the same `canon/` catalogue. A **cross-catalogue** gate — distinct from the per-file `ELEM-*` checks above, it requires scanning the whole catalogue. Ambiguous surface forms make F8 cross-source entity resolution unreliable, so a collision is a hard error at canon admission. A value shared with the element's *own* `name`/aliases is not a collision. (Per the element-aliases architecture decision; §3 `aliases` field.) **Extended for `TERM`** (§7.30): a `TERM`'s own `name` also participates in this scan as if it were an alias — two plain `name`s colliding is otherwise allowed (names are unique only within a TYPE catalogue), but a `TERM` restating another element's `name`/`aliases[]` is exactly the failure mode this TYPE exists to prevent, so it is folded into the same gate rather than left uncaught. |
 | `INT-001` | error | An `INTEGRATION` element carries `interface_semantics: true` but is missing one or more of the conditionally required fields: `protocol`, `payload_class`, `sensitivity`, `directionality`. When `interface_semantics: true`, all four must be present in addition to the always-required `source` and `target`. |
 | `INT-002` | error | An `INTEGRATION` element carries `interface_semantics: true` but `source` or `target` does not resolve to an admitted `APPLICATION-…` element. Interface-semantics INTEGRATION endpoints must both be application-layer elements (§7.8.1). |
 | `INT-003` | error | `sensitivity` is not one of `public`, `internal`, `confidential`, `restricted`. |
@@ -1101,6 +1145,8 @@ Element-primitive-specific rules. The shared header (`HDR-001..004`, [CONTRACT.m
 | `RELEASE-003` | error | `predecessor` is present but resolves to a `RELEASE` whose `of` differs from this element's own `of` — a predecessor chain must stay within one subject's release history. |
 | `RELEASE-004` | error / warning | `predecessor` names this same element's own `id` — a self-reference (`error`; single-file, no catalogue scan needed). Otherwise, following `predecessor` links from this `RELEASE` (or from any `RELEASE` of the same `of`) revisits an id already seen — a cycle in the chain (`warning`; cross-cutting, requires walking the full release history for the subject). |
 | `RELEASE-005` | error | Two admitted `RELEASE` elements share the same `of` and the same `version` string (exact match — `version` is never parsed or normalised before comparison). |
+| `TERM-001` | error | A `TERM` element is missing `id`, `name`, `description`, or any required envelope field; or `id` does not match `TERM-[<middle>-]<INTEGER>`. |
+| `TERM-002` | error | A `TERM.derived_from` entry resolves to an admitted artefact whose TYPE is not one of `LAW`, `REGULATION`, `POLICY`, `INTERNAL_STANDARD` (or does not resolve to any admitted codex artefact at all). A TERM derives only from codex source documents — the same restriction `REQ-003` applies to `REQUIREMENT.derived_from` ([elements/15-requirement.md](elements/15-requirement.md) §4). |
 
 ---
 

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -102,6 +102,7 @@ Elements that get referenced across documents.
 | `REL` | first-class time-aware relation between two canonical primitives — `parent`, `action_goal`, `goal_parent`, `depends_on`, `required_for`, etc. Carries its own `valid_from` / `valid_to` so changes to a relation (a capability re-parenting, a goal re-aimed, a requirement dependency, an obligation moving into or out of scope for a release) are first-class temporal events. Deprecated alias: `activity_goal` → `action_goal`. | Relations catalogue (`canon/relations/`); one file per relation. Schema: [17-relations.md](elements/17-relations.md). |
 | `MILESTONE` | project-narrative milestone — a decision gate, certification date, or programme-level marker that belongs in an Action Card's narrative. Distinct from a "schedule milestone" (a zero-duration action inside an Action schedule document, see [07-action.md](./views/diagrams/07-action.md) §5.9), which exists for critical-path computation. | Defined inside an Action Card document (`*.action-card.transitrix.yaml`); scope is the parent card document. Schema: [18-action-card.md](./views/diagrams/18-action-card.md). |
 | `RELEASE` | implementation-layer **state of a modelled subject** — one dated/versioned release of a `PRODUCT` or `APPLICATION`. Not to be confused with a release *of the methodology itself* ([CONTRACT.md](CONTRACT.md) §10). Predecessor chains (`predecessor`, same-TYPE, inline) express version order; a `RELEASE` carries no list of its own contents — composition is derived by query. Catalogued only when referenced (STEP-style promotion restraint, [ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §1), so a vendor's full version history is not imported as inert catalogue noise. | Obligations/claims-per-release model — the `required_for` relation (REQUIREMENT → RELEASE, [elements/17-relations.md](elements/17-relations.md) §3, derived scope query §3.2) and the `ASSERTION` / `VERIFICATION` release qualifiers. Schema: [ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §7.29. |
+| `TERM` | business-layer **vocabulary entry** (ArchiMate Meaning) — a name and a definition, nothing else: industry vocabulary, an abbreviation, or a word used in a particular sense. Not a modelled object — a concept that already has its own element is defined by that element's `description`, never restated as a `TERM` (enforced by an `ELEM-ALIAS-001` extension, [ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §7.30/§9). Cites the codex artefact it was drawn from via `derived_from` when taken from an external standard, restricted to `LAW` / `REGULATION` / `POLICY` / `INTERNAL_STANDARD` (`TERM-002`). | Terms catalogue (`canon/elements/02_business/terms/`); one of the two provenances the generated glossary projects over. Schema: [ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §7.30. |
 
 ### 3.2 View-level types
 
@@ -126,6 +127,7 @@ Each notation file carries its own ID using the same grammar; the TYPE names the
 | `MRD` | `*.mrd.transitrix.yaml` |
 | `SRS` | `*.srs.transitrix.yaml` |
 | `SDD` | `*.sdd.transitrix.yaml` |
+| `GLOSSARY` | `*.glossary.transitrix.yaml` |
 
 BPMN diagrams use their `process.id` as the document identifier; that field is a free-form string defined by the spec, not by this appendix.
 
@@ -213,6 +215,7 @@ Each TYPE has a scope within which its IDs must be unique. Cross-document refere
 | `RISK` | within the organisation's element catalogue (`canon/elements/01_motivation/risks/`), one file per RISK. |
 | `NEED` | within the organisation's element catalogue (`canon/elements/01_motivation/needs/`), one file per NEED. |
 | `TARGET_STATE` | within the organisation's element catalogue (`canon/elements/05_implementation/target-states/`), one file per TARGET_STATE. |
+| `TERM` | within the organisation's element catalogue (`canon/elements/02_business/terms/`), one file per TERM. A TERM's `name` additionally participates in the `ELEM-ALIAS-001` cross-catalogue name/alias scan ([ELEMENT_PRIMITIVES.md](ELEMENT_PRIMITIVES.md) §9) — restating an existing element's definition under a new TERM fails admission. |
 | `REL` | within the organisation's `canon/relations/` folder, one file per REL. |
 | `MILESTONE` | within the action-card document that defines it. MILESTONE IDs are not required to be unique across the organisation; they are document-scoped element identifiers (the parent card binds them). |
 | `RELEASE` | within the organisation's element catalogue (`canon/elements/05_implementation/releases/`), one file per RELEASE. `version` is not part of the uniqueness scope of the id — two admitted releases of the same `of` subject sharing the same `version` string is a separate validation error (`RELEASE-005`), not an id collision. |

--- a/notations/README.md
+++ b/notations/README.md
@@ -25,7 +25,7 @@ Each renders a visual diagram.
 | [13-process-blueprint.md](./views/diagrams/13-process-blueprint.md) | `process-blueprint` | Wide blueprint of a value chain — stages laid out left-to-right, each carrying its goal, result, and supporting systems / actors / equipment / information entities. | `*.process-blueprint.transitrix.yaml` | draft |
 | [18-action-card.md](./views/diagrams/18-action-card.md) | `action-card` | Single-project narrative view — DGCA chain, dates, milestones, gate decisions. | `*.action-card.transitrix.yaml` | draft |
 
-### Report views (C = 4)
+### Report views (C = 5)
 
 Each produces a derived report or table from a declarative view-config, per [`REPORT_VIEW_CONFIG.md`](views/REPORT_VIEW_CONFIG.md).
 
@@ -35,6 +35,7 @@ Each produces a derived report or table from a declarative view-config, per [`RE
 | [21-compliance-impact.md](./views/reports/21-compliance-impact.md) | `compliance-impact` | Report-config view over the compliance overlay — derives the (obligation × subject) matrix from `ASSERTION` + process flow + `REQUIREMENT` status; distinguishes "No mapped obligation (current model)" from `n_a`. | `*.compliance-impact.transitrix.yaml` | draft |
 | [22-coverage-metric.md](./views/reports/22-coverage-metric.md) | `coverage-metric` | Report-config view over coverage of canon — counts subjects with zero admitted obligations from each regime, broken down per jurisdiction; distinguishes "Not yet modelled" (modelling gap) from "No obligation asserted (modelled fact)". | `*.coverage-metric.transitrix.yaml` | draft |
 | [23-actions-tree.md](./views/reports/23-actions-tree.md) | `actions-tree` | Report-config view over the `ACTION` element catalogue — renders the strategic portfolio as a top-down tree from Initiative through Programme, Project, to Task. | `*.actions-tree.transitrix.yaml` | draft |
+| [32-glossary.md](./views/reports/32-glossary.md) | `glossary` | Report-config view over the whole catalogue — projects `name` + `aliases[]` + `description` for every admitted element (`TERM` and modelled objects alike) into one flat, alphabetised lookup surface. | `*.glossary.transitrix.yaml` | draft |
 
 ### Document views (D = 3)
 

--- a/notations/views/reports/32-glossary.md
+++ b/notations/views/reports/32-glossary.md
@@ -1,0 +1,157 @@
+---
+notation: "Glossary"
+version: "0.1"
+author: "Valerii Korobeinikov"
+last_updated: "2026-08-10"
+status: "draft"
+file_extension: "*.glossary.transitrix.yaml"
+dsm_status: "planned"
+---
+
+# Glossary Notation — Reference
+
+**Scope:** Report-config view over the whole catalogue — projects `name` + `aliases[]` + `description` for every admitted element, whatever TYPE it is, into one flat, alphabetised lookup surface. No entry is defined inline in this document — it is a projection configuration, not an authoring surface (the reconstruction invariant, [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §1.1).
+**Renderer:** Transitrix Studio — glossary panel (planned); Transitrix DSM — planned.
+
+---
+
+## File header
+
+Header rules — required `notation:` field, `spec_version:` semantics, validator behaviour, extension/content match — are shared across all Transitrix notations and defined in [CONTRACT.md](../../CONTRACT.md). This notation's per-notation values:
+
+| Field | Value |
+|---|---|
+| `notation:` value | `glossary` |
+| File extension | `*.glossary.transitrix.yaml` |
+
+---
+
+## 1. Overview
+
+A Glossary document configures a single projection over the **entire admitted catalogue**, not one element TYPE: every element under `canon/elements/` contributes one entry — `name`, `aliases[]`, `description` — regardless of which TYPE it is. Two provenances feed it, and the renderer does not distinguish between them in the output shape:
+
+- **`TERM`** elements ([ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.30) — business-layer vocabulary with no modelled behaviour of its own: industry terms, abbreviations, words used in a particular sense.
+- **Every other TYPE** — a `BUSINESS_OBJECT`, a `CAPABILITY`, an `APPLICATION`, … — whatever the organisation has already modelled, read for its `name` / `aliases[]` / `description` alone.
+
+An entry from either provenance renders **indistinguishable in shape**: `name`, its `aliases[]` (if any), and `description`. This is deliberate — the glossary is a lookup surface, not a catalogue browser; a reader (or the document engine resolving a token) does not need to know or care which TYPE backs a definition, only that the definition exists and is singular (the `ELEM-ALIAS-001` extension at [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.30/§9 is what guarantees singularity — a `TERM` restating an existing entry never reaches canon, so the glossary never carries two entries competing for one name).
+
+**Two purposes:**
+
+- **The single lookup surface for the document engine** — a token resolves to a definition without the renderer knowing which kind of element it hit ([document-view engine](../../PACKAGES.md), token resolution).
+- **The readable glossary for onboarding** — a flat, alphabetised reference a new reader can scan cover to cover.
+
+---
+
+## 2. When to use
+
+| Use case | Notation |
+|---|---|
+| One flat, alphabetised name → definition lookup across the whole catalogue | Glossary |
+| Feed the document engine's token resolution | Glossary |
+| Show a hierarchy, matrix, or filtered subset of one element TYPE | The TYPE's own diagram/report view (e.g. [23-actions-tree.md](23-actions-tree.md) for `ACTION`) |
+| Define a new business-layer term with no modelled behaviour | Author a `TERM` element ([ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.30) — the glossary picks it up automatically at render time |
+
+---
+
+## 3. File location and naming
+
+Per the named view-config convention ([REPORT_VIEW_CONFIG.md](../REPORT_VIEW_CONFIG.md) §2):
+
+```
+<repo-root>/canon/views/glossary/<NAME>.glossary.transitrix.yaml
+```
+
+Examples:
+- `canon/views/glossary/full.glossary.transitrix.yaml`
+- `canon/views/glossary/business-layer.glossary.transitrix.yaml`
+
+---
+
+## 4. Document structure
+
+```yaml
+notation: glossary
+spec_version: "0.1"
+
+id: GLOSSARY-FULL-1
+name: "Full Glossary"
+description: "Every named element across the catalogue, alphabetised."
+
+view_config:
+  scope:
+    types: []                 # ELEMENT TYPEs to include; omit or [] = every TYPE
+  display:
+    group_by: "first_letter"  # "first_letter" | "none" — see §5.2
+    show_type_badge: true     # show the source TYPE next to each entry
+```
+
+Every field beyond the required envelope (`notation:`, `id:`, `name:`) has an explicit default (§5) — a minimal document with just those three fields renders the full catalogue, alphabetised, with type badges shown, per the zero-configuration-default convention ([REPORT_VIEW_CONFIG.md](../REPORT_VIEW_CONFIG.md) §6).
+
+---
+
+## 5. Fields
+
+### Document root
+
+| Field | Required | Description |
+|---|---|---|
+| `notation` | yes | MUST equal `glossary` (per [CONTRACT.md](../../CONTRACT.md) §3). |
+| `spec_version` | no | reserved field per the shared contract |
+| `id` | yes | document ID — `GLOSSARY-[<middle>-]<INTEGER>` per the canonical ID grammar ([IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §1) |
+| `name` | yes | human-readable name for this glossary document |
+| `description` | no | one-paragraph context |
+| `view_config` | no | rendering configuration — see §5.1 / §5.2 |
+
+### 5.1 `view_config.scope`
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `types` | no | `[]` (every TYPE) | List of element TYPEs to include (e.g. `[TERM, BUSINESS_OBJECT]`). When present and non-empty, only elements of the listed TYPEs contribute entries. Omit or leave empty to include every element in the catalogue that carries a `name`. |
+
+### 5.2 `view_config.display`
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `group_by` | no | `first_letter` | `first_letter` groups entries under an A–Z rail; `none` renders one flat alphabetised list. |
+| `show_type_badge` | no | `true` | Show the source element TYPE next to each entry (e.g. `TERM`, `BUSINESS_OBJECT`). Set `false` for a pure dictionary reading with no provenance shown. |
+
+---
+
+## 6. Entry shape
+
+Each glossary entry, regardless of source TYPE:
+
+| Field | Source | Notes |
+|---|---|---|
+| Name | `<element>.name` | The heading. |
+| Also known as | `<element>.aliases[]` | Rendered as a secondary line under the name, when present. |
+| Definition | `<element>.description` | The body text. An element with no `description` contributes no entry (nothing to define). |
+| Type badge | `<element>` TYPE | Shown when `show_type_badge: true`. |
+
+Entries are sorted alphabetically by `name` (case-insensitive), independent of TYPE, layer, or admission order. Two entries alphabetically adjacent may come from any two TYPEs — the renderer never groups by TYPE unless a future revision adds that as an explicit `group_by` value.
+
+---
+
+## 7. Validation rules
+
+| Rule | Severity | Description |
+|---|---|---|
+| `GLOS-001` | error | `notation` missing or not equal to `glossary`. |
+| `GLOS-002` | error | `id` missing or not matching `GLOSSARY-[<middle>-]<INTEGER>`. |
+| `GLOS-003` | error | `name` missing or empty. |
+| `GLOS-004` | warning | `view_config.scope.types[]` references a value that is not a TYPE in the element registry ([IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §3.1). |
+
+The shared header rules (`HDR-001..004`, [CONTRACT.md](../../CONTRACT.md) §2) apply to glossary documents.
+
+Glossary documents do **not** carry an admission record or primitive lifecycle — they are view configuration, not canon primitives.
+
+---
+
+## 8. References
+
+- `TERM` element schema and the boundary rule against restating a modelled object: [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §7.30.
+- Cross-catalogue name/alias uniqueness gate (`ELEM-ALIAS-001`, extended for `TERM`): [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §9.
+- Named view-config convention (location, naming, listing, re-running): [REPORT_VIEW_CONFIG.md](../REPORT_VIEW_CONFIG.md).
+- Reconstruction invariant — why a view document carries no canonical content of its own: [ELEMENT_PRIMITIVES.md](../../ELEMENT_PRIMITIVES.md) §1.1.
+- ID grammar: [IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §1.
+- View-level TYPE registry (`GLOSSARY`): [IDS_AND_REFERENCES.md](../../IDS_AND_REFERENCES.md) §3.2.

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -42,7 +42,7 @@ methodology_version: "3.4.0"
 #   promotable  the TYPE starts inline and gains a standalone file only when a
 #               SECOND document references it (§1 promotion rule); id never changes
 #
-# 30 live TYPEs. Retired names are under `deprecated_element_types` below and are
+# 31 live TYPEs. Retired names are under `deprecated_element_types` below and are
 # NOT part of that count.
 # ---------------------------------------------------------------------------
 element_types:
@@ -153,6 +153,13 @@ element_types:
     mode: standalone
     layer: 02_business
     folder: 02_business/business-objects/
+    promotable: false
+  TERM:
+    # Business-layer vocabulary entry — name + definition only, no modelled
+    # behaviour. Schema: ELEMENT_PRIMITIVES.md §7.30.
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/terms/
     promotable: false
 
   # --- 03_application ------------------------------------------------------
@@ -865,6 +872,18 @@ rule_codes:
   FRESHNESS-001:
     severity: warning
     spec: notations/CONTRACT.md
+  GLOS-001:
+    severity: error
+    spec: notations/views/reports/32-glossary.md
+  GLOS-002:
+    severity: error
+    spec: notations/views/reports/32-glossary.md
+  GLOS-003:
+    severity: error
+    spec: notations/views/reports/32-glossary.md
+  GLOS-004:
+    severity: warning
+    spec: notations/views/reports/32-glossary.md
   GOALS-001:
     severity: error
     spec: notations/views/diagrams/04-goals.md
@@ -1225,6 +1244,12 @@ rule_codes:
   STAKE-003:
     severity: error
     spec: notations/elements/20-stakeholders.md
+  TERM-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  TERM-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
   TSVC-001:
     severity: error
     spec: notations/ELEMENT_PRIMITIVES.md

--- a/packages/ingest-cli/src/canon.mjs
+++ b/packages/ingest-cli/src/canon.mjs
@@ -20,6 +20,11 @@
 //     one file), so it is collected here as the nameMap is built. A value shared
 //     within a single element's own name/aliases is NOT a collision. repo-check
 //     surfaces the count (data-free) as an integrity red flag.
+//   - TERM extension (ELEMENT_PRIMITIVES §7.30/§9): a TERM's own `name` claim is
+//     ALSO collision-triggering, even when both sides matched on 'name' -- a TERM
+//     restating another element's name is exactly the failure mode the TYPE exists
+//     to prevent, so its name is folded into the alias-collision surface instead of
+//     the ordinary "two plain names may coincide" rule every other TYPE gets.
 
 import { readdir, readFile, access } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
@@ -49,6 +54,10 @@ async function walkYaml(dir) {
 // Normalise a name/alias string for case-insensitive matching (F8).
 function normName(s) { return typeof s === 'string' ? s.trim().toLowerCase() : null; }
 
+// Is this a TERM element id? TERM's own `name` opts into the alias-collision
+// surface (ELEMENT_PRIMITIVES §7.30/§9) -- see the claim() extension below.
+function isTermId(id) { return typeof id === 'string' && id.startsWith('TERM-'); }
+
 // Build a read-only index of canon/ for one org root.
 // Returns { ids: Set, rels: Set, nameMap: Map, collisions: [], unreadable: [] }.
 //   ids        -- admitted element/assertion IDs (for review-queue idempotency).
@@ -77,14 +86,18 @@ export async function buildCanonIndex(orgRoot) {
   // name or alias. Two different elements legitimately sharing a `name` is NOT a
   // collision — names are unique only within a TYPE catalogue (§8), so a Stakeholder
   // and an Actor both named "Operations" is allowed. The same id re-using a value
-  // (an alias equal to its own name) is benign and recorded once.
+  // (an alias equal to its own name) is benign and recorded once. TERM extension:
+  // a TERM id on either side also triggers the collision, even when both sides
+  // matched on 'name' — see the module comment above.
   const claim = (value, id, matched_on) => {
     const key = normName(value);
     if (!key) return;
     const prev = nameMap.get(key);
     if (!prev) { nameMap.set(key, { id, matched_on }); return; }
     if (prev.id === id) return;
-    if (matched_on === 'alias' || prev.matched_on === 'alias') collisions.push({ value, a: prev.id, b: id });
+    if (matched_on === 'alias' || prev.matched_on === 'alias' || isTermId(id) || isTermId(prev.id)) {
+      collisions.push({ value, a: prev.id, b: id });
+    }
   };
 
   for (const file of await walkYaml(canonDir)) {

--- a/packages/ingest-cli/src/canon.test.mjs
+++ b/packages/ingest-cli/src/canon.test.mjs
@@ -1,0 +1,70 @@
+// Unit tests for canon.mjs's alias-uniqueness gate (ELEM-ALIAS-001) and its TERM
+// extension (ELEMENT_PRIMITIVES.md §7.30/§9, transitrix-hq#118).
+//
+// Run: node --test packages/ingest-cli/src/canon.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildCanonIndex } from './canon.mjs';
+
+function tmpOrgRoot() {
+  return mkdtempSync(join(tmpdir(), 'canon-test-'));
+}
+
+function writeElement(root, layer, folder, id, name, extra = '') {
+  const dir = join(root, 'canon', 'elements', layer, folder);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${id}.yaml`), `id: ${id}\nname: "${name}"\n${extra}`, 'utf8');
+}
+
+test('buildCanonIndex: two different elements sharing a plain name is NOT a collision', async () => {
+  const root = tmpOrgRoot();
+  writeElement(root, '01_motivation', 'stakeholders', 'STAKEHOLDER-1', 'Operations');
+  writeElement(root, '02_business', 'actors', 'ACTOR-1', 'Operations');
+  const { collisions } = await buildCanonIndex(root);
+  assert.deepEqual(collisions, []);
+});
+
+test('buildCanonIndex: an alias colliding with another element\'s name IS a collision', async () => {
+  const root = tmpOrgRoot();
+  writeElement(root, '02_business', 'business-objects', 'BUSINESS_OBJECT-1', 'Customer Order');
+  writeElement(root, '02_business', 'roles', 'ROLE-1', 'Order Desk', 'aliases:\n  - "Customer Order"\n');
+  const { collisions } = await buildCanonIndex(root);
+  assert.equal(collisions.length, 1);
+  assert.equal(collisions[0].value, 'Customer Order');
+});
+
+test('buildCanonIndex: a TERM restating another element\'s plain name IS a collision', async () => {
+  const root = tmpOrgRoot();
+  writeElement(root, '02_business', 'business-objects', 'BUSINESS_OBJECT-1', 'Customer Order');
+  writeElement(root, '02_business', 'terms', 'TERM-1', 'Customer Order');
+  const { collisions } = await buildCanonIndex(root);
+  assert.equal(collisions.length, 1);
+  assert.deepEqual([collisions[0].a, collisions[0].b].sort(), ['BUSINESS_OBJECT-1', 'TERM-1']);
+});
+
+test('buildCanonIndex: a TERM admitted first, then a plain-named element reusing it, IS a collision', async () => {
+  const root = tmpOrgRoot();
+  writeElement(root, '02_business', 'terms', 'TERM-1', 'Data Residency');
+  writeElement(root, '01_motivation', 'requirements', 'REQUIREMENT-1', 'Data Residency');
+  const { collisions } = await buildCanonIndex(root);
+  assert.equal(collisions.length, 1);
+});
+
+test('buildCanonIndex: two different TERMs is still not a collision when names differ', async () => {
+  const root = tmpOrgRoot();
+  writeElement(root, '02_business', 'terms', 'TERM-1', 'Data Residency');
+  writeElement(root, '02_business', 'terms', 'TERM-2', 'Data Localisation');
+  const { collisions } = await buildCanonIndex(root);
+  assert.deepEqual(collisions, []);
+});
+
+test('buildCanonIndex: a TERM re-using its own name/alias is not a self-collision', async () => {
+  const root = tmpOrgRoot();
+  writeElement(root, '02_business', 'terms', 'TERM-1', 'Data Residency', 'aliases:\n  - "Data Residency"\n');
+  const { collisions } = await buildCanonIndex(root);
+  assert.deepEqual(collisions, []);
+});

--- a/transitrix/.claude-plugin/plugin.json
+++ b/transitrix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix",
-  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 12 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Integration map, Products, Action Card) + PlantUML rendering, or one of the 4 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric), or a codex artefact.",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 12 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Integration map, Products, Action Card) + PlantUML rendering, or one of the 5 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric, Glossary), or a codex artefact.",
   "version": "0.1.0",
   "author": {
     "name": "Transitrix"

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -335,6 +335,7 @@ Use the matrix below to pick a notation. Full specs at `notations/<NN>-<name>.md
 | Stakeholder-facing document listing design-input requirements grouped under the need each satisfies | **MRD** | `*.mrd.transitrix.yaml` |
 | Software requirements specification — software-tier requirements sectioned by functional / quality | **SRS** | `*.srs.transitrix.yaml` |
 | Design-facing document listing which application/technology elements realise which requirements | **SDD** | `*.sdd.transitrix.yaml` |
+| One flat, alphabetised name → definition lookup across the whole catalogue (TERM entries and every other TYPE's name/aliases/description alike) | **Glossary** | `*.glossary.transitrix.yaml` |
 
 **Family rule:** the strategy-chain notations split by shape. **DGCA** uses the **flat form** — top-level arrays at the document root (`factors[]` / `goals[]` / `changes[]` / `actions[]`), cross-references upstream inside the flat arrays. **Goals tree** and **Action schedule** (both since v2.0) are **pure projections** — the view document carries only `view_config`, and each `GOAL-…` / `ACTION-…` lives as a standalone element file under `canon/elements/…`; the parent link (Goals) and predecessor / duration / cross-refs (Action) live on the element files, not in the view. In all three, hierarchy uses `parent: <SAME-TYPE>-…` on the child; no nested wrapper keys.
 
@@ -367,6 +368,7 @@ Schema: `notations/elements/14-codex.md` for codex; `notations/CONTRACT.md` §5�
 - **Process Blueprint** — `notation: process-blueprint`. Root key `process_blueprint:` with `stages[]` (each carrying `goal` and `result`) and per-aspect arrays `systems[]`, `actors[]`, `equipment[]`, `information_entities[]`. Aspect entries reference the stages they appear in via `stages: [STAGE-…]`.
 - **Compliance Impact** — `notation: compliance-impact`. Report-config over the compliance overlay (sibling of Scenarios). Root key `view:` declaring `subjects` (products / processes), `obligations` (`include` or `filter`), `grouping`, `status_display`, and `empty_cells`. Carries no canonical content — every cell is derived from `ASSERTION` + process flow + `REQUIREMENT` status.
 - **Coverage Metric** — `notation: coverage-metric`. Report-config over the coverage read of canon (sibling of Compliance Impact). Root key `view:` declaring `subjects` (products / processes), `regimes` (`include` or `filter`), `grouping`, `coverage_rule`, and `empty_cells`. Carries no canonical content — counts the subjects with zero admitted obligations per regulatory regime and splits "Not yet modelled" (modelling gap) from "No obligation asserted (modelled fact)" (an admitted `n_a` `ASSERTION`).
+- **Glossary** — `notation: glossary`. Report-config view over the whole catalogue. Root fields `id`, `name`, optional `description`, optional `view_config` (`scope.types[]` to filter by TYPE, `display.group_by` — `first_letter` | `none` — and `display.show_type_badge`). Carries no canonical content — projects `name` / `aliases[]` / `description` from every admitted element, `TERM` (`ELEMENT_PRIMITIVES.md` §7.30) and every other TYPE alike, into one flat, alphabetised lookup surface.
 - **Codex** *(zone primitives, not a view document)* — each artefact is a single `<ID>.yaml` file under `codex/external/<jurisdiction>/` (external: `LAW` / `REGULATION`) or `codex/internal/` (internal: `POLICY` / `INTERNAL_STANDARD`). No `notation:` header; carries the admission record (`CONTRACT.md` §6, `zone: codex`, `gate_checks.source_authority`) plus codex frontmatter (external: `jurisdiction` + `effective_date`; internal: `issuing_authority` + `effective_date`). A codex artefact stores the **source document only** — bindings to entities and processes live on `REQUIREMENT.derived_from` (`notations/elements/15-requirement.md`) and on `ASSERTION` (`notations/elements/16-assertion.md`), not on the codex artefact itself.
 
 ### ID grammar — canon
@@ -428,6 +430,7 @@ The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI
 | MRD | `templates/mrd.mrd.transitrix.yaml` |
 | SRS | `templates/srs.srs.transitrix.yaml` |
 | SDD | `templates/sdd.sdd.transitrix.yaml` |
+| Glossary | `templates/glossary.glossary.transitrix.yaml` |
 
 ### Codex zone primitives (drop into `codex/external/<jurisdiction>/` or `codex/internal/` in Step 3)
 

--- a/transitrix/skills/onboard/templates/glossary.glossary.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/glossary.glossary.transitrix.yaml
@@ -1,0 +1,18 @@
+notation: glossary
+spec_version: "0.1"
+
+# Glossary. Spec: notations/views/reports/32-glossary.md
+# Report-config view over the whole catalogue.
+# No entry is defined here — it is a projection over every admitted
+# element's name / aliases[] / description, TERM and modelled objects alike.
+
+id: GLOSSARY-FILL-ME-1
+name: "FILL-ME — Full Glossary"
+description: "FILL-ME — what this glossary covers, e.g. every named element across the catalogue, alphabetised"
+
+view_config:
+  scope:
+    types: []                 # ELEMENT TYPEs to include; omit or [] = every TYPE
+  display:
+    group_by: "first_letter"  # "first_letter" | "none"
+    show_type_badge: true     # show the source TYPE next to each entry


### PR DESCRIPTION
## Summary
- Adds `TERM` (business-layer vocabulary, ArchiMate Meaning) as a new standalone element TYPE — name + definition only, no modelled behaviour.
- Extends the `ELEM-ALIAS-001` cross-catalogue uniqueness gate so a `TERM`'s own `name` also participates in collision detection — restating an existing element's definition under a new `TERM` fails admission.
- Adds the generated glossary report view (`notations/views/reports/32-glossary.md`) — projects `name`/`aliases[]`/`description` from `TERM` and every other TYPE into one flat, alphabetised lookup surface.
- Registers `TERM`/`GLOSSARY` in the vocabulary, ID grammar, and rule-codes tables; adds unit tests for the collision-gate extension; wires the new test into CI.

## Test plan
- [x] `node --test packages/ingest-cli/src/canon.test.mjs` — 6/6 pass
- [x] `node scripts/check-notations.mjs` — doc-lint clean

closes THQ-118