### PR TITLE
fix(adl-guard): normalize CRLF before parsing decision-record front-matter

### DIFF
--- a/packages/ingest-cli/assets/check-adl.mjs
+++ b/packages/ingest-cli/assets/check-adl.mjs
@@ -63,6 +63,14 @@ function relPosix(abs) {
   return relative(REPO_ROOT, abs).split('\\').join('/');
 }
 
+// Normalise CRLF to LF once at every point text enters the script, so a
+// Windows checkout (core.autocrlf=true → \r\n on disk) can't desync the
+// front-matter delimiter match or the A2 body/front-matter comparisons,
+// which are all written against a bare \n.
+function normalizeEol(text) {
+  return text.replace(/\r\n/g, '\n');
+}
+
 function isRecordPath(rel) {
   return DATE_FILE_RE.test(rel) || LEGACY_FILE_RE.test(rel);
 }
@@ -117,8 +125,9 @@ function parseFm(fmText) {
 // git show <ref>:<relpath> → string, or null if not present / no git.
 function gitShow(ref, relpath) {
   try {
-    return execFileSync('git', ['show', `${ref}:${relpath}`],
+    const out = execFileSync('git', ['show', `${ref}:${relpath}`],
       { cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return normalizeEol(out);
   } catch { return null; }
 }
 
@@ -162,7 +171,7 @@ async function main() {
 
   for (const abs of records) {
     const rel = relPosix(abs);
-    const text = await readFile(abs, 'utf8');
+    const text = normalizeEol(await readFile(abs, 'utf8'));
     const { fm: fmText, body } = splitFrontMatter(text);
 
     // A1 — front-matter validity

--- a/scripts/check-adl.mjs
+++ b/scripts/check-adl.mjs
@@ -63,6 +63,14 @@ function relPosix(abs) {
   return relative(REPO_ROOT, abs).split('\\').join('/');
 }
 
+// Normalise CRLF to LF once at every point text enters the script, so a
+// Windows checkout (core.autocrlf=true → \r\n on disk) can't desync the
+// front-matter delimiter match or the A2 body/front-matter comparisons,
+// which are all written against a bare \n.
+function normalizeEol(text) {
+  return text.replace(/\r\n/g, '\n');
+}
+
 function isRecordPath(rel) {
   return DATE_FILE_RE.test(rel) || LEGACY_FILE_RE.test(rel);
 }
@@ -117,8 +125,9 @@ function parseFm(fmText) {
 // git show <ref>:<relpath> → string, or null if not present / no git.
 function gitShow(ref, relpath) {
   try {
-    return execFileSync('git', ['show', `${ref}:${relpath}`],
+    const out = execFileSync('git', ['show', `${ref}:${relpath}`],
       { cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return normalizeEol(out);
   } catch { return null; }
 }
 
@@ -162,7 +171,7 @@ async function main() {
 
   for (const abs of records) {
     const rel = relPosix(abs);
-    const text = await readFile(abs, 'utf8');
+    const text = normalizeEol(await readFile(abs, 'utf8'));
     const { fm: fmText, body } = splitFrontMatter(text);
 
     // A1 — front-matter validity


### PR DESCRIPTION
## Summary

- `check-adl.mjs`'s front-matter split (`^---\n...\n---\n?`) and A2 body/front-matter comparisons all assume a bare `\n`. On a Windows checkout with `core.autocrlf=true`, decision records check out CRLF, the opening delimiter never matches, and every record fails A1 with "no front-matter block" — a checkout artifact, not a content defect.
- Fix: normalize `\r\n` → `\n` once at every point external text enters the script (file reads via `readFile`, `git show` output), rather than adding `\r?` piecemeal to each regex. This also closes a latent A2 false-positive (body/front-matter comparison against a base ref would otherwise diff on line-ending alone).
- Applied identically to `packages/ingest-cli/assets/check-adl.mjs`, the vendored copy the `adopt-adl` command ships to new adopters, per the README's "kept in sync by hand" note.

This is suggested fix (a) from the filed issue (regex/parsing robustness — "stops mattering what any given contributor's local line-ending settings are"). Suggested fix (b) (a root `.gitattributes` forcing LF in `acme-corp`) is **not** included here: (a) alone fixes the guard regardless of where it's vendored or which repo's checkout settings are in play, and `acme-corp` hasn't actually vendored `check-adl.mjs` yet (no `scripts/check-adl.mjs` or CI wiring found there — that's the separate CI-wiring work under THQ-209). Noting explicitly per the issue's own acceptance criteria so (b) isn't independently rediscovered: if `acme-corp` (or any adopter) later hits CRLF trouble in a *different* tool that also assumes bare `\n`, that's the point to reach for a root `.gitattributes` instead of re-patching every tool's regex.

## Verification

- Reproduced the reported failure: copied the pre-fix script into a local `acme-corp` checkout (Windows, `core.autocrlf=true`, confirmed CRLF via `xxd`) and ran it against the 6 existing `ADR-000N-*.md` records — all 6 failed A1 exactly as reported.
- Copied the fixed script into the same checkout and reran — `ADL guard clean — 6 decision record(s) ... valid.`, exit 0. Test files removed afterward; `acme-corp` working tree left clean (verified via `git status`).
- `node scripts/check-adl.mjs` (this repo) — clean.
- `node --test packages/ingest-cli/src/adl-join.test.mjs` — 4/4 pass.
- `node scripts/check-notations.mjs` — clean (pre-existing SIZE1 warnings only, unrelated).

## Test plan

- [x] `check-adl.mjs` passes cleanly against the existing `acme-corp` decision records on a fresh Windows checkout — verified above.
- [x] Fix choice ((a), not (b)) noted explicitly.

Closes THQ-210.