### PR TITLE
feat(document-renderer): pass 2, run record, and PDF output

### DIFF
--- a/.github/workflows/document-renderer-test.yml
+++ b/.github/workflows/document-renderer-test.yml
@@ -16,6 +16,13 @@ name: document-renderer test
 # frozen output is what an independent implementation checks itself against. It
 # never regenerates the fixture; a failure is a regression or a deliberate,
 # separately reviewed re-freeze.
+#
+# Pass 2, the run record and PDF output are agent-free too: pass 2 takes the
+# agent as a caller-supplied `fill` hook (never calling one itself); the run
+# record is a pure function over its inputs; and PDF output is a hand-rolled,
+# dependency-free Markdown-to-PDF writer (no external tool, no npm dependency)
+# — every check in this workflow runs unconditionally, nothing is skipped for
+# lack of an installed binary.
 
 on:
   pull_request:
@@ -48,3 +55,15 @@ jobs:
 
       - name: Run conformance tests (frozen fixture)
         run: node packages/document-renderer/tests/test_conformance.mjs
+
+      - name: Run pass-2 tests (instruction-slot filling)
+        run: node packages/document-renderer/tests/test_pass2.mjs
+
+      - name: Run run-record tests
+        run: node packages/document-renderer/tests/test_run_record.mjs
+
+      - name: Run PDF-output tests
+        run: node packages/document-renderer/tests/test_render_pdf.mjs
+
+      - name: Run full-run end-to-end test
+        run: node packages/document-renderer/tests/test_full_run.mjs

--- a/packages/document-renderer/README.md
+++ b/packages/document-renderer/README.md
@@ -1,8 +1,10 @@
 # @transitrix/document-renderer
 
 **The reference implementation of the `{{ … }}` directive language** — parser for
-the `.ttrs` document-template format and its pass 1 deterministic resolver,
-which runs and is testable with no agent present.
+the `.ttrs` document-template format, its pass 1 deterministic resolver (which
+runs and is testable with no agent present), pass 2 (which fills the
+instruction slots pass 1 left, through a caller-supplied agent hook), the run
+record, and PDF output.
 
 ## This is a reference implementation, not a product
 
@@ -193,6 +195,126 @@ import { parseTemplate } from '@transitrix/document-renderer/src/parse-template.
 const { header, ast, errors } = parseTemplate(text);
 ```
 
+## Pass 2 — filling instruction slots
+
+Pass 2 fills the instruction slots pass 1 left untouched. It is **agent-agnostic
+by construction**: the agent is a caller-supplied `fill` hook, the same shape as
+pass 1's `rasterise` hook for figures. Nothing in `pass2.mjs` calls a model —
+it orchestrates one.
+
+```js
+import { runPass1 } from '@transitrix/document-renderer/src/pass1.mjs';
+import { runPass2 } from '@transitrix/document-renderer/src/pass2.mjs';
+
+const { markdown, instructionSlots } = await runPass1({ text, templatePath });
+
+const { markdown: finalMarkdown, slotResults } = await runPass2({
+  markdown,
+  instructionSlots,
+  fill: async ({ slotId, question, inputs, sufficient }) => {
+    // Call an agent, or anything else that can execute the instruction.
+    // Return exactly one of:
+    return { status: 'sufficient', text: '…', attributions: inputs };
+    // or:
+    // return { status: 'insufficient' };
+  },
+});
+```
+
+The structural rules below are normative (the 2026-08-12 decision "an
+instruction slot specifies the outcome, not the procedure", accepted
+2026-08-15) — pass 2 enforces them; it does not itself judge whether a
+filler's answer is good, only whether the slot was fillable at all and what the
+filler reported:
+
+| Rule | What pass 2 does |
+|---|---|
+| `inputs:` is a closed list | A slot declaring **none** is not fillable by a conforming implementation — `fill` is **never called** for it; the slot resolves `not-attempted`, reason `no declared inputs`. A filler that attributes to an id outside the slot's declared `inputs:` is rejected (`TypeError`) — the one part of the attribution obligation this module can check mechanically. |
+| No `fill` configured | Every slot resolves `not-attempted`, reason `no filler configured` — pass 2 with no agent behaves like pass 1 alone. |
+| Attribution is mostly the filler's obligation | Pass 2 carries whatever `attributions` the filler reports and rejects any outside the closed input list; it does not itself verify that a given *sentence* is actually supported by what it cites — that content-level obligation binds the filler, per the decision's §4. |
+| Insufficient is declared, not padded | `{ status: 'insufficient' }` renders the section as `*Open — not answered.*` — never as text that reads like an answer. |
+| Self-disclosure | A `sufficient` slot's text is followed by a fixed sentence stating the section was machine-produced and not admitted through a review gate. |
+
+`slotResults` is what the run record is built from: every slot, in document
+order, each carrying `{ slotId, question, inputs, sufficient, verdict, reason,
+text }` — `verdict` is `sufficient` · `insufficient` · `not-attempted`.
+
+## The run record
+
+The third of a full run's three artefacts, alongside Markdown and the PDF:
+template id and version, repository commit, model id, run timestamp, and — per slot, including
+every slot that produced nothing — the instruction and its verdict.
+
+`buildRunRecord` is a **pure function over its inputs**. It reads no
+filesystem and no git — `repositoryCommit` (which commit the repository was
+read at) and `modelId` (which model ran pass 2) are facts about the run's
+environment that only the caller has, the same way `renderDate` is pass 1's
+own input rather than something it derives from the clock.
+
+```js
+import { buildRunRecord, serializeRunRecord }
+  from '@transitrix/document-renderer/src/run-record.mjs';
+
+const record = buildRunRecord({
+  header,                    // pass 1's `header`
+  repositoryCommit,          // e.g. `git rev-parse HEAD` in the repository the caller read;
+                              // null when no repository was configured for this run
+  modelId,                   // identifies which model ran pass 2; null when nothing was filled
+  renderDate,                 // pass 1's renderDate
+  runTimestamp,               // ISO 8601 — when this run happened; defaults to now if omitted
+  profile: 'strict',
+  slotResults,                // pass 2's slotResults
+});
+
+await writeFile(`${name}.run.json`, serializeRunRecord(record));
+```
+
+`record.slots` carries every slot pass 2 reported, in document order —
+`slot_id`, `question`, `inputs`, `sufficient`, `verdict`, `reason`,
+`produced_text`, `attributions` — including a slot whose verdict is
+`not-attempted`: a slot absent from the record would be indistinguishable from
+one that was never in the template at all.
+
+## PDF output
+
+The third artefact per run alongside Markdown and the run record — a
+**hand-rolled, dependency-free** Markdown-to-PDF writer. Every package in this
+repository ships zero runtime dependencies (`package.json`); a full HTML/PDF
+pipeline would break that posture for one output format, so this module
+assembles a minimal, valid PDF directly (a Catalog, a Pages tree, one shared
+Type1 Helvetica font, one Page + content stream per page) rather than shelling
+out to an external renderer.
+
+```js
+import { renderMarkdownToPdf } from '@transitrix/document-renderer/src/render-pdf.mjs';
+
+const pdfBytes = renderMarkdownToPdf(finalMarkdown);
+await writeFile(`${name}.pdf`, pdfBytes);
+```
+
+This is **named, not silent, scope** — not a general Markdown renderer: bold
+and italic markers are stripped rather than styled, and a figure (`{{ view
+… }}` / `{{ figure … }}`, already resolved to a Markdown image by pass 1)
+becomes a text placeholder — `[Figure: <caption>]` — never rasterised, since
+embedding an image is a separate, larger feature this module does not take
+on. A reader comparing the PDF to the Markdown will see plainer typography and
+a placeholder where a figure was, not a missing section.
+
+**A4 is non-negotiable** — an explicit constraint on this output. Every page
+this module emits declares `/MediaBox [0 0 595 842]` (A4 at 72dpi) outright,
+because a renderer that omits the declaration defaults to US Letter and
+silently spills the last 18mm onto a second page. Pagination breaks a new page
+whenever the next line would cross the bottom margin — a long document spans
+more than one `/Page` automatically, never truncated.
+
+Base-14 `Helvetica` needs no font embedding, so this module ships no font
+file. Text outside printable ASCII is sanitised: common prose punctuation
+(en/em dashes, curly quotes, an ellipsis) maps to its nearest ASCII
+equivalent, and this package's own failure markers (`«unresolved: …»`, `⚑U`)
+map to a bracketed/plain-letter form that stays legible; anything left maps to
+`?` rather than corrupting the byte stream — the base-14 fonts are not
+expected to carry full Unicode.
+
 ## Failure discipline
 
 An unresolvable reference **fails the run by name**. It never renders as empty
@@ -290,11 +412,17 @@ that never checked — that is the one failure mode which reads as success.
 node packages/document-renderer/tests/test_parse_template.mjs
 node packages/document-renderer/tests/test_pass1.mjs
 node packages/document-renderer/tests/test_conformance.mjs
+node packages/document-renderer/tests/test_pass2.mjs
+node packages/document-renderer/tests/test_run_record.mjs
+node packages/document-renderer/tests/test_render_pdf.mjs
+node packages/document-renderer/tests/test_full_run.mjs
 ```
 
 `tests/fixtures/product.mrd.ttrs` is a complete worked template — every slot kind,
 one instruction slot — rendered end-to-end against `tests/fixtures/canon/` by the
-pass-1 suite.
+pass-1 suite. `test_full_run.mjs` carries that same template all the way through
+pass 2, the run record and the PDF, the way an adopter's CLI would compose the
+four modules — the full loop an adopter's CLI is expected to complete.
 
 ## Conformance fixture
 
@@ -328,11 +456,19 @@ comparison would hold on one platform only.
 
 ## Scope
 
-Pass 1 only. Filling instruction slots, emitting the run record, and PDF output
-are not in this package. Nothing here calls a model, and nothing here may —
-rendering happens in the CLI, never the agent.
+Pass 1, pass 2, the run record and PDF output. **Nothing in this package calls
+a model, and nothing in it may** — pass 1 has no agent-shaped input to call one
+with at all, and pass 2's model is a caller-supplied `fill` hook it only
+orchestrates. Rendering happens in the CLI, never the agent; this package is
+the library a CLI composes, not the agent invocation itself.
 
 `{{# instruct … }}` stays in the grammar and in the specification — a notation
-expresses the slot; who fills it is an implementation's property — but nothing
-here executes one. Pass 1 copies each slot through byte-for-byte so the unfilled
-section is visible in the output rather than silently blank.
+expresses the slot; who fills it is an implementation's property. Pass 1
+copies each slot through byte-for-byte so the unfilled section is visible in
+the output rather than silently blank; pass 2 fills what its caller's `fill`
+hook can fill and leaves the rest exactly as visibly open, per the accepted
+2026-08-12 decision.
+
+Out of scope, still: choosing or running an actual agent (that is the CLI's
+or the adopter's), and rasterising a figure into the PDF (named as a text
+placeholder instead — see [PDF output](#pdf-output)).

--- a/packages/document-renderer/package.json
+++ b/packages/document-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@transitrix/document-renderer",
   "version": "0.0.1",
-  "description": "Parser for the .ttrs document-template format and its pass 1 deterministic resolver — resolves model-object references and derived figures with no agent present, leaving instruction slots for pass 2.",
+  "description": "Reference implementation of the .ttrs document-template format: pass 1 (deterministic resolution, no agent present), pass 2 (instruction-slot filling via a caller-supplied agent hook), the run record, and dependency-free PDF output.",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/packages/document-renderer/src/pass2.mjs
+++ b/packages/document-renderer/src/pass2.mjs
@@ -1,0 +1,156 @@
+// Pass 2 — fills the instruction slots pass 1 left untouched.
+//
+// Pass 1 is deterministic and calls no model (pass1.mjs). Pass 2 is the other
+// half of the two-pass split: "an agent, executing the instruction the slot
+// carries". This module stays agent-agnostic on purpose —
+// it takes the agent as a caller-supplied `fill` hook, the same shape pass 1
+// already uses for figure rasterisation (`rasterise`). Nothing in this file
+// calls a model; it orchestrates a caller-supplied one.
+//
+// The rules below are normative — the 2026-08-12 decision "an instruction
+// slot specifies the outcome, not the procedure" (accepted 2026-08-15):
+//
+//   * `inputs:` is a closed list. A slot declaring none is not fillable by a
+//     conforming implementation — it renders open, verdict `not-attempted`,
+//     and `fill` is never called for it.
+//   * Every statement in a filled slot is attributable to a declared input —
+//     that is the filler's obligation, not this module's; pass 2 only carries
+//     the filler's own account of what it used, and rejects the one part of
+//     that account it CAN check mechanically: an attribution outside the
+//     slot's own declared `inputs:` is a closed-list violation, not a content
+//     question, so it throws rather than passing it through.
+//   * An insufficient answer is declared, not padded — a slot the filler could
+//     not fill to `sufficient:` stays visibly open, never dressed up as text
+//     that reads like an answer.
+//   * The run record — built from this module's `slotResults`, see
+//     run-record.mjs — carries a verdict per slot: `sufficient`,
+//     `insufficient`, or `not-attempted`.
+//
+// Scope: filling slots and rewriting the markdown they sit in. Nothing here
+// writes to the model, and nothing here decides what a "sufficient" answer
+// looks like beyond what the filler itself reports.
+
+// Matches a `{{# instruct <slot-id> }} … {{/ instruct }}` span, verbatim, the
+// same shape pass 1 copies through untouched
+// (DIRECTIVE_LANGUAGE.md §4.2 — the body is opaque). Pass 2 deliberately does
+// not re-parse the slot body; it locates the span in pass 1's own markdown
+// output and treats it as a unit to replace, matching pass1's instructionSlots
+// (by document order) for the instruction text.
+const INSTRUCT_SPAN = /\{\{#\s*instruct\s+([a-z0-9][a-z0-9-]*)\s*\}\}[\s\S]*?\{\{\/\s*instruct\s*\}\}/g;
+
+const OPEN_MARKER = '*Open — not answered.*';
+const DISCLOSURE =
+  '\n\n*This section was produced by an automated pass; it has not been admitted through a review gate.*';
+
+function notAttempted(slot, reason) {
+  return { ...slot, verdict: 'not-attempted', reason, text: null };
+}
+
+async function resolveSlot(slot, fill) {
+  if (slot.inputs.length === 0) {
+    return notAttempted(slot, 'no declared inputs');
+  }
+  if (typeof fill !== 'function') {
+    return notAttempted(slot, 'no filler configured');
+  }
+
+  const outcome = await fill({
+    slotId: slot.slotId,
+    question: slot.question,
+    inputs: slot.inputs,
+    sufficient: slot.sufficient,
+  });
+
+  if (!outcome || (outcome.status !== 'sufficient' && outcome.status !== 'insufficient')) {
+    throw new TypeError(
+      `pass2: fill(${JSON.stringify(slot.slotId)}) must resolve to `
+      + '{ status: "sufficient", text } or { status: "insufficient" }, '
+      + `got ${JSON.stringify(outcome)}`,
+    );
+  }
+
+  if (outcome.status === 'insufficient') {
+    return { ...slot, verdict: 'insufficient', reason: null, text: null };
+  }
+
+  if (typeof outcome.text !== 'string' || outcome.text.trim() === '') {
+    throw new TypeError(
+      `pass2: fill(${JSON.stringify(slot.slotId)}) reported "sufficient" with no text`,
+    );
+  }
+
+  const attributions = Array.isArray(outcome.attributions) ? outcome.attributions : [];
+  // The closed-input discipline (2026-08-12 ADR §3, §6) is mechanically checkable
+  // at this one point: a filler cannot attribute a statement to something it was
+  // never given. Content-level attribution — that each *sentence* is actually
+  // supported by what it cites — stays the filler's own obligation; this module
+  // only enforces that it cited from the set it was allowed to read.
+  const undeclared = attributions.filter((a) => !slot.inputs.includes(a));
+  if (undeclared.length > 0) {
+    throw new TypeError(
+      `pass2: fill(${JSON.stringify(slot.slotId)}) attributed to ${JSON.stringify(undeclared)}, `
+      + `not in this slot's declared inputs ${JSON.stringify(slot.inputs)} — inputs is a closed list`,
+    );
+  }
+
+  return {
+    ...slot,
+    verdict: 'sufficient',
+    reason: null,
+    text: outcome.text,
+    attributions,
+  };
+}
+
+/**
+ * Run pass 2 over pass 1's output.
+ *
+ * @param {object} options
+ * @param {string} options.markdown          pass 1's `markdown` — instruction
+ *                                            slots still present verbatim
+ * @param {Array}  options.instructionSlots   pass 1's `instructionSlots`, in
+ *                                            document order
+ * @param {Function} [options.fill]           `(slot) => Promise<{status, text?}>`
+ *                                            — the agent. Omitted entirely, every
+ *                                            slot resolves `not-attempted` and pass 2
+ *                                            behaves like pass 1 alone: unfilled and
+ *                                            visible.
+ * @returns {Promise<{markdown, slotResults}>}
+ */
+export async function runPass2({ markdown, instructionSlots, fill } = {}) {
+  const spans = [...markdown.matchAll(INSTRUCT_SPAN)];
+  if (spans.length !== instructionSlots.length) {
+    throw new Error(
+      `pass2: markdown carries ${spans.length} instruction slot(s) but `
+      + `instructionSlots lists ${instructionSlots.length} — pass 2 must run `
+      + 'against the markdown pass 1 produced for the same template',
+    );
+  }
+  for (let i = 0; i < spans.length; i++) {
+    if (spans[i][1] !== instructionSlots[i].slotId) {
+      throw new Error(
+        `pass2: slot order mismatch at position ${i} — markdown has `
+        + `"${spans[i][1]}", instructionSlots has "${instructionSlots[i].slotId}"`,
+      );
+    }
+  }
+
+  const slotResults = [];
+  for (const slot of instructionSlots) {
+    slotResults.push(await resolveSlot(slot, fill));
+  }
+
+  let cursor = 0;
+  let out = '';
+  let i = 0;
+  for (const match of markdown.matchAll(INSTRUCT_SPAN)) {
+    out += markdown.slice(cursor, match.index);
+    const result = slotResults[i];
+    out += result.verdict === 'sufficient' ? `${result.text}${DISCLOSURE}` : OPEN_MARKER;
+    cursor = match.index + match[0].length;
+    i++;
+  }
+  out += markdown.slice(cursor);
+
+  return { markdown: out, slotResults };
+}

--- a/packages/document-renderer/src/render-pdf.mjs
+++ b/packages/document-renderer/src/render-pdf.mjs
@@ -1,0 +1,231 @@
+// Markdown → PDF, hand-rolled and dependency-free.
+//
+// Every package in this repository ships with zero runtime dependencies
+// (`package.json`'s `dependencies` is `{}` throughout, and `ids.mjs`/
+// `syntax.mjs` hand-roll ID grammar and a YAML-front-matter reader for the
+// same reason). A full-fidelity Markdown renderer or an HTML-to-PDF pipeline
+// would break that posture for one output format. What this module produces
+// instead is a plain, paginated PDF: headings, paragraphs (word-wrapped,
+// bold/italic markers stripped rather than styled), and figures reduced to a
+// text placeholder — never rasterised, since embedding an image is a second,
+// larger feature this module deliberately does not take on.
+//
+// This is named, not silent, scope: a reader comparing the PDF to the
+// Markdown will see plainer typography and a placeholder where a figure was.
+// What is NOT negotiable is an explicit constraint on this output — the page
+// size. **A4, declared explicitly**, because a renderer that omits the
+// declaration defaults to US Letter and silently spills the last 18mm onto a
+// second page. A4 at 72 dpi is 595 x 842 pt; every page this module emits
+// carries that exact `/MediaBox`.
+//
+// The base-14 font `Helvetica` needs no embedding — every conformant PDF
+// reader carries it — so this module ships no font file either.
+
+const PAGE_WIDTH = 595; // A4, 72dpi — an explicit constraint on this output
+const PAGE_HEIGHT = 842;
+const MARGIN = 56; // ~20mm
+const USABLE_WIDTH = PAGE_WIDTH - 2 * MARGIN;
+
+const BODY_SIZE = 11;
+const HEADING_SIZE = { 1: 18, 2: 15, 3: 13 };
+const LINE_HEIGHT = 1.4; // multiple of font size
+const PARAGRAPH_GAP = BODY_SIZE * 0.9;
+const HEADING_GAP_BEFORE = { 1: BODY_SIZE * 1.6, 2: BODY_SIZE * 1.3, 3: BODY_SIZE };
+
+// Helvetica has no fixed width, but every layout decision here only needs to
+// avoid overflowing the page, not to justify text — an average glyph width
+// of half the font size is close enough for that, and keeps this file free
+// of a 256-entry width table.
+const AVG_CHAR_WIDTH_FACTOR = 0.52;
+
+// Characters this module's own output can contain (the `«unresolved: …»` /
+// `⚑U` markers pass 1 and pass 2 emit) plus common prose punctuation, mapped
+// to their nearest WinAnsi/ASCII equivalent. Anything left outside printable
+// ASCII after this pass becomes `?` rather than corrupting the byte stream —
+// the base-14 fonts are not expected to carry full Unicode.
+const CHAR_MAP = {
+  '–': '-', // en dash
+  '—': '--', // em dash
+  '‘': "'",
+  '’': "'",
+  '“': '"',
+  '”': '"',
+  '…': '...',
+  '«': '<<', // «
+  '»': '>>', // »
+  '⚑': '!', // ⚑
+  '☐': '[ ]',
+};
+
+function sanitize(text) {
+  let out = '';
+  for (const ch of text) {
+    if (CHAR_MAP[ch] !== undefined) { out += CHAR_MAP[ch]; continue; }
+    const code = ch.codePointAt(0);
+    out += (code >= 0x20 && code <= 0x7E) ? ch : '?';
+  }
+  return out;
+}
+
+function stripEmphasis(text) {
+  return text.replace(/\*\*(.+?)\*\*/g, '$1').replace(/__(.+?)__/g, '$1').replace(/`(.+?)`/g, '$1');
+}
+
+// Greedy word wrap at a given font size, using the average-width estimate.
+function wrap(text, size) {
+  const maxChars = Math.max(1, Math.floor(USABLE_WIDTH / (size * AVG_CHAR_WIDTH_FACTOR)));
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current === '' ? word : `${current} ${word}`;
+    if (candidate.length > maxChars && current !== '') {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current !== '') lines.push(current);
+  return lines.length > 0 ? lines : [''];
+}
+
+const HEADING_RE = /^(#{1,3})\s+(.*)$/;
+const IMAGE_RE = /^!\[(.*?)\]\((.*?)\)$/;
+
+// Blocks: 'heading' | 'paragraph' | 'figure'. Blank lines separate
+// paragraphs; a heading or a figure line is always its own block.
+function toBlocks(markdown) {
+  const blocks = [];
+  let paragraph = [];
+  const flush = () => {
+    if (paragraph.length > 0) { blocks.push({ type: 'paragraph', text: paragraph.join(' ') }); paragraph = []; }
+  };
+  for (const raw of markdown.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === '') { flush(); continue; }
+    const heading = HEADING_RE.exec(line);
+    if (heading) { flush(); blocks.push({ type: 'heading', level: heading[1].length, text: heading[2] }); continue; }
+    const image = IMAGE_RE.exec(line);
+    if (image) { flush(); blocks.push({ type: 'figure', caption: image[1] }); continue; }
+    paragraph.push(line);
+  }
+  flush();
+  return blocks;
+}
+
+// Blocks → laid-out lines, each carrying its own font size and the vertical
+// gap to leave before it. Pagination (render-pdf.mjs's other half) only
+// needs to walk this list and break pages on overflow — it does not need to
+// know it came from Markdown at all.
+function layout(markdown) {
+  const lines = [];
+  for (const block of toBlocks(markdown)) {
+    if (block.type === 'heading') {
+      const size = HEADING_SIZE[block.level] ?? HEADING_SIZE[3];
+      const wrapped = wrap(sanitize(stripEmphasis(block.text)), size);
+      wrapped.forEach((text, i) => {
+        lines.push({ text, size, gapBefore: i === 0 ? HEADING_GAP_BEFORE[block.level] ?? HEADING_GAP_BEFORE[3] : 0 });
+      });
+    } else if (block.type === 'figure') {
+      // Rasterising a figure into the PDF is out of scope (module header) —
+      // named here as a placeholder rather than silently dropped.
+      const text = sanitize(`[Figure: ${block.caption || 'untitled'}]`);
+      lines.push({ text, size: BODY_SIZE, gapBefore: PARAGRAPH_GAP });
+    } else {
+      const wrapped = wrap(sanitize(stripEmphasis(block.text)), BODY_SIZE);
+      wrapped.forEach((text, i) => {
+        lines.push({ text, size: BODY_SIZE, gapBefore: i === 0 ? PARAGRAPH_GAP : 0 });
+      });
+    }
+  }
+  return lines;
+}
+
+// Lines → pages, each page a list of { text, size, x, y } ready to place in
+// a content stream. A line whose own gap plus height would cross the bottom
+// margin starts a new page instead.
+function paginate(lines) {
+  const pages = [];
+  let page = [];
+  let cursorY = PAGE_HEIGHT - MARGIN;
+  const newPage = () => { pages.push(page); page = []; cursorY = PAGE_HEIGHT - MARGIN; };
+  for (const line of lines) {
+    const advance = line.gapBefore + line.size * LINE_HEIGHT;
+    if (cursorY - advance < MARGIN && page.length > 0) newPage();
+    cursorY -= line.gapBefore + line.size;
+    page.push({ text: line.text, size: line.size, x: MARGIN, y: cursorY });
+    cursorY -= line.size * (LINE_HEIGHT - 1);
+  }
+  pages.push(page); // always at least one page, even for an empty document
+  return pages;
+}
+
+function escapePdfString(text) {
+  return text.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}
+
+function contentStreamFor(page) {
+  const ops = ['BT'];
+  for (const line of page) {
+    ops.push(`/F1 ${line.size} Tf`);
+    ops.push(`1 0 0 1 ${line.x} ${line.y} Tm`);
+    ops.push(`(${escapePdfString(line.text)}) Tj`);
+  }
+  ops.push('ET');
+  return ops.join('\n');
+}
+
+// Assembles a minimal, valid PDF: a Catalog, a Pages tree, one Type1
+// Helvetica font shared by every page, and one Page + one Contents object
+// per page. Byte offsets for the xref table are tracked as each object is
+// appended, in the same pass — there is no second pass over the buffer.
+function assemblePdf(pages) {
+  const objects = [];
+  objects.push('<< /Type /Catalog /Pages 2 0 R >>'); // 1
+  const pageObjNums = pages.map((_, i) => 4 + 2 * i);
+  const contentObjNums = pages.map((_, i) => 5 + 2 * i);
+  objects.push(`<< /Type /Pages /Kids [${pageObjNums.map((n) => `${n} 0 R`).join(' ')}] /Count ${pages.length} >>`); // 2
+  objects.push('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>'); // 3
+  pages.forEach((page, i) => {
+    const contentNum = contentObjNums[i];
+    objects.push(
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${PAGE_WIDTH} ${PAGE_HEIGHT}] `
+      + `/Resources << /Font << /F1 3 0 R >> >> /Contents ${contentNum} 0 R >>`,
+    ); // page object
+    const stream = contentStreamFor(page);
+    objects.push({ stream }); // content object, marked so we know to wrap it as a stream
+  });
+
+  let out = '%PDF-1.4\n';
+  const offsets = [];
+  objects.forEach((obj, i) => {
+    offsets.push(out.length);
+    const num = i + 1;
+    if (typeof obj === 'object' && obj.stream !== undefined) {
+      const length = Buffer.byteLength(obj.stream, 'latin1');
+      out += `${num} 0 obj\n<< /Length ${length} >>\nstream\n${obj.stream}\nendstream\nendobj\n`;
+    } else {
+      out += `${num} 0 obj\n${obj}\nendobj\n`;
+    }
+  });
+
+  const xrefOffset = out.length;
+  let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) xref += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  out += xref;
+  out += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return Buffer.from(out, 'latin1');
+}
+
+/**
+ * Render Markdown to a PDF, A4, one Helvetica text stream per page.
+ *
+ * @param {string} markdown
+ * @returns {Buffer} PDF bytes
+ */
+export function renderMarkdownToPdf(markdown) {
+  const pages = paginate(layout(String(markdown ?? '')));
+  return assemblePdf(pages);
+}

--- a/packages/document-renderer/src/run-record.mjs
+++ b/packages/document-renderer/src/run-record.mjs
@@ -1,0 +1,75 @@
+// The run record — the third artefact a full render produces, beside the
+// Markdown and the PDF.
+//
+// What it must carry:
+//
+//   template id and version, repository commit, model id, run timestamp
+//   (ISO 8601), and per instruction slot the instruction text and the text
+//   it produced — every slot, including those that produced nothing.
+//
+// The 2026-08-12 ADR adds one more field per slot: a verdict —
+// `sufficient` / `insufficient` / `not-attempted` — because that is the
+// evidence a reader needs to tell "this section is missing" from "this
+// section was tried and the model could not support an answer". This module
+// only assembles the record; it computes nothing pass 1 and pass 2 have not
+// already decided.
+//
+// This is a pure function over its inputs. It does not read the filesystem
+// or git — `repositoryCommit` and `modelId` are the caller's to supply,
+// because "which commit" and "which model" are facts about the run's
+// environment, not something a record-builder can discover on its own
+// without inventing a dependency this package does not otherwise carry.
+
+/**
+ * @param {object} options
+ * @param {object} options.header          pass 1's `header` — carries
+ *                                          `template_id` and `template_version`
+ * @param {string} [options.repositoryCommit] the commit the repository was
+ *                                          read at; `null` when no repository
+ *                                          was configured for this run
+ * @param {string} [options.modelId]       identifies which model ran pass 2;
+ *                                          `null` when pass 2 filled nothing
+ *                                          (no `fill` supplied)
+ * @param {string} [options.runTimestamp]  ISO 8601 timestamp; defaults to now
+ * @param {string} options.renderDate      pass 1's `renderDate` — the date
+ *                                          validity was resolved at
+ * @param {string} options.profile         pass 1's `profile` — `strict` | `review`
+ * @param {Array}  options.slotResults     pass 2's `slotResults`, in document order
+ * @returns {object} a plain, JSON-serialisable run record
+ */
+export function buildRunRecord({
+  header, repositoryCommit = null, modelId = null, runTimestamp, renderDate, profile, slotResults = [],
+} = {}) {
+  if (!header) {
+    throw new TypeError('buildRunRecord: header is required — pass 1 must have parsed the template');
+  }
+  return {
+    template_id: header.template_id,
+    template_version: header.template_version,
+    repository_commit: repositoryCommit,
+    model_id: modelId,
+    run_timestamp: runTimestamp ?? new Date().toISOString(),
+    render_date: renderDate,
+    profile,
+    // Every slot pass 1 found, in document order — including one that
+    // produced nothing. A slot absent from this list would be indistinguishable
+    // from a slot that was never in the template at all.
+    slots: slotResults.map((s) => ({
+      slot_id: s.slotId,
+      question: s.question,
+      inputs: s.inputs,
+      sufficient: s.sufficient,
+      verdict: s.verdict,
+      reason: s.reason ?? null,
+      produced_text: s.text ?? null,
+      attributions: s.attributions ?? [],
+    })),
+  };
+}
+
+// Newline-terminated, stable key order (object literals above already fix
+// it) — the record is written as one file, not diffed field-by-field, so
+// pretty JSON is the readable choice over a packed one.
+export function serializeRunRecord(record) {
+  return `${JSON.stringify(record, null, 2)}\n`;
+}

--- a/packages/document-renderer/tests/test_full_run.mjs
+++ b/packages/document-renderer/tests/test_full_run.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// End-to-end test: the whole loop a full run must complete, run against the
+// package's own committed template — pass 1, pass 2, the run record, and PDF —
+// composed exactly as an adopter's CLI would compose them. This package ships
+// none of that composition as a product (README: "reference implementation,
+// not a product"); this test exists so the loop is exercised at least once,
+// the way `product.mrd.ttrs` was chosen ("one instruction slot is enough to
+// exercise the whole loop").
+//
+// Acceptance criterion exercised: a full run emits all three artefacts, and
+// the PDF reports A4.
+//
+// Run: node packages/document-renderer/tests/test_full_run.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runPass1 } from '../src/pass1.mjs';
+import { runPass2 } from '../src/pass2.mjs';
+import { buildRunRecord, serializeRunRecord } from '../src/run-record.mjs';
+import { renderMarkdownToPdf } from '../src/render-pdf.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = join(HERE, 'fixtures', 'product.mrd.ttrs');
+const RENDER_DATE = '2026-08-07';
+const RUN_TIMESTAMP = '2026-08-07T12:00:00Z';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+// A reference filler, standing in for "an agent, executing the instruction
+// the slot carries". It answers only from the ids the slot
+// itself declared in `inputs:` — CAP-1 and REQ-14, both read from this same
+// fixture canon above — so the attribution obligation
+// (2026-08-12-instruction-slots-specify-the-outcome-not-the-procedure.md §4)
+// is demonstrated, not merely asserted: every fact in the produced text traces
+// to one of those two records.
+async function referenceFill({ slotId, inputs }) {
+  if (slotId === 'market-size' && inputs.includes('CAP-1') && inputs.includes('REQ-14')) {
+    return {
+      status: 'sufficient',
+      text: 'No market-sizing data is recorded against CAP-1 (Batch release) or REQ-14 '
+        + '(Operator confirms a batch before release) in the current model.',
+      attributions: ['CAP-1', 'REQ-14'],
+    };
+  }
+  return { status: 'insufficient' };
+}
+
+const { header, markdown: pass1Markdown, instructionSlots, ok: pass1Ok, errors } = await runPass1({
+  text: await (await import('node:fs/promises')).readFile(TEMPLATE_PATH, 'utf8'),
+  templatePath: TEMPLATE_PATH,
+  renderDate: RENDER_DATE,
+  profile: 'strict',
+});
+
+check(pass1Ok, `pass 1 renders the committed template clean: ${JSON.stringify(errors)}`);
+check(instructionSlots.length === 1 && instructionSlots[0].slotId === 'market-size',
+  'the template exercises exactly the one instruction slot the epic asked for');
+
+const { markdown, slotResults } = await runPass2({
+  markdown: pass1Markdown, instructionSlots, fill: referenceFill,
+});
+
+check(slotResults[0].verdict === 'sufficient', 'the reference filler answers the one slot');
+check(markdown.includes('No market-sizing data is recorded'), 'and its text lands in the final markdown');
+check(!markdown.includes('{{# instruct'), 'with no directive syntax left in the deliverable');
+check(markdown.includes('produced by an automated pass'), 'self-disclosing that the section is machine-produced');
+
+// ── The run record ──────────────────────────────────────────────────────
+// `repositoryCommit` and `modelId` are facts about this run's environment,
+// not something run-record.mjs discovers on its own (it is a pure function
+// over its inputs) — the caller (here, a stand-in for the CLI) supplies both.
+
+const repositoryCommit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+const record = buildRunRecord({
+  header,
+  repositoryCommit,
+  modelId: 'reference-filler-test',
+  renderDate: RENDER_DATE,
+  runTimestamp: RUN_TIMESTAMP,
+  profile: 'strict',
+  slotResults,
+});
+
+check(record.template_id === 'product.mrd' && record.template_version === '1.0',
+  'the run record names the template and its version');
+check(record.repository_commit === repositoryCommit, 'and the repository commit it was read at');
+check(record.slots.length === 1, 'and every slot the template declared, here the one');
+check(record.slots[0].verdict === 'sufficient' && record.slots[0].produced_text.length > 0,
+  'carrying the verdict and the produced text');
+
+const recordJson = serializeRunRecord(record);
+check(JSON.parse(recordJson).template_id === 'product.mrd', 'the serialised run record round-trips');
+
+// ── PDF — A4, declared explicitly ─────────────────────────────────────────
+
+const pdfBytes = renderMarkdownToPdf(markdown);
+const pdfText = pdfBytes.toString('latin1');
+check(pdfText.includes('/MediaBox [0 0 595 842]'),
+  `the PDF must report A4 — 595 x 842pt, got: ${pdfText.match(/\/MediaBox \[[^\]]*\]/)}`);
+check(pdfText.includes('No market-sizing data is recorded'),
+  'the filled section\'s text reaches the PDF, not only the Markdown');
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('Full-run check passed: pass 1, pass 2, the run record, and the PDF, end to end.');

--- a/packages/document-renderer/tests/test_pass2.mjs
+++ b/packages/document-renderer/tests/test_pass2.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// Unit tests for src/pass2.mjs — the instruction-slot fill pass, against the
+// normative rules of the 2026-08-12 decision "an instruction slot specifies
+// the outcome, not the procedure" (accepted 2026-08-15):
+//
+//   * a slot declaring no inputs is not fillable — `not-attempted`, `fill`
+//     never called;
+//   * omitting `fill` entirely resolves every slot `not-attempted` and pass 2
+//     behaves like pass 1 alone;
+//   * `sufficient` replaces the slot span with the produced text plus the
+//     self-declaration disclosure;
+//   * `insufficient` leaves the slot visibly open, never padded;
+//   * an attribution outside the slot's own declared `inputs:` is rejected —
+//     the one part of the filler's account pass 2 can check mechanically;
+//   * pass 2 runs only against the markdown pass 1 produced for the same
+//     template — a slot-count or slot-order mismatch is a caller error.
+//
+// Run: node packages/document-renderer/tests/test_pass2.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { runPass2 } from '../src/pass2.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+async function checkThrows(fn, msg) {
+  try {
+    await fn();
+    _failures.push(`${msg} (expected a throw, got none)`);
+  } catch {
+    // expected
+  }
+}
+
+function slot(overrides = {}) {
+  return {
+    slotId: 'market-size',
+    question: 'How large is the addressable market?',
+    inputs: [],
+    sufficient: 'A number, a currency and a year.',
+    ...overrides,
+  };
+}
+
+function withSlot(s) {
+  return {
+    markdown: `Before.\n\n{{# instruct ${s.slotId} }}\nquestion: ${s.question}\ninputs: ${s.inputs.join(', ')}\nsufficient: ${s.sufficient}\n{{/ instruct }}\n\nAfter.`,
+    instructionSlots: [s],
+  };
+}
+
+// ── No declared inputs — not fillable, `fill` never called ───────────────
+
+{
+  const s = slot({ inputs: [] });
+  const { markdown } = withSlot(s);
+  let called = false;
+  const result = await runPass2({
+    markdown,
+    instructionSlots: [s],
+    fill: async () => { called = true; return { status: 'sufficient', text: 'x' }; },
+  });
+  check(!called, 'fill is never invoked for a slot with no declared inputs');
+  check(result.slotResults[0].verdict === 'not-attempted', 'the slot is reported not-attempted');
+  check(result.slotResults[0].reason === 'no declared inputs', 'carrying the §3 reason');
+  check(result.markdown.includes('Open — not answered.'), 'and stays visibly open in the markdown');
+  check(!result.markdown.includes('{{# instruct'), 'the raw directive syntax does not leak through');
+}
+
+// ── No `fill` supplied — every slot not-attempted, pass 2 is inert ───────
+
+{
+  const s = slot({ inputs: ['CAP-1'] });
+  const { markdown } = withSlot(s);
+  const result = await runPass2({ markdown, instructionSlots: [s] });
+  check(result.slotResults[0].verdict === 'not-attempted', 'with no filler configured, nothing is attempted');
+  check(result.slotResults[0].reason === 'no filler configured', 'reason names why');
+  check(result.markdown.includes('Open — not answered.'), 'and the section is left open');
+}
+
+// ── Sufficient — text replaces the span, self-declaration attached ───────
+
+{
+  const s = slot({ inputs: ['CAP-1', 'REQ-14'] });
+  const { markdown } = withSlot(s);
+  const result = await runPass2({
+    markdown,
+    instructionSlots: [s],
+    fill: async ({ slotId }) => {
+      check(slotId === 'market-size', 'fill receives the slot id');
+      return { status: 'sufficient', text: 'The market is $4B, growing 12%/yr (source: CAP-1).', attributions: ['CAP-1'] };
+    },
+  });
+  check(result.slotResults[0].verdict === 'sufficient', 'a sufficient outcome is recorded as such');
+  check(result.markdown.includes('The market is $4B'), 'and the produced text replaces the slot');
+  check(!result.markdown.includes('{{# instruct'), 'the directive syntax is gone from the rendered output');
+  check(
+    result.markdown.includes('was produced by an automated pass') && result.markdown.includes('not been admitted through a review gate'),
+    'the self-declaration is attached beside the produced text',
+  );
+  check(result.markdown.includes('Before.') && result.markdown.includes('After.'),
+    'text outside the slot is untouched');
+  check(result.slotResults[0].attributions.length === 1 && result.slotResults[0].attributions[0] === 'CAP-1',
+    "the filler's own attribution account is carried through");
+}
+
+// ── Insufficient — declared, not padded; stays visibly open ──────────────
+
+{
+  const s = slot({ inputs: ['CAP-1'] });
+  const { markdown } = withSlot(s);
+  const result = await runPass2({
+    markdown,
+    instructionSlots: [s],
+    fill: async () => ({ status: 'insufficient' }),
+  });
+  check(result.slotResults[0].verdict === 'insufficient', 'an insufficient outcome is recorded as such');
+  check(result.slotResults[0].text === null, 'and carries no text — nothing padded in');
+  check(result.markdown.includes('Open — not answered.'), 'the section stays visibly open');
+  check(!result.markdown.includes('{{# instruct'), 'not left as raw directive syntax either');
+}
+
+// ── Attribution outside the declared inputs — a closed-list violation ────
+
+{
+  const s = slot({ inputs: ['CAP-1'] });
+  const { markdown } = withSlot(s);
+  await checkThrows(
+    () => runPass2({
+      markdown,
+      instructionSlots: [s],
+      fill: async () => ({ status: 'sufficient', text: 'x', attributions: ['REQ-99'] }),
+    }),
+    'an attribution outside the declared inputs is rejected',
+  );
+}
+
+// ── Malformed filler outcomes ─────────────────────────────────────────────
+
+{
+  const s = slot({ inputs: ['CAP-1'] });
+  const { markdown } = withSlot(s);
+  await checkThrows(
+    () => runPass2({ markdown, instructionSlots: [s], fill: async () => ({ status: 'maybe' }) }),
+    'an unrecognised status is rejected',
+  );
+}
+
+{
+  const s = slot({ inputs: ['CAP-1'] });
+  const { markdown } = withSlot(s);
+  await checkThrows(
+    () => runPass2({ markdown, instructionSlots: [s], fill: async () => ({ status: 'sufficient', text: '  ' }) }),
+    '"sufficient" with blank text is rejected',
+  );
+}
+
+// ── Multiple slots resolve independently, in document order ──────────────
+
+{
+  const a = slot({ slotId: 'market-size', inputs: ['CAP-1'] });
+  const b = slot({ slotId: 'risk-profile', inputs: [] });
+  const markdown = `${withSlot(a).markdown}\n\n${withSlot(b).markdown}`;
+  const result = await runPass2({
+    markdown,
+    instructionSlots: [a, b],
+    fill: async ({ slotId }) => (slotId === 'market-size'
+      ? { status: 'sufficient', text: 'Filled market text.', attributions: ['CAP-1'] }
+      : { status: 'sufficient', text: 'should never be reached' }),
+  });
+  check(result.slotResults.length === 2, 'both slots are reported');
+  check(result.slotResults[0].verdict === 'sufficient' && result.slotResults[1].verdict === 'not-attempted',
+    'each slot resolves on its own — declared inputs gate fill() per slot, not per run');
+  check(result.markdown.includes('Filled market text.'), 'the fillable slot is filled');
+  check(result.markdown.includes('Open — not answered.'), 'the unfillable one stays open');
+}
+
+// ── Caller error: pass 2 run against markdown that is not pass 1's own ───
+
+{
+  const s = slot({ inputs: ['CAP-1'] });
+  await checkThrows(
+    () => runPass2({ markdown: 'No instruction slot here at all.', instructionSlots: [s] }),
+    'a slot-count mismatch between markdown and instructionSlots is rejected',
+  );
+}
+
+{
+  const a = slot({ slotId: 'market-size', inputs: [] });
+  const b = slot({ slotId: 'risk-profile', inputs: [] });
+  // Markdown carries the slots in one order; instructionSlots claims another.
+  const markdown = `${withSlot(a).markdown}\n\n${withSlot(b).markdown}`;
+  await checkThrows(
+    () => runPass2({ markdown, instructionSlots: [b, a] }),
+    'a slot-order mismatch between markdown and instructionSlots is rejected',
+  );
+}
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('All pass2 checks passed.');

--- a/packages/document-renderer/tests/test_render_pdf.mjs
+++ b/packages/document-renderer/tests/test_render_pdf.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Unit tests for src/render-pdf.mjs, against its own PDF constraint: page
+// size is A4, declared explicitly — a renderer that omits the declaration
+// defaults to US Letter and silently spills the last 18 mm onto a second
+// page. Verify the rendered output reports 595 x 842 pt.
+//
+// This module ships no PDF parser (zero-dependency posture, see
+// render-pdf.mjs's own header) — these checks read the structure directly:
+// the magic header/footer, the explicit `/MediaBox`, and that the xref
+// table's byte offsets actually land on the object they claim to.
+//
+// Run: node packages/document-renderer/tests/test_render_pdf.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { renderMarkdownToPdf } from '../src/render-pdf.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+function asLatin1(buf) { return buf.toString('latin1'); }
+
+// Parses the xref table this module writes and asserts every offset in it
+// lands exactly on "<n> 0 obj" for object n — i.e. the table is not just
+// present, it is correct.
+function checkXrefOffsets(buf, text) {
+  const startxrefMatch = /startxref\n(\d+)\n%%EOF/.exec(text);
+  if (!check(startxrefMatch, 'startxref points to an offset, and %%EOF follows it')) return;
+  const xrefOffset = Number(startxrefMatch[1]);
+  check(text.slice(xrefOffset, xrefOffset + 4) === 'xref', 'startxref\'s own offset lands exactly on the xref table');
+
+  const xrefBlock = /xref\n0 (\d+)\n([\s\S]*?)trailer/.exec(text);
+  if (!check(xrefBlock, 'the xref table is well-formed')) return;
+  const count = Number(xrefBlock[1]);
+  // Split on the line terminator only, filtering the one empty trailing
+  // element `\n`-splitting leaves behind — NOT `.trim()` first: every real
+  // entry (including the last) ends "n \n", and trimming the block strips
+  // that final entry's own significant trailing space along with the
+  // newline, which would fail it as malformed when it is not.
+  const entries = xrefBlock[2].split('\n').filter((line) => line.length > 0);
+  check(entries.length === count, `xref declares ${count} entries and carries that many`);
+
+  // Entry 0 is the free-list head; objects are numbered from 1.
+  for (let i = 1; i < entries.length; i++) {
+    const m = /^(\d{10}) 00000 n/.exec(entries[i]);
+    if (!check(m, `xref entry ${i} is well-formed`)) continue;
+    const offset = Number(m[1]);
+    const objNum = i;
+    check(
+      text.slice(offset, offset + `${objNum} 0 obj`.length) === `${objNum} 0 obj`,
+      `xref entry for object ${objNum} points at byte ${offset}, which is where "${objNum} 0 obj" actually starts`,
+    );
+  }
+}
+
+// ── The A4 constraint — the one requirement the epic names by exact value ─
+
+{
+  const buf = renderMarkdownToPdf('# Title\n\nA short paragraph.');
+  const text = asLatin1(buf);
+  check(text.startsWith('%PDF-1.4'), 'the file starts with a PDF magic header');
+  check(text.trimEnd().endsWith('%%EOF'), 'the file ends with %%EOF');
+  check(text.includes('/MediaBox [0 0 595 842]'), 'every page declares A4 explicitly — 595 x 842 pt at 72dpi');
+  checkXrefOffsets(buf, text);
+}
+
+// ── Content actually reaches the page ─────────────────────────────────────
+
+{
+  const buf = renderMarkdownToPdf('# Batch release capability\n\nThe lead requirement is present.');
+  const text = asLatin1(buf);
+  check(text.includes('(Batch release capability) Tj'), 'a heading is placed in a content stream');
+  check(text.includes('The lead requirement is present.') || /\(.*lead requirement.*\) Tj/.test(text),
+    'paragraph text reaches a content stream');
+  check(text.includes('/BaseFont /Helvetica'), 'the base-14 Helvetica font needs no embedding, and carries none');
+}
+
+// ── Multi-page pagination — a long document produces more than one /Page ─
+
+{
+  const longBody = Array.from({ length: 200 }, (_, i) => `Paragraph number ${i} of a long document, long enough to force a page break somewhere in the middle of this run.`).join('\n\n');
+  const buf = renderMarkdownToPdf(longBody);
+  const text = asLatin1(buf);
+  const pageCount = (text.match(/\/Type \/Page(?!s)/g) ?? []).length;
+  check(pageCount > 1, `a long document paginates — got ${pageCount} page object(s)`);
+  const kidsMatch = /\/Kids \[([^\]]*)\]/.exec(text);
+  check(kidsMatch, '/Pages carries a /Kids array');
+  if (kidsMatch) {
+    const kidsCount = kidsMatch[1].trim().split(/\s+0\s+R\s*/).filter(Boolean).length;
+    check(kidsCount === pageCount, `/Kids lists exactly as many pages as were emitted (${kidsCount} vs ${pageCount})`);
+  }
+  check(/\/Count (\d+)/.exec(text)[1] === String(pageCount), '/Pages /Count agrees with the number of pages emitted');
+  checkXrefOffsets(buf, text);
+}
+
+// ── Figures become a named placeholder, never a silently dropped line ────
+
+{
+  const buf = renderMarkdownToPdf('Before figure.\n\n![Context diagram](diagrams/context.png)\n\nAfter figure.');
+  const text = asLatin1(buf);
+  check(text.includes('[Figure: Context diagram]'), 'a figure is placed as a named, visible placeholder');
+}
+
+// ── Special characters this module\'s own markers use are never corrupted ─
+
+{
+  const buf = renderMarkdownToPdf('Unresolved: «unresolved: REQ-999» flagged ⚑U — an em dash, too.');
+  const text = asLatin1(buf);
+  check(!/[^\x00-\xFF]/.test(text), 'the emitted bytes never fall outside a single byte per character');
+  check(text.includes('<<unresolved: REQ-999>>') || text.includes('unresolved: REQ-999'),
+    'the unresolved-reference marker text survives sanitisation in recognisable form');
+  check(text.trimEnd().endsWith('%%EOF'), 'the file is still well-formed after non-ASCII input');
+}
+
+// ── Escaping — parens and backslashes in text never break the content stream
+
+{
+  const buf = renderMarkdownToPdf('A line with (parens) and a backslash \\ in it.');
+  const text = asLatin1(buf);
+  check(text.includes('\\(parens\\)'), 'parentheses in text are escaped for the PDF string literal');
+  checkXrefOffsets(buf, text);
+}
+
+// ── Empty input still produces a well-formed, single-page PDF ────────────
+
+{
+  const buf = renderMarkdownToPdf('');
+  const text = asLatin1(buf);
+  check(text.includes('/MediaBox [0 0 595 842]'), 'even an empty document gets one well-formed A4 page');
+  check((text.match(/\/Type \/Page(?!s)/g) ?? []).length === 1, 'exactly one page, not zero');
+}
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('All render-pdf checks passed.');

--- a/packages/document-renderer/tests/test_run_record.mjs
+++ b/packages/document-renderer/tests/test_run_record.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Unit tests for src/run-record.mjs, against transitrix-hq#53's "Outputs"
+// requirement: the run record names template id and version, repository
+// commit, model id, run timestamp (ISO 8601), and — per slot, including one
+// that produced nothing — the instruction and the text it produced. The
+// 2026-08-12 ADR adds a verdict per slot.
+//
+// Run: node packages/document-renderer/tests/test_run_record.mjs
+// Exit: 0 = all pass; 1 = a check failed.
+
+import { buildRunRecord, serializeRunRecord } from '../src/run-record.mjs';
+
+const _failures = [];
+function check(cond, msg) { if (!cond) _failures.push(msg); return cond; }
+
+const HEADER = {
+  document: 'Market Requirements Document',
+  kind: 'mrd',
+  template_id: 'product.mrd',
+  template_version: '1.0',
+  canon: 'canon',
+};
+
+const SUFFICIENT_SLOT = {
+  slotId: 'market-size',
+  question: 'How large is the addressable market?',
+  inputs: ['CAP-1', 'REQ-14'],
+  sufficient: 'A number, a currency and a year.',
+  verdict: 'sufficient',
+  reason: null,
+  text: 'The market is $4B, growing 12%/yr.',
+  attributions: ['CAP-1'],
+};
+
+const NOT_ATTEMPTED_SLOT = {
+  slotId: 'risk-profile',
+  question: 'What is the principal adoption risk?',
+  inputs: [],
+  sufficient: 'A named risk and its mitigation.',
+  verdict: 'not-attempted',
+  reason: 'no declared inputs',
+  text: null,
+};
+
+// ── Required fields, named exactly as the epic states them ───────────────
+
+{
+  const record = buildRunRecord({
+    header: HEADER,
+    repositoryCommit: 'abc1234',
+    modelId: 'claude-sonnet-5',
+    runTimestamp: '2026-08-15T12:00:00.000Z',
+    renderDate: '2026-08-15',
+    profile: 'strict',
+    slotResults: [SUFFICIENT_SLOT, NOT_ATTEMPTED_SLOT],
+  });
+
+  check(record.template_id === 'product.mrd', 'template id is carried from the header');
+  check(record.template_version === '1.0', 'template version is carried from the header');
+  check(record.repository_commit === 'abc1234', 'repository commit is named');
+  check(record.model_id === 'claude-sonnet-5', 'model id is named');
+  check(record.run_timestamp === '2026-08-15T12:00:00.000Z', 'run timestamp is carried through, not recomputed');
+  check(record.render_date === '2026-08-15', 'render date is carried from pass 1');
+  check(record.profile === 'strict', 'the profile a run used is named');
+  check(record.slots.length === 2, 'every slot present in the template is named — including the empty one');
+}
+
+// ── Every slot, including one that produced nothing ───────────────────────
+
+{
+  const record = buildRunRecord({
+    header: HEADER,
+    renderDate: '2026-08-15',
+    profile: 'strict',
+    slotResults: [NOT_ATTEMPTED_SLOT],
+  });
+  const slot = record.slots[0];
+  check(slot.slot_id === 'risk-profile', 'the slot id is present');
+  check(slot.question === NOT_ATTEMPTED_SLOT.question, 'the instruction text is present in full');
+  check(slot.verdict === 'not-attempted', 'the verdict is carried through');
+  check(slot.reason === 'no declared inputs', 'and its reason');
+  check(slot.produced_text === null, 'a slot that produced nothing is recorded as such, not omitted');
+  check(Array.isArray(slot.attributions) && slot.attributions.length === 0,
+    'a slot with no attributions still carries an (empty) attributions list, never undefined');
+}
+
+{
+  const record = buildRunRecord({
+    header: HEADER,
+    renderDate: '2026-08-15',
+    profile: 'strict',
+    slotResults: [SUFFICIENT_SLOT],
+  });
+  const slot = record.slots[0];
+  check(slot.produced_text === SUFFICIENT_SLOT.text, 'the produced text is carried through in full');
+  check(slot.verdict === 'sufficient', 'and its verdict');
+  check(slot.attributions.length === 1 && slot.attributions[0] === 'CAP-1',
+    'the filler\'s attribution account is carried through');
+}
+
+// ── No slots — still a valid, empty-list record ───────────────────────────
+
+{
+  const record = buildRunRecord({ header: HEADER, renderDate: '2026-08-15', profile: 'strict' });
+  check(Array.isArray(record.slots) && record.slots.length === 0,
+    'a template with no instruction slots still gets a well-formed record');
+}
+
+// ── Repository commit / model id are null, not omitted, when absent ──────
+
+{
+  const record = buildRunRecord({ header: HEADER, renderDate: '2026-08-15', profile: 'strict' });
+  check('repository_commit' in record && record.repository_commit === null,
+    'no repository configured for this run is still a named field, not a missing key');
+  check('model_id' in record && record.model_id === null,
+    'no model used (nothing to fill) is still a named field, not a missing key');
+}
+
+// ── Timestamp defaults to now when the caller does not pin one ───────────
+
+{
+  const record = buildRunRecord({ header: HEADER, renderDate: '2026-08-15', profile: 'strict' });
+  check(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(record.run_timestamp),
+    `an unpinned run timestamp still defaults to a real ISO 8601 value, got: ${record.run_timestamp}`);
+}
+
+// ── A missing header is a caller error, not a half-built record ──────────
+
+{
+  let threw = false;
+  try { buildRunRecord({ renderDate: '2026-08-15', profile: 'strict' }); } catch { threw = true; }
+  check(threw, 'building a run record with no header throws rather than emitting a partial one');
+}
+
+// ── Serialisation — stable, parseable, newline-terminated ────────────────
+
+{
+  const record = buildRunRecord({
+    header: HEADER,
+    runTimestamp: '2026-08-15T12:00:00.000Z',
+    renderDate: '2026-08-15',
+    profile: 'strict',
+    slotResults: [SUFFICIENT_SLOT],
+  });
+  const text = serializeRunRecord(record);
+  check(text.endsWith('\n'), 'the serialised record is newline-terminated');
+  const roundTripped = JSON.parse(text);
+  check(JSON.stringify(roundTripped) === JSON.stringify(record), 'it round-trips through JSON exactly');
+}
+
+if (_failures.length > 0) {
+  console.error(`${_failures.length} check(s) failed:\n`);
+  for (const f of _failures) console.error(`- ${f}\n`);
+  process.exit(1);
+}
+console.log('All run-record checks passed.');

--- a/packages/document-renderer/tests/test_run_record.mjs
+++ b/packages/document-renderer/tests/test_run_record.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// Unit tests for src/run-record.mjs, against transitrix-hq#53's "Outputs"
-// requirement: the run record names template id and version, repository
-// commit, model id, run timestamp (ISO 8601), and — per slot, including one
-// that produced nothing — the instruction and the text it produced. The
-// 2026-08-12 ADR adds a verdict per slot.
+// Unit tests for src/run-record.mjs, against the run record's own
+// requirement: it names template id and version, repository commit, model
+// id, run timestamp (ISO 8601), and — per slot, including one that produced
+// nothing — the instruction and the text it produced. The 2026-08-12 decision
+// "an instruction slot specifies the outcome, not the procedure" adds a
+// verdict per slot.
 //
 // Run: node packages/document-renderer/tests/test_run_record.mjs
 // Exit: 0 = all pass; 1 = a check failed.


### PR DESCRIPTION
## Summary

Completes the document-renderer loop that pass 1 (THQ-54) left open:

- **Pass 2** (`src/pass2.mjs`) fills `{{# instruct … }}` slots through a caller-supplied `fill` hook — agent-agnostic by construction, the same shape as pass 1's `rasterise` hook. Enforces the accepted 2026-08-12 decision ("an instruction slot specifies the outcome, not the procedure"): a slot with no declared `inputs:` is never filled, an attribution outside the slot's own declared inputs is rejected, and an insufficient answer stays visibly open rather than padded.
- **The run record** (`src/run-record.mjs`) — a pure function over its inputs: template id/version, repository commit, model id, run timestamp, and a per-slot verdict (`sufficient` / `insufficient` / `not-attempted`), including every slot that produced nothing.
- **PDF output** (`src/render-pdf.mjs`) — hand-rolled and dependency-free, matching this package's zero-npm-dependency posture. Declares A4 explicitly (`/MediaBox [0 0 595 842]`), paginates automatically, and reduces a figure to a named placeholder rather than rasterising one.
- **End-to-end test** (`tests/test_full_run.mjs`) composes all four modules against the package's committed `product.mrd.ttrs` template, the way an adopter's CLI would.

Out of scope, per THQ-147's directive (flagged there as separate work, not blocking this dispatch): the `DIRECTIVE_LANGUAGE.md` §4.2 specification edits the 2026-08-12 decision requires, and a checker for document-level constraints over rendered output (does not exist yet).

## Test plan

- [x] `node packages/document-renderer/tests/test_pass1.mjs`
- [x] `node packages/document-renderer/tests/test_conformance.mjs` (frozen fixture, unaffected)
- [x] `node packages/document-renderer/tests/test_pass2.mjs`
- [x] `node packages/document-renderer/tests/test_run_record.mjs`
- [x] `node packages/document-renderer/tests/test_render_pdf.mjs`
- [x] `node packages/document-renderer/tests/test_full_run.mjs`
- [x] `node scripts/check-notations.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)