### PR TITLE
ci(hygiene): run public-surface scan on push to main

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -48,9 +48,17 @@ name: Public-surface hygiene
 #   so it is checked by content rather than banned by name. Safe no-op when
 #   the secret is unset. Same never-print discipline as above — file path
 #   only, never the matched term.
+#
+# Runs on push to main as well as on pull requests, so a direct push bypasses
+# nothing the PR path would have caught. On a push event there is no PR
+# title/body (those variables resolve empty and simply match nothing) and the
+# diff range is github.event.before..github.event.after rather than the PR's
+# base/head.
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-hygiene:
@@ -70,8 +78,8 @@ jobs:
           BLOCKLIST_3: ${{ secrets.HYGIENE_BLOCKLIST_3 }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event_name == 'push' && github.event.after || github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
@@ -389,8 +397,8 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event_name == 'push' && github.event.after || github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- The public-surface hygiene workflow only triggered on `pull_request`, so a direct push to `main` bypassed the guard entirely.
- Adds a `push` trigger scoped to `main`; the diff/commit-message range now resolves to `before..after` on a push event and to the PR's base/head otherwise. PR title/body already resolve empty on a push and match nothing, so no other step needed changes.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/public-surface-hygiene.yml'))"` parses cleanly, triggers confirmed as `{pull_request: None, push: {branches: [main]}}`
- [ ] First push-triggered run on `main` completes green (can't be exercised from a branch — worth a look after merge)