### PR TITLE
feat(plugin): lead README with generated, rendered view examples

### DIFF
--- a/.github/workflows/plugin-examples-drift.yml
+++ b/.github/workflows/plugin-examples-drift.yml
@@ -1,0 +1,47 @@
+name: Plugin examples drift check
+
+# transitrix/README.md leads with rendered SVG examples of the notation views
+# the plugin's onboard skill lets a user author (epic transitrix-hq#158,
+# deliverable 2). The images are generated, not hand-drawn — regenerating
+# them from this repository's own notations/examples/ sources via
+# @transitrix/plugin-examples must reproduce the committed
+# transitrix/examples/*.svg files byte-for-byte.
+#
+# This regenerates into a scratch directory and diffs it against what's
+# committed, failing the build on any difference — same style as the
+# notations doc-lint and the document-renderer conformance check.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/plugin-examples/**'
+      - 'notations/examples/**'
+      - 'transitrix/examples/**'
+      - 'transitrix/README.md'
+      - '.github/workflows/plugin-examples-drift.yml'
+  workflow_dispatch:
+  schedule:
+    # Mondays 10:35 UTC — weekly safety net, offset from the other Monday crons.
+    - cron: '35 10 * * 1'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: packages/plugin-examples
+        run: npm ci --legacy-peer-deps
+
+      - name: Regenerate examples into a scratch directory
+        run: node packages/plugin-examples/src/generate.mjs "$RUNNER_TEMP/plugin-examples-scratch"
+
+      - name: Diff regenerated output against committed transitrix/examples/
+        run: diff -rq transitrix/examples "$RUNNER_TEMP/plugin-examples-scratch" --exclude=.gitattributes

--- a/packages/plugin-examples/package-lock.json
+++ b/packages/plugin-examples/package-lock.json
@@ -1,0 +1,61 @@
+{
+  "name": "@transitrix/plugin-examples",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@transitrix/plugin-examples",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@transitrix/diagrams": "1.9.18",
+        "js-yaml": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@transitrix/diagrams": {
+      "version": "1.9.18",
+      "resolved": "https://registry.npmjs.org/@transitrix/diagrams/-/diagrams-1.9.18.tgz",
+      "integrity": "sha512-mcaxPThI/Mm5foIdP6WW9uCDWBrKJZYPAjZ/kF9hB30gMZy29YtNL18QqicDbKXmaI1oXxyeuvA14VrJTwGqMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "reactflow": "^11.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/packages/plugin-examples/package.json
+++ b/packages/plugin-examples/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@transitrix/plugin-examples",
+  "version": "0.0.1",
+  "description": "Generates the rendered notation-view SVGs shown in transitrix/README.md from this repository's own notations/examples/ sources, via the shared @transitrix/diagrams rendering library. Regeneration is byte-reproducible: pinned exact dependency version, deterministic layout, no randomness.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "src/"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Transitrix"
+  },
+  "repository": "https://github.com/transitrix/methodology",
+  "dependencies": {
+    "@transitrix/diagrams": "1.9.18",
+    "js-yaml": "4.3.1"
+  }
+}

--- a/packages/plugin-examples/src/generate.mjs
+++ b/packages/plugin-examples/src/generate.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Regenerates the rendered notation-view SVGs embedded in transitrix/README.md.
+ *
+ * Reads this repository's own worked examples under notations/examples/<kind>/,
+ * runs each through the matching parse/validate + render pipeline from the
+ * shared @transitrix/diagrams library (the same rendering code Studio and DSM
+ * use — see the root README's "How it works in five lines"), and writes the
+ * output to transitrix/examples/<kind>.svg.
+ *
+ * Deterministic: the same source + the same pinned @transitrix/diagrams
+ * version always produce the same bytes. That's what
+ * .github/workflows/plugin-examples-drift.yml checks — it re-runs this
+ * script into a scratch directory and diffs against what's committed here.
+ *
+ * Only notation kinds with a real, published SVG renderer in
+ * @transitrix/diagrams are covered. Kinds whose webview renderer only
+ * produces an HTML fragment (Applications, Products, Process Map,
+ * Capability Map's card view, Scenarios), and kinds with no renderer at all
+ * (Integration Map; the BPMN layout algorithm is not published — only its
+ * SVG body emitter is; Action Card's resolver needs canon element/relation
+ * sources this repository's standalone examples don't provide), are not
+ * generated here. That is a capability gap, not a bug — nothing is
+ * hand-drawn to paper over it.
+ *
+ * Usage: node packages/plugin-examples/src/generate.mjs
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+
+import { parseCanonicalGoals } from '@transitrix/diagrams/goals/parse-canonical.js';
+import { renderGoalsSvg } from '@transitrix/diagrams/webview/render-goals.js';
+
+import { parseCanonicalFGCA } from '@transitrix/diagrams/fgca/parse-canonical.js';
+import { renderFgcaSvg } from '@transitrix/diagrams/webview/render-fgca.js';
+
+import { validateCapabilityMap } from '@transitrix/diagrams/capability-map/validate.js';
+import { renderCapabilityTreeSvg } from '@transitrix/diagrams/capability-map/render-capability-tree.js';
+
+import { validateProcessBlueprint } from '@transitrix/diagrams/process-blueprint/validate.js';
+import { renderProcessBlueprintSvg } from '@transitrix/diagrams/webview/render-process-blueprint.js';
+
+import { validateActivities } from '@transitrix/diagrams/activities/validate.js';
+import { renderActivitiesSvg } from '@transitrix/diagrams/webview/render-activities.js';
+
+import { validateBlocks } from '@transitrix/diagrams/blocks/validate.js';
+import { renderBlocksSvg } from '@transitrix/diagrams/webview/render-blocks.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const EXAMPLES_DIR = join(REPO_ROOT, 'notations', 'examples');
+const OUT_DIR = join(REPO_ROOT, 'transitrix', 'examples');
+
+function loadYaml(relPath) {
+  const text = readFileSync(join(EXAMPLES_DIR, relPath), 'utf8');
+  return coerceDatesToIsoStrings(yaml.load(text));
+}
+
+function fail(kind, errors) {
+  const detail = (errors ?? []).map((e) => `${e.code}: ${e.message}`).join('; ');
+  throw new Error(`${kind}: source failed validation${detail ? ` — ${detail}` : ''}`);
+}
+
+/** Goals — hierarchical tree, notations/04-goals.md. */
+function generateGoals() {
+  const doc = loadYaml('goals/strategy-2026.goals.transitrix.yaml');
+  const result = parseCanonicalGoals(doc);
+  if (!result.valid || !result.parsed) fail('goals', result.errors);
+  const treeName = typeof doc.name === 'string' ? doc.name : '';
+  return renderGoalsSvg(result.parsed, { treeName });
+}
+
+/** DGCA/DGA — Driver/Goal/Change/Action chain, notations/02-fgca.md. Self-contained
+ * inline example (no canon-projection resolution needed). */
+function generateDgca() {
+  const doc = loadYaml('dgca/startup.dgca.transitrix.yaml');
+  const result = parseCanonicalFGCA(doc);
+  if (!result.valid || !result.parsed) fail('dgca', result.errors);
+  const title = typeof doc.name === 'string' ? doc.name : '';
+  return renderFgcaSvg(result.parsed, { variant: 'dgca', title });
+}
+
+/** Capability map — tree view, via the public renderCapabilityTreeSvg entry point. */
+function generateCapabilityMap() {
+  const doc = loadYaml('capability-map/business.capability-map.transitrix.yaml');
+  const v = validateCapabilityMap(doc);
+  if (!v.valid) fail('capability-map', v.errors);
+  return renderCapabilityTreeSvg(doc.capability_map);
+}
+
+/** Process Blueprint — stage x aspect grid, notations/views/diagrams. */
+function generateProcessBlueprint() {
+  const doc = loadYaml('process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml');
+  const v = validateProcessBlueprint(doc);
+  if (!v.valid) fail('process-blueprint', v.errors);
+  const title = doc.process_blueprint && typeof doc.process_blueprint.name === 'string'
+    ? doc.process_blueprint.name
+    : '';
+  return renderProcessBlueprintSvg(doc, { title });
+}
+
+/** Action schedule — network (PSND) view of an Action document.
+ * validateActivities normalises the canonical `actions:` root key onto
+ * `doc.activities` in place, which is why the render call below reads
+ * `doc` (not a separate `.parsed` field). */
+function generateActionSchedule() {
+  const doc = loadYaml('action/office-relocation.action.transitrix.yaml');
+  const v = validateActivities(doc);
+  if (!v.valid) fail('action', v.errors);
+  const title = typeof doc.name === 'string' ? doc.name : '';
+  return renderActivitiesSvg(doc, { title });
+}
+
+/** Nested blocks — tree form, notations/08-blocks.md. */
+function generateBlocks() {
+  const doc = loadYaml('blocks/architecture.blocks.transitrix.yaml');
+  const v = validateBlocks(doc);
+  if (!v.valid) fail('blocks', v.errors);
+  const title = doc.nested_blocks && typeof doc.nested_blocks.name === 'string'
+    ? doc.nested_blocks.name
+    : '';
+  return renderBlocksSvg(doc, { title });
+}
+
+const KINDS = [
+  { key: 'goals', label: 'Goals', generate: generateGoals },
+  { key: 'dgca', label: 'DGCA/DGA', generate: generateDgca },
+  { key: 'capability-map', label: 'Capability map', generate: generateCapabilityMap },
+  { key: 'process-blueprint', label: 'Process Blueprint', generate: generateProcessBlueprint },
+  { key: 'action', label: 'Action schedule', generate: generateActionSchedule },
+  { key: 'blocks', label: 'Nested blocks', generate: generateBlocks },
+];
+
+export function generateAll(outDir = OUT_DIR) {
+  mkdirSync(outDir, { recursive: true });
+  const written = [];
+  for (const { key, label, generate } of KINDS) {
+    const svg = generate();
+    if (typeof svg !== 'string' || !svg.startsWith('<svg')) {
+      throw new Error(`${key}: renderer did not return a well-formed <svg> document`);
+    }
+    const out = svg.endsWith('\n') ? svg : `${svg}\n`;
+    const outPath = join(outDir, `${key}.svg`);
+    writeFileSync(outPath, out, 'utf8');
+    written.push({ key, label, outPath });
+  }
+  return written;
+}
+
+// This module is always invoked as a CLI entry point (directly by a maintainer,
+// or as a subprocess by the drift-check workflow) — never imported by another
+// module — so it runs unconditionally rather than gating on an
+// import.meta.url === argv[1] check, which is unreliable across platforms
+// (Windows file:// URLs vs. drive-letter argv paths).
+//
+// Optional first CLI arg overrides the output directory (relative to the
+// current working directory) so the drift check can regenerate into a
+// scratch location and diff it against the committed transitrix/examples/
+// without touching the working tree.
+const targetDir = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : OUT_DIR;
+const written = generateAll(targetDir);
+for (const { key, label, outPath } of written) {
+  console.log(`generated ${label} (${key}) -> ${outPath}`);
+}

--- a/transitrix/README.md
+++ b/transitrix/README.md
@@ -19,6 +19,30 @@ Transitrix is a text-native methodology for enterprise architecture: every artef
 
 ---
 
+## What it produces
+
+Real output, not a mockup — each image below is rendered from this repository's own worked examples (`notations/examples/`) by [`@transitrix/diagrams`](https://www.npmjs.com/package/@transitrix/diagrams), the same shared rendering library that draws these notations in Studio and in DSM. Every notation the plugin's `onboard` skill can scaffold has a real renderer in that library; this gallery shows only the subset that renders as a static image today (a diagram view, not an HTML fragment or a data report). A view with no example here is a view this plugin does not yet turn into a picture — nothing below is drawn by hand.
+
+| Goals | DGCA/DGA |
+|---|---|
+| ![Goals tree](examples/goals.svg) | ![DGCA chain](examples/dgca.svg) |
+
+| Capability map | Nested blocks |
+|---|---|
+| ![Capability map tree](examples/capability-map.svg) | ![Nested blocks](examples/blocks.svg) |
+
+**Process Blueprint**
+
+![Process Blueprint](examples/process-blueprint.svg)
+
+**Action schedule**
+
+![Action schedule network view](examples/action.svg)
+
+Regenerate with `node packages/plugin-examples/src/generate.mjs`; CI (`.github/workflows/plugin-examples-drift.yml`) regenerates on every PR touching the sources and fails the build if the committed images differ by a single byte.
+
+---
+
 ## Skills
 
 | Skill | Invocation | What it does | Min methodology version |

--- a/transitrix/examples/.gitattributes
+++ b/transitrix/examples/.gitattributes
@@ -1,0 +1,8 @@
+# These SVGs are compared byte-for-byte by the drift check in
+# .github/workflows/plugin-examples-drift.yml (regenerate and diff against
+# what's committed here), so every checkout must produce identical bytes.
+#
+# Without this, `core.autocrlf=true` on Windows checks these files out with
+# CRLF while Linux CI (and the generator itself) produces LF, and the diff
+# fails on line endings alone rather than on real drift.
+* text eol=lf

--- a/transitrix/examples/action.svg
+++ b/transitrix/examples/action.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="3598" height="256" viewBox="0 0 3598 256">
+<style>:root{--ts-bg:#ffffff;--ts-bg-surface:#f8fafc;--ts-bg-elevated:#f1f5f9;--ts-text:#0f172a;--ts-text-muted:#64748b;--ts-text-inverse:#ffffff;--ts-border:#e2e8f0;--ts-divider:#cbd5e1;--ts-status-success-bg:#d1fae5;--ts-status-success-fg:#065f46;--ts-status-warning-bg:#fef9c3;--ts-status-warning-fg:#854d0e;--ts-status-info-bg:#e0f2fe;--ts-status-info-fg:#0c4a6e;--ts-status-error-bg:#fee2e2;--ts-status-error-fg:#991b1b;--ts-layer-driver:#eaf3f6;--ts-layer-factor:#eaf3f6;--ts-layer-goal:#d9ecf2;--ts-layer-change:#c7e5ef;--ts-layer-activity:#b4e0ee;--ts-node-stroke:#004d67;--ts-edge-stroke:#004d67;--ts-text-primary:#0d2b35;--ts-text-secondary:#516970;--ts-header-text:#0d2b35;--ts-maturity-1:#bf2518;--ts-maturity-2:#b05911;--ts-maturity-3:#8d7011;--ts-maturity-4:#407d21;--ts-maturity-5:#237b48;--ts-brand-amber:#ffaf00;--ts-brand-orange:#ff4d00;--ts-brand-orange-tint:#ffeee5;--ts-level-0:#eef4f7;--ts-level-1:#e6f1f4;--ts-level-2:#dfedf1;--ts-level-3:#d7e9ef;--ts-level-4:#cee6ed;--ts-level-5:#c6e2ec;--ts-level-6:#bfe0eb;--ts-level-7:#b7deeb;--ts-tree-level-0:#e6f1f4;--ts-tree-level-1:#d0e9f1;--ts-tree-level-2:#b5e3f2;--ts-tree-maturity-1:#bf2518;--ts-tree-maturity-2:#b05911;--ts-tree-maturity-3:#8d7011;--ts-tree-maturity-4:#407d21;--ts-tree-maturity-5:#237b48;}.diagram-node{stroke:var(--ts-node-stroke);stroke-width:1;}
+.layer-driver{fill:var(--ts-layer-driver);}
+.layer-factor{fill:var(--ts-layer-factor);}
+.layer-goal{fill:var(--ts-layer-goal);}
+.layer-change{fill:var(--ts-layer-change);}
+.layer-activity{fill:var(--ts-layer-activity);}
+.level-0{fill:var(--ts-level-0);}.level-1{fill:var(--ts-level-1);}.level-2{fill:var(--ts-level-2);}.level-3{fill:var(--ts-level-3);}.level-4{fill:var(--ts-level-4);}.level-5{fill:var(--ts-level-5);}.level-6{fill:var(--ts-level-6);}.level-7{fill:var(--ts-level-7);}
+.diagram-edge{stroke:var(--ts-edge-stroke);stroke-width:1.5;fill:none;}
+.arrow-fill{fill:var(--ts-edge-stroke);}
+.text-header{fill:var(--ts-header-text);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:13px;font-weight:700;dominant-baseline:central;}
+.text-primary{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:600;dominant-baseline:central;}
+.text-secondary{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:400;dominant-baseline:central;}
+.text-id{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:10px;font-weight:600;dominant-baseline:central;}
+.text-pill{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:500;dominant-baseline:central;}
+.maturity-1{fill:var(--ts-maturity-1);}
+.maturity-2{fill:var(--ts-maturity-2);}
+.maturity-3{fill:var(--ts-maturity-3);}
+.maturity-4{fill:var(--ts-maturity-4);}
+.maturity-5{fill:var(--ts-maturity-5);}
+.compliance-gap{fill:var(--ts-status-warning-bg);stroke:var(--ts-status-warning-fg);}
+.compliance-gap text{fill:var(--ts-status-warning-fg);}
+.compliance-deadline{fill:var(--ts-status-error-bg);stroke:var(--ts-status-error-fg);}
+.compliance-deadline text{fill:var(--ts-status-error-fg);}
+.compliance-badge{fill:var(--ts-status-error-fg);}
+.compliance-badge-text{fill:var(--ts-text-inverse);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:8px;font-weight:700;}
+.tree-level-0{fill:var(--ts-tree-level-0);}
+.tree-level-1{fill:var(--ts-tree-level-1);}
+.tree-level-2{fill:var(--ts-tree-level-2);}
+.tree-maturity-1{fill:var(--ts-tree-maturity-1);}
+.tree-maturity-2{fill:var(--ts-tree-maturity-2);}
+.tree-maturity-3{fill:var(--ts-tree-maturity-3);}
+.tree-maturity-4{fill:var(--ts-tree-maturity-4);}
+.tree-maturity-5{fill:var(--ts-tree-maturity-5);}
+.tree-collapse-btn{cursor:pointer;fill:white;stroke:var(--ts-node-stroke);stroke-width:1.5;}
+.tree-collapse-btn:hover{fill:var(--ts-bg-elevated);}
+.tree-collapse-lbl{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:700;dominant-baseline:central;pointer-events:none;}
+.blocks-grid-border{fill:none;stroke:var(--ts-border);}
+  .act-node { fill: var(--ts-layer-activity, #d4edda); stroke: var(--ts-node-stroke, #004d67); stroke-width: 1; }
+  .critical-node { fill: var(--ts-brand-orange-tint, #ffeee5); stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1; }
+  .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
+  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1.5; }
+  .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
+</style>
+<defs>
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
+  </marker>
+</defs>
+<text class="text-header" x="24" y="18">Office Relocation — HQ Move 2026</text>
+<rect class="diagram-node act-node critical-node" x="24" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="149" y="75" text-anchor="middle" dominant-baseline="central">Requirements gathering</text>
+<text class="text-id" x="149" y="103" text-anchor="middle" dominant-baseline="central">A-101</text>
+<text class="text-secondary" x="266" y="120" text-anchor="end">10d</text>
+<rect class="diagram-node act-node critical-node" x="354" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="479" y="75" text-anchor="middle" dominant-baseline="central">Site selection</text>
+<text class="text-id" x="479" y="103" text-anchor="middle" dominant-baseline="central">A-102</text>
+<text class="text-secondary" x="596" y="120" text-anchor="end">15d</text>
+<rect class="diagram-node act-node critical-node" x="684" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="809" y="75" text-anchor="middle" dominant-baseline="central">Lease negotiation</text>
+<text class="text-id" x="809" y="103" text-anchor="middle" dominant-baseline="central">A-103</text>
+<text class="text-secondary" x="926" y="120" text-anchor="end">10d</text>
+<rect class="diagram-node act-node critical-node milestone-node" x="1014" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="1139" y="75" text-anchor="middle" dominant-baseline="central">Lease signed</text>
+<text class="text-id" x="1139" y="103" text-anchor="middle" dominant-baseline="central">M-LEASE-SIGNED</text>
+<rect class="diagram-node act-node critical-node" x="1344" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="1469" y="75" text-anchor="middle" dominant-baseline="central">Construction permits</text>
+<text class="text-id" x="1469" y="103" text-anchor="middle" dominant-baseline="central">A-201</text>
+<text class="text-secondary" x="1586" y="120" text-anchor="end">20d</text>
+<rect class="diagram-node act-node" x="1344" y="152" width="250" height="80" rx="8"/>
+<text class="text-primary" x="1469" y="179" text-anchor="middle" dominant-baseline="central">Interior design</text>
+<text class="text-id" x="1469" y="207" text-anchor="middle" dominant-baseline="central">A-202</text>
+<text class="text-secondary" x="1586" y="224" text-anchor="end">15d</text>
+<rect class="diagram-node act-node critical-node" x="1674" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="1799" y="75" text-anchor="middle" dominant-baseline="central">Construction work</text>
+<text class="text-id" x="1799" y="103" text-anchor="middle" dominant-baseline="central">A-203</text>
+<text class="text-secondary" x="1916" y="120" text-anchor="end">30d</text>
+<rect class="diagram-node act-node critical-node" x="2004" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="2129" y="75" text-anchor="middle" dominant-baseline="central">IT infrastructure install</text>
+<text class="text-id" x="2129" y="103" text-anchor="middle" dominant-baseline="central">A-204</text>
+<text class="text-secondary" x="2246" y="120" text-anchor="end">12d</text>
+<rect class="diagram-node act-node" x="2004" y="152" width="250" height="80" rx="8"/>
+<text class="text-primary" x="2129" y="179" text-anchor="middle" dominant-baseline="central">Furniture delivery</text>
+<text class="text-id" x="2129" y="207" text-anchor="middle" dominant-baseline="central">A-205</text>
+<text class="text-secondary" x="2246" y="224" text-anchor="end">5d</text>
+<rect class="diagram-node act-node critical-node" x="2334" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="2459" y="75" text-anchor="middle" dominant-baseline="central">Pack-up</text>
+<text class="text-id" x="2459" y="103" text-anchor="middle" dominant-baseline="central">A-301</text>
+<text class="text-secondary" x="2576" y="120" text-anchor="end">3d</text>
+<rect class="diagram-node act-node critical-node" x="2664" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="2789" y="75" text-anchor="middle" dominant-baseline="central">Physical move</text>
+<text class="text-id" x="2789" y="103" text-anchor="middle" dominant-baseline="central">A-302</text>
+<text class="text-secondary" x="2906" y="120" text-anchor="end">2d</text>
+<rect class="diagram-node act-node critical-node" x="2994" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="3119" y="75" text-anchor="middle" dominant-baseline="central">Unpacking and setup</text>
+<text class="text-id" x="3119" y="103" text-anchor="middle" dominant-baseline="central">A-303</text>
+<text class="text-secondary" x="3236" y="120" text-anchor="end">3d</text>
+<rect class="diagram-node act-node critical-node milestone-node" x="3324" y="48" width="250" height="80" rx="8"/>
+<text class="text-primary" x="3449" y="75" text-anchor="middle" dominant-baseline="central">New HQ opens</text>
+<text class="text-id" x="3449" y="103" text-anchor="middle" dominant-baseline="central">M-OPEN-DAY</text>
+<path d="M1264,88 C1347.2,88 1260.8,192 1344,192" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M1594,192 C1677.2,192 1590.8,88 1674,88" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M1924,88 C2007.2,88 1920.8,192 2004,192" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M2254,192 C2337.2,192 2250.8,88 2334,88" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M274,88 C338,88 290,88 354,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M604,88 C668,88 620,88 684,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M934,88 C998,88 950,88 1014,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M1264,88 C1328,88 1280,88 1344,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M1594,88 C1658,88 1610,88 1674,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M1924,88 C1988,88 1940,88 2004,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M2254,88 C2318,88 2270,88 2334,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M2584,88 C2648,88 2600,88 2664,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M2914,88 C2978,88 2930,88 2994,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+<path d="M3244,88 C3308,88 3260,88 3324,88" class="diagram-edge critical-edge" marker-end="url(#arrow-crit)"/>
+</svg>

--- a/transitrix/examples/blocks.svg
+++ b/transitrix/examples/blocks.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1156" height="456" viewBox="0 0 1156 456">
+<style>:root{--ts-bg:#ffffff;--ts-bg-surface:#f8fafc;--ts-bg-elevated:#f1f5f9;--ts-text:#0f172a;--ts-text-muted:#64748b;--ts-text-inverse:#ffffff;--ts-border:#e2e8f0;--ts-divider:#cbd5e1;--ts-status-success-bg:#d1fae5;--ts-status-success-fg:#065f46;--ts-status-warning-bg:#fef9c3;--ts-status-warning-fg:#854d0e;--ts-status-info-bg:#e0f2fe;--ts-status-info-fg:#0c4a6e;--ts-status-error-bg:#fee2e2;--ts-status-error-fg:#991b1b;--ts-layer-driver:#eaf3f6;--ts-layer-factor:#eaf3f6;--ts-layer-goal:#d9ecf2;--ts-layer-change:#c7e5ef;--ts-layer-activity:#b4e0ee;--ts-node-stroke:#004d67;--ts-edge-stroke:#004d67;--ts-text-primary:#0d2b35;--ts-text-secondary:#516970;--ts-header-text:#0d2b35;--ts-maturity-1:#bf2518;--ts-maturity-2:#b05911;--ts-maturity-3:#8d7011;--ts-maturity-4:#407d21;--ts-maturity-5:#237b48;--ts-brand-amber:#ffaf00;--ts-brand-orange:#ff4d00;--ts-brand-orange-tint:#ffeee5;--ts-level-0:#eef4f7;--ts-level-1:#e6f1f4;--ts-level-2:#dfedf1;--ts-level-3:#d7e9ef;--ts-level-4:#cee6ed;--ts-level-5:#c6e2ec;--ts-level-6:#bfe0eb;--ts-level-7:#b7deeb;--ts-tree-level-0:#e6f1f4;--ts-tree-level-1:#d0e9f1;--ts-tree-level-2:#b5e3f2;--ts-tree-maturity-1:#bf2518;--ts-tree-maturity-2:#b05911;--ts-tree-maturity-3:#8d7011;--ts-tree-maturity-4:#407d21;--ts-tree-maturity-5:#237b48;}.diagram-node{stroke:var(--ts-node-stroke);stroke-width:1;}
+.layer-driver{fill:var(--ts-layer-driver);}
+.layer-factor{fill:var(--ts-layer-factor);}
+.layer-goal{fill:var(--ts-layer-goal);}
+.layer-change{fill:var(--ts-layer-change);}
+.layer-activity{fill:var(--ts-layer-activity);}
+.level-0{fill:var(--ts-level-0);}.level-1{fill:var(--ts-level-1);}.level-2{fill:var(--ts-level-2);}.level-3{fill:var(--ts-level-3);}.level-4{fill:var(--ts-level-4);}.level-5{fill:var(--ts-level-5);}.level-6{fill:var(--ts-level-6);}.level-7{fill:var(--ts-level-7);}
+.diagram-edge{stroke:var(--ts-edge-stroke);stroke-width:1.5;fill:none;}
+.arrow-fill{fill:var(--ts-edge-stroke);}
+.text-header{fill:var(--ts-header-text);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:13px;font-weight:700;dominant-baseline:central;}
+.text-primary{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:600;dominant-baseline:central;}
+.text-secondary{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:400;dominant-baseline:central;}
+.text-id{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:10px;font-weight:600;dominant-baseline:central;}
+.text-pill{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:500;dominant-baseline:central;}
+.maturity-1{fill:var(--ts-maturity-1);}
+.maturity-2{fill:var(--ts-maturity-2);}
+.maturity-3{fill:var(--ts-maturity-3);}
+.maturity-4{fill:var(--ts-maturity-4);}
+.maturity-5{fill:var(--ts-maturity-5);}
+.compliance-gap{fill:var(--ts-status-warning-bg);stroke:var(--ts-status-warning-fg);}
+.compliance-gap text{fill:var(--ts-status-warning-fg);}
+.compliance-deadline{fill:var(--ts-status-error-bg);stroke:var(--ts-status-error-fg);}
+.compliance-deadline text{fill:var(--ts-status-error-fg);}
+.compliance-badge{fill:var(--ts-status-error-fg);}
+.compliance-badge-text{fill:var(--ts-text-inverse);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:8px;font-weight:700;}
+.tree-level-0{fill:var(--ts-tree-level-0);}
+.tree-level-1{fill:var(--ts-tree-level-1);}
+.tree-level-2{fill:var(--ts-tree-level-2);}
+.tree-maturity-1{fill:var(--ts-tree-maturity-1);}
+.tree-maturity-2{fill:var(--ts-tree-maturity-2);}
+.tree-maturity-3{fill:var(--ts-tree-maturity-3);}
+.tree-maturity-4{fill:var(--ts-tree-maturity-4);}
+.tree-maturity-5{fill:var(--ts-tree-maturity-5);}
+.tree-collapse-btn{cursor:pointer;fill:white;stroke:var(--ts-node-stroke);stroke-width:1.5;}
+.tree-collapse-btn:hover{fill:var(--ts-bg-elevated);}
+.tree-collapse-lbl{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:700;dominant-baseline:central;pointer-events:none;}
+.blocks-grid-border{fill:none;stroke:var(--ts-border);}</style>
+<text class="text-header" x="24" y="18">Nested Blocks — Software architecture</text>
+<rect class="diagram-node level-0" x="24" y="24" width="1108" height="192" rx="8"/>
+<text class="text-primary" x="578" y="35" text-anchor="middle" dominant-baseline="central">Application Layer</text>
+<text class="text-id" x="578" y="47" text-anchor="middle" dominant-baseline="central">APPLICATION_LAYER</text>
+<rect class="diagram-node level-1" x="36" y="68" width="536" height="136" rx="8"/>
+<text class="text-primary" x="304" y="79" text-anchor="middle" dominant-baseline="central">Frontend</text>
+<text class="text-id" x="304" y="91" text-anchor="middle" dominant-baseline="central">FRONTEND</text>
+<rect class="diagram-node level-2" x="48" y="112" width="250" height="80" rx="8"/>
+<text class="text-primary" x="173" y="146" text-anchor="middle" dominant-baseline="central">React App</text>
+<text class="text-id" x="173" y="160" text-anchor="middle" dominant-baseline="central">REACT_APP</text>
+<rect class="diagram-node level-2" x="310" y="112" width="250" height="80" rx="8"/>
+<text class="text-primary" x="435" y="146" text-anchor="middle" dominant-baseline="central">Redux Store</text>
+<text class="text-id" x="435" y="160" text-anchor="middle" dominant-baseline="central">REDUX_STORE</text>
+<rect class="diagram-node level-1" x="584" y="68" width="536" height="136" rx="8"/>
+<text class="text-primary" x="852" y="79" text-anchor="middle" dominant-baseline="central">Backend</text>
+<text class="text-id" x="852" y="91" text-anchor="middle" dominant-baseline="central">BACKEND</text>
+<rect class="diagram-node level-2" x="596" y="112" width="250" height="80" rx="8"/>
+<text class="text-primary" x="721" y="146" text-anchor="middle" dominant-baseline="central">REST API</text>
+<text class="text-id" x="721" y="160" text-anchor="middle" dominant-baseline="central">REST_API</text>
+<rect class="diagram-node level-2" x="858" y="112" width="250" height="80" rx="8"/>
+<text class="text-primary" x="983" y="146" text-anchor="middle" dominant-baseline="central">Business Logic</text>
+<text class="text-id" x="983" y="160" text-anchor="middle" dominant-baseline="central">BUSINESS_LOGIC</text>
+<rect class="diagram-node level-0" x="24" y="240" width="1108" height="192" rx="8"/>
+<text class="text-primary" x="578" y="251" text-anchor="middle" dominant-baseline="central">Data Layer</text>
+<text class="text-id" x="578" y="263" text-anchor="middle" dominant-baseline="central">DATA_LAYER</text>
+<rect class="diagram-node level-1" x="36" y="284" width="536" height="136" rx="8"/>
+<text class="text-primary" x="304" y="295" text-anchor="middle" dominant-baseline="central">PostgreSQL</text>
+<text class="text-id" x="304" y="307" text-anchor="middle" dominant-baseline="central">POSTGRESQL</text>
+<rect class="diagram-node level-2" x="48" y="328" width="250" height="80" rx="8"/>
+<text class="text-primary" x="173" y="362" text-anchor="middle" dominant-baseline="central">Users</text>
+<text class="text-id" x="173" y="376" text-anchor="middle" dominant-baseline="central">USERS_TABLE</text>
+<rect class="diagram-node level-2" x="310" y="328" width="250" height="80" rx="8"/>
+<text class="text-primary" x="435" y="362" text-anchor="middle" dominant-baseline="central">Orders</text>
+<text class="text-id" x="435" y="376" text-anchor="middle" dominant-baseline="central">ORDERS_TABLE</text>
+<rect class="diagram-node level-1" x="584" y="284" width="536" height="136" rx="8"/>
+<text class="text-primary" x="852" y="295" text-anchor="middle" dominant-baseline="central">Redis Cache</text>
+<text class="text-id" x="852" y="307" text-anchor="middle" dominant-baseline="central">REDIS_CACHE</text>
+<rect class="diagram-node level-2" x="596" y="328" width="250" height="80" rx="8"/>
+<text class="text-primary" x="721" y="362" text-anchor="middle" dominant-baseline="central">Sessions</text>
+<text class="text-id" x="721" y="376" text-anchor="middle" dominant-baseline="central">SESSIONS_CACHE</text>
+<rect class="diagram-node level-2" x="858" y="328" width="250" height="80" rx="8"/>
+<text class="text-primary" x="983" y="362" text-anchor="middle" dominant-baseline="central">Rate Limits</text>
+<text class="text-id" x="983" y="376" text-anchor="middle" dominant-baseline="central">RATE_LIMITS_CACHE</text>
+</svg>

--- a/transitrix/examples/capability-map.svg
+++ b/transitrix/examples/capability-map.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="966" height="860" viewBox="0 0 966 860">
+<defs>
+  <marker id="cap-tree-arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+</defs>
+<path d="M274,116 C338,116 290,64 354,64" class="diagram-edge"/>
+<path d="M604,168 C687.2,168 600.8,64 684,64" class="diagram-edge"/>
+<path d="M604,168 C668,168 620,168 684,168" class="diagram-edge"/>
+<path d="M274,116 C338,116 290,168 354,168" class="diagram-edge"/>
+<path d="M274,348 C338,348 290,296 354,296" class="diagram-edge"/>
+<path d="M274,348 C338,348 290,400 354,400" class="diagram-edge"/>
+<g>
+  <rect class="tree-level-0" x="354" y="24" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-3" x="364" y="55" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="378" y="64" text-anchor="middle" fill="white">L3</text>
+  <text class="text-primary" x="400" y="56" dominant-baseline="central">Order Intake</text>
+  <text class="text-id" x="400" y="73" dominant-baseline="central">CAPABILITY-V1.1</text>
+  
+</g>
+<g>
+  <rect class="tree-level-0" x="684" y="24" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-2" x="694" y="55" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="708" y="64" text-anchor="middle" fill="white">L2</text>
+  <text class="text-primary" x="730" y="56" dominant-baseline="central">Pick &amp; Pack</text>
+  <text class="text-id" x="730" y="73" dominant-baseline="central">CAPABILITY-V1.2.1</text>
+  
+</g>
+<g>
+  <rect class="tree-level-0" x="684" y="128" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-1" x="694" y="159" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="708" y="168" text-anchor="middle" fill="white">L1</text>
+  <text class="text-primary" x="730" y="160" dominant-baseline="central">Last-mile Delivery</text>
+  <text class="text-id" x="730" y="177" dominant-baseline="central">CAPABILITY-V1.2.2</text>
+  
+</g>
+<g>
+  <rect class="tree-level-0" x="354" y="128" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-2" x="364" y="159" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="378" y="168" text-anchor="middle" fill="white">L2</text>
+  <text class="text-primary" x="400" y="160" dominant-baseline="central">Order Fulfilment</text>
+  <text class="text-id" x="400" y="177" dominant-baseline="central">CAPABILITY-V1.2</text>
+  <circle class="tree-collapse-btn" cx="604" cy="168" r="8" data-node-id="CAPABILITY-V1.2" data-collapsed="false"/>
+  <text class="tree-collapse-lbl" x="604" y="168" text-anchor="middle">−</text>
+</g>
+<g>
+  <rect class="tree-level-0" x="24" y="76" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-2" x="34" y="107" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="48" y="116" text-anchor="middle" fill="white">L2</text>
+  <text class="text-primary" x="70" y="108" dominant-baseline="central">Order Management</text>
+  <text class="text-id" x="70" y="125" dominant-baseline="central">CAPABILITY-V1</text>
+  <circle class="tree-collapse-btn" cx="274" cy="116" r="8" data-node-id="CAPABILITY-V1" data-collapsed="false"/>
+  <text class="tree-collapse-lbl" x="274" y="116" text-anchor="middle">−</text>
+</g>
+<g>
+  <rect class="tree-level-0" x="354" y="256" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-2" x="364" y="287" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="378" y="296" text-anchor="middle" fill="white">L2</text>
+  <text class="text-primary" x="400" y="288" dominant-baseline="central">Customer Acquisition</text>
+  <text class="text-id" x="400" y="305" dominant-baseline="central">CAPABILITY-V2.1</text>
+  
+</g>
+<g>
+  <rect class="tree-level-0" x="354" y="360" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-3" x="364" y="391" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="378" y="400" text-anchor="middle" fill="white">L3</text>
+  <text class="text-primary" x="400" y="392" dominant-baseline="central">Customer Service</text>
+  <text class="text-id" x="400" y="409" dominant-baseline="central">CAPABILITY-V2.2</text>
+  
+</g>
+<g title="Customer Relationship Management">
+  <rect class="tree-level-0" x="24" y="308" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-3" x="34" y="339" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="48" y="348" text-anchor="middle" fill="white">L3</text>
+  <text class="text-primary" x="70" y="340" dominant-baseline="central">Customer Relationship…</text>
+  <text class="text-id" x="70" y="357" dominant-baseline="central">CAPABILITY-V2</text>
+  <circle class="tree-collapse-btn" cx="274" cy="348" r="8" data-node-id="CAPABILITY-V2" data-collapsed="false"/>
+  <text class="tree-collapse-lbl" x="274" y="348" text-anchor="middle">−</text>
+</g>
+<g>
+  <rect class="tree-level-0" x="24" y="436" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-4" x="34" y="467" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="48" y="476" text-anchor="middle" fill="white">L4</text>
+  <text class="text-primary" x="70" y="468" dominant-baseline="central">Financial Management</text>
+  <text class="text-id" x="70" y="485" dominant-baseline="central">CAPABILITY-V3</text>
+  
+</g>
+<g>
+  <rect class="tree-level-0" x="24" y="564" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-1" x="34" y="595" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="48" y="604" text-anchor="middle" fill="white">L1</text>
+  <text class="text-primary" x="70" y="596" dominant-baseline="central">Master Data Management</text>
+  <text class="text-id" x="70" y="613" dominant-baseline="central">CAPABILITY-H1</text>
+  
+</g>
+<g>
+  <rect class="tree-level-0" x="24" y="692" width="250" height="80" rx="11" stroke="var(--ts-node-stroke,#004d67)" stroke-width="3"/>
+  <rect class="tree-maturity-2" x="34" y="723" width="28" height="18" rx="4"/>
+  <text class="text-pill" x="48" y="732" text-anchor="middle" fill="white">L2</text>
+  <text class="text-primary" x="70" y="724" dominant-baseline="central">ESG &amp; Compliance</text>
+  <text class="text-id" x="70" y="741" dominant-baseline="central">CAPABILITY-H2</text>
+  
+</g>
+<rect class="tree-level-0" x="24" y="808" width="918" height="24" rx="4" stroke="var(--ts-node-stroke,#004d67)" stroke-width="1"/>
+  <text class="text-id" x="483" y="820" text-anchor="middle" dominant-baseline="central">Levels 0–2</text>
+</svg>

--- a/transitrix/examples/dgca.svg
+++ b/transitrix/examples/dgca.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="272" viewBox="0 0 1520 272">
+<style>:root{--ts-bg:#ffffff;--ts-bg-surface:#f8fafc;--ts-bg-elevated:#f1f5f9;--ts-text:#0f172a;--ts-text-muted:#64748b;--ts-text-inverse:#ffffff;--ts-border:#e2e8f0;--ts-divider:#cbd5e1;--ts-status-success-bg:#d1fae5;--ts-status-success-fg:#065f46;--ts-status-warning-bg:#fef9c3;--ts-status-warning-fg:#854d0e;--ts-status-info-bg:#e0f2fe;--ts-status-info-fg:#0c4a6e;--ts-status-error-bg:#fee2e2;--ts-status-error-fg:#991b1b;--ts-layer-driver:#eaf3f6;--ts-layer-factor:#eaf3f6;--ts-layer-goal:#d9ecf2;--ts-layer-change:#c7e5ef;--ts-layer-activity:#b4e0ee;--ts-node-stroke:#004d67;--ts-edge-stroke:#004d67;--ts-text-primary:#0d2b35;--ts-text-secondary:#516970;--ts-header-text:#0d2b35;--ts-maturity-1:#bf2518;--ts-maturity-2:#b05911;--ts-maturity-3:#8d7011;--ts-maturity-4:#407d21;--ts-maturity-5:#237b48;--ts-brand-amber:#ffaf00;--ts-brand-orange:#ff4d00;--ts-brand-orange-tint:#ffeee5;--ts-level-0:#eef4f7;--ts-level-1:#e6f1f4;--ts-level-2:#dfedf1;--ts-level-3:#d7e9ef;--ts-level-4:#cee6ed;--ts-level-5:#c6e2ec;--ts-level-6:#bfe0eb;--ts-level-7:#b7deeb;--ts-tree-level-0:#e6f1f4;--ts-tree-level-1:#d0e9f1;--ts-tree-level-2:#b5e3f2;--ts-tree-maturity-1:#bf2518;--ts-tree-maturity-2:#b05911;--ts-tree-maturity-3:#8d7011;--ts-tree-maturity-4:#407d21;--ts-tree-maturity-5:#237b48;}.diagram-node{stroke:var(--ts-node-stroke);stroke-width:1;}
+.layer-driver{fill:var(--ts-layer-driver);}
+.layer-factor{fill:var(--ts-layer-factor);}
+.layer-goal{fill:var(--ts-layer-goal);}
+.layer-change{fill:var(--ts-layer-change);}
+.layer-activity{fill:var(--ts-layer-activity);}
+.level-0{fill:var(--ts-level-0);}.level-1{fill:var(--ts-level-1);}.level-2{fill:var(--ts-level-2);}.level-3{fill:var(--ts-level-3);}.level-4{fill:var(--ts-level-4);}.level-5{fill:var(--ts-level-5);}.level-6{fill:var(--ts-level-6);}.level-7{fill:var(--ts-level-7);}
+.diagram-edge{stroke:var(--ts-edge-stroke);stroke-width:1.5;fill:none;}
+.arrow-fill{fill:var(--ts-edge-stroke);}
+.text-header{fill:var(--ts-header-text);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:13px;font-weight:700;dominant-baseline:central;}
+.text-primary{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:600;dominant-baseline:central;}
+.text-secondary{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:400;dominant-baseline:central;}
+.text-id{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:10px;font-weight:600;dominant-baseline:central;}
+.text-pill{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:500;dominant-baseline:central;}
+.maturity-1{fill:var(--ts-maturity-1);}
+.maturity-2{fill:var(--ts-maturity-2);}
+.maturity-3{fill:var(--ts-maturity-3);}
+.maturity-4{fill:var(--ts-maturity-4);}
+.maturity-5{fill:var(--ts-maturity-5);}
+.compliance-gap{fill:var(--ts-status-warning-bg);stroke:var(--ts-status-warning-fg);}
+.compliance-gap text{fill:var(--ts-status-warning-fg);}
+.compliance-deadline{fill:var(--ts-status-error-bg);stroke:var(--ts-status-error-fg);}
+.compliance-deadline text{fill:var(--ts-status-error-fg);}
+.compliance-badge{fill:var(--ts-status-error-fg);}
+.compliance-badge-text{fill:var(--ts-text-inverse);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:8px;font-weight:700;}
+.tree-level-0{fill:var(--ts-tree-level-0);}
+.tree-level-1{fill:var(--ts-tree-level-1);}
+.tree-level-2{fill:var(--ts-tree-level-2);}
+.tree-maturity-1{fill:var(--ts-tree-maturity-1);}
+.tree-maturity-2{fill:var(--ts-tree-maturity-2);}
+.tree-maturity-3{fill:var(--ts-tree-maturity-3);}
+.tree-maturity-4{fill:var(--ts-tree-maturity-4);}
+.tree-maturity-5{fill:var(--ts-tree-maturity-5);}
+.tree-collapse-btn{cursor:pointer;fill:white;stroke:var(--ts-node-stroke);stroke-width:1.5;}
+.tree-collapse-btn:hover{fill:var(--ts-bg-elevated);}
+.tree-collapse-lbl{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:700;dominant-baseline:central;pointer-events:none;}
+.blocks-grid-border{fill:none;stroke:var(--ts-border);}</style>
+<defs>
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+</defs>
+<text class="text-header" x="20" y="14">Product launch — strategy chain</text>
+<text class="text-header" x="145" y="36" text-anchor="middle" dominant-baseline="central">Drivers (D)</text>
+<text class="text-header" x="555" y="36" text-anchor="middle" dominant-baseline="central">Goals (G)</text>
+<text class="text-header" x="965" y="36" text-anchor="middle" dominant-baseline="central">Changes (C)</text>
+<text class="text-header" x="1375" y="36" text-anchor="middle" dominant-baseline="central">Actions (A)</text>
+<rect class="diagram-node layer-driver" x="20" y="72" width="250" height="80" rx="8"/>
+<text class="text-primary" x="145" y="92" text-anchor="middle" dominant-baseline="central">Growing demand for automated</text>
+<text class="text-primary" x="145" y="106" text-anchor="middle" dominant-baseline="central">reporting</text>
+<text class="text-id" x="145" y="134" text-anchor="middle" dominant-baseline="central">DRIVER-MARKET-1</text>
+<rect class="diagram-node layer-goal" x="430" y="72" width="250" height="80" rx="8"/>
+<text class="text-primary" x="555" y="92" text-anchor="middle" dominant-baseline="central">Launch our analytics product to</text>
+<text class="text-primary" x="555" y="106" text-anchor="middle" dominant-baseline="central">market</text>
+<text class="text-id" x="555" y="134" text-anchor="middle" dominant-baseline="central">GOAL-1</text>
+<rect class="diagram-node layer-change" x="840" y="72" width="250" height="80" rx="8"/>
+<text class="text-primary" x="965" y="92" text-anchor="middle" dominant-baseline="central">Build and release the core</text>
+<text class="text-primary" x="965" y="106" text-anchor="middle" dominant-baseline="central">reporting feature set</text>
+<text class="text-id" x="965" y="134" text-anchor="middle" dominant-baseline="central">CHANGE-1</text>
+<rect class="diagram-node layer-activity" x="1250" y="72" width="250" height="80" rx="8"/>
+<text class="text-primary" x="1375" y="99" text-anchor="middle" dominant-baseline="central">Analytics MVP</text>
+<text class="text-id" x="1375" y="127" text-anchor="middle" dominant-baseline="central">ACTION-1</text>
+<rect class="diagram-node layer-activity" x="1250" y="172" width="250" height="80" rx="8"/>
+<text class="text-primary" x="1375" y="199" text-anchor="middle" dominant-baseline="central">Beta programme</text>
+<text class="text-id" x="1375" y="227" text-anchor="middle" dominant-baseline="central">ACTION-2</text>
+<path d="M270,112 C350,112 350,112 430,112" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M680,112 C760,112 760,112 840,112" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M1090,112 C1170,112 1170,112 1250,112" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M1090,112 C1170,112 1170,212 1250,212" class="diagram-edge" marker-end="url(#arrow)"/>
+</svg>

--- a/transitrix/examples/goals.svg
+++ b/transitrix/examples/goals.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="998" height="336" viewBox="0 0 998 336">
+<style>:root{--ts-bg:#ffffff;--ts-bg-surface:#f8fafc;--ts-bg-elevated:#f1f5f9;--ts-text:#0f172a;--ts-text-muted:#64748b;--ts-text-inverse:#ffffff;--ts-border:#e2e8f0;--ts-divider:#cbd5e1;--ts-status-success-bg:#d1fae5;--ts-status-success-fg:#065f46;--ts-status-warning-bg:#fef9c3;--ts-status-warning-fg:#854d0e;--ts-status-info-bg:#e0f2fe;--ts-status-info-fg:#0c4a6e;--ts-status-error-bg:#fee2e2;--ts-status-error-fg:#991b1b;--ts-layer-driver:#eaf3f6;--ts-layer-factor:#eaf3f6;--ts-layer-goal:#d9ecf2;--ts-layer-change:#c7e5ef;--ts-layer-activity:#b4e0ee;--ts-node-stroke:#004d67;--ts-edge-stroke:#004d67;--ts-text-primary:#0d2b35;--ts-text-secondary:#516970;--ts-header-text:#0d2b35;--ts-maturity-1:#bf2518;--ts-maturity-2:#b05911;--ts-maturity-3:#8d7011;--ts-maturity-4:#407d21;--ts-maturity-5:#237b48;--ts-brand-amber:#ffaf00;--ts-brand-orange:#ff4d00;--ts-brand-orange-tint:#ffeee5;--ts-level-0:#eef4f7;--ts-level-1:#e6f1f4;--ts-level-2:#dfedf1;--ts-level-3:#d7e9ef;--ts-level-4:#cee6ed;--ts-level-5:#c6e2ec;--ts-level-6:#bfe0eb;--ts-level-7:#b7deeb;--ts-tree-level-0:#e6f1f4;--ts-tree-level-1:#d0e9f1;--ts-tree-level-2:#b5e3f2;--ts-tree-maturity-1:#bf2518;--ts-tree-maturity-2:#b05911;--ts-tree-maturity-3:#8d7011;--ts-tree-maturity-4:#407d21;--ts-tree-maturity-5:#237b48;}.diagram-node{stroke:var(--ts-node-stroke);stroke-width:1;}
+.layer-driver{fill:var(--ts-layer-driver);}
+.layer-factor{fill:var(--ts-layer-factor);}
+.layer-goal{fill:var(--ts-layer-goal);}
+.layer-change{fill:var(--ts-layer-change);}
+.layer-activity{fill:var(--ts-layer-activity);}
+.level-0{fill:var(--ts-level-0);}.level-1{fill:var(--ts-level-1);}.level-2{fill:var(--ts-level-2);}.level-3{fill:var(--ts-level-3);}.level-4{fill:var(--ts-level-4);}.level-5{fill:var(--ts-level-5);}.level-6{fill:var(--ts-level-6);}.level-7{fill:var(--ts-level-7);}
+.diagram-edge{stroke:var(--ts-edge-stroke);stroke-width:1.5;fill:none;}
+.arrow-fill{fill:var(--ts-edge-stroke);}
+.text-header{fill:var(--ts-header-text);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:13px;font-weight:700;dominant-baseline:central;}
+.text-primary{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:600;dominant-baseline:central;}
+.text-secondary{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:400;dominant-baseline:central;}
+.text-id{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:10px;font-weight:600;dominant-baseline:central;}
+.text-pill{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:500;dominant-baseline:central;}
+.maturity-1{fill:var(--ts-maturity-1);}
+.maturity-2{fill:var(--ts-maturity-2);}
+.maturity-3{fill:var(--ts-maturity-3);}
+.maturity-4{fill:var(--ts-maturity-4);}
+.maturity-5{fill:var(--ts-maturity-5);}
+.compliance-gap{fill:var(--ts-status-warning-bg);stroke:var(--ts-status-warning-fg);}
+.compliance-gap text{fill:var(--ts-status-warning-fg);}
+.compliance-deadline{fill:var(--ts-status-error-bg);stroke:var(--ts-status-error-fg);}
+.compliance-deadline text{fill:var(--ts-status-error-fg);}
+.compliance-badge{fill:var(--ts-status-error-fg);}
+.compliance-badge-text{fill:var(--ts-text-inverse);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:8px;font-weight:700;}
+.tree-level-0{fill:var(--ts-tree-level-0);}
+.tree-level-1{fill:var(--ts-tree-level-1);}
+.tree-level-2{fill:var(--ts-tree-level-2);}
+.tree-maturity-1{fill:var(--ts-tree-maturity-1);}
+.tree-maturity-2{fill:var(--ts-tree-maturity-2);}
+.tree-maturity-3{fill:var(--ts-tree-maturity-3);}
+.tree-maturity-4{fill:var(--ts-tree-maturity-4);}
+.tree-maturity-5{fill:var(--ts-tree-maturity-5);}
+.tree-collapse-btn{cursor:pointer;fill:white;stroke:var(--ts-node-stroke);stroke-width:1.5;}
+.tree-collapse-btn:hover{fill:var(--ts-bg-elevated);}
+.tree-collapse-lbl{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:700;dominant-baseline:central;pointer-events:none;}
+.blocks-grid-border{fill:none;stroke:var(--ts-border);}</style>
+<defs>
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+</defs>
+<text class="text-header" x="24" y="18">Goal tree — Strategy 2026 — Goals Tree</text>
+<g>
+  <rect class="diagram-node level-2" x="724" y="24" width="250" height="80" rx="8"/>
+  <text class="text-primary" x="849" y="42" text-anchor="middle" dominant-baseline="central">Open Berlin office</text>
+<text class="text-secondary" x="849" y="60" text-anchor="middle" dominant-baseline="central">Project Goal</text>
+<text class="text-id" x="849" y="88" text-anchor="middle" dominant-baseline="central">GOAL-BERLIN-1</text>
+</g>
+<g>
+  <rect class="diagram-node level-2" x="724" y="128" width="250" height="80" rx="8"/>
+  <text class="text-primary" x="849" y="146" text-anchor="middle" dominant-baseline="central">Obtain EU regulatory approval</text>
+<text class="text-secondary" x="849" y="164" text-anchor="middle" dominant-baseline="central">Project Goal</text>
+<text class="text-id" x="849" y="192" text-anchor="middle" dominant-baseline="central">GOAL-EU-REG-1</text>
+</g>
+<g>
+  <rect class="diagram-node level-1" x="374" y="76" width="250" height="80" rx="8"/>
+  <text class="text-primary" x="499" y="94" text-anchor="middle" dominant-baseline="central">Launch in 3 EU markets</text>
+<text class="text-secondary" x="499" y="112" text-anchor="middle" dominant-baseline="central">Strategic Goal</text>
+<text class="text-id" x="499" y="140" text-anchor="middle" dominant-baseline="central">GOAL-EU-1</text>
+</g>
+<g>
+  <rect class="diagram-node level-2" x="724" y="232" width="250" height="80" rx="8"/>
+  <text class="text-primary" x="849" y="250" text-anchor="middle" dominant-baseline="central">Partner with Dubai distributor</text>
+<text class="text-secondary" x="849" y="268" text-anchor="middle" dominant-baseline="central">Project Goal</text>
+<text class="text-id" x="849" y="296" text-anchor="middle" dominant-baseline="central">GOAL-DUBAI-1</text>
+</g>
+<g>
+  <rect class="diagram-node level-1" x="374" y="232" width="250" height="80" rx="8"/>
+  <text class="text-primary" x="499" y="250" text-anchor="middle" dominant-baseline="central">Launch in MENA</text>
+<text class="text-secondary" x="499" y="268" text-anchor="middle" dominant-baseline="central">Strategic Goal</text>
+<text class="text-id" x="499" y="296" text-anchor="middle" dominant-baseline="central">GOAL-MENA-1</text>
+</g>
+<g>
+  <rect class="diagram-node level-0" x="24" y="128" width="250" height="80" rx="8"/>
+  <text class="text-primary" x="149" y="146" text-anchor="middle" dominant-baseline="central">Triple revenue in 3 years</text>
+<text class="text-secondary" x="149" y="164" text-anchor="middle" dominant-baseline="central">Strategy</text>
+<text class="text-id" x="149" y="192" text-anchor="middle" dominant-baseline="central">GOAL-REVENUE-1</text>
+</g>
+<path d="M624,116 C688,116 660,64 724,64" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M624,116 C688,116 660,168 724,168" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M624,272 C688,272 660,272 724,272" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M274,168 C338,168 310,116 374,116" class="diagram-edge" marker-end="url(#arrow)"/>
+<path d="M274,168 C357.2,168 290.8,272 374,272" class="diagram-edge" marker-end="url(#arrow)"/>
+</svg>

--- a/transitrix/examples/process-blueprint.svg
+++ b/transitrix/examples/process-blueprint.svg
@@ -1,0 +1,135 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1288" height="659" viewBox="0 0 1288 659">
+<style>:root{--ts-bg:#ffffff;--ts-bg-surface:#f8fafc;--ts-bg-elevated:#f1f5f9;--ts-text:#0f172a;--ts-text-muted:#64748b;--ts-text-inverse:#ffffff;--ts-border:#e2e8f0;--ts-divider:#cbd5e1;--ts-status-success-bg:#d1fae5;--ts-status-success-fg:#065f46;--ts-status-warning-bg:#fef9c3;--ts-status-warning-fg:#854d0e;--ts-status-info-bg:#e0f2fe;--ts-status-info-fg:#0c4a6e;--ts-status-error-bg:#fee2e2;--ts-status-error-fg:#991b1b;--ts-layer-driver:#eaf3f6;--ts-layer-factor:#eaf3f6;--ts-layer-goal:#d9ecf2;--ts-layer-change:#c7e5ef;--ts-layer-activity:#b4e0ee;--ts-node-stroke:#004d67;--ts-edge-stroke:#004d67;--ts-text-primary:#0d2b35;--ts-text-secondary:#516970;--ts-header-text:#0d2b35;--ts-maturity-1:#bf2518;--ts-maturity-2:#b05911;--ts-maturity-3:#8d7011;--ts-maturity-4:#407d21;--ts-maturity-5:#237b48;--ts-brand-amber:#ffaf00;--ts-brand-orange:#ff4d00;--ts-brand-orange-tint:#ffeee5;--ts-level-0:#eef4f7;--ts-level-1:#e6f1f4;--ts-level-2:#dfedf1;--ts-level-3:#d7e9ef;--ts-level-4:#cee6ed;--ts-level-5:#c6e2ec;--ts-level-6:#bfe0eb;--ts-level-7:#b7deeb;--ts-tree-level-0:#e6f1f4;--ts-tree-level-1:#d0e9f1;--ts-tree-level-2:#b5e3f2;--ts-tree-maturity-1:#bf2518;--ts-tree-maturity-2:#b05911;--ts-tree-maturity-3:#8d7011;--ts-tree-maturity-4:#407d21;--ts-tree-maturity-5:#237b48;}.diagram-node{stroke:var(--ts-node-stroke);stroke-width:1;}
+.layer-driver{fill:var(--ts-layer-driver);}
+.layer-factor{fill:var(--ts-layer-factor);}
+.layer-goal{fill:var(--ts-layer-goal);}
+.layer-change{fill:var(--ts-layer-change);}
+.layer-activity{fill:var(--ts-layer-activity);}
+.level-0{fill:var(--ts-level-0);}.level-1{fill:var(--ts-level-1);}.level-2{fill:var(--ts-level-2);}.level-3{fill:var(--ts-level-3);}.level-4{fill:var(--ts-level-4);}.level-5{fill:var(--ts-level-5);}.level-6{fill:var(--ts-level-6);}.level-7{fill:var(--ts-level-7);}
+.diagram-edge{stroke:var(--ts-edge-stroke);stroke-width:1.5;fill:none;}
+.arrow-fill{fill:var(--ts-edge-stroke);}
+.text-header{fill:var(--ts-header-text);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:13px;font-weight:700;dominant-baseline:central;}
+.text-primary{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:600;dominant-baseline:central;}
+.text-secondary{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:400;dominant-baseline:central;}
+.text-id{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:10px;font-weight:600;dominant-baseline:central;}
+.text-pill{fill:var(--ts-text-primary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:11px;font-weight:500;dominant-baseline:central;}
+.maturity-1{fill:var(--ts-maturity-1);}
+.maturity-2{fill:var(--ts-maturity-2);}
+.maturity-3{fill:var(--ts-maturity-3);}
+.maturity-4{fill:var(--ts-maturity-4);}
+.maturity-5{fill:var(--ts-maturity-5);}
+.compliance-gap{fill:var(--ts-status-warning-bg);stroke:var(--ts-status-warning-fg);}
+.compliance-gap text{fill:var(--ts-status-warning-fg);}
+.compliance-deadline{fill:var(--ts-status-error-bg);stroke:var(--ts-status-error-fg);}
+.compliance-deadline text{fill:var(--ts-status-error-fg);}
+.compliance-badge{fill:var(--ts-status-error-fg);}
+.compliance-badge-text{fill:var(--ts-text-inverse);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:8px;font-weight:700;}
+.tree-level-0{fill:var(--ts-tree-level-0);}
+.tree-level-1{fill:var(--ts-tree-level-1);}
+.tree-level-2{fill:var(--ts-tree-level-2);}
+.tree-maturity-1{fill:var(--ts-tree-maturity-1);}
+.tree-maturity-2{fill:var(--ts-tree-maturity-2);}
+.tree-maturity-3{fill:var(--ts-tree-maturity-3);}
+.tree-maturity-4{fill:var(--ts-tree-maturity-4);}
+.tree-maturity-5{fill:var(--ts-tree-maturity-5);}
+.tree-collapse-btn{cursor:pointer;fill:white;stroke:var(--ts-node-stroke);stroke-width:1.5;}
+.tree-collapse-btn:hover{fill:var(--ts-bg-elevated);}
+.tree-collapse-lbl{fill:var(--ts-text-secondary);font-family:var(--vscode-font-family, system-ui, -apple-system, sans-serif);font-size:12px;font-weight:700;dominant-baseline:central;pointer-events:none;}
+.blocks-grid-border{fill:none;stroke:var(--ts-border);}
+.bp-row-bg { fill: none; }
+.bp-border { fill: none; stroke: var(--ts-border, #cbd5e1); stroke-width: 1; }</style>
+<text class="text-header" x="24" y="18">Order fulfilment — operational blueprint</text>
+<rect class="diagram-node level-0 bp-row-bg" x="24" y="48" width="1240" height="587" rx="6" stroke="none"/>
+<defs><clipPath id="bp-clip"><rect x="24" y="48" width="1240" height="587" rx="6"/></clipPath></defs>
+<g clip-path="url(#bp-clip)"><rect class="diagram-node level-1" x="164" y="48" width="220" height="40" stroke="none"/>
+<text class="text-header" x="274" y="68" text-anchor="middle" dominant-baseline="central">Receive order</text>
+<rect class="diagram-node level-1" x="384" y="48" width="220" height="40" stroke="none"/>
+<text class="text-header" x="494" y="68" text-anchor="middle" dominant-baseline="central">Allocate inventory</text>
+<rect class="diagram-node level-1" x="604" y="48" width="220" height="40" stroke="none"/>
+<text class="text-header" x="714" y="68" text-anchor="middle" dominant-baseline="central">Pick &amp; pack</text>
+<rect class="diagram-node level-1" x="824" y="48" width="220" height="40" stroke="none"/>
+<text class="text-header" x="934" y="68" text-anchor="middle" dominant-baseline="central">Ship</text>
+<rect class="diagram-node level-1" x="1044" y="48" width="220" height="40" stroke="none"/>
+<text class="text-header" x="1154" y="68" text-anchor="middle" dominant-baseline="central">Confirm delivery &amp; close</text>
+<rect class="diagram-node level-2 bp-row-bg" x="24" y="88" width="140" height="71" stroke="none"/>
+<text class="text-primary" x="36" y="123.5" dominant-baseline="central">Goal</text>
+<rect class="diagram-node level-2 bp-row-bg" x="24" y="159" width="140" height="88" stroke="none"/>
+<text class="text-primary" x="36" y="203" dominant-baseline="central">Result</text>
+<rect class="diagram-node level-2 bp-row-bg" x="24" y="247" width="140" height="188" stroke="none"/>
+<text class="text-primary" x="36" y="341" dominant-baseline="central">Systems</text>
+<rect class="diagram-node level-2 bp-row-bg" x="24" y="435" width="140" height="100" stroke="none"/>
+<text class="text-primary" x="36" y="485" dominant-baseline="central">Actors</text>
+<rect class="diagram-node level-2 bp-row-bg" x="24" y="535" width="140" height="100" stroke="none"/>
+<text class="text-primary" x="36" y="585" dominant-baseline="central">Equipment</text>
+<rect class="diagram-node level-3 bp-row-bg" x="164" y="88" width="220" height="71" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="174" y="115">Capture a validated</tspan><tspan x="174" y="132">customer order.</tspan></text>
+<rect class="diagram-node level-3 bp-row-bg" x="384" y="88" width="220" height="71" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="394" y="106.5">Reserve stock to satisfy</tspan><tspan x="394" y="123.5">the order from the optimal</tspan><tspan x="394" y="140.5">warehouse.</tspan></text>
+<rect class="diagram-node level-3 bp-row-bg" x="604" y="88" width="220" height="71" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="614" y="106.5">Assemble the physical</tspan><tspan x="614" y="123.5">order from the reserved</tspan><tspan x="614" y="140.5">inventory.</tspan></text>
+<rect class="diagram-node level-3 bp-row-bg" x="824" y="88" width="220" height="71" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="834" y="106.5">Hand the shipment to the</tspan><tspan x="834" y="123.5">carrier and notify the</tspan><tspan x="834" y="140.5">customer.</tspan></text>
+<rect class="diagram-node level-3 bp-row-bg" x="1044" y="88" width="220" height="71" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="1054" y="106.5">Confirm delivery, settle</tspan><tspan x="1054" y="123.5">payment, and close the</tspan><tspan x="1054" y="140.5">order.</tspan></text>
+<rect class="diagram-node level-4 bp-row-bg" x="164" y="159" width="220" height="88" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="174" y="186">Validated order record in</tspan><tspan x="174" y="203">OMS with payment</tspan><tspan x="174" y="220">pre-authorised.</tspan></text>
+<rect class="diagram-node level-4 bp-row-bg" x="384" y="159" width="220" height="88" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="394" y="186">Reservation lines linked</tspan><tspan x="394" y="203">to the order across one or</tspan><tspan x="394" y="220">more warehouses.</tspan></text>
+<rect class="diagram-node level-4 bp-row-bg" x="604" y="159" width="220" height="88" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="614" y="177.5">Packed shipment scanned</tspan><tspan x="614" y="194.5">out of the warehouse and</tspan><tspan x="614" y="211.5">ready for carrier</tspan><tspan x="614" y="228.5">handover.</tspan></text>
+<rect class="diagram-node level-4 bp-row-bg" x="824" y="159" width="220" height="88" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="834" y="186">In-transit shipment with</tspan><tspan x="834" y="203">tracking number sent to</tspan><tspan x="834" y="220">the customer.</tspan></text>
+<rect class="diagram-node level-4 bp-row-bg" x="1044" y="159" width="220" height="88" stroke="none"/>
+<text class="text-secondary" dominant-baseline="central"><tspan x="1054" y="186">Closed order; payment</tspan><tspan x="1054" y="203">captured; post-purchase</tspan><tspan x="1054" y="220">feedback request queued.</tspan></text>
+<rect class="diagram-node level-5 bp-row-bg" x="164" y="247" width="1100" height="188" stroke="none"/>
+<rect class="diagram-node level-6 bp-row-bg" x="164" y="435" width="1100" height="100" stroke="none"/>
+<rect class="diagram-node level-7 bp-row-bg" x="164" y="535" width="1100" height="100" stroke="none"/>
+<line class="diagram-edge" x1="24" y1="88" x2="1264" y2="88"/>
+<line class="diagram-edge" x1="24" y1="159" x2="1264" y2="159"/>
+<line class="diagram-edge" x1="24" y1="247" x2="1264" y2="247"/>
+<line class="diagram-edge" x1="24" y1="435" x2="1264" y2="435"/>
+<line class="diagram-edge" x1="24" y1="535" x2="1264" y2="535"/>
+<line class="diagram-edge" x1="164" y1="48" x2="164" y2="635"/>
+<line class="diagram-edge" x1="384" y1="48" x2="384" y2="635"/>
+<line class="diagram-edge" x1="604" y1="48" x2="604" y2="635"/>
+<line class="diagram-edge" x1="824" y1="48" x2="824" y2="635"/>
+<line class="diagram-edge" x1="1044" y1="48" x2="1044" y2="635"/><rect class="diagram-node level-5" x="172" y="299" width="1084" height="40" rx="6"/>
+<text class="text-pill" x="714" y="311.5" text-anchor="middle" dominant-baseline="central">Order Management System</text>
+<text class="text-secondary" x="714" y="326.5" text-anchor="middle" dominant-baseline="central">APPLICATION-OMS-1</text>
+<rect class="diagram-node level-5" x="392" y="255" width="424" height="40" rx="6"/>
+<text class="text-pill" x="604" y="267.5" text-anchor="middle" dominant-baseline="central">Warehouse Management System</text>
+<text class="text-secondary" x="604" y="282.5" text-anchor="middle" dominant-baseline="central">APPLICATION-WMS-1</text>
+<rect class="diagram-node level-5" x="832" y="255" width="424" height="40" rx="6"/>
+<text class="text-pill" x="1044" y="267.5" text-anchor="middle" dominant-baseline="central">Transportation Management System</text>
+<text class="text-secondary" x="1044" y="282.5" text-anchor="middle" dominant-baseline="central">APPLICATION-TMS-1</text>
+<rect class="diagram-node level-5" x="172" y="255" width="204" height="40" rx="6"/>
+<text class="text-pill" x="274" y="267.5" text-anchor="middle" dominant-baseline="central">Payment gateway</text>
+<text class="text-secondary" x="274" y="282.5" text-anchor="middle" dominant-baseline="central">APPLICATION-PAYMENT-1</text>
+<rect class="diagram-node level-5" x="1052" y="387" width="204" height="40" rx="6"/>
+<text class="text-pill" x="1154" y="399.5" text-anchor="middle" dominant-baseline="central">Payment gateway</text>
+<text class="text-secondary" x="1154" y="414.5" text-anchor="middle" dominant-baseline="central">APPLICATION-PAYMENT-1</text>
+<rect class="diagram-node level-5" x="832" y="343" width="424" height="40" rx="6"/>
+<text class="text-pill" x="1044" y="363" text-anchor="middle" dominant-baseline="central">Carrier tracking webhook</text>
+<rect class="diagram-node level-6" x="172" y="443" width="204" height="40" rx="6"/>
+<text class="text-pill" x="274" y="455.5" text-anchor="middle" dominant-baseline="central">Customer service</text>
+<text class="text-pill" x="274" y="470.5" text-anchor="middle" dominant-baseline="central">representative</text>
+<rect class="diagram-node level-6" x="1052" y="443" width="204" height="40" rx="6"/>
+<text class="text-pill" x="1154" y="455.5" text-anchor="middle" dominant-baseline="central">Customer service</text>
+<text class="text-pill" x="1154" y="470.5" text-anchor="middle" dominant-baseline="central">representative</text>
+<rect class="diagram-node level-6" x="392" y="443" width="204" height="40" rx="6"/>
+<text class="text-pill" x="494" y="455.5" text-anchor="middle" dominant-baseline="central">Inventory planner</text>
+<text class="text-secondary" x="494" y="470.5" text-anchor="middle" dominant-baseline="central">ROLE-INVENTORY-PLANNER-1</text>
+<rect class="diagram-node level-6" x="612" y="443" width="424" height="40" rx="6"/>
+<text class="text-pill" x="824" y="455.5" text-anchor="middle" dominant-baseline="central">Warehouse operator</text>
+<text class="text-secondary" x="824" y="470.5" text-anchor="middle" dominant-baseline="central">ROLE-WAREHOUSE-OP-1</text>
+<rect class="diagram-node level-6" x="1052" y="487" width="204" height="40" rx="6"/>
+<text class="text-pill" x="1154" y="499.5" text-anchor="middle" dominant-baseline="central">Finance operations</text>
+<text class="text-secondary" x="1154" y="514.5" text-anchor="middle" dominant-baseline="central">ROLE-FINANCE-OP-1</text>
+<rect class="diagram-node level-7" x="612" y="587" width="424" height="40" rx="6"/>
+<text class="text-pill" x="824" y="607" text-anchor="middle" dominant-baseline="central">Barcode scanner</text>
+<rect class="diagram-node level-7" x="612" y="543" width="204" height="40" rx="6"/>
+<text class="text-pill" x="714" y="563" text-anchor="middle" dominant-baseline="central">Packing station</text>
+<rect class="diagram-node level-7" x="832" y="543" width="204" height="40" rx="6"/>
+<text class="text-pill" x="934" y="563" text-anchor="middle" dominant-baseline="central">Label printer</text></g>
+<rect class="bp-border" x="24" y="48" width="1240" height="587" rx="6" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary

`transitrix/README.md` now leads with a gallery of rendered SVG examples of the notation views the plugin's `onboard` skill lets a user author — a reader can see real output before installing anything.

- New package `packages/plugin-examples/` (`@transitrix/diagrams` pinned to an exact version, `js-yaml` for full YAML parsing) generates each SVG from this repository's own `notations/examples/` sources via the shared rendering library's parse/validate → render pipeline (the same library Studio and DSM use).
- Images committed under `transitrix/examples/*.svg`, referenced by relative Markdown path — static, no JS, no external host, no build step to view.
- CI (`.github/workflows/plugin-examples-drift.yml`) regenerates into a scratch directory and diffs byte-for-byte against the committed files on every relevant PR, failing the build on drift.

**Views covered (real SVG renderer, real repo example, verified byte-reproducible):** Goals, DGCA/DGA, Capability map, Process Blueprint, Action schedule, Nested blocks.

**Views intentionally omitted (not misrepresented as producible this round):**
- Applications, Products, Process landscape map, Scenarios — the library's renderer for these emits an HTML fragment, not SVG/PNG.
- Integration map — no renderer exists in the library at all.
- BPMN — the SVG body emitter is published, but the layout algorithm that turns parsed BPMN YAML into a renderable layout is not; it's bundled privately inside Studio's own extension, not part of the shared library.
- Action Card — its resolver needs canon element/relation documents (the project and change it references); this repo's standalone example doesn't have those as real files, and fabricating them was out of scope.
- Actions tree, Compliance Impact, Coverage Metric, Glossary (report views) — these produce HTML/data matrices, not images.

`transitrix/plugin.json` is untouched, as scoped — this PR only changes what the README's gallery can show, not the capability description.

## Test plan
- [x] `node packages/plugin-examples/src/generate.mjs` runs clean, produces 6 well-formed `<svg>` files (tag-balance checked, no truncation)
- [x] Regenerating into a scratch dir and diffing against committed output confirms byte-identical reproduction
- [x] `node scripts/check-notations.mjs` passes (no broken links introduced)
- [x] `transitrix/README.md` re-read in full after edit, no truncation