### PR TITLE
fix(report-skill): point the renderer pre-check at @transitrix/cli, not the unresolvable cervin name

### DIFF
--- a/transitrix/README.md
+++ b/transitrix/README.md
@@ -50,7 +50,7 @@ Regenerate with `node packages/plugin-examples/src/generate.mjs`; CI (`.github/w
 | **Onboard** | `/transitrix:onboard` | Scaffolds a new adopter repository (zoned `canon/` + `field/` + `codex/` layout, assistant-neutral `AGENTS.md`, `transitrix.yaml` manifest) and walks through a first notation file | 0.5.0 |
 | **Ingest** | `/transitrix:ingest` | Turns raw organisational documents — interviews, policies, org charts — into `field`-zone artefacts and typed canon candidates, then stages a human review queue | 0.6.0 |
 | **Repo-check** | `/transitrix:repo-check` | Read-only health check: methodology version, coverage-profile resolution, per-TYPE element counts, and integrity flags — all data-free, safe to share externally | 0.6.0 |
-| **Report** | `/transitrix:report` | Produces a reproducible compliance report (obligation × subject impact matrix or per-regime coverage metric) via a committed view-config artefact and the `cervin` CLI renderer | 0.6.0 |
+| **Report** | `/transitrix:report` | Produces a reproducible compliance report (obligation × subject impact matrix or per-regime coverage metric) via a committed view-config artefact and the `@transitrix/cli` renderer | 0.6.0 |
 | **Reg-intel** | `/transitrix:reg-intel` | Monitors regulatory sources, classifies new instruments against the organisation's obligation catalogue, and stages a review digest for human triage | 0.6.0 |
 | **ADR** | `/transitrix:adr` | Runs a Context/Decision/Consequences interview and lands the result as a gated Architecture Decision Record (`operations/decisions/ADR-YYYY-MM-DD-*.md`), never self-accepting and never editing an accepted record's body | 0.6.0 |
 | **Feedback** | `/transitrix:feedback` | Routes a methodology-directed finding away from data/model problems, runs a scrub-gated interview, and lands it as an anonymised `FB-NNNN` entry in `operations/feedback.md`; exports a ready-to-send message on request only, never transmits it itself | 2.1.0 |
@@ -62,7 +62,7 @@ Regenerate with `node packages/plugin-examples/src/generate.mjs`; CI (`.github/w
 - **Claude Code** — the plugin runs inside a Claude Code session.
 - **An adopter repository** — a repository following the Transitrix zoned layout (`canon/` + `field/` + `codex/`). Create one with `/transitrix:onboard`, or clone the worked example at `github.com/transitrix/acme-corp`.
 - **Methodology version pin** — the repository must declare its methodology version in `transitrix.yaml`. Skills check the declared version against their `min_version` field and warn if the repo is on an older release.
-- **Transitrix Studio / CLI** (optional) — the `ingest` and `report` skills delegate deterministic work to `@transitrix/ingest-cli` and `cervin` respectively. Both skills run a pre-check (Step 0) and tell the user to install the CLI if it is absent; they do not hand-roll the logic.
+- **Transitrix Studio / CLI** (optional) — the `ingest` and `report` skills delegate deterministic work to `@transitrix/ingest-cli` and `@transitrix/cli` respectively. Both skills run a pre-check (Step 0) and tell the user to install the CLI if it is absent; they do not hand-roll the logic.
 
 ---
 

--- a/transitrix/skills/report/README.md
+++ b/transitrix/skills/report/README.md
@@ -1,6 +1,6 @@
 # `report` skill
 
-The conversational front-end for **compliance reporting** over a Transitrix repository. A user asks for a report in plain language; the skill resolves the parameters into a declarative **view-config artefact** and renders it through the deterministic `cervin export-compliance` CLI — to Markdown or PDF.
+The conversational front-end for **compliance reporting** over a Transitrix repository. A user asks for a report in plain language; the skill resolves the parameters into a declarative **view-config artefact** and renders it through the deterministic `@transitrix/cli export-compliance` command — to Markdown or PDF.
 
 It is the operator UX for two derived views:
 
@@ -15,14 +15,14 @@ Per the architecture decision *"Reports are rendered from declarative view-confi
 - **Rendering lives in the CLI**, never in the agent — so the same config re-renders identically under any runtime.
 - **The skill is thin and script-backed** — [`SKILL.md`](SKILL.md) sequences [`scripts/report.py`](scripts/report.py); both are agent-neutral.
 
-This is **Step 2** of the ADR's sequenced delivery. Step 1 — the `cervin export-compliance` renderer — ships in Transitrix Studio v1.4.x.
+This is **Step 2** of the ADR's sequenced delivery. Step 1 — the `export-compliance` renderer — ships as a subcommand of [`@transitrix/cli`](https://www.npmjs.com/package/@transitrix/cli), the same published CLI that also ships bundled inside **Transitrix Studio**. (A pre-2.0 build of this CLI used a `cervin` bin alias; that name is retired and unpublished — use `transitrix` / `@transitrix/cli`.)
 
 ## Files
 
 | Path | Role |
 |---|---|
 | [`SKILL.md`](SKILL.md) | The agent-facing protocol: pre-check → resolve parameters → materialise + render → return report + provenance. |
-| [`scripts/report.py`](scripts/report.py) | Dependency-free, cross-platform orchestrator over `cervin export-compliance`. Subcommands: `render`, `list`. |
+| [`scripts/report.py`](scripts/report.py) | Dependency-free, cross-platform orchestrator over `@transitrix/cli export-compliance`. Subcommands: `render`, `list`. |
 
 ## Quick start
 
@@ -52,10 +52,10 @@ python scripts/report.py list --root <repo>
 python scripts/report.py render --report-id … --name … --dry-run --root <repo>
 ```
 
-`render` resolves the renderer as `cervin`, then `npx cervin`, then `$TRANSITRIX_CLI`. Named reports are written to `<root>/canon/views/<notation>/<id>.<notation>.transitrix.yaml`. PDF output requires WeasyPrint on PATH (`pipx install weasyprint`).
+`render` resolves the renderer as `transitrix`, then `npx @transitrix/cli`, then `$TRANSITRIX_CLI`. Named reports are written to `<root>/canon/views/<notation>/<id>.<notation>.transitrix.yaml`. PDF output requires WeasyPrint on PATH (`pipx install weasyprint`).
 
 ## Prerequisites
 
-- **Transitrix Studio** (the `cervin` binary), v1.4.x or later — the renderer.
+- **[`@transitrix/cli`](https://www.npmjs.com/package/@transitrix/cli)** — the renderer. `npm install -g @transitrix/cli` (provides the `transitrix` bin), or use `npx @transitrix/cli` with no install. Also ships bundled inside the **Transitrix Studio** editor extension.
 - **Python 3.8+** — the orchestrator (stdlib only; no packages to install).
 - **WeasyPrint** — only for `--format pdf`.

--- a/transitrix/skills/report/SKILL.md
+++ b/transitrix/skills/report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Transitrix Report
-description: "Produce a compliance report (obligation × subject impact matrix, or per-regime coverage metric) from a Transitrix repository, by conversation. Resolves the report's parameters — from the request, from the view spec's defaults, or from a named saved view-config — materialises a versioned view-config artefact, and renders it through the deterministic `cervin export-compliance` CLI to Markdown or PDF. The skill never computes a matrix itself; rendering stays in the CLI so the same config re-renders identically next quarter. Reports are reproducible and auditable: every report has a committed parameter artefact, and the skill states which spec defaults it assumed."
+description: "Produce a compliance report (obligation × subject impact matrix, or per-regime coverage metric) from a Transitrix repository, by conversation. Resolves the report's parameters — from the request, from the view spec's defaults, or from a named saved view-config — materialises a versioned view-config artefact, and renders it through the deterministic `@transitrix/cli export-compliance` command to Markdown or PDF. The skill never computes a matrix itself; rendering stays in the CLI so the same config re-renders identically next quarter. Reports are reproducible and auditable: every report has a committed parameter artefact, and the skill states which spec defaults it assumed."
 when_to_use: 'User says "give me the compliance report", "show the obligation impact for product X", "what is our GDPR coverage", "export the compliance matrix to PDF", "run the Q3 obligations matrix", "which obligations have no assertion (the gap report)", or wants a reproducible compliance/coverage report rendered from canon rather than hand-assembled.'
 min_version: "1.0.0"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
@@ -12,13 +12,13 @@ The **conversational front-end for compliance reporting.** A user asks for a rep
 
 This directory is the **`report` skill** within the `transitrix` plugin (the plugin root is [`transitrix/`](../../), which carries the shared [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) manifest, one `skills/<name>/` directory per skill). Invoked as `/transitrix:report`.
 
-> **Status — Step 2 of the report-skill architecture decision.** Step 1 (the deterministic `cervin export-compliance` CLI) ships in Transitrix Studio v1.4.x. This skill is the thin layer over it. All rendering is the CLI's; this `SKILL.md` and its [`scripts/report.py`](scripts/report.py) orchestrator only sequence it — so the skill loads agent-neutrally (Claude, Copilot, or a human at a shell).
+> **Status — Step 2 of the report-skill architecture decision.** Step 1 (the deterministic `export-compliance` renderer) ships as a subcommand of [`@transitrix/cli`](https://www.npmjs.com/package/@transitrix/cli) — the same published CLI the `validate` and `compile` commands ship from, bundled into **Transitrix Studio** and installable standalone via npm. (An earlier, pre-2.0 build of this CLI shipped a `cervin` bin alias; that name is retired and not published — use `transitrix` / `@transitrix/cli`.) This skill is the thin layer over it. All rendering is the CLI's; this `SKILL.md` and its [`scripts/report.py`](scripts/report.py) orchestrator only sequence it — so the skill loads agent-neutrally (Claude, Copilot, or a human at a shell).
 
 ---
 
 ## The one rule that governs everything
 
-**Parameters in an artefact, rendering in the CLI — never the agent.** The report's parameters (scope, filters, grouping, ordering) live in a versioned view-config the skill writes; the matrix is computed by `cervin export-compliance` from `(view-config + canon)`. The agent MUST NOT compute, tabulate, or "fill in" a matrix itself. A report assembled by the agent in chat is not reproducible, not diffable, and not auditable — exactly what the ADR exists to prevent. If the CLI is absent, stop (Step 0) rather than hand-rolling the render.
+**Parameters in an artefact, rendering in the CLI — never the agent.** The report's parameters (scope, filters, grouping, ordering) live in a versioned view-config the skill writes; the matrix is computed by `@transitrix/cli export-compliance` from `(view-config + canon)`. The agent MUST NOT compute, tabulate, or "fill in" a matrix itself. A report assembled by the agent in chat is not reproducible, not diffable, and not auditable — exactly what the ADR exists to prevent. If the CLI is absent, stop (Step 0) rather than hand-rolling the render.
 
 ---
 
@@ -27,11 +27,13 @@ This directory is the **`report` skill** within the `transitrix` plugin (the plu
 The deterministic work (scan canon, build the matrix, render Markdown/PDF) is done by the CLI, never reimplemented in the agent. Confirm it is available:
 
 ```
-cervin export-compliance --format md --scope matrix --root . > /dev/null
+transitrix export-compliance --format md --scope matrix --root . > /dev/null
+# or, without a global install:
+npx @transitrix/cli export-compliance --format md --scope matrix --root . > /dev/null
 ```
 
-- **Present** → proceed. (A non-zero exit with a usage error is fine here — it means the binary exists.)
-- **Absent** (`command not found`) → tell the user to install **Transitrix Studio** (the `cervin` binary, v1.4.x+). The orchestrator also tries `npx cervin`; if neither resolves, do not hand-roll the report. Set `TRANSITRIX_CLI` to override the binary name.
+- **Present** under either form → proceed. (A non-zero exit with a usage error is fine here — it means the binary exists.) The orchestrator (Step 2) resolves the same way: `transitrix` on PATH, else `npx @transitrix/cli`, else `$TRANSITRIX_CLI` if set.
+- **Absent** under both → tell the user to install the renderer: `npm install -g @transitrix/cli` ([npmjs.com/package/@transitrix/cli](https://www.npmjs.com/package/@transitrix/cli)), or use the `npx` form with no install. Do not hand-roll the report. (This is the same CLI bundled into the **Transitrix Studio** editor extension; installing Studio also puts `transitrix` on PATH. An older pre-2.0 build of this CLI used a `cervin` bin alias — that name was retired and is not published; do not search for it.)
 
 Also confirm you are inside a Transitrix repository (a `transitrix.yaml` manifest, with `canon/` containing `REQUIREMENT`, `ASSERTION`, `PRODUCT`, and `codex/` artefacts). With no canon there is nothing to report on.
 
@@ -79,10 +81,10 @@ python transitrix/skills/report/scripts/report.py render \
 For a coverage report add `--notation coverage-metric` and use `--regimes <codex-ids>` instead of `--obligations*`. Add `--format pdf --output <path>` for PDF. Add `--dry-run` to preview the config without rendering.
 
 The script:
-1. **resolves the renderer** (`cervin`, or `npx cervin`, or `$TRANSITRIX_CLI`);
+1. **resolves the renderer** (`transitrix`, or `npx @transitrix/cli`, or `$TRANSITRIX_CLI`);
 2. for a named report, **writes/updates** `<root>/canon/views/<notation>/<id>.<notation>.transitrix.yaml` — the canonical view-config artefact (it prints the path);
 3. **states the spec defaults** it left to the renderer for every field you did not pin;
-4. **invokes `cervin export-compliance`** and streams Markdown to stdout (or writes the file for `--output`/PDF);
+4. **invokes `export-compliance`** and streams Markdown to stdout (or writes the file for `--output`/PDF);
 5. **reports the config path used**, so the report is reproducible.
 
 ---

--- a/transitrix/skills/report/scripts/report.py
+++ b/transitrix/skills/report/scripts/report.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Report-skill orchestrator — a thin, agent-neutral layer over the
-`cervin export-compliance` renderer CLI.
+`@transitrix/cli export-compliance` renderer command.
 
 Per the report-skill architecture decision:
 the report's parameters live in a *declarative view-config artefact*, the
@@ -51,15 +51,18 @@ COVERAGE_DEFAULTS = {
     "order": "rows and columns by id; all summary totals shown",
 }
 
-DEFAULT_CLI = os.environ.get("TRANSITRIX_CLI", "cervin")
+DEFAULT_CLI = os.environ.get("TRANSITRIX_CLI", "transitrix")
+CLI_PACKAGE = "@transitrix/cli"
 
 
 def find_cli(cli: str) -> list[str] | None:
-    """Resolve the renderer CLI invocation. Tries the bare binary, then `npx`."""
+    """Resolve the renderer CLI invocation. Tries the bare binary, then `npx`
+    (the `@transitrix/cli` package for the default binary, or the override
+    name itself for a custom TRANSITRIX_CLI)."""
     if shutil.which(cli):
         return [cli]
     if shutil.which("npx"):
-        return ["npx", cli]
+        return ["npx", CLI_PACKAGE if cli == DEFAULT_CLI else cli]
     return None
 
 
@@ -98,7 +101,7 @@ def build_view_config(args, notation: str, mver: str) -> tuple[str, list[str]]:
     products = split_list(args.products)
     lines = [
         f"# Materialised by the Transitrix report skill — {notation} view-config.",
-        f"# Renders via `cervin export-compliance`; spec: notations/views/"
+        f"# Renders via `@transitrix/cli export-compliance`; spec: notations/views/"
         + ("21-compliance-impact.md" if notation == "compliance-impact" else "22-coverage-metric.md")
         + ".",
         "",
@@ -161,7 +164,8 @@ def cmd_render(args) -> int:
     if cli is None:
         print(
             f"report: renderer CLI '{args.cli}' not found on PATH (nor via npx). "
-            f"Install Transitrix Studio (the `cervin` binary) or set TRANSITRIX_CLI.",
+            f"Install `@transitrix/cli` (`npm install -g @transitrix/cli`, or use "
+            f"`npx @transitrix/cli`) or set TRANSITRIX_CLI.",
             file=sys.stderr,
         )
         return 127
@@ -255,7 +259,7 @@ def run_cli(cmd: list[str], output: str | None) -> int:
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="report.py",
-        description="Thin orchestrator over `cervin export-compliance` (ADR 2026-06-09).",
+        description="Thin orchestrator over `@transitrix/cli export-compliance` (ADR 2026-06-09).",
     )
     p.add_argument("--cli", default=DEFAULT_CLI, help=f"renderer binary (default: {DEFAULT_CLI}; or $TRANSITRIX_CLI)")
     sub = p.add_subparsers(dest="command", required=True)


### PR DESCRIPTION
## What changed

The `report` skill's Step 0 renderer pre-check, `SKILL.md`, `README.md`, `scripts/report.py`, and the plugin `transitrix/README.md` all named a renderer binary, `cervin`, "bundled with Transitrix Studio v1.4.x+" — a name that resolves nowhere public. A first-time adopter following only this repo's docs hits a dead end on the skill's very first invocation.

`npm view @transitrix/cli readme` confirms `cervin` was a real but retired pre-2.0 bin alias:

> The package is born in the 2.0 era of the methodology. The legacy `cervin` bin alias is not shipped — only `transitrix` is on PATH.

The published [`@transitrix/cli`](https://www.npmjs.com/package/@transitrix/cli) package — already the CLI this repo documents everywhere else for `validate`/`compile` (`CONTRIBUTING.md`, `GETTING_STARTED.md`, `README.md`, `integration/tooling.md`, …) — ships the exact `export-compliance` subcommand the ADR ([`2026-06-09-report-skill-over-declarative-views`](https://github.com/transitrix/methodology)) describes ("a compliance/view export CLI, backed by the shared `@transitrix/diagrams` library"), bundled into Transitrix Studio and installable standalone via `npm install -g @transitrix/cli` or `npx @transitrix/cli`.

Repoints:
- Step 0 pre-check in `SKILL.md` (`transitrix export-compliance …`, `npx @transitrix/cli export-compliance …`)
- All renderer-resolution prose in `SKILL.md` / `README.md` / `transitrix/README.md`
- `report.py`'s CLI resolution: bare `transitrix` bin → `npx @transitrix/cli` (package name, not bin name) → `$TRANSITRIX_CLI`
- The install-failure error message

States the retirement explicitly ("an older pre-2.0 build used a `cervin` bin alias; that name is retired and unpublished") so an adopter who searched for `cervin` (as the filer of THQ-201 did) gets a real answer instead of another dead end.

Fixes THQ-201.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (2 pre-existing SIZE1 warnings, unrelated)
- [x] `python -m py_compile` / `ast.parse` on `report.py` — valid
- [x] `git grep cervin` in `transitrix/` — no remaining unmarked references (only the explicit "retired/unpublished" callouts)
- [ ] Not run: no local Python interpreter with network access to actually invoke `@transitrix/cli export-compliance` end-to-end (no test suite exists for this skill to exercise in CI either — confirmed via `transitrix/skills/report/` has no `tests/` dir, unlike the `ingest` skill)