### PR TITLE
docs(changelog): 3.5.0 release notes + version pin bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [3.5.0] — 2026-08-15
+
+Bump category: **MINOR** — new `TERM` element type, a new catalogue-integration spec surface (levels, binding envelope, adopter pattern, `ingest-cli` commands), a new render contract section, and `document-renderer` pass 2/run-record/PDF output; all additive, no migration recipe required. Also cuts the tag `v3.4.0` never got — `notations/CURRENT_VERSION.yaml` was bumped in #475 but the release was never tagged; this release folds that gap in rather than shipping an intermediate untagged version.
+
+### Added
+
+- **`TERM` element type** (business-layer vocabulary, ArchiMate Meaning) — the 31st live element TYPE, folded into the `ELEM-ALIAS-001` cross-catalogue uniqueness gate. New **glossary report view** (`32-glossary.md`) projects name/aliases/description from `TERM` and every other TYPE into one flat, alphabetised lookup surface. (#479)
+- **Catalogue integration — four levels and the binding envelope.** The ownership rule and the four separately-enabled levels (decisions / vocabulary / recognition / promotion) at which a project repository joins a network around a central catalogue repository, plus the `canon_id`/`origin` binding envelope and its validation rules (`BIND-001`–`005`). (#477)
+- **Catalogue publication, the consumer pin, and the L1 vocabulary-divergence check** — publication format, the `transitrix.yaml` `catalogue:` pin, the fails-closed load rule, the pin-bump ADR gate, and a report-only L1 divergence check; `ingest-cli` gains a fails-closed catalogue loader. (#478)
+- **`ingest-cli` L2 recognition + L3 promotion** — `catalogue-recognize` (propose a binding by unambiguous name/alias + TYPE match), `catalogue-bind` (human-gated write, fails closed against `BIND-001`–`004`), and `catalogue-promote` (emits a promotion proposal, never writes across the repository boundary); `repo-check` surfaces the full `BIND-001`–`005` envelope check. (#480)
+- **Catalogue — adopter-facing half.** New pattern (`patterns/network-catalogue.md`), a §7 "Setting it up" section on the catalogue-integration doc, and `ingest-cli`'s `adopt-adl` (L0) and `catalogue-pin` (L1) commands. (#481)
+- **`blocks` render contract for the matrix subset (§7a)** — what a conformant renderer must produce for a `grid:` root document: rectangular table sizing, header order, pre-layout `assign:` expansion, and inline validation surfacing per `BL-020`–`025`. States explicitly that the general layered-grid superset remains unspecified by design. (#484)
+- **`document-renderer` pass 2** — fills `{{# instruct ... }}` slots left open by pass 1 via a caller-supplied `fill` hook, agent-agnostic by construction, enforcing the closed-input discipline of the 2026-08-12 instruction-slot decision. (#485)
+- **`document-renderer` run record** — a pure function over template id/version, repository commit, model id, run timestamp, and per-slot instruction/verdict (sufficient / insufficient / not-attempted). (#485)
+- **`document-renderer` PDF output** — dependency-free Markdown-to-PDF, A4, paginating automatically; bold/italic stripped and figures become text placeholders as named, non-silent scope limits. (#485)
+
+### Changed
+
+- Dependabot now watches all six npm manifests under `packages/`, including `document-renderer` and `document-view-engine`. (#482)
+- The public-surface hygiene scan now also runs on direct pushes to `main`, not only on pull requests. (#483)
+
+---
+
 ## [3.4.0] — 2026-08-09
 
 Bump category: **MINOR** — new notation spec file (diagram view), additive `ingest-cli` checks, and tooling/doc fixes only; no migration recipe required.

--- a/method/02-team-operations.md
+++ b/method/02-team-operations.md
@@ -146,7 +146,7 @@ Deliberately **not** one-file-per-record like ADR/WI: a single file, `operations
 ---
 ### FB-0002
 type: notation-gap
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 raised_by: modeler
 date: "2026-07-27"
 status: sent-upstream

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -880,7 +880,7 @@ Structural layout of a view document:
 ```yaml
 notation: dgca                # §1 — required header
 spec_version: "0.1"           # §1 — optional header
-methodology_version: "3.4.0"  # manifest-pinned methodology version
+methodology_version: "3.5.0"  # manifest-pinned methodology version
 name: "Retail strategy chain" # §1.1 — required document name
 
 view:                         # view identity block — id only; name lives at root per §1.1
@@ -961,7 +961,7 @@ views/
 ```yaml
 view_id: DGCA-RETAIL-1               # canonical ID of the view being captured
 generated_at: "2026-06-20T14:30:00Z" # ISO-8601 UTC timestamp — matches the file name
-methodology_version: "3.4.0"          # methodology version in use at generation time
+methodology_version: "3.5.0"          # methodology version in use at generation time
 # …notation-specific element list follows (format defined per notation spec)…
 ```
 

--- a/notations/COVERAGE_PROFILES.md
+++ b/notations/COVERAGE_PROFILES.md
@@ -24,7 +24,7 @@ A profile is declared at the repository root in `transitrix.yaml` under the `cov
 
 ```yaml
 transitrix: 1
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core         # short form — name a shipped preset
@@ -250,7 +250,7 @@ The shipped presets (`minimal`, `core`, `full`) are *re-defined per methodology 
 ```yaml
 # transitrix.yaml
 transitrix: 1
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 notations: [dgca, goals, activities, capability-map, applications]
 zones: [canon, field]
 # coverage_profile omitted → defaults to `full`

--- a/notations/CURRENT_VERSION.yaml
+++ b/notations/CURRENT_VERSION.yaml
@@ -5,4 +5,4 @@
 # placeholder allowlist in scripts/check-notations.mjs. Enforced by that
 # script's V1 check. See notations/CONTRACT.md §10 for the versioning and
 # compatibility policy this pin follows.
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -29,7 +29,7 @@ A worked example lives at `transitrix.yaml` in the [acme-corp reference repo](ht
 
 ```yaml
 transitrix: 1                       # manifest schema version (integer)
-methodology_version: "3.4.0"        # the methodology release this repo conforms to
+methodology_version: "3.5.0"        # the methodology release this repo conforms to
 notations: [dgca, goals, action, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md

--- a/notations/PACKAGES.md
+++ b/notations/PACKAGES.md
@@ -20,7 +20,7 @@ A package is declared at the repository root in `transitrix.yaml` under the `pac
 
 ```yaml
 transitrix: 1
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core

--- a/notations/examples/compliance-impact/README.md
+++ b/notations/examples/compliance-impact/README.md
@@ -25,7 +25,7 @@ A compliance-impact view file carries the shared envelope (`notation:`, `spec_ve
 ```yaml
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: COMPLIANCE_IMPACT-<NAME>-1

--- a/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
+++ b/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 name: "Retail product — GDPR obligations"
 
 view:

--- a/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
+++ b/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 id: DGCA-DATA-RESIDENCY-1
 name: "EU data-residency DGCA chain"

--- a/notations/examples/dgca/startup.dgca.transitrix.yaml
+++ b/notations/examples/dgca/startup.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 id: DGCA-STARTUP-1
 name: "Product launch — strategy chain"

--- a/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 id: DGCA-STRATEGY-2026-DGA
 name: "Strategy 2026 — DGA view"

--- a/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 id: DGCA-STRAT-1
 name: "Strategy 2026 — DGCA chain"

--- a/notations/examples/integration-map/README.md
+++ b/notations/examples/integration-map/README.md
@@ -26,7 +26,7 @@ An integration-map view file carries the shared envelope (`notation:`, `spec_ver
 ```yaml
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: INTEGRATION_MAP-<NAME>-1

--- a/notations/examples/integration-map/enterprise.integration-map.transitrix.yaml
+++ b/notations/examples/integration-map/enterprise.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 name: "Enterprise integration landscape"
 
 view:

--- a/notations/examples/integration-map/rule-violations/attempted-inline-edge.integration-map.transitrix.yaml
+++ b/notations/examples/integration-map/rule-violations/attempted-inline-edge.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 name: "Attempted inline edge — invalid on purpose"
 
 view:

--- a/notations/examples/mrd/README.md
+++ b/notations/examples/mrd/README.md
@@ -34,7 +34,7 @@ An MRD view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: mrd
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: MRD-<NAME>-1

--- a/notations/examples/mrd/incident-status.mrd.transitrix.yaml
+++ b/notations/examples/mrd/incident-status.mrd.transitrix.yaml
@@ -2,7 +2,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Incident status communication — MRD"
 generated_at: "2026-08-04"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: MRD-INCIDENT-STATUS-1

--- a/notations/examples/packages/reqif-workflow/transitrix.yaml
+++ b/notations/examples/packages/reqif-workflow/transitrix.yaml
@@ -4,7 +4,7 @@
 # (packages/reqif-cli/tests/test_reqif_integrity.py Part B) stays unaffected
 # by content the XML converter does not carry (see this folder's README).
 transitrix: 1
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/packages/reqif/transitrix.yaml
+++ b/notations/examples/packages/reqif/transitrix.yaml
@@ -3,7 +3,7 @@
 # permitted cross-reference (Transitrix.CanonRef, reqif.md §3) something real
 # to cite, plus the reqif/ package folder itself.
 transitrix: 1
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/scenarios/README.md
+++ b/notations/examples/scenarios/README.md
@@ -26,7 +26,7 @@ A post-reclassification scenarios view file carries no canonical content. It dec
 ```yaml
 notation: scenarios
 spec_version: "0.3"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: SCENARIOS-2027-CUT-1

--- a/notations/examples/sdd/README.md
+++ b/notations/examples/sdd/README.md
@@ -35,7 +35,7 @@ An SDD view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: sdd
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: SDD-<NAME>-1

--- a/notations/examples/sdd/data-export.sdd.transitrix.yaml
+++ b/notations/examples/sdd/data-export.sdd.transitrix.yaml
@@ -2,7 +2,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Data export capability — SDD"
 generated_at: "2026-08-04"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: SDD-DATA-EXPORT-1

--- a/notations/examples/srs/README.md
+++ b/notations/examples/srs/README.md
@@ -33,7 +33,7 @@ An SRS view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: srs
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: SRS-<NAME>-1

--- a/notations/examples/srs/backup-power.srs.transitrix.yaml
+++ b/notations/examples/srs/backup-power.srs.transitrix.yaml
@@ -2,7 +2,7 @@ notation: srs
 spec_version: "0.1"
 name: "Backup-power controller — SRS"
 generated_at: "2026-08-04"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: SRS-BACKUP-POWER-1

--- a/notations/packages/reqif.md
+++ b/notations/packages/reqif.md
@@ -21,7 +21,7 @@ This is a package, not a core notation: nothing here changes `IDS_AND_REFERENCES
 
 ```yaml
 transitrix: 1
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 packages: [reqif]
 ```
 

--- a/notations/views/diagrams/02-dgca.md
+++ b/notations/views/diagrams/02-dgca.md
@@ -154,7 +154,7 @@ A DGCA document opens with a shared header block (`notation:`, `spec_version:`, 
 ```yaml
 notation: dgca
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 id: DGCA-LAUNCH-1
 name: "Product launch strategy chain"
 period: "2026"
@@ -188,7 +188,7 @@ notation: dgca
 spec_version: "0.1"
 id: DGCA-RETAIL-1
 name: "Retail strategy chain 2026"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view_config:
   goals:

--- a/notations/views/diagrams/04-goals.md
+++ b/notations/views/diagrams/04-goals.md
@@ -117,7 +117,7 @@ After goals are promoted to `canon/elements/01_motivation/goals/`, the view beco
 ```yaml
 notation: goals
 spec_version: "0.1"
-methodology_version: "3.4.0"          # required from v2.0 onward
+methodology_version: "3.5.0"          # required from v2.0 onward
 
 id: GOALS-STRAT-2026-1                 # required — GOALS-[<middle>-]<INTEGER>
 name: "Strategy 2026 — Goals Tree"    # required per CONTRACT.md §1.1

--- a/notations/views/diagrams/07-action.md
+++ b/notations/views/diagrams/07-action.md
@@ -128,7 +128,7 @@ After actions are promoted to `canon/elements/05_implementation/actions/`, the v
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "3.4.0"          # required from v2.0 onward
+methodology_version: "3.5.0"          # required from v2.0 onward
 
 id: ACTION_SCHED-PLATFORM-2026-1      # required — ACTION_SCHED-[<middle>-]<INTEGER>
 name: "Platform Launch 2026"          # required per CONTRACT.md §1.1
@@ -344,7 +344,7 @@ Both views are projections of the same underlying schedule. A document never "be
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 id: ACTION_SCHED-MINIMAL-1
 name: "Minimal schedule example"           # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                # optional per CONTRACT.md §4

--- a/notations/views/diagrams/12-integration-map.md
+++ b/notations/views/diagrams/12-integration-map.md
@@ -45,7 +45,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   # ... see §3
 ```
@@ -86,7 +86,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Enterprise integration landscape"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: INTEGRATION_MAP-ENTERPRISE-1
@@ -169,7 +169,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Full integration map"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   id: INTEGRATION_MAP-ALL-1
   name: "Full integration map"

--- a/notations/views/documents/29-mrd.md
+++ b/notations/views/documents/29-mrd.md
@@ -45,7 +45,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Incident status communication — MRD"   # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: MRD-INCIDENT-STATUS-1
@@ -168,7 +168,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Full MRD — all needs"           # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"             # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   id: MRD-ALL-1
   name: "Full MRD — all needs"

--- a/notations/views/documents/30-srs.md
+++ b/notations/views/documents/30-srs.md
@@ -45,7 +45,7 @@ notation: srs
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   # ... see §3
 ```
@@ -97,7 +97,7 @@ notation: srs
 spec_version: "0.1"
 name: "Backup-power controller — SRS"          # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                     # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: SRS-BACKUP-POWER-1
@@ -158,7 +158,7 @@ notation: srs
 spec_version: "0.1"
 name: "Full SRS — all software-tier requirements"    # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                           # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   id: SRS-ALL-1
   name: "Full SRS — all software-tier requirements"

--- a/notations/views/documents/31-sdd.md
+++ b/notations/views/documents/31-sdd.md
@@ -45,7 +45,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   # ... see §3
 ```
@@ -101,7 +101,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Data export capability — SDD"          # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: SDD-DATA-EXPORT-1
@@ -170,7 +170,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Full SDD — all design elements"   # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"               # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   id: SDD-ALL-1
   name: "Full SDD — all design elements"

--- a/notations/views/reports/11-scenarios.md
+++ b/notations/views/reports/11-scenarios.md
@@ -45,7 +45,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   # ... see §3
 ```
@@ -95,7 +95,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Optimistic vs Conservative — 2027 cut"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                       # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: SCENARIOS-<NAME>-1
@@ -152,7 +152,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "All scenarios"                   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   id: SCENARIOS-ALL-1
   name: "All scenarios"

--- a/notations/views/reports/21-compliance-impact.md
+++ b/notations/views/reports/21-compliance-impact.md
@@ -45,7 +45,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   # ... see §3
 ```
@@ -103,7 +103,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Retail product — GDPR obligations"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: COMPLIANCE_IMPACT-RETAIL-GDPR-1
@@ -190,7 +190,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Full compliance matrix"          # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   id: COMPLIANCE_IMPACT-ALL-1
   name: "Full compliance matrix"

--- a/notations/views/reports/22-coverage-metric.md
+++ b/notations/views/reports/22-coverage-metric.md
@@ -45,7 +45,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Retail product — regime coverage"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 view:
   id: COVERAGE_METRIC-RETAIL-1
@@ -199,7 +199,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Full coverage metric"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 view:
   id: COVERAGE_METRIC-ALL-1
   name: "Full coverage metric"

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -27,7 +27,7 @@
 # the ingest CLI needs to place and validate it.
 
 # Must equal notations/CURRENT_VERSION.yaml (enforced by check V1).
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 # ---------------------------------------------------------------------------
 # Element TYPE registry — ELEMENT_PRIMITIVES.md §4 (mode table) and §6 (layer

--- a/transitrix/skills/feedback/SKILL.md
+++ b/transitrix/skills/feedback/SKILL.md
@@ -179,7 +179,7 @@ element"* — which passes.
    ---
    ### FB-0003
    type: notation-gap
-   methodology_version: "3.4.0"
+   methodology_version: "3.5.0"
    raised_by: Modeler
    date: "2026-07-28"
    status: open

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -158,7 +158,7 @@ The root `transitrix.yaml` pins which methodology release this repo conforms to 
 
 ```yaml
 transitrix: 1
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 notations: [dgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```

--- a/transitrix/skills/onboard/templates/action.action.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/action.action.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: action
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 # Action schedule — pure projection over standalone ACTION elements.
 # Spec: notations/views/diagrams/07-action.md (v2.0). No action data is authored inline.

--- a/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: coverage-metric
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 # Coverage Metric. Spec: notations/views/reports/22-coverage-metric.md
 # Report-config over the coverage read of canon (sibling of Compliance Impact).

--- a/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: goals
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 # Goals tree — pure projection over standalone GOAL elements.
 # Spec: notations/views/diagrams/04-goals.md (v2.0). No element data is authored inline.

--- a/transitrix/skills/onboard/templates/integration-map.integration-map.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/integration-map.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "3.4.0"
+methodology_version: "3.5.0"
 
 # Integration Map. Spec: notations/views/diagrams/12-integration-map.md
 # Application-cooperation / data-flow graph, projected from admitted


### PR DESCRIPTION
Runs RELEASING.md's per-release checklist for the 8 PRs (#477–#485) landed since #475's 3.4.0 bump. Highest bump category across the set is **MINOR** (new `TERM` element type, new catalogue-integration spec surface, new blocks render-contract section, `document-renderer` pass 2/run-record/PDF — all additive; #482/#483 are CI-only).

Also closes a standing gap: `notations/CURRENT_VERSION.yaml` was bumped to 3.4.0 in #475 but no `v3.4.0` tag was ever cut. Rather than tag an intermediate version nobody consumed, this folds it into one 3.5.0 release.

- Bumped `notations/CURRENT_VERSION.yaml` to `3.5.0`.
- Bumped every `methodology_version` pin the V1 doc-lint check flags (41 files), plus the remaining illustrative-example occurrences in files with more than one pin block, for doc consistency (`node scripts/check-notations.mjs` clean).
- New `CHANGELOG.md` §3.5.0 entry categorising the 8 PRs.

Once merged, I'll tag `v3.5.0` at the merge commit and update the acme-corp companion pin — tracked on `THQ-187`, where Studio asked for a tag covering the document-renderer pass2/PDF/run-record files from #485.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>