### PR TITLE
feat(plugin): generate a portable Agent Plugins v1.0.0 manifest

### DIFF
--- a/.github/workflows/plugin-manifest.yml
+++ b/.github/workflows/plugin-manifest.yml
@@ -1,0 +1,41 @@
+name: Plugin manifest
+
+# Keeps the plugin's two manifests from drifting apart and keeps
+# `claude plugin validate` passing on every PR, not only before a
+# community-catalogue submission (epic transitrix-hq#158, deliverable 1).
+#
+# `transitrix/.claude-plugin/plugin.json` is Claude Code's own manifest,
+# hand-maintained. `transitrix/plugin.json` is the portable Agent Plugins
+# v1.0.0 manifest <https://agent-plugins.org/specification>, generated from
+# it (scripts/generate-plugin-manifests.mjs) so the two never disagree on
+# name or version. Runs on every PR, unconditional on paths touched — a
+# manifest can silently drift from an unrelated release-version bump.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Mondays 09:05 UTC — weekly safety net for drift introduced via
+    # direct-commit changes to main that bypass PR review.
+    - cron: '5 9 * * 1'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check transitrix/plugin.json is generated, not hand-edited out of sync
+        run: node scripts/generate-plugin-manifests.mjs --check
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Validate the Claude Code plugin manifest
+        run: claude plugin validate ./transitrix --strict

--- a/scripts/generate-plugin-manifests.mjs
+++ b/scripts/generate-plugin-manifests.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Plugin manifest generator — derives the portable Agent Plugins v1.0.0
+// manifest (`transitrix/plugin.json`) from the hand-maintained Claude Code
+// manifest (`transitrix/.claude-plugin/plugin.json`), so the two never drift
+// out of hand-editing sync (epic transitrix-hq#158, deliverable 1).
+//
+// Agent Plugins Specification v1.0.0 <https://agent-plugins.org/specification>
+// closes the root `plugin.json` schema to exactly: $schema, name, version,
+// description, author, homepage, repository, license, keywords, extensions.
+// Every one of those (bar $schema, which is fixed, and extensions, which we
+// don't use) already exists on the Claude Code manifest, so generation is a
+// field copy plus the schema URL — no client-specific fields survive.
+//
+// Usage:
+//   node scripts/generate-plugin-manifests.mjs          # write transitrix/plugin.json
+//   node scripts/generate-plugin-manifests.mjs --check  # fail if it would change (CI drift check)
+//
+// Exit codes: 0 clean/written · 1 drift found (--check only) · 2 script-internal error
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE_PATH = join(REPO_ROOT, 'transitrix', '.claude-plugin', 'plugin.json');
+const TARGET_PATH = join(REPO_ROOT, 'transitrix', 'plugin.json');
+
+const AGENT_PLUGINS_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+
+// Fields the Agent Plugins v1.0.0 manifest schema permits, in the order
+// they're emitted. `$schema` and `extensions` are handled separately.
+const PORTABLE_FIELDS = ['name', 'version', 'description', 'author', 'homepage', 'repository', 'license', 'keywords'];
+
+// §5.5 plugin name constraints: 1-64 chars, lowercase alnum/hyphen/period,
+// alnum start and end, no consecutive hyphens or periods.
+const NAME_RE = /^[a-z0-9](?:[a-z0-9]|-(?!-)|\.(?!\.))*[a-z0-9]$|^[a-z0-9]$/;
+
+export function derivePortableManifest(source) {
+  if (!NAME_RE.test(source.name) || source.name.length > 64) {
+    throw new Error(`source manifest name "${source.name}" violates Agent Plugins §5.5 name constraints`);
+  }
+  const manifest = { $schema: AGENT_PLUGINS_SCHEMA };
+  for (const field of PORTABLE_FIELDS) {
+    if (source[field] !== undefined) manifest[field] = source[field];
+  }
+  return manifest;
+}
+
+function serialize(manifest) {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+async function main() {
+  const check = process.argv.includes('--check');
+
+  const source = JSON.parse(await readFile(SOURCE_PATH, 'utf8'));
+  const generated = serialize(derivePortableManifest(source));
+
+  if (check) {
+    let existing;
+    try {
+      existing = await readFile(TARGET_PATH, 'utf8');
+    } catch {
+      console.error(`generate-plugin-manifests: ${TARGET_PATH} does not exist. Run without --check to create it.`);
+      process.exitCode = 1;
+      return;
+    }
+    if (existing !== generated) {
+      console.error(`generate-plugin-manifests: ${TARGET_PATH} is stale relative to ${SOURCE_PATH}.`);
+      console.error('Run: node scripts/generate-plugin-manifests.mjs');
+      process.exitCode = 1;
+      return;
+    }
+    console.log('generate-plugin-manifests: transitrix/plugin.json is up to date.');
+    return;
+  }
+
+  await writeFile(TARGET_PATH, generated, 'utf8');
+  console.log(`generate-plugin-manifests: wrote ${TARGET_PATH}`);
+}
+
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 2;
+  });
+}

--- a/transitrix/README.md
+++ b/transitrix/README.md
@@ -15,6 +15,8 @@ Transitrix is a text-native methodology for enterprise architecture: every artef
 /plugin install transitrix@transitrix-methodology
 ```
 
+**Other agent hosts:** this directory also carries [`plugin.json`](plugin.json), a manifest conforming to the [Agent Plugins Specification v1.0.0](https://agent-plugins.org/specification) — the open, vendor-neutral packaging format six agent-tool vendors published in August 2026. Any client that implements that specification discovers this plugin's skills directly from `skills/` per the spec's fixed-location discovery rule; consult that client's own documentation for how it loads a plugin directory or repository. `plugin.json` is generated from the Claude Code manifest above (`.claude-plugin/plugin.json`, `scripts/generate-plugin-manifests.mjs`) so the two never disagree on name or version.
+
 ---
 
 ## Skills

--- a/transitrix/plugin.json
+++ b/transitrix/plugin.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "transitrix",
+  "version": "0.1.0",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 12 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Integration map, Products, Action Card) + PlantUML rendering, or one of the 5 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric, Glossary), or a codex artefact.",
+  "author": {
+    "name": "Transitrix"
+  },
+  "homepage": "https://transitrix.com",
+  "repository": "https://github.com/transitrix/methodology",
+  "license": "MIT",
+  "keywords": [
+    "enterprise-architecture",
+    "architecture-as-text",
+    "methodology",
+    "scaffolding",
+    "onboarding",
+    "transitrix",
+    "bpmn",
+    "dgca",
+    "capability-map",
+    "process-blueprint"
+  ]
+}


### PR DESCRIPTION
## Summary

Deliverable 1 of 5 from the plugin-distribution epic: one manifest source, every supported host, CI-enforced validate + drift check.

- Adds `transitrix/plugin.json`, a manifest conforming to the [Agent Plugins Specification v1.0.0](https://agent-plugins.org/specification) — the open, vendor-neutral packaging format published 2026-08-06 and implemented across six agent-tool hosts. It's generated by `scripts/generate-plugin-manifests.mjs` from the existing hand-maintained Claude Code manifest (`transitrix/.claude-plugin/plugin.json`), so the two can't drift apart by hand-editing.
- Existing `transitrix/skills/<name>/SKILL.md` layout already satisfies the portable spec's fixed skill-discovery rule (§7.1) — no skill files moved.
- New CI workflow (`.github/workflows/plugin-manifest.yml`), unconditional on paths touched, runs on every PR:
  - `node scripts/generate-plugin-manifests.mjs --check` — fails the build if the portable manifest disagrees with the source manifest on name, version, or any other field.
  - `claude plugin validate ./transitrix --strict` — fails the build if the Claude Code manifest itself stops validating (today it passes clean).
- One line added to `transitrix/README.md` pointing at the portable manifest, without asserting per-host install syntax I can't verify from this repo (see judgement call below).

## Verified, not assumed

- Generated manifest checked field-for-field against the *published* JSON Schema (`agent-plugins.org/schemas/1.0.0/plugin.schema.json`), not just my reading of the spec prose.
- The Agent Plugins §5.5 name-constraint regex tested against every valid/invalid example in the spec text.
- `claude plugin validate ./transitrix --strict` run locally, both before and after adding `transitrix/plugin.json`, to confirm Claude Code's own loader ignores the new root file (no path conflict).
- Drift check tested to actually fail on a deliberately corrupted `transitrix/plugin.json`, then confirmed clean again after restoring.

## Judgement calls (flagging, not deciding silently)

- **No per-host one-command install syntax in the README.** The Agent Plugins spec defines the *package format* only — how a given client (Cursor, Copilot, VS Code, Kiro, ChatGPT/Codex) discovers/installs a plugin from a repository is each client's own UX, undocumented in the spec itself, and I have no way to test any of the six from this environment. Rather than publish unverified slash-commands to a public README, I described the manifest and pointed at the spec; a reader on any of those hosts follows that host's own plugin-loading docs. If per-host install commands are wanted, that's better sourced from someone who can actually drive each client.
- **Didn't touch `.claude-plugin/marketplace.json`.** `claude plugin validate .` surfaces a pre-existing unrelated warning there (`homepage` unknown field) — out of scope for this deliverable (which is about `transitrix/plugin.json` specifically), left alone.
- **RELEASING.md untouched.** It governs the *methodology spec* version (`notations/CURRENT_VERSION.yaml`), a separate track from the plugin's own package version (`transitrix/.claude-plugin/plugin.json`, currently 0.1.0). The CI drift check already makes "every manifest agrees" mechanically true regardless of when the plugin version is bumped, so no process-doc change seemed needed — flagging in case a maintainer disagrees.

## Test plan

- [x] `node scripts/generate-plugin-manifests.mjs` then `--check` — clean
- [x] Manifest validated against published JSON Schema
- [x] `claude plugin validate ./transitrix --strict` — passes, before and after
- [x] `node scripts/check-notations.mjs` — no new findings introduced (pre-existing local-only noise from a gitignored stray worktree, unrelated to this change and invisible to CI)