### PR TITLE
docs(governance): a human may ratify a bounded class of change in advance

### DIFF
--- a/method/07-decisions.md
+++ b/method/07-decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Decisions — record shape and multi-repo aggregation
 status: active
-last_reviewed: 2026-08-16
+last_reviewed: 2026-08-18
 audience: public
 license: MIT
 tags: [transitrix, methodology, operations, adr, adl, togaf, governance]
@@ -119,6 +119,8 @@ The local filename and `id:` are unchanged — **no change to the per-repo conve
 
 An agent may author a record and open it as `status: proposed`. It may **not** self-promote to `accepted`. This is the mechanism [`08-governance.md`](08-governance.md) states as doctrine; this section is its mechanics.
 
+**A ratified class needs no per-instance record.** Where a human has accepted a standing grant covering a bounded class of change ([`08-governance.md`](08-governance.md) §2.1), an agent acting inside that class is executing a ratified decision rather than taking one, and the record of each instance is the run rather than a new ADR. The grant itself is an ordinary record — `author: human-architect`, ratified by a person, immutable once accepted, superseded rather than rewritten — so nothing above is loosened: the table still says an `author: agent` record is in force only when a human ratifies it, and an agent still cannot author or widen the grant it acts under.
+
 **The authorship limit — where, not just what.** An agent may author a decision record that is local to its own repository; it may **not** author one that crosses a boundary outside that repository — including writing directly into the central architecture repository, another project repository, or any location its own repository's agent cannot itself read. The control is structural rather than a review step: the crossing is defined by material the agent does not have (another repository's audience, confidentiality boundary, or reasoning), so the agent cannot reliably detect that it has crossed one — the boundary has to be enforced by *who may author where*, not by checking the record afterward. An agent that judges its own repository's decision belongs in the central log (§1) proposes that move to whoever can write there; it never writes across the boundary itself.
 
 ## 5. The harvest — central pull job
@@ -198,5 +200,5 @@ The mechanism is specified above (§2–§8); the step-by-step path through it �
 
 **Next:** [`08-governance.md`](08-governance.md) — who may change what, what gates it, and what an agent may do unattended.
 
-**Last reviewed:** 2026-08-16. Merges the former `03-architecture-decision-log.md` with the ADR record shape formerly at `02-team-operations.md` §3.1 — see those files for the redirect. The two are combined here because the record shape and its multi-repo aggregation are one question, not two.
+**Last reviewed:** 2026-08-18. §4 records that a class ratified in advance ([`08-governance.md`](08-governance.md) §2.1) needs no per-instance record — the run is the record — while the `author: agent` gate in the table above is unchanged. Prior 2026-08-16: Merges the former `03-architecture-decision-log.md` with the ADR record shape formerly at `02-team-operations.md` §3.1 — see those files for the redirect. The two are combined here because the record shape and its multi-repo aggregation are one question, not two.
 **Status:** Active.

--- a/method/08-governance.md
+++ b/method/08-governance.md
@@ -1,7 +1,7 @@
 ---
 title: Governance — who may change what, and what gates it
 status: active
-last_reviewed: 2026-08-16
+last_reviewed: 2026-08-18
 audience: public
 license: MIT
 tags: [transitrix, methodology, governance, agents]
@@ -29,12 +29,35 @@ This asymmetry is enforced the same way across every mechanism it applies to:
 | Mechanism | An agent may | Only a human may | Specified in |
 |---|---|---|---|
 | Decision records (ADR) | author a record at `status: proposed`, `author: agent` | flip `proposed → accepted` | [`07-decisions.md`](07-decisions.md) §2.1, §4 |
-| Methodology / catalog version upgrades | prepare the bounded upgrade PR (pin bump, recipe-scoped diff, the ADR) | ratify the accompanying ADR | [`09-releases-and-propagation.md`](09-releases-and-propagation.md) §5 |
+| Methodology / catalog version upgrades | prepare the bounded upgrade PR (pin bump, recipe-scoped diff, the ADR) — and, inside a class ratified in advance (§2.1), land it | ratify the accompanying ADR, or the class ahead of time | [`09-releases-and-propagation.md`](09-releases-and-propagation.md) §5 |
 | Catalogue bindings (recognition, promotion) | stage a proposed binding | accept it (the one write to `canon_id`) | [`09-releases-and-propagation.md`](09-releases-and-propagation.md) §6 |
 
-**The rule in one sentence: an agent may author a record or prepare a change; it may never self-ratify, self-accept, or self-merge it.** The worst an unattended agent can do, under every mechanism above, is leave a proposal for a human to review — never a change already in force.
+**The rule in one sentence: an agent may author a record or prepare a change; it may never self-ratify, self-accept, or self-merge it.** The worst an unattended agent can do, under every mechanism above, is leave a change no human authorised — and it cannot do that either, because a change is in force only where a human ratified it: the instance, or the class it belongs to (§2.1).
 
 **The authorship limit is also spatial, not only temporal.** An agent may author a decision, a binding proposal, or an upgrade that is local to its own repository. It may **not** write into a central architecture repository, another project repository, or any location its own repository's agent cannot itself read — see [`07-decisions.md`](07-decisions.md) §4 ("the authorship limit — where, not just what"). The boundary is enforced structurally, by who may author where, because the crossing is defined by context (another repository's audience, confidentiality boundary, reasoning) the agent does not have and cannot reliably self-check.
+
+### 2.1 Ratification may precede the change — the standing grant
+
+The asymmetry above is about **who decides**, not about **when**. Read as a rule about timing it produces a false choice, and the choice is false in a way that costs something either way: either every instance of a repeating mechanical change waits for a person, or a change is in force with nothing having ratified it.
+
+Neither is necessary, because **a repeating mechanical change is usually not a decision each time — it is the Nth execution of one decision.** Where that is true, a human ratifies the **class** ahead of time, in a **standing grant**.
+
+A grant is a record like any other: authored by a human, accepted by a human, immutable once accepted, superseded rather than rewritten (§3). What it must name:
+
+1. **The repository and the exact change permitted** — narrow enough that a reader can tell whether a given change is inside it without interpreting intent.
+2. **The conditions that must hold on every use** — and **every one of them mechanically checkable**. See the limit below; this is the load-bearing requirement, not a quality note.
+3. **The end condition** — stated when the grant is written, not left to whoever remembers to revisit it.
+
+An agent acting inside a ratified class is **executing** a decision, not taking one. The per-instance record is therefore the run — the mechanism, its conditions, and their results — rather than a fresh decision record per instance. A record per instance would document a judgement that was not made.
+
+**What a grant does not do — the part to read if you read nothing else here:**
+
+- **An agent may not author a grant, widen one, or ratify one — including the one it acts under.** A grant is ratified by a human, exactly like the instance it replaces. Nothing in this section gives an agent a path to enlarging its own authority.
+- **A change outside every grant in force falls back to the default:** propose, and wait. "No applicable grant" is never read as permission; it is read as the ordinary case.
+- **A condition stated in prose is not a condition.** If a class boundary cannot be checked mechanically, there is no grant — this is §4 applied to grants, and it is what keeps a grant from degenerating into a blanket permission written in words the agent itself gets to interpret. A grant whose guard is missing is not a grant operating on trust; it is not in force.
+- **A grant does not travel.** It is local to the repository whose maintainers ratified it, by the same reasoning as the spatial limit above. An adopter inherits the mechanism, never anyone else's grants.
+
+**Why this is stronger than per-instance review rather than a relaxation of it.** A person ratifying a class writes the conditions down once, in a form a machine then enforces on every single use. A person ratifying each instance re-reads a diff whose sameness is precisely what makes attention lapse — and a gate that gets approved without being read is a gate in name. The grant moves the human judgement to where it is actually exercised, and leaves the repetition to the mechanism that does not tire.
 
 ## 3. Immutability and supersession
 
@@ -49,6 +72,8 @@ Every rule in §2 and §3 is enforced by a CI guard, not merely documented:
 - `scripts/check-adl.mjs` mechanically rejects a body diff to an accepted decision record, and rejects an `author: agent` record introduced already `accepted` ([`07-decisions.md`](07-decisions.md) §7).
 - `scripts/check-notations.mjs` gates the model-side validation matrix and the version-pin consistency ([`05-working-the-model.md`](05-working-the-model.md) §2; [`09-releases-and-propagation.md`](09-releases-and-propagation.md) §4).
 
+A standing grant (§2.1) is held to the same standard, and it is the reason the standard is stated as strictly as it is: a grant's conditions are in force only where a guard evaluates them on every use and fails the pull request when one does not hold. A grant whose conditions no guard checks has not moved a judgement earlier — it has removed one.
+
 A discipline that only a human is expected to remember is not a discipline this methodology relies on. Where a rule above matters enough to state as doctrine, it matters enough to have a guard that fails a pull request mechanically when broken.
 
 ## 5. The versioning and compatibility promise
@@ -59,7 +84,9 @@ Governance extends to the methodology's own releases: an adopter can trust that 
 
 Drawing the threads above together, the one test that applies everywhere in this repository and in any repository following this methodology:
 
-> **An agent may prepare, propose, stage, and open a pull request. It may never merge its own change, ratify its own decision, or write across a repository boundary it does not own.**
+> **An agent may prepare, propose, stage, and open a pull request. It may land a change only inside a class a human ratified in advance, on conditions a guard checks every time. It may never ratify its own decision, author or widen the grant it acts under, or write across a repository boundary it does not own.**
+
+The two halves are one rule, not an allowance carved out of a prohibition: **every change in force was ratified by a human** — the instance, or the class. What an agent never does is supply that ratification itself.
 
 Everything else — what counts as "prepared," what a proposal must carry, which CI guard enforces which half of it — is mechanism, specified where the mechanism lives (§2's table). This section is what stays true regardless of which mechanism a future addition to the methodology introduces.
 
@@ -67,5 +94,5 @@ Everything else — what counts as "prepared," what a proposal must carry, which
 
 **Next:** [`09-releases-and-propagation.md`](09-releases-and-propagation.md) — how a new version reaches an adopter.
 
-**Last reviewed:** 2026-08-16. New section, assembled from material formerly scattered across `02-team-operations.md` §3.1.1 and §6.1–§6.2, `03-architecture-decision-log.md` §6–§8, `04-methodology-update-propagation.md` §5, and `01-methodology.md` §7 (closing line), §8, and §13 — see those files' redirects. §13's inline paraphrase of the compatibility policy is replaced here by a pointer to [`notations/CONTRACT.md`](../notations/CONTRACT.md) §10, its canonical source.
+**Last reviewed:** 2026-08-18. New §2.1 — a human may ratify a bounded **class** of change in advance (a standing grant), so a repeating mechanical change need not wait for a per-instance decision that nobody is actually making. §2's table row, its closing rule and §6's summary test are amended together, since a reader who skims must not come away with a weaker guarantee than the one that holds: every change in force was ratified by a human — the instance, or the class — and an agent may never author, widen, or ratify the grant it acts under. §4 gains the condition that carries the whole idea: a grant's conditions are in force only where a guard evaluates them on every use. Prior 2026-08-16: New section, assembled from material formerly scattered across `02-team-operations.md` §3.1.1 and §6.1–§6.2, `03-architecture-decision-log.md` §6–§8, `04-methodology-update-propagation.md` §5, and `01-methodology.md` §7 (closing line), §8, and §13 — see those files' redirects. §13's inline paraphrase of the compatibility policy is replaced here by a pointer to [`notations/CONTRACT.md`](../notations/CONTRACT.md) §10, its canonical source.
 **Status:** Active.

--- a/method/09-releases-and-propagation.md
+++ b/method/09-releases-and-propagation.md
@@ -1,7 +1,7 @@
 ---
 title: Releases and propagation — how a new version reaches an adopter
 status: active
-last_reviewed: 2026-08-16
+last_reviewed: 2026-08-18
 audience: public
 license: MIT
 tags: [transitrix, methodology, operations, upgrade, versioning, catalogue, agents]
@@ -61,13 +61,19 @@ A `MINOR` or `PATCH` bump that carries no migration recipe (additive specs only)
 
 ## 5. The bound on autonomous agents
 
-An agent may prepare an upgrade. An agent may not silently apply one. The mechanism is the ADL ratification gate ([`07-decisions.md`](07-decisions.md) §4; doctrine: [`08-governance.md`](08-governance.md) §2):
+An agent may prepare an upgrade. An agent may not apply one that no human authorised. The mechanism is the ADL ratification gate ([`07-decisions.md`](07-decisions.md) §4; doctrine: [`08-governance.md`](08-governance.md) §2), and it has two paths — which one applies depends on whether a human ratified this upgrade or its class.
+
+**The default path — the human ratifies the instance.**
 
 - An agent-prepared upgrade PR **must** include an ADR with `author: agent` and `status: proposed` that records the bump. A worked example is `operations/decisions/ADR-0002-pin-methodology-0-5-0.md` in the acme-corp reference repo.
 - The pin in `transitrix.yaml` may change in the same PR, but the decision is **not in force** until a human flips the ADR `proposed → accepted` in a separate, reviewed change.
 - The ADL CI guard (`scripts/check-adl.mjs`, check A3) mechanically rejects an `author: agent` record introduced as `accepted`. The gate is enforced, not advised.
 
-The worst an unattended agent can do, then, is leave a *proposed* upgrade for human review — the entire bounded, recipe-scoped diff plus the ADR are visible in one PR.
+The worst an unattended agent can do on this path is leave a *proposed* upgrade for human review — the entire bounded, recipe-scoped diff plus the ADR are visible in one PR.
+
+**Under a standing grant — the human ratified the class first.** Where a repository's maintainers have accepted a standing grant for a bounded class of upgrade ([`08-governance.md`](08-governance.md) §2.1), an agent may land an upgrade inside that class without a per-instance ADR: the ratification happened when the grant was accepted, and the record of each landing is the run. A repeated non-major pin bump is the usual case — it is not a decision each time, and a per-instance record would document a judgement nobody made.
+
+This narrows nothing away from the paragraph above. The grant is accepted by a human; its conditions are checked mechanically on every use, or it is not in force; a bump outside the class — a `MAJOR` upgrade, or one whose conditions do not hold — takes the default path; and an agent can neither write a grant nor widen the one it acts under.
 
 ## 6. Catalogue integration — joining a network around a central catalogue
 
@@ -142,5 +148,5 @@ L0 is one command (`transitrix-ingest adopt-adl`) — see [`guides/adl-adopter-s
 
 ---
 
-**Last reviewed:** 2026-08-16. Merges the former `04-methodology-update-propagation.md` §1–§6, §8–§9 with `05-catalogue-integration.md` — see those files' redirects. §7 (Discovery) moved to [`RELEASING.md`](../RELEASING.md), a maintainer-side operational document, rather than staying in this adopter-facing folder. §6 above condenses the former standalone catalogue-integration document, pointing at [`notations/CONTRACT.md`](../notations/CONTRACT.md) §17 for the binding envelope's field shapes rather than restating them, to avoid the two documents drifting apart.
+**Last reviewed:** 2026-08-18. §5 now states the two paths an agent-prepared upgrade can take — the default per-instance ratification, unchanged, and landing inside a class ratified in advance ([`08-governance.md`](08-governance.md) §2.1). Previously it restated the doctrine in a form that a standing grant would contradict. Prior 2026-08-16: Merges the former `04-methodology-update-propagation.md` §1–§6, §8–§9 with `05-catalogue-integration.md` — see those files' redirects. §7 (Discovery) moved to [`RELEASING.md`](../RELEASING.md), a maintainer-side operational document, rather than staying in this adopter-facing folder. §6 above condenses the former standalone catalogue-integration document, pointing at [`notations/CONTRACT.md`](../notations/CONTRACT.md) §17 for the binding envelope's field shapes rather than restating them, to avoid the two documents drifting apart.
 **Status:** Active.


### PR DESCRIPTION
## What changed

New **§2.1** in `method/08-governance.md` — *Ratification may precede the change — the standing grant*.

§2's asymmetry ("an agent may propose; only a human may commit the repository to a decision") is about **who decides**. Read as a rule about **when**, it forces a false choice: either every instance of a repeating mechanical change waits for a person, or a change is in force with nothing having ratified it. §2.1 states the third case — a repeating mechanical change is usually not a decision each time, but the Nth execution of one decision, so a human ratifies the **class** ahead of time in a standing grant that names the exact change permitted, the conditions that must hold on every use, and an end condition. An agent acting inside a ratified class executes a decision rather than taking one, and the record of each instance is the run rather than a fresh decision record.

The guarantee is unchanged, and is restated at every point a skimming reader lands so nobody comes away with a weaker one:

- **§2's closing rule** and **§6's summary test** now say it directly — every change in force was ratified by a human, the instance or the class, and an agent never supplies that ratification itself.
- §2.1's own bullets: an agent may not author, widen, or ratify a grant (including its own); a change outside every grant falls back to the default of propose-and-wait, because "no applicable grant" is the ordinary case rather than permission; a grant does not travel to another repository, so an adopter inherits the mechanism and never anyone else's grants.
- **§4** carries the load-bearing condition: a grant's conditions are in force only where a guard evaluates them on every use, so a grant whose guard is missing has not moved a judgement earlier — it has removed one.

**§2's table row** for methodology/catalog version upgrades is amended to match.

Two files restated the doctrine in a form §2.1 would contradict, and now point at it instead:

- `method/09-releases-and-propagation.md` §5 — splits into the default per-instance path (unchanged, including the `check-adl.mjs` A3 gate) and landing inside a ratified class, with a `MAJOR` bump or an unmet condition taking the default path.
- `method/07-decisions.md` §4 — a ratified class needs no per-instance record; the `author: agent` gate in the table above is untouched, and the grant itself is an ordinary human-authored, human-accepted, immutable record.

## How it is verified

- `node scripts/check-notations.mjs` — clean (20 view notations; examples, internal links, version pins and notation counts consistent). Two pre-existing `SIZE1` soft-ceiling warnings on `06-team-operations.md` and `07-decisions.md` are unchanged: this PR adds one `###` subsection and no `##` sections.
- `node scripts/check-adl.mjs` — clean.
- Documentation only; no script, schema, or notation behaviour changes.

## Checklist

- [x] Based on `main`, one concern per PR.
- [x] Commits are signed off (`git commit -s`) — DCO.
- [x] No hub/work-item references in committed files, this description, or commit messages.
