### PR TITLE
ci(dependabot): cover document-renderer and document-view-engine manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Four independently published CLI packages — each is its own manifest.
+  # Independently published npm packages under packages/ — each is its own manifest.
   - package-ecosystem: "npm"
     directory: "/packages/decisions-cli"
     schedule:
@@ -27,6 +27,22 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/packages/reqif-cli"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/packages/document-renderer"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/packages/document-view-engine"
     schedule:
       interval: "weekly"
     ignore:


### PR DESCRIPTION
## Summary
- Add the two npm manifests under `packages/document-renderer` and `packages/document-view-engine` to `.github/dependabot.yml` — they landed after the config was written and were never added, so Dependabot was only watching 4 of the 6 npm packages in the tree.
- Corrected the now-stale comment above the npm block ("Four independently published CLI packages") — two of the six are not CLIs.

## Context
Found while surveying this repo's Deliverable A (continuous updates) coverage for the family's dependency-maintenance epic. No other manifest types (pip, Docker) exist in this repo.

## Test plan
- [x] Re-read the file in full after editing to confirm no truncation, structure matches the existing five entries
- [x] Confirmed all 6 `package.json` files under `packages/` now have a corresponding dependabot entry
- [x] Confirmed no other manifest types (requirements.txt, Pipfile, Dockerfile) exist in this repo
- [ ] CI green