### PR TITLE
fix(ingest-cli): pin PRESETS_VERSION to the version pin and check it mechanically

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,13 +24,14 @@ For every release, in order:
 
 1. **Confirm the bump category.** Read every PR landed since the previous tag; categorise each change per the table above; pick the bump.
 2. **Bump `notations/CURRENT_VERSION.yaml`** to the new version, in the same PR as the release notes. This is the manifest pin `scripts/check-notations.mjs`'s V1 check enforces every other concrete `methodology_version:` pin in this repo against — run `node scripts/check-notations.mjs` after bumping it and fix every pin the check flags (or add it to the script's allowlist if it is an intentional placeholder, e.g. a migration fixture pinned to a fixed source version). The tag is cut from a commit where this check is already clean — do not tag first and bump after.
-3. **Update `methodology_version` in the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo's `transitrix.yaml`** to the new version, via a companion PR in that repo. acme-corp is the fixture adopter and tracks the latest released version.
-4. **Update each notation spec's `version:` frontmatter** if any spec changed in this release. (`spec_version` on individual files is informational — see CONTRACT §10.1 — so this step is bookkeeping for discoverability, not enforcement.)
-5. **Write release notes** describing what changed by category (`Added`, `Changed`, `Fixed`, `Removed`). Reference PR numbers.
-6. **For a `MAJOR` release** — ship a migration recipe under `migrations/<prev>-to-<this>/` (recipe format: see [`migrations/`](migrations/) and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10.4). The recipe is a precondition for the tag.
-7. **Tag** the release commit with `vX.Y.Z`.
-8. **Publish** the release notes as a GitHub Release on the tag.
-9. **Announce** the release (channel TBD with the maintainer).
+3. **Bump `PRESETS_VERSION` in `packages/ingest-cli/src/coverage-presets.mjs`** to the same new version, in the same PR, and re-state each preset's element + relation lists against [`notations/COVERAGE_PROFILES.md`](notations/COVERAGE_PROFILES.md) §3 / §3.1 if this release changed either. Required on **every** release including `PATCH`: `repo-check` compares this string to the adopter's declared `methodology_version` for exact equality, so any divergence reports a false "stale CLI" mismatch and pins its headline `tooling.ok` signal to false for correctly pinned adopters. `check-notations.mjs`'s `PRESETS1` check enforces both halves — the version and the tables — so step 2's run covers this; the step is listed because the fix belongs in the release PR, not because it needs remembering.
+4. **Update `methodology_version` in the [`transitrix/acme-corp`](https://github.com/transitrix/acme-corp) reference repo's `transitrix.yaml`** to the new version, via a companion PR in that repo. acme-corp is the fixture adopter and tracks the latest released version.
+5. **Update each notation spec's `version:` frontmatter** if any spec changed in this release. (`spec_version` on individual files is informational — see CONTRACT §10.1 — so this step is bookkeeping for discoverability, not enforcement.)
+6. **Write release notes** describing what changed by category (`Added`, `Changed`, `Fixed`, `Removed`). Reference PR numbers.
+7. **For a `MAJOR` release** — ship a migration recipe under `migrations/<prev>-to-<this>/` (recipe format: see [`migrations/`](migrations/) and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10.4). The recipe is a precondition for the tag.
+8. **Tag** the release commit with `vX.Y.Z`.
+9. **Publish** the release notes as a GitHub Release on the tag.
+10. **Announce** the release (channel TBD with the maintainer).
 
 ---
 
@@ -65,7 +66,7 @@ When an adopter repo moves from one methodology version to another, **four artef
    ```
    transitrix-ingest repo-check [org-root]
    ```
-   A clean run shows `tooling.ok: true` and no version-mismatch red flag. If `tooling.ok: false` still appears, the installed binary is still the old version — repeat step 4.
+   A clean run shows `tooling.ok: true` and no version-mismatch red flag. If `tooling.ok: false` still appears, compare the reported `cli_presets_version` against the version you pinned: if they differ and the binary really is freshly installed, the mismatch is upstream's — the release shipped without bumping `PRESETS_VERSION` (step 3 of the per-release checklist), not something you did wrong. Report it rather than reinstalling repeatedly; `check-notations.mjs`'s `PRESETS1` check exists to stop that release from being cut in the first place. Otherwise the installed binary is still the old version — repeat step 4.
 7. **Re-resolve the coverage profile** (if the new release changed the preset vocabulary — see `COVERAGE_PROFILES.md` §7 for what changes between versions). Fix `transitrix.yaml` if needed, then re-run `repo-check` to clear any `coverage_warning`.
 
 Steps 1–3 handle the **spec and canon**; step 4 handles the **CLI**; step 5 handles the **whole-repo validator**; steps 6–7 confirm all four artefacts are in sync. Skipping step 4 leaves the CLI binary stale — it will run against new artefacts with old validators and a mismatched coverage-preset vocabulary. Skipping step 5 leaves `.validators/lint.py` on its scaffold-time snapshot — any fix or rule change landed in `tools/lint.py` since then stays invisible to the adopter's own CI.

--- a/packages/ingest-cli/src/coverage-presets.mjs
+++ b/packages/ingest-cli/src/coverage-presets.mjs
@@ -8,13 +8,22 @@
 // resolve correctly); the resolver flattens to membership sets. `full` is the sentinel
 // "everything" — it carries no allowlist because every registry TYPE / REL kind is in.
 //
-// RELEASE DISCIPLINE: on every methodology MINOR or MAJOR bump, update PRESETS_VERSION
-// to match the new methodology_version and re-state each preset's element + relation
-// lists against COVERAGE_PROFILES.md §3 / §3.1 for that release. This is a manual
-// release step — run `node packages/ingest-cli/ingest.mjs repo-check <repo>` on a repo
-// pinned to the new version to confirm no false-negative mismatch before tagging.
+// RELEASE DISCIPLINE: on EVERY methodology release — PATCH included — update
+// PRESETS_VERSION to match the new methodology_version, and re-state each preset's
+// element + relation lists against COVERAGE_PROFILES.md §3 / §3.1 for that release.
+//
+// PATCH is included because repo-check compares this string to the adopter's declared
+// `methodology_version` for exact equality (repo-check.mjs — `tooling.ok`), so any
+// divergence at all, of any bump size, reports a false stale-CLI mismatch. That is not
+// hypothetical: this constant sat at 2.1.0 across the 3.2.0 → 3.6.0 releases, leaving
+// `tooling.ok` permanently false for every correctly pinned adopter (transitrix-hq#199).
+//
+// Both halves of the step are now mechanical rather than remembered — `PRESETS1` in
+// scripts/check-notations.mjs fails CI when PRESETS_VERSION diverges from
+// notations/CURRENT_VERSION.yaml, or when the tables below stop matching the §3 / §3.1
+// tables they encode. A release PR that bumps the pin and not this file cannot go green.
 
-export const PRESETS_VERSION = '2.1.0';
+export const PRESETS_VERSION = '3.6.0';
 
 export const LAYERS = ['01_motivation', '02_business', '03_application', '04_technology', '05_implementation'];
 

--- a/packages/ingest-cli/src/repo-check.test.mjs
+++ b/packages/ingest-cli/src/repo-check.test.mjs
@@ -11,6 +11,13 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { profileCompleteness, elementTypesOnDisk, repoCheck } from './repo-check.mjs';
+import { PRESETS_VERSION } from './coverage-presets.mjs';
+
+// Fixture manifests declare the version the built-in presets were stated against,
+// read from the constant rather than hardcoded — a literal here goes stale at every
+// release and silently flips `tooling.ok` to false in every fixture below, which is
+// the same drift transitrix-hq#199 reported in the constant itself.
+const MANIFEST = `methodology_version: "${PRESETS_VERSION}"\ncoverage_profile: core\n`;
 
 // ── profileCompleteness — pure-function unit tests ──────────────────────
 
@@ -97,7 +104,7 @@ test('elementTypesOnDisk: absent canon/elements/ yields an empty set, not a thro
 
 test('repoCheck: a hand-placed out-of-profile TYPE is flagged even though nothing loaded it as a candidate', async () => {
   const root = tmpOrgRoot();
-  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  writeFileSync(join(root, 'transitrix.yaml'), MANIFEST, 'utf8');
   const nodesDir = join(root, 'canon', 'elements', '04_technology', 'nodes');
   mkdirSync(nodesDir, { recursive: true });
   // `core` (coverage-presets.mjs) excludes NODE — the issue's own example.
@@ -111,7 +118,7 @@ test('repoCheck: a hand-placed out-of-profile TYPE is flagged even though nothin
 
 test('repoCheck: an unresolved profile is reported as not-resolvable, never a false-clean empty list', async () => {
   const root = tmpOrgRoot();
-  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: not-a-real-preset\n', 'utf8');
+  writeFileSync(join(root, 'transitrix.yaml'), `methodology_version: "${PRESETS_VERSION}"\ncoverage_profile: not-a-real-preset\n`, 'utf8');
   const nodesDir = join(root, 'canon', 'elements', '04_technology', 'nodes');
   mkdirSync(nodesDir, { recursive: true });
   writeFileSync(join(nodesDir, 'NODE-1.yaml'), 'id: NODE-1\nname: Test Node\n', 'utf8');
@@ -123,7 +130,7 @@ test('repoCheck: an unresolved profile is reported as not-resolvable, never a fa
 
 test('repoCheck: a TYPE covered by the profile raises no flag', async () => {
   const root = tmpOrgRoot();
-  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  writeFileSync(join(root, 'transitrix.yaml'), MANIFEST, 'utf8');
   const goalsDir = join(root, 'canon', 'elements', '01_motivation', 'goals');
   mkdirSync(goalsDir, { recursive: true });
   writeFileSync(join(goalsDir, 'GOAL-1.yaml'), 'id: GOAL-1\nname: Test Goal\n', 'utf8');
@@ -143,7 +150,7 @@ test('repoCheck: a TYPE covered by the profile raises no flag', async () => {
 
 test('repoCheck: a clean repo reports zero unreadable files and no red flag for it', async () => {
   const root = tmpOrgRoot();
-  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  writeFileSync(join(root, 'transitrix.yaml'), MANIFEST, 'utf8');
   const goalsDir = join(root, 'canon', 'elements', '01_motivation', 'goals');
   mkdirSync(goalsDir, { recursive: true });
   writeFileSync(join(goalsDir, 'GOAL-1.yaml'), 'id: GOAL-1\nname: Test Goal\n', 'utf8');
@@ -155,7 +162,7 @@ test('repoCheck: a clean repo reports zero unreadable files and no red flag for 
 
 test('repoCheck: the data-free report never carries the per-file unreadable detail', async () => {
   const root = tmpOrgRoot();
-  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  writeFileSync(join(root, 'transitrix.yaml'), MANIFEST, 'utf8');
 
   const report = await repoCheck(root);
   const serialized = JSON.stringify(report);
@@ -165,11 +172,39 @@ test('repoCheck: the data-free report never carries the per-file unreadable deta
   }
 });
 
+// ── version currency (F11.2) — `tooling.ok`, the report's headline signal ─
+//
+// transitrix-hq#199: PRESETS_VERSION sat at 2.1.0 across the 3.2.0 → 3.6.0
+// releases, so this signal read false for every adopter who correctly kept
+// `methodology_version` current — and nothing here covered it. These two tests
+// pin both directions of the comparison.
+
+test('repoCheck: tooling.ok is true when the declared version matches the built-in presets', async () => {
+  const root = tmpOrgRoot();
+  writeFileSync(join(root, 'transitrix.yaml'), MANIFEST, 'utf8');
+
+  const report = await repoCheck(root);
+  assert.equal(report.tooling.cli_presets_version, PRESETS_VERSION);
+  assert.equal(report.tooling.methodology_version_match, true);
+  assert.equal(report.tooling.ok, true);
+  assert.ok(!report.integrity.red_flags.some((f) => f.includes('does not match the CLI built-in presets version')));
+});
+
+test('repoCheck: a declared version behind the built-in presets flips tooling.ok and raises a red flag', async () => {
+  const root = tmpOrgRoot();
+  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "0.0.1"\ncoverage_profile: core\n', 'utf8');
+
+  const report = await repoCheck(root);
+  assert.equal(report.tooling.methodology_version_match, false);
+  assert.equal(report.tooling.ok, false);
+  assert.ok(report.integrity.red_flags.some((f) => f.includes('does not match the CLI built-in presets version')));
+});
+
 // ── binding envelope (BIND-001..005, CONTRACT.md §17.2) surfaces here too ─
 
 test('repoCheck: a clean repo (no canon_id, no origin) carries no `bindings` section at all', async () => {
   const root = tmpOrgRoot();
-  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  writeFileSync(join(root, 'transitrix.yaml'), MANIFEST, 'utf8');
   const goalsDir = join(root, 'canon', 'elements', '01_motivation', 'goals');
   mkdirSync(goalsDir, { recursive: true });
   writeFileSync(join(goalsDir, 'GOAL-1.yaml'), 'id: GOAL-1\nname: Test Goal\n', 'utf8');
@@ -180,7 +215,7 @@ test('repoCheck: a clean repo (no canon_id, no origin) carries no `bindings` sec
 
 test('repoCheck: BIND-005 — an `origin` field on a project repository\'s own element is flagged', async () => {
   const root = tmpOrgRoot();
-  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  writeFileSync(join(root, 'transitrix.yaml'), MANIFEST, 'utf8');
   const goalsDir = join(root, 'canon', 'elements', '01_motivation', 'goals');
   mkdirSync(goalsDir, { recursive: true });
   writeFileSync(join(goalsDir, 'GOAL-1.yaml'), 'id: GOAL-1\nname: Test Goal\norigin:\n  repository: acme/architecture\n  id: GOAL-1\n', 'utf8');
@@ -192,7 +227,7 @@ test('repoCheck: BIND-005 — an `origin` field on a project repository\'s own e
 
 test('repoCheck: BIND-004 — a canon_id present with no catalogue pin configured is flagged', async () => {
   const root = tmpOrgRoot();
-  writeFileSync(join(root, 'transitrix.yaml'), 'methodology_version: "2.1.0"\ncoverage_profile: core\n', 'utf8');
+  writeFileSync(join(root, 'transitrix.yaml'), MANIFEST, 'utf8');
   const goalsDir = join(root, 'canon', 'elements', '01_motivation', 'goals');
   mkdirSync(goalsDir, { recursive: true });
   writeFileSync(join(goalsDir, 'GOAL-1.yaml'), 'id: GOAL-1\nname: Test Goal\ncanon_id: "TERM-001"\n', 'utf8');

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -77,6 +77,13 @@
 //   SIZE1 per-file soft ceiling (warn-only) — a method/*.md file over 250
 //       lines or with more than nine `##` sections warns. Never fails the
 //       build — see main()'s separate warnings collection.
+//   PRESETS1 shipped coverage presets — packages/ingest-cli/src/coverage-presets.mjs
+//       carries `PRESETS_VERSION` equal to the version source of truth, and its
+//       `PRESETS` tables encode exactly the preset membership stated in
+//       COVERAGE_PROFILES.md §3 (element TYPEs) and §3.1 (relation kinds).
+//       `full` must stay the sentinel "everything" on both sides rather than
+//       an enumeration. Fails closed: an unimportable module or unparseable
+//       table is a failure, not a skip.
 //
 // Exit codes:
 //   0 — clean
@@ -101,6 +108,8 @@ const ELEMENT_PRIMITIVES_PATH = join(REPO_ROOT, 'notations', 'ELEMENT_PRIMITIVES
 const RELATIONS_SPEC_PATH = join(REPO_ROOT, 'notations', 'elements', '17-relations.md');
 const IDS_AND_REFERENCES_PATH = join(REPO_ROOT, 'notations', 'IDS_AND_REFERENCES.md');
 const CONVENTIONS_PATH = join(REPO_ROOT, 'notations', 'CONVENTIONS.md');
+const COVERAGE_PROFILES_PATH = join(REPO_ROOT, 'notations', 'COVERAGE_PROFILES.md');
+const COVERAGE_PRESETS_MODULE = join(REPO_ROOT, 'packages', 'ingest-cli', 'src', 'coverage-presets.mjs');
 // Both files carry a deliberate ✓/✗ (or "invalid" — labelled) comparison
 // table teaching the grammar by counter-example; ID1 would otherwise flag
 // the ✗ side as a live violation.
@@ -1539,6 +1548,167 @@ async function checkSizeCeiling(warnings) {
   }
 }
 
+// --- PRESETS1: shipped coverage presets vs COVERAGE_PROFILES.md ------------
+//
+// packages/ingest-cli/src/coverage-presets.mjs hand-encodes two things the
+// release step is supposed to keep current: PRESETS_VERSION (the methodology
+// release the tables were stated against) and the per-layer element/relation
+// membership of each shipped preset. Both were remembered rather than checked,
+// and PRESETS_VERSION went five releases without moving (transitrix-hq#199) —
+// which pins repo-check's headline `tooling.ok` signal to false for every
+// adopter who correctly keeps `methodology_version` current, since repo-check
+// compares the two strings for exact equality.
+//
+// The version half is the drift that was reported; the membership half is the
+// other half of the same manual step, and is checked here too so that bumping
+// the version can't quietly assert a table nobody re-stated.
+//
+// `full` is the sentinel "everything" in both places — no allowlist in the
+// module, no enumeration in the spec — so the check asserts it stays a
+// sentinel on both sides instead of comparing members.
+
+// Pure — no I/O. Parses one of COVERAGE_PROFILES.md's preset tables into
+// Map<preset, {sentinel, layers: Map<layer, string[]>}>. `heading` selects the
+// section (§3's element table or §3.1's relation table) and `cellIndex` the
+// column holding the membership list, which differs between the two tables.
+// A cell that begins "Every …" is the sentinel row. Throws on a missing
+// section, an unparseable segment, or a table that yields no rows — a
+// corrupted artefact must fail this check, never pass silently.
+export function parsePresetTable(text, heading, cellIndex) {
+  const headingIdx = text.indexOf(`\n${heading}`);
+  if (headingIdx < 0) throw new Error(`COVERAGE_PROFILES.md: "${heading}" not found`);
+  const afterHeading = headingIdx + 1 + heading.length;
+  const nextHeadingOffset = text.slice(afterHeading).search(/\n#{2,3} /);
+  const section = nextHeadingOffset < 0 ? text.slice(afterHeading) : text.slice(afterHeading, afterHeading + nextHeadingOffset);
+
+  const out = new Map();
+  for (const line of section.split('\n')) {
+    if (!line.startsWith('| **`')) continue; // only preset data rows
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    const nameM = cells[0].match(/^\*\*`([a-z][a-z0-9_-]*)`\*\*$/);
+    if (!nameM) continue;
+    const preset = nameM[1];
+    const cell = cells[cellIndex];
+    if (cell === undefined) {
+      throw new Error(`COVERAGE_PROFILES.md ${heading}: the ${preset} row has no column ${cellIndex}`);
+    }
+    if (/^Every\b/.test(cell)) {
+      out.set(preset, { sentinel: true, layers: new Map() });
+      continue;
+    }
+    const layers = new Map();
+    for (const chunk of cell.split('·')) {
+      const segment = chunk.trim();
+      if (!segment) continue;
+      const segM = segment.match(/^(\d\d_[a-z]+):\s*(.+)$/);
+      if (!segM) {
+        throw new Error(`COVERAGE_PROFILES.md ${heading}: unparseable segment "${segment}" in the ${preset} row`);
+      }
+      const values = [...segM[2].matchAll(/`([^`]+)`/g)].map(m => m[1]);
+      if (values.length === 0) {
+        throw new Error(`COVERAGE_PROFILES.md ${heading}: the ${preset} row names layer ${segM[1]} with no code-span values`);
+      }
+      layers.set(segM[1], values);
+    }
+    if (layers.size === 0) {
+      throw new Error(`COVERAGE_PROFILES.md ${heading}: the ${preset} row enumerates no layers`);
+    }
+    out.set(preset, { sentinel: false, layers });
+  }
+  if (out.size === 0) throw new Error(`COVERAGE_PROFILES.md ${heading}: table parsed empty`);
+  return out;
+}
+
+// Pure — no I/O. Compares the module's PRESETS table against the two parsed
+// spec tables and returns finding messages (empty when they agree). Membership
+// is compared as a set per layer — the spec's reading order is presentational,
+// so a reordering is not drift, but a missing/extra TYPE or layer is.
+export function derivePresetMembershipFindings(modulePresets, specElements, specRelations) {
+  const findings = [];
+  const names = [...new Set([...Object.keys(modulePresets), ...specElements.keys(), ...specRelations.keys()])].sort();
+
+  for (const name of names) {
+    const inModule = Object.prototype.hasOwnProperty.call(modulePresets, name);
+    const specEl = specElements.get(name);
+    const specRel = specRelations.get(name);
+    if (!inModule) {
+      findings.push(`COVERAGE_PROFILES.md ships preset \`${name}\` but coverage-presets.mjs PRESETS has no such entry — the CLI cannot resolve it.`);
+      continue;
+    }
+    if (!specEl || !specRel) {
+      const missing = [!specEl && '§3 (element TYPEs)', !specRel && '§3.1 (relation kinds)'].filter(Boolean).join(' and ');
+      findings.push(`coverage-presets.mjs PRESETS carries preset \`${name}\` with no matching row in COVERAGE_PROFILES.md ${missing}.`);
+      continue;
+    }
+
+    const moduleEntry = modulePresets[name];
+    const moduleIsSentinel = moduleEntry === 'ALL';
+    if (moduleIsSentinel !== (specEl.sentinel && specRel.sentinel)) {
+      findings.push(
+        `preset \`${name}\`: coverage-presets.mjs treats it as ${moduleIsSentinel ? 'the "everything" sentinel' : 'an enumerated allowlist'} ` +
+        `but COVERAGE_PROFILES.md §3/§3.1 state it as ${specEl.sentinel && specRel.sentinel ? 'the "everything" sentinel' : 'an enumerated allowlist'}.`
+      );
+      continue;
+    }
+    if (moduleIsSentinel) continue; // nothing to compare — both sides say "everything"
+
+    for (const [axis, moduleAxis, specAxis] of [
+      ['elements', moduleEntry.elements || {}, specEl.layers],
+      ['relations', moduleEntry.relations || {}, specRel.layers],
+    ]) {
+      const layers = [...new Set([...Object.keys(moduleAxis), ...specAxis.keys()])].sort();
+      for (const layer of layers) {
+        const mine = new Set(moduleAxis[layer] || []);
+        const theirs = new Set(specAxis.get(layer) || []);
+        const onlyModule = [...mine].filter(v => !theirs.has(v)).sort();
+        const onlySpec = [...theirs].filter(v => !mine.has(v)).sort();
+        if (onlyModule.length === 0 && onlySpec.length === 0) continue;
+        const parts = [];
+        if (onlySpec.length > 0) parts.push(`missing from the module: ${onlySpec.join(', ')}`);
+        if (onlyModule.length > 0) parts.push(`present only in the module: ${onlyModule.join(', ')}`);
+        findings.push(
+          `preset \`${name}\` ${axis} in ${layer} disagree with COVERAGE_PROFILES.md ` +
+          `${axis === 'elements' ? '§3' : '§3.1'} — ${parts.join('; ')}.`
+        );
+      }
+    }
+  }
+  return findings;
+}
+
+async function checkCoveragePresets(failures) {
+  const sotText = await readFile(VERSION_SOT, 'utf8');
+  const sotMatch = sotText.match(/^methodology_version:\s*"?([^"\s#]+)"?/m);
+  if (!sotMatch) throw new Error(`${relPosix(VERSION_SOT)}: methodology_version (source of truth) not found`);
+  const sot = sotMatch[1];
+
+  const mod = await import(pathToFileURL(COVERAGE_PRESETS_MODULE).href);
+  const modRel = relPosix(COVERAGE_PRESETS_MODULE);
+  if (typeof mod.PRESETS_VERSION !== 'string') {
+    throw new Error(`${modRel}: PRESETS_VERSION is not exported as a string`);
+  }
+  if (!mod.PRESETS || typeof mod.PRESETS !== 'object') {
+    throw new Error(`${modRel}: PRESETS is not exported as an object`);
+  }
+
+  if (mod.PRESETS_VERSION !== sot) {
+    failures.push({
+      check: 'PRESETS1',
+      message: `${modRel}: PRESETS_VERSION "${mod.PRESETS_VERSION}" ≠ source of truth "${sot}" (${relPosix(VERSION_SOT)}). ` +
+        `repo-check compares this string to the adopter's declared methodology_version for exact equality, so any ` +
+        `divergence reports a false "stale CLI" mismatch and pins its tooling.ok signal to false. Bump it in the same ` +
+        `PR as the pin, re-stating each preset's lists against COVERAGE_PROFILES.md §3 / §3.1 for the new release.`,
+    });
+  }
+
+  const profilesText = await readFile(COVERAGE_PROFILES_PATH, 'utf8');
+  const specElements = parsePresetTable(profilesText, '## 3. Shipped presets', 2);
+  const specRelations = parsePresetTable(profilesText, '### 3.1 Per-preset relation allowlists', 1);
+  for (const message of derivePresetMembershipFindings(mod.PRESETS, specElements, specRelations)) {
+    failures.push({ check: 'PRESETS1', message });
+  }
+}
+
 // --- main ------------------------------------------------------------------
 
 async function main() {
@@ -1561,6 +1731,7 @@ async function main() {
     await checkIdGrammar(failures);
     await checkLayerEnumeration(failures);
     await checkDualHomeTables(failures);
+    await checkCoveragePresets(failures);
     await checkSizeCeiling(warnings);
   } catch (e) {
     console.error(`error: ${e.message}`);

--- a/scripts/check-notations.test.mjs
+++ b/scripts/check-notations.test.mjs
@@ -29,6 +29,8 @@ import {
   findLayerEnumerationGroups,
   parseMarkdownTables,
   findSizeCeilingWarnings,
+  parsePresetTable,
+  derivePresetMembershipFindings,
 } from './check-notations.mjs';
 
 test('deriveClassCounts — positive: counts non-deprecated specs per class', () => {
@@ -691,4 +693,150 @@ test('findSizeCeilingWarnings — negative: more than nine "##" sections warns',
   assert.equal(warnings.length, 1);
   assert.equal(warnings[0].check, 'SIZE1');
   assert.match(warnings[0].message, /10 "##" sections/);
+});
+
+// --- PRESETS1: shipped coverage presets vs COVERAGE_PROFILES.md --------------
+
+// §3-shaped: three columns, membership in the third. §3.1-shaped: two columns,
+// membership in the second. Both carry a `full` row stated as a sentinel.
+const PRESET_SPEC_FIXTURE = `
+## 3. Shipped presets
+
+| Preset | Intent | Element TYPEs (in scope) |
+|---|---|---|
+| **\`minimal\`** | Bare chain. | 01_motivation: \`DRIVER\`, \`GOAL\` · 05_implementation: \`ACTION\` |
+| **\`full\`** | Everything. | Every TYPE in [\`IDS_AND_REFERENCES.md\`](IDS_AND_REFERENCES.md) §3.1. |
+
+### 3.1 Per-preset relation allowlists
+
+| Preset | Allowed relation kinds (per \`from\` layer) |
+|---|---|
+| **\`minimal\`** | 01_motivation: \`goal_parent\` · 05_implementation: \`action_goal\` |
+| **\`full\`** | Every relation kind in [\`elements/17-relations.md\`](elements/17-relations.md) §3. |
+
+## 4. Custom profiles
+`;
+
+test('parsePresetTable — positive: reads the §3 element table, its layers, and the sentinel row', () => {
+  const table = parsePresetTable(PRESET_SPEC_FIXTURE, '## 3. Shipped presets', 2);
+  assert.deepEqual([...table.keys()].sort(), ['full', 'minimal']);
+  assert.equal(table.get('minimal').sentinel, false);
+  assert.deepEqual(table.get('minimal').layers.get('01_motivation'), ['DRIVER', 'GOAL']);
+  assert.deepEqual(table.get('minimal').layers.get('05_implementation'), ['ACTION']);
+  assert.equal(table.get('full').sentinel, true, '"Every TYPE in …" is the sentinel, not an enumeration');
+});
+
+test('parsePresetTable — positive: reads the §3.1 relation table from its own column index', () => {
+  const table = parsePresetTable(PRESET_SPEC_FIXTURE, '### 3.1 Per-preset relation allowlists', 1);
+  assert.deepEqual(table.get('minimal').layers.get('01_motivation'), ['goal_parent']);
+  assert.deepEqual(table.get('minimal').layers.get('05_implementation'), ['action_goal']);
+  assert.equal(table.get('full').sentinel, true);
+});
+
+test('parsePresetTable — positive: stops at the next heading and does not read the following section', () => {
+  const table = parsePresetTable(PRESET_SPEC_FIXTURE, '## 3. Shipped presets', 2);
+  // §3.1's rows sit after the next heading; reading them here would put a
+  // relation kind in the element table.
+  assert.equal(table.get('minimal').layers.get('01_motivation').includes('goal_parent'), false);
+});
+
+test('parsePresetTable — negative: a missing section heading throws', () => {
+  assert.throws(() => parsePresetTable('# nothing here\n', '## 3. Shipped presets', 2), /not found/);
+});
+
+test('parsePresetTable — negative: a membership segment with no layer prefix throws', () => {
+  const text = '\n## 3. Shipped presets\n\n| P | I | E |\n|---|---|---|\n| **`minimal`** | x | `DRIVER`, `GOAL` |\n';
+  assert.throws(() => parsePresetTable(text, '## 3. Shipped presets', 2), /unparseable segment/);
+});
+
+test('parsePresetTable — negative: a layer named with no code-span values throws', () => {
+  const text = '\n## 3. Shipped presets\n\n| P | I | E |\n|---|---|---|\n| **`minimal`** | x | 01_motivation: DRIVER |\n';
+  assert.throws(() => parsePresetTable(text, '## 3. Shipped presets', 2), /no code-span values/);
+});
+
+test('parsePresetTable — negative: a section with no preset rows throws rather than passing empty', () => {
+  const text = '\n## 3. Shipped presets\n\nProse only, no table.\n';
+  assert.throws(() => parsePresetTable(text, '## 3. Shipped presets', 2), /parsed empty/);
+});
+
+// --- derivePresetMembershipFindings -----------------------------------------
+
+const specEl = () => parsePresetTable(PRESET_SPEC_FIXTURE, '## 3. Shipped presets', 2);
+const specRel = () => parsePresetTable(PRESET_SPEC_FIXTURE, '### 3.1 Per-preset relation allowlists', 1);
+
+const AGREEING_MODULE = {
+  minimal: {
+    elements: { '01_motivation': ['DRIVER', 'GOAL'], '05_implementation': ['ACTION'] },
+    relations: { '01_motivation': ['goal_parent'], '05_implementation': ['action_goal'] },
+  },
+  full: 'ALL',
+};
+
+test('derivePresetMembershipFindings — positive: agreeing module and spec yield no findings', () => {
+  assert.deepEqual(derivePresetMembershipFindings(AGREEING_MODULE, specEl(), specRel()), []);
+});
+
+test('derivePresetMembershipFindings — positive: reordering within a layer is presentational, not drift', () => {
+  const reordered = structuredClone(AGREEING_MODULE);
+  reordered.minimal.elements['01_motivation'] = ['GOAL', 'DRIVER'];
+  assert.deepEqual(derivePresetMembershipFindings(reordered, specEl(), specRel()), []);
+});
+
+test('derivePresetMembershipFindings — negative: a TYPE the spec states but the module omits is flagged', () => {
+  const drifted = structuredClone(AGREEING_MODULE);
+  drifted.minimal.elements['01_motivation'] = ['DRIVER'];
+  const findings = derivePresetMembershipFindings(drifted, specEl(), specRel());
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /missing from the module: GOAL/);
+  assert.match(findings[0], /§3/);
+});
+
+test('derivePresetMembershipFindings — negative: a TYPE only the module carries is flagged', () => {
+  const drifted = structuredClone(AGREEING_MODULE);
+  drifted.minimal.elements['01_motivation'] = ['DRIVER', 'GOAL', 'CAPABILITY'];
+  const findings = derivePresetMembershipFindings(drifted, specEl(), specRel());
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /present only in the module: CAPABILITY/);
+});
+
+test('derivePresetMembershipFindings — negative: a relation-kind drift is reported against §3.1', () => {
+  const drifted = structuredClone(AGREEING_MODULE);
+  drifted.minimal.relations['05_implementation'] = ['action_goal', 'depends_on'];
+  const findings = derivePresetMembershipFindings(drifted, specEl(), specRel());
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /relations in 05_implementation/);
+  assert.match(findings[0], /§3\.1/);
+  assert.match(findings[0], /present only in the module: depends_on/);
+});
+
+test('derivePresetMembershipFindings — negative: a whole layer only one side names is flagged', () => {
+  const drifted = structuredClone(AGREEING_MODULE);
+  drifted.minimal.elements['02_business'] = ['CAPABILITY'];
+  const findings = derivePresetMembershipFindings(drifted, specEl(), specRel());
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /02_business/);
+});
+
+test('derivePresetMembershipFindings — negative: turning the "everything" sentinel into an allowlist is flagged', () => {
+  const drifted = structuredClone(AGREEING_MODULE);
+  drifted.full = { elements: { '01_motivation': ['DRIVER'] }, relations: {} };
+  const findings = derivePresetMembershipFindings(drifted, specEl(), specRel());
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /sentinel/);
+});
+
+test('derivePresetMembershipFindings — negative: a preset the spec ships but the CLI cannot resolve is flagged', () => {
+  const drifted = structuredClone(AGREEING_MODULE);
+  delete drifted.minimal;
+  const findings = derivePresetMembershipFindings(drifted, specEl(), specRel());
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /cannot resolve/);
+});
+
+test('derivePresetMembershipFindings — negative: a module preset with no spec row is flagged', () => {
+  const drifted = structuredClone(AGREEING_MODULE);
+  drifted.compliance = { elements: { '01_motivation': ['REQUIREMENT'] }, relations: {} };
+  const findings = derivePresetMembershipFindings(drifted, specEl(), specRel());
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /no matching row/);
 });


### PR DESCRIPTION
## What changed

`packages/ingest-cli/src/coverage-presets.mjs` exports `PRESETS_VERSION`, the methodology release its built-in coverage-preset tables were stated against. It read `2.1.0` while `notations/CURRENT_VERSION.yaml` had moved through `3.2.0` → `3.6.0`.

`repo-check` compares that constant to the adopter's declared `methodology_version` for **exact equality** (`repo-check.mjs`, `tooling.methodology_version_match` → `tooling.ok`). With the two diverged, `tooling.ok` was `false` for every adopter who kept their pin current, accompanied by a red flag advising them to reinstall a CLI that was not in fact stale.

- **`PRESETS_VERSION` → `3.6.0`.** The `PRESETS` tables already matched `COVERAGE_PROFILES.md` §3 / §3.1 exactly, so the bump asserts nothing that was not already true.
- **New `PRESETS1` check in `scripts/check-notations.mjs`**, covering both halves of what was a remembered manual step:
  - `PRESETS_VERSION` equals the version source of truth;
  - the `PRESETS` tables encode exactly the element membership in §3 and the relation membership in §3.1.

  Membership compares as a set per layer, so reordering within the spec is presentational rather than drift; a missing or extra TYPE, kind, or whole layer fails. `full` must remain the "everything" sentinel on both sides rather than becoming an enumeration. Fails closed — an unimportable module or unparseable table is a failure, not a skip.
- **Release-discipline note corrected.** It said "on every methodology MINOR or MAJOR bump"; because the comparison is exact equality, a `PATCH` divergence reports the same false mismatch, so the step applies to every release.
- **`repo-check.test.mjs` fixtures** derive their manifest version from `PRESETS_VERSION` rather than a literal that goes stale at each release and silently flips `tooling.ok` in every fixture.
- **Two new `repo-check` tests** pin the version-currency signal in both directions. It is the signal that was broken and it had no test.
- **`RELEASING.md`**: the bump is now a numbered checklist step, and the adopter upgrade procedure no longer attributes every `tooling.ok: false` to a stale local install — it tells the adopter how to tell the two causes apart.

`PRESETS1` runs in the existing `notations-doc-lint` workflow, so a release PR that bumps the pin without this constant cannot go green.

## How it is verified

- `node scripts/check-notations.mjs` — clean (2 pre-existing `SIZE1` warnings, non-blocking).
- Reverting `PRESETS_VERSION` to `2.1.0` reproduces the reported defect as a `PRESETS1` failure with exit 1; restored.
- `node --test scripts/check-notations.test.mjs` — 20 new cases over the two new pure functions (both table shapes, sentinel handling, section bounding, four parse-failure paths; membership agreement, reordering-is-not-drift, missing/extra TYPE, relation drift, layer drift, sentinel flip, preset present on only one side).
- `node --test packages/ingest-cli/src/*.test.mjs` (the seven suites CI runs) — 110 pass, 0 fail.

Refs THQ-199