### PR TITLE
fix(ingest-cli): exclude the shipped ADR template from workflow-status's proposed count

### DIFF
--- a/packages/ingest-cli/src/workflow-status.mjs
+++ b/packages/ingest-cli/src/workflow-status.mjs
@@ -13,7 +13,7 @@
 // recomputing admission state.
 
 import { readdir, readFile, access } from 'node:fs/promises';
-import { join, resolve, relative } from 'node:path';
+import { join, resolve, relative, basename } from 'node:path';
 import { readTopScalar } from './yaml.mjs';
 import { checkStale } from './check-stale.mjs';
 import { isUnresolvedPath } from './unresolved.mjs';
@@ -24,6 +24,20 @@ async function listMdFiles(dir) {
   let entries;
   try { entries = await readdir(dir, { withFileTypes: true }); } catch { return []; }
   return entries.filter(e => e.isFile() && e.name.endsWith('.md')).map(e => join(dir, e.name));
+}
+
+// operations/decisions/ADR-*.md filename shapes (method/07-decisions.md §2, §2.2) —
+// kept in sync by hand with scripts/check-adl.mjs's DATE_FILE_RE/LEGACY_FILE_RE
+// (and its vendored copy, packages/ingest-cli/assets/check-adl.mjs). Excludes by
+// construction anything that isn't a real record — most notably the shipped ADR
+// template (transitrix/skills/adr/templates/ADR-template.md), whose id and any
+// filename it might be copied in under never actually matches
+// ADR-<date>-<slug>.md or the legacy ADR-<NNNN>-<slug>.md shape
+// (transitrix-hq#211).
+const ADR_DATE_RE = /^ADR-\d{4}-\d{2}-\d{2}-[^/]+\.md$/;
+const ADR_LEGACY_RE = /^ADR-\d{4}-[^/]+\.md$/;
+function isAdrRecordFilename(name) {
+  return ADR_DATE_RE.test(name) || ADR_LEGACY_RE.test(name);
 }
 
 async function walkYaml(dir) {
@@ -62,16 +76,16 @@ function todayIso() { return new Date().toISOString().slice(0, 10); }
 
 // operations/decisions/ADR-*.md — status: proposed|accepted|superseded
 // (method/07-decisions.md §2.1), author:agent proposed broken out as its own phase
-// (method/07-decisions.md §2.1). ADR ids are opaque strings throughout — both
-// ADR-NNNN and ADR-YYYY-MM-DD-<slug> forms work
-// without special-casing, since only `status`/`author` front-matter fields
-// are read here, never the id's shape.
+// (method/07-decisions.md §2.1). Once a file clears the isAdrRecordFilename() gate,
+// its `id:` front-matter is read and reported as an opaque string — both ADR-NNNN
+// and ADR-YYYY-MM-DD-<slug> forms work without special-casing there.
 async function scanAdr(root) {
   const dir = join(root, 'operations', 'decisions');
   if (!(await exists(dir))) return null;
   const counts = { proposed_agent: 0, proposed_human: 0, accepted: 0, superseded: 0, unknown: 0 };
   const ids = { proposed_agent: [], proposed_human: [], accepted: [], superseded: [], unknown: [] };
   for (const file of await listMdFiles(dir)) {
+    if (!isAdrRecordFilename(basename(file))) continue;
     const text = await readFile(file, 'utf8');
     const fm = frontMatterOf(text);
     const id = (fm && readTopScalar(fm, 'id')) || relative(root, file);

--- a/packages/ingest-cli/src/workflow-status.test.mjs
+++ b/packages/ingest-cli/src/workflow-status.test.mjs
@@ -1,0 +1,64 @@
+// Regression test for transitrix-hq#211 — workflow-status.mjs's ADR scan must not
+// count the shipped ADR template (or any other non-record .md file dropped into
+// operations/decisions/) as a real proposed record.
+//
+// Run: node --test packages/ingest-cli/src/workflow-status.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { computeWorkflowStatus } from './workflow-status.mjs';
+
+function tmpOrgRoot() {
+  return mkdtempSync(join(tmpdir(), 'workflow-status-test-'));
+}
+
+function writeAdr(decisionsDir, filename, frontMatter) {
+  const fm = Object.entries(frontMatter).map(([k, v]) => `${k}: ${v}`).join('\n');
+  writeFileSync(join(decisionsDir, filename), `---\n${fm}\n---\n\nbody\n`, 'utf8');
+}
+
+test('scanAdr: the shipped template (literal ADR-YYYY-MM-DD-*.template.md) is excluded', async () => {
+  const root = tmpOrgRoot();
+  const decisions = join(root, 'operations', 'decisions');
+  mkdirSync(decisions, { recursive: true });
+  writeAdr(decisions, 'ADR-YYYY-MM-DD-short-slug.template.md', {
+    id: 'ADR-YYYY-MM-DD-short-slug', title: 'FILL-ME', status: 'proposed', date: '"YYYY-MM-DD"', author: 'human-architect',
+  });
+  writeAdr(decisions, 'ADR-2026-08-18-real-decision.md', {
+    id: 'ADR-2026-08-18-real-decision', title: 'Real', status: 'proposed', date: '"2026-08-18"', author: 'agent',
+  });
+
+  const { sections } = await computeWorkflowStatus(root);
+  const adr = sections.find(s => s.object === 'ADR');
+  const total = adr.rows.reduce((n, r) => n + r.count, 0);
+  assert.equal(total, 1, 'template must not be counted alongside the one real record');
+  assert.deepEqual(adr.rows.find(r => r.phase === 'proposed (author: agent)').ids, ['ADR-2026-08-18-real-decision']);
+});
+
+test('scanAdr: legacy ADR-NNNN records are still counted (not filename-shape false negatives)', async () => {
+  const root = tmpOrgRoot();
+  const decisions = join(root, 'operations', 'decisions');
+  mkdirSync(decisions, { recursive: true });
+  writeAdr(decisions, 'ADR-0001-legacy-decision.md', {
+    id: 'ADR-0001', title: 'Legacy', status: 'accepted', date: '"2026-01-01"', author: 'human-architect',
+  });
+
+  const { sections } = await computeWorkflowStatus(root);
+  const adr = sections.find(s => s.object === 'ADR');
+  assert.deepEqual(adr.rows.find(r => r.phase === 'accepted').ids, ['ADR-0001']);
+});
+
+test('scanAdr: an arbitrary non-record .md file in the folder is ignored, not bucketed unknown', async () => {
+  const root = tmpOrgRoot();
+  const decisions = join(root, 'operations', 'decisions');
+  mkdirSync(decisions, { recursive: true });
+  writeFileSync(join(decisions, 'README.md'), '# Decisions folder\n', 'utf8');
+
+  const { sections } = await computeWorkflowStatus(root);
+  const adr = sections.find(s => s.object === 'ADR');
+  const total = adr.rows.reduce((n, r) => n + r.count, 0);
+  assert.equal(total, 0);
+});


### PR DESCRIPTION
## Summary

- `workflow-status.mjs`'s ADR scan (`scanAdr`, via `listMdFiles`) filtered `operations/decisions/` by `.md` extension only, with no filename-shape check. A copy of the shipped ADR template (`transitrix/skills/adr/templates/ADR-template.md`, id `ADR-YYYY-MM-DD-<slug>`) left in the folder un-renamed — e.g. as `ADR-YYYY-MM-DD-short-slug.template.md` — reports as an extra `proposed (author: human)` record, with the phantom placeholder id surfaced in the open-items list as if a human needs to act on it.
- `scripts/check-adl.mjs` already excludes the template, but only as a side effect of its id-grammar regex (`DATE_FILE_RE`/`LEGACY_FILE_RE`) failing to match the literal `YYYY-MM-DD` placeholder text — not by deliberate design, per the filed issue.
- Fix: give `workflow-status.mjs` its own explicit `isAdrRecordFilename()` guard mirroring `check-adl.mjs`'s filename-shape scope definition (`method/07-decisions.md` §2, §2.2 — `ADR-YYYY-MM-DD-<slug>.md` or legacy `ADR-NNNN-<slug>.md`), applied deliberately rather than relying on the regex's accidental non-match. Scoped to the ADR scan only (`scanWi`'s `listMdFiles` call is untouched — no WI-template double-count was reported).

Closes THQ-211.

## Verification

- New `packages/ingest-cli/src/workflow-status.test.mjs`: template excluded (count stays at 1 for the one real record alongside it), legacy `ADR-NNNN` records still counted (no false-negative from the new guard), and an arbitrary non-record `.md` file in the folder is silently ignored.
- `node --test packages/ingest-cli/src/*.test.mjs` — 131/131 pass.
- `node scripts/check-notations.mjs` — clean (pre-existing SIZE1 warnings only, unrelated).
- `node scripts/check-adl.mjs` — clean.

## Test plan

- [x] `workflow-status` no longer counts the shipped ADR template as a proposed record, on a repo that hasn't touched it — covered by the new test.
- [x] Fix is correct by construction (explicit filename-shape guard), not reliant on `check-adl.mjs`'s regex accidentally also working.