### PR TITLE
fix(notations): correct RELEASE lifecycle semantics and record its provenance decision

### DIFF
--- a/notations/ELEMENT_PRIMITIVES.md
+++ b/notations/ELEMENT_PRIMITIVES.md
@@ -1004,12 +1004,16 @@ A `RELEASE` is a dated/versioned **state of a modelled subject** — one shipped
 | `of` | **yes** | string | `PRODUCT-…` or `APPLICATION-…` — the subject this is a release of. No other TYPE is a valid entry. |
 | `version` | **yes** | string | An opaque label (`"2.4.0"`, `"2026.07-hotfix1"`, whatever the subject's own versioning scheme uses). **Never parsed, compared, or sorted anywhere in shipped code** — order between releases of the same subject is expressed exclusively by `predecessor`, never inferred from this string. |
 | `predecessor` | no | string | `RELEASE-…` — the prior release of the *same* subject this one succeeds. Same-TYPE, inline, timeless — the same shape as `CHANGE.parent` (§7.3) and `LOCATION.parent` (§7.22). The only expression of version order; a subject's release history is a chain (or, where a vendor branches maintenance lines, more than one chain) reconstructed by following `predecessor` links, never by comparing `version` strings. |
-| `released_at` | no | string | Date this release shipped — quoted ISO 8601 ([CONTRACT.md](CONTRACT.md) §4). Distinct from `valid_from`/`valid_to` (§3), which record the *element record's* canon lifecycle, not the shipped subject's own release date. |
+| `released_at` | no | string | Date this release shipped — quoted ISO 8601 ([CONTRACT.md](CONTRACT.md) §4). **Normally equal to `valid_from`**: a release takes effect when it ships, and [CONTRACT.md](CONTRACT.md) §7 defines the lifecycle as a property of the *modelled thing*, not of the record — so a release admitted long after it shipped carries the **ship date** in `valid_from`, never the admission date (that is `admitted_at`, and it is what freshness decays from — [CONTRACT.md](CONTRACT.md) §11.3). The two fields are kept separate because `released_at` is optional and records the subject's own historical ship date, while `valid_from` is required and pairs with `valid_to`, which closes the window if the release is later withdrawn. |
 | `description` | recommended | string | One-paragraph elaboration — what changed in this release, if worth recording beyond what `predecessor` and the attached claims already say. |
 
 **No list of its own contents.** A `RELEASE` does not enumerate what it contains — no `requirements[]`, no `changes[]`. Composition (which obligations apply to it, which claims target it) is derived by querying the `required_for` relation kind ([elements/17-relations.md](elements/17-relations.md) §3, `REQUIREMENT` → `RELEASE` — a first-class REL file, not a field on either endpoint) and the `ASSERTION`/`VERIFICATION` release qualifiers for this release's id, never stored on the `RELEASE` element itself — the same "derive, don't duplicate" discipline as `CHANGE`'s impact set (§7.3.1). The obligation side of that derivation, including how `predecessor` carries an obligation forward from one release to the next, is specified at [elements/17-relations.md](elements/17-relations.md) §3.2.
 
 **Authoring rule — catalogued only when referenced.** A `RELEASE` is not created preemptively for every version a vendor or a team has ever shipped. It is admitted to canon only once something needs to distinguish it — a `required_for` obligation that applies from a specific release onward, or an `ASSERTION`/`VERIFICATION` whose outcome differs by release. This mirrors the `STEP` promotion rule's restraint (§7.20, [`IDS_AND_REFERENCES.md`](IDS_AND_REFERENCES.md) §1) without being the same mechanic: `STEP` is inline-then-promoted (it has a containing `PROCESS` to live in before promotion); `RELEASE` has no such containing document — it is always authored directly as a standalone file, just sparingly, so a subject's full vendor version history is never implied to belong in the catalogue as inert entries.
+
+**Provenance — no per-TYPE fields, because the envelope already carries it.** A `RELEASE` admitted from tag/branch evidence rather than a signed release document cites that evidence through **`derived_from`** (§3) — an envelope field every `standalone` TYPE carries, not one a TYPE opts into. There is consequently nothing for this section to add and nothing missing: a tag-sourced release is exactly as auditable as a document-sourced one, and its provenance belongs there rather than buried in free-text `description`. The matching field artefact for a repository/tag survey is an `OBSERVATION` ([IDS_AND_REFERENCES.md](IDS_AND_REFERENCES.md) §3.4).
+
+`RELEASE` has **no** `extraction_confidence` field — and neither does any other canon element, of any TYPE. `extraction_confidence` is a review flag on an ingest **candidate** (`candidate.extraction_confidence`, [vocabulary.yaml](vocabulary.yaml)); it is surfaced in the review queue, drives reviewer-authority routing ([CONTRACT.md](CONTRACT.md) §6.2), and is **never persisted into canon**. An admitted element carrying it is a defect in whatever wrote it, not a precedent to follow. (Decision recorded per `transitrix-hq#197`: documented convention, no schema extension.)
 
 ```yaml
 # canon/elements/05_implementation/releases/RELEASE-PAYMENTS-GATEWAY-2.yaml
@@ -1027,17 +1031,21 @@ released_at: "2026-07-15"
 
 # Admission record (CONTRACT.md §6)
 zone: canon
-admitted_at: "2026-07-15"
+admitted_at: "2026-08-03"          # when the record passed the gate — weeks after the ship date
 admitted_by: "v.korobeinikov"
 gate_checks:
   uniqueness: pass
   consistency: pass
   completeness: pass
+derived_from:                      # optional (§3) — the evidence this release was admitted from
+  - OBSERVATION-payments-gateway-tag-survey-1
 
 # Primitive lifecycle (CONTRACT.md §7)
-valid_from: "2026-07-15"
+valid_from: "2026-07-15"           # the SHIP date, not the admission date
 valid_to: null
 ```
+
+The three dates are deliberately not all equal. `released_at` and `valid_from` coincide — a release takes effect when it ships — while `admitted_at` is later, because the catalogue recorded it afterwards. An example in which all three carry the same date demonstrates nothing, and has been read as licence to set `valid_from` from the admission date; it is not.
 
 No view inline shape: `RELEASE` is standalone-only, like `RISK` and `NEED` — it is not authored inline inside any view document.
 

--- a/notations/examples/release-qualifiers/canon/elements/05_implementation/releases/RELEASE-TELEMETRY-PLATFORM-1.yaml
+++ b/notations/examples/release-qualifiers/canon/elements/05_implementation/releases/RELEASE-TELEMETRY-PLATFORM-1.yaml
@@ -18,5 +18,5 @@ gate_checks:
   consistency: pass
   completeness: pass
 
-valid_from: "2026-08-07"
+valid_from: "2026-03-02"
 valid_to: null

--- a/notations/examples/release-qualifiers/canon/elements/05_implementation/releases/RELEASE-TELEMETRY-PLATFORM-2.yaml
+++ b/notations/examples/release-qualifiers/canon/elements/05_implementation/releases/RELEASE-TELEMETRY-PLATFORM-2.yaml
@@ -18,5 +18,5 @@ gate_checks:
   consistency: pass
   completeness: pass
 
-valid_from: "2026-08-07"
+valid_from: "2026-06-18"
 valid_to: null

--- a/notations/examples/release-qualifiers/rule-violations/canon/elements/05_implementation/releases/RELEASE-EDGE-COLLECTOR-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/elements/05_implementation/releases/RELEASE-EDGE-COLLECTOR-1.yaml
@@ -18,5 +18,5 @@ gate_checks:
   consistency: pass
   completeness: pass
 
-valid_from: "2026-08-07"
+valid_from: "2026-05-11"
 valid_to: null


### PR DESCRIPTION
## What changed

Two decisions on the `RELEASE` notation's edges, and the example fixes that follow from them. Raised as `THQ-197`.

### 1. `valid_from` on a `RELEASE` is the **ship date**, not the admission date

The two normative statements disagreed:

- **`CONTRACT.md` §7** — the primitive lifecycle is a property of *the modelled thing*, "independent of when it was admitted", and "an artefact admitted today may legitimately carry `valid_from` years in the past".
- **`ELEMENT_PRIMITIVES.md` §7.29** — described `valid_from`/`valid_to` as recording "the *element record's* canon lifecycle", which is precisely what `admitted_at` records.

`CONTRACT.md` §7 is the contract §7.29 cites, so it wins; §7.29's parenthetical is the defect and is replaced. The distinction between `released_at` and `valid_from` is restated on a correct basis (optionality, and `valid_to` having no `released_at` counterpart) rather than a wrong one.

This had already propagated: **the five bundled `RELEASE` examples disagreed with each other** — the three under `release-qualifiers/` set `valid_from` from `admitted_at`, the two under `relations/required-for/` set it from `released_at`. The three are corrected; the two were already right and are untouched.

§7.29's own worked example gave `released_at`, `admitted_at` and `valid_from` all the same date, so it could not settle the question either way. `admitted_at` now differs, and a sentence says why.

### 2. `RELEASE` provenance — documented convention, **no schema extension**

The issue asked for a decision between extending the schema and documenting a convention. Neither of the gaps it assumed turns out to exist:

- **`derived_from` is not missing from `RELEASE`.** It is a §3 *envelope* field carried by every `standalone` TYPE, not something a TYPE opts into — so a release admitted from tag/branch evidence is already exactly as auditable as a document-sourced one, and provenance never needs to be buried in `description`. §7.29 now says so, and the worked example demonstrates it (an `OBSERVATION`, the field-artefact type for a repository survey — `IDS_AND_REFERENCES.md` §3.4).
- **`extraction_confidence` is not a field on `APPLICATION` or any other canon element.** It is a review flag on an ingest *candidate* (`candidate.extraction_confidence` in `vocabulary.yaml`, `spec: null`), and `transitrix/skills/ingest/` states three times that it is "never persisted into canon". An admitted element carrying it is a defect in whatever wrote it, not a precedent.

## Why the confusion was reasonable

`CONTRACT.md` §6.2 calls `extraction_confidence` one of "the two trust signals (`source_quality`, `extraction_confidence` — §11)", but §11 defines only `source_quality` and freshness — it never mentions `extraction_confidence`. A reader following that pointer finds nothing and concludes the field is an element-level one that `RELEASE` lacks.

**That dangling cross-reference is left in place here** — fixing it means editing `CONTRACT.md` §6/§11 and two ingest-skill citations of a `§11.8` that says nothing on the subject, which is a separate concern from the `RELEASE` notation and belongs in its own PR. Noted on the issue.

## How it is verified

- `node scripts/check-notations.mjs` — clean (20 view notations; examples, internal links, `methodology_version` pins and notation counts all consistent). The two `SIZE1` warnings it prints are pre-existing, in `method/`, and unrelated.
- Corrected `valid_from` values are each the file's own `released_at`; `valid_to` stays `null`, so no `LIFECYCLE-003`/`LIFECYCLE-004` interaction.
- No schema, validation rule, or TYPE prefix is added — the change is documentation plus three one-line example fixes.

Refs: `THQ-197`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
