### PR TITLE
docs(contributing): document Skill contributions, fix stale validator path, add issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: A validator, a spec, an example, or the documentation behaves incorrectly or inconsistently with what it says.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For this repository's own defects: a validator false positive/negative, a
+        documentation bug, or a methodology ambiguity. See
+        [CONTRIBUTING.md § Reporting issues](../../CONTRIBUTING.md#reporting-issues).
+
+        Not for this: model content in an adopter repository (report it there
+        instead), or a question about a specific organisation's own architecture.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Validator false positive (flags something that should be valid)
+        - Validator false negative (misses something that should be invalid)
+        - Documentation bug (wrong, outdated, or broken content/link)
+        - Methodology question or ambiguity
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: File path or section reference
+      description: The file and, where useful, the section (e.g. a spec §, a schema field).
+      placeholder: notations/views/01-bpmn.md §3
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: What you observed
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction (optional)
+      description: A short snippet, example file, or command that reproduces this.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Other enquiries
+    url: mailto:hello@transitrix.com
+    about: Anything that isn't a bug report or a change request for this repository — see CONTRIBUTING.md § Communication.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature or change request
+description: Propose a new notation, validation rule, view template, or Skill — or a change to an existing one.
+title: "[Request] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        See [CONTRIBUTING.md § What kinds of contributions are welcome](../../CONTRIBUTING.md#what-kinds-of-contributions-are-welcome).
+        Substantive changes (new notation, schema change, validation rule) need this
+        issue open *before* a pull request — see
+        [CONTRIBUTING.md § Submitting changes](../../CONTRIBUTING.md#submitting-changes).
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of change
+      options:
+        - New notation
+        - Change to an existing notation or schema
+        - New or changed validation rule
+        - New or changed Skill (see CONTRIBUTING.md § Adding or changing a Skill)
+        - New or changed view template
+        - Tooling integration
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What gap or limitation does this address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,17 @@
 ## What changed
 
-<!-- The change itself. -->
+<!--
+The change itself, and how it works. One concern per PR (see CONTRIBUTING.md).
+Do not explain why the change was wanted, or recount how a prior check/audit/
+cleanup came about — state the current change only.
+-->
 
 ## How it is verified
 
 <!-- Commands run, tests added, what a reviewer can re-run. -->
+
+## Checklist
+
+- [ ] Based on `main`, one concern per PR.
+- [ ] Commits are signed off (`git commit -s`) — DCO.
+- [ ] No hub/work-item references (`HUB-…`, `task #…`, `epic #…`) in committed files, this description, or commit messages — a PR-scoped reference to *this* repo's own issues/PRs (`#12`, `closes #12`) is fine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ Thanks for considering a contribution. This document describes how to get involv
 
 - **Methodology refinements** — edits to the files under `method/`, the glossary, or the project rules. Substantive changes (new notation, schema change, validation rule) need an issue first; phrasing and documentation fixes can land directly as a pull request.
 - **Worked examples** — contribute directly to the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo (its own PR flow), or propose a new sibling worked-example repo for a pattern not yet covered.
-- **Validators and templates** — new validation rules in `.validators/lint.py`, new YAML templates in `.templates/`, or new view templates in `views/`.
+- **Validators and templates** — new validation rules in `tools/lint.py` (the canonical whole-repo linter; adopter repos vendor a copy as `.validators/lint.py` at scaffold time), or new view templates under `transitrix/skills/onboard/templates/`.
+- **Skills** — adding or changing a Claude Code Skill under `transitrix/skills/<name>/`. See "Adding or changing a Skill" below.
 - **Tooling integrations** — patches that make Transitrix easier to use with editors, CI systems, or downstream consumers (renderers, exporters, etc.).
 - **Translations** — translations of `methodology.md` into other languages, placed under `translations/<lang>/`. The English version remains canonical; translations are derivative.
 
@@ -28,9 +29,48 @@ For each issue, include the file path or section reference, what you observed, a
 1. **Open or claim an issue** for non-trivial work. This avoids parallel effort and gives you context before you write.
 2. **Branch from `main`.** Use a descriptive branch name (`docs/methodology-bpmn-clarifications`, `feat/validator-rule-policy-archive`).
 3. **Keep pull requests focused.** One concern per PR.
-4. **Run validators locally.** `python3 organizations/<org>/.validators/lint.py` for any organisation you touch.
+4. **Run the relevant validators locally, before opening the PR.** This repo's own gate is not a single command — `.validators/lint.py` is what an *adopter* repo runs against its `canon/`; this repo has no `canon/` of its own to validate. What CI actually runs here, by what you touched:
+   - Any `notations/**` spec or example, or `transitrix/skills/onboard/templates/**` — `node scripts/check-notations.mjs` (mechanical invariants: example extensions, `notation:` headers, internal link resolution, version-pin consistency).
+   - A single view notation file (`*.transitrix.yaml`) — `npx @transitrix/cli validate <file>` (`npx.cmd` on Windows PowerShell with a restricted execution policy).
+   - `tools/lint.py` itself — the encoding regression test in `.github/workflows/lint-encoding-test.yml`.
+   - A Claude Code Skill under `transitrix/skills/<name>/` — see "Adding or changing a Skill" below.
+   - Anything else — check `.github/workflows/` for a job whose `paths:` trigger matches the files you touched; most packages and skills carry their own targeted test workflow.
 5. **Update related docs.** If your change affects naming, layout, or rules, update the relevant file(s) under `method/` (naming: `method/03-modelling.md`; layout: `method/02-repository.md`), `method/00-glossary.md`, and `README.md` as needed.
-6. **Open a pull request.** Describe what changed, why, and link the issue.
+6. **Open a pull request.** Describe what changed and how it works (not why it was wanted), and link the issue. Sign off your commits (see DCO below); the PR template asks for the same "what changed" / "how it is verified" structure.
+
+## Adding or changing a Skill
+
+A Skill is a packaged Claude Code capability under `transitrix/skills/<name>/`, one directory per skill, inside the `transitrix` plugin (plugin root `transitrix/`, shared manifest `transitrix/.claude-plugin/plugin.json`). The existing skills — `adr`, `feedback`, `ingest`, `knowledge-store`, `onboard`, `reg-intel`, `repo-check`, `report`, `status` — are the precedent to follow; `repo-check` is a short, self-contained example worth reading first.
+
+**Every skill pairs two files at its root:**
+
+- `SKILL.md` — the agent-facing protocol. Front matter carries `name`, `description`, `when_to_use`, `min_version`, and `allowed-tools`; the body is the step-by-step procedure the agent follows. `description` and `when_to_use` are what a host uses to decide when to invoke the skill, so write them as trigger phrases and concrete scenarios, not summary prose.
+- `README.md` — the human-facing overview: what the skill does, why it exists, what it deliberately does not do, and how to invoke it (`/transitrix:<name>`).
+
+Add supporting material only as the skill needs it, following existing precedent: `templates/` for scaffolded files (`onboard/templates/`), `prompts/` for multi-step prompt sequences (`ingest/prompts/`, `reg-intel/prompts/`), `schemas/` for JSON Schema the skill validates against, `tests/` for a deterministic integrity test (`onboard/tests/`, `knowledge-store/tests/`).
+
+**Changing an existing skill:**
+
+1. Read the skill's `SKILL.md` and `README.md` in full before editing — the two must stay consistent with each other and with the skill's actual behaviour.
+2. If the skill ships a `tests/` directory, run its test(s) locally before committing (see the validation-gate table below).
+3. If your change touches the `onboard` skill's family-selection matrix or `templates/`, run `node scripts/check-skill-cheatsheet.mjs` — it diffs the cheat sheet against `notations/README.md`'s notation catalogue and fails the build on drift.
+
+**Adding a new skill:**
+
+1. Open an issue first (see "Submitting changes" above) — a new skill is substantive.
+2. Create `transitrix/skills/<name>/SKILL.md` and `README.md` following the pairing above; model the front matter on an existing skill of similar shape.
+3. If the skill needs a deterministic CI check, add `tests/` and a workflow under `.github/workflows/` following the naming of the existing skill-test workflows (`onboarding-skill-test.yml`, `knowledge-store-lint-test.yml`), gated on `pull_request: paths: ['transitrix/skills/<name>/**']` so it runs only when that skill changes.
+4. A new skill does not need to be registered anywhere else — `transitrix/.claude-plugin/plugin.json` declares the plugin as a whole, not each skill individually; a host that loads the plugin discovers every `skills/<name>/SKILL.md` under it.
+
+**Validation gate for Skills:**
+
+| Touching | Run |
+|---|---|
+| Any skill's `SKILL.md`/`README.md` prose | No dedicated linter for this tree — `node scripts/check-notations.mjs`'s link check is scoped to `notations/**/*.md` only, so check relative links by hand. |
+| `onboard`'s family-selection matrix or `templates/` | `node scripts/check-skill-cheatsheet.mjs` |
+| `onboard`'s scaffold logic | `python transitrix/skills/onboard/tests/test_skill_integrity.py` |
+| `knowledge-store`'s linter or pattern doc | the test(s) under `transitrix/skills/knowledge-store/tests/` |
+| Any skill with its own `tests/` | the test(s) in that directory — check `.github/workflows/` for the matching `paths:`-gated job before assuming there isn't one |
 
 ## Review process
 


### PR DESCRIPTION
## What changed

`CONTRIBUTING.md` gains an "Adding or changing a Skill" section: skill directory structure (`transitrix/skills/<name>/`), the `SKILL.md`/`README.md` pairing and front-matter fields, where supporting material (`templates/`, `prompts/`, `schemas/`, `tests/`) goes, and a per-touched-path validation-gate table.

Step 4 of "Submitting changes" and the "Validators and templates" bullet are corrected: they cited `organizations/<org>/.validators/lint.py`, `.templates/`, and `views/`, none of which exist in this repo (`.validators/lint.py` is what an adopter repo vendors from this repo's own `tools/lint.py`; view templates live at `transitrix/skills/onboard/templates/`). Both now point at what CI actually runs here — `node scripts/check-notations.mjs`, `npx @transitrix/cli validate <file>`, `node scripts/check-skill-cheatsheet.mjs`, and per-skill test suites — keyed to what was touched.

Adds `.github/ISSUE_TEMPLATE/` (`bug_report.yml`, `feature_request.yml`, `config.yml`) as GitHub issue forms, scoped to this repository's own issues per the existing "Reporting issues" categories. Extends `.github/pull_request_template.md` with a checklist for DCO sign-off, one-concern-per-PR, and the no-work-item-reference rule the `public-surface-hygiene` workflow already enforces.

## How it is verified

- `node scripts/check-notations.mjs` — clean (20 view notations, links, version pins all consistent).
- `node --test scripts/check-notations.test.mjs` — 54/54 passing.
- `node scripts/check-skill-cheatsheet.mjs` — clean (20 notations checked).
- All three new YAML issue-form files parse (`yaml.safe_load`).
- Walked the contribution path from a genuinely fresh clone of this branch: confirmed every path now cited in `CONTRIBUTING.md` exists (`tools/lint.py`, `transitrix/skills/onboard/templates/`, `scripts/check-notations.mjs`, `scripts/check-skill-cheatsheet.mjs`, `transitrix/skills/onboard/tests/test_skill_integrity.py`, `transitrix/skills/knowledge-store/tests/`), and ran each command the doc now tells a contributor to run — `node scripts/check-notations.mjs`, `node scripts/check-skill-cheatsheet.mjs`, both skill integrity Python tests, and `npx @transitrix/cli@1 validate` against a real example file — all exited 0 (the CLI validate ran a real network install and reported real warnings on the target file, confirming the command works as documented, not just that the path exists). The old `organizations/<org>/.validators/lint.py` line would have failed this same walk, since neither `organizations/` nor `.validators/` exists in this repo — that's what the fix above corrects.