### PR TITLE
fix(skills): re-sync ingest/onboard prompts to BUSINESS_OBJECT

### DIFF
--- a/transitrix/skills/ingest/SKILL.md
+++ b/transitrix/skills/ingest/SKILL.md
@@ -282,7 +282,7 @@ Where an admitted element lands is **not** a judgement call. Every element TYPE 
 
 - The review queue annotates each element candidate with its resolved `placement` (`mode`, `layer`, `folder`). Admit a `standalone` element to exactly that folder, one file per element.
 - Check any TYPE on demand: `transitrix-ingest resolve-placement <TYPE>`.
-- **Honour the §1 promotion rule explicitly.** A `view-defined` / `contained` TYPE (`INTEGRATION`, `STEP`, `EQUIPMENT`, `INFORMATION_ENTITY`, registry rows) stays **inline** in its host/view document and is promoted to its own catalogue file **only when a second document references it** — the id never changes on promotion. Do not pre-create a standalone file for a still-single-reference element.
+- **Honour the §1 promotion rule explicitly.** A `view-defined` / `contained` TYPE (`INTEGRATION`, `STEP`, `EQUIPMENT`, registry rows) stays **inline** in its host/view document and is promoted to its own catalogue file **only when a second document references it** — the id never changes on promotion. Do not pre-create a standalone file for a still-single-reference element.
 - After admitting, verify placement: `transitrix-ingest check-placement [org-root]` flags any admitted element sitting outside its §4 folder (and any `view-defined` TYPE wrongly given its own catalogue file). Read-only over `canon/`.
 
 ---

--- a/transitrix/skills/ingest/prompts/03_application.md
+++ b/transitrix/skills/ingest/prompts/03_application.md
@@ -1,6 +1,6 @@
 ---
 layer: application
-extracts: [APPLICATION, INTEGRATION, INFORMATION_ENTITY]
+extracts: [APPLICATION, INTEGRATION, BUSINESS_OBJECT]
 version: "0.1"
 status: draft
 ---
@@ -36,7 +36,7 @@ A single JSON object, nothing else:
 |---|---|---|
 | `APPLICATION` | names a software system or application the org uses | one element per distinct system |
 | `INTEGRATION` | describes a connection/interface between systems | typically links two `APPLICATION`s |
-| `INFORMATION_ENTITY` | names a kind of information the business handles | a data concept, not a database table |
+| `BUSINESS_OBJECT` | names a kind of information the business handles | a data concept, not a database table |
 
 Application-layer relations you may propose (only above a high bar) come from the **closed** relation registry ([17-relations.md](https://raw.githubusercontent.com/transitrix/methodology/main/notations/elements/17-relations.md)). An integration *between* two named systems is often best expressed as an `INTEGRATION` element referencing them; only emit a relation when the source states the link plainly.
 
@@ -52,7 +52,7 @@ Extract only the **stable** identity fields. Time-varying attributes (a system's
 
 - Do not invent TYPEs, relation kinds, or attribute fields.
 - Do not output `source_quality`, admission fields, or `admitted_to`.
-- Do not model a database schema; `INFORMATION_ENTITY` is a business information concept.
+- Do not model a database schema; `BUSINESS_OBJECT` is a business information concept.
 - Do not reference existing canon — read only the one field artefact.
 
 ## See also

--- a/transitrix/skills/ingest/prompts/README.md
+++ b/transitrix/skills/ingest/prompts/README.md
@@ -6,7 +6,7 @@ Per-layer **system prompts** the ingest agent runs over a `field` artefact to pr
 |---|---|---|
 | [`01_motivation.md`](01_motivation.md) | Motivation | `DRIVER`, `GOAL`, `CONSTRAINT`, `REQUIREMENT`, `STAKEHOLDER` |
 | [`02_business.md`](02_business.md) | Business | `ACTOR`, `ROLE`, `PROCESS`, `RULE`, `PRODUCT`, `CAPABILITY` |
-| [`03_application.md`](03_application.md) | Application | `APPLICATION`, `INTEGRATION`, `INFORMATION_ENTITY` |
+| [`03_application.md`](03_application.md) | Application | `APPLICATION`, `INTEGRATION`, `BUSINESS_OBJECT` |
 | [`04_implementation.md`](04_implementation.md) | Implementation & Migration | `ACTIVITY`, `CHANGE`, `TARGET_STATE` (+ milestone candidates routed through these two TYPEs until `MILESTONE` lands) |
 | [`05_approvers.md`](05_approvers.md) | Cross-cutting | `ACTOR`, `ROLE` from a document's approval / sign-off chain, plus `role_assignment_proposals[]` |
 

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -375,7 +375,7 @@ Schema: `notations/elements/14-codex.md` for codex; `notations/CONTRACT.md` §5�
 
 Every typed ID follows `<TYPE>-[<middle>-]<INTEGER>` per `notations/IDS_AND_REFERENCES.md`:
 
-- Uppercase TYPE prefix (letters, digits, underscore; starts with a letter). Multi-word TYPEs are uppercase with underscores: `PROCESS_BLUEPRINT`, `INFORMATION_ENTITY`.
+- Uppercase TYPE prefix (letters, digits, underscore; starts with a letter). Multi-word TYPEs are uppercase with underscores: `PROCESS_BLUEPRINT`, `BUSINESS_OBJECT`.
 - Optional middle segments for disambiguation: `GOAL-RETENTION-12`, `ACTIVITY-Q3-2026-7`.
 - Terminal positive integer, **no leading zeros** (`-1` not `-001`).
 - Exception: `CAPABILITY-V1.2`, `CAPABILITY-H1.2.3` — capabilities use V/H diagram addresses instead of plain integers.

--- a/transitrix/skills/onboard/extraction/03_application.md
+++ b/transitrix/skills/onboard/extraction/03_application.md
@@ -1,6 +1,6 @@
 ---
 layer: 03_application
-extracts: [APPLICATION, INTEGRATION, INFORMATION_ENTITY]
+extracts: [APPLICATION, INTEGRATION, BUSINESS_OBJECT]
 version: "0.1"
 status: "draft"
 ---
@@ -15,7 +15,7 @@ This prompt runs in **autonomous mode** alongside [`01_motivation.md`](01_motiva
 
 ## Role
 
-You are an **application-layer extraction agent**. Your job is to read raw Field material an organisation has gathered about itself and produce draft canonical primitives — `APPLICATION`, `INTEGRATION`, `INFORMATION_ENTITY` — that an admission gate will later promote to the organisation's Canon.
+You are an **application-layer extraction agent**. Your job is to read raw Field material an organisation has gathered about itself and produce draft canonical primitives — `APPLICATION`, `INTEGRATION`, `BUSINESS_OBJECT` — that an admission gate will later promote to the organisation's Canon.
 
 You produce **structured drafts**, not opinions. You faithfully extract what the source material asserts; everything you emit must be defensible against the source.
 
@@ -46,7 +46,7 @@ You produce draft primitives of these TYPEs (per [IDS_AND_REFERENCES.md](../../.
 |---|---|---|
 | `APPLICATION` | A software system the organisation operates — packaged product, custom-built service, platform, or data store | The source names a system the org runs ("our CRM", "the order management system", "the data warehouse", "the in-house mobile app backend") |
 | `INTEGRATION` | A point-to-point connection between two applications (or to an external system) — a typed channel for data or events | The source describes how two systems exchange data ("OMS sends order events to CRM via Kafka", "we sync customer records from CRM to the marketing platform nightly") |
-| `INFORMATION_ENTITY` | A discrete data record, document, or artefact that flows through processes or is stored in applications | The source names a structured piece of information ("the customer master record", "the purchase order document", "the daily settlement file") |
+| `BUSINESS_OBJECT` | A discrete data record, document, or artefact that flows through processes or is stored in applications | The source names a structured piece of information ("the customer master record", "the purchase order document", "the daily settlement file") |
 
 ### When to choose `APPLICATION` `type`
 
@@ -79,7 +79,7 @@ You emit a list of draft primitives. Each draft is a valid YAML document in **ca
 **Every draft you emit:**
 
 - Uses a canonical ID per the grammar in [IDS_AND_REFERENCES.md](../../../../notations/IDS_AND_REFERENCES.md) §1 (`<TYPE>-[<middle>-]<INTEGER>`).
-- Uses canonical full TYPE prefixes (`APPLICATION-…`, `INTEGRATION-…`, `INFORMATION_ENTITY-…`) — never legacy abbreviations like `APP-` / `INT-`.
+- Uses canonical full TYPE prefixes (`APPLICATION-…`, `INTEGRATION-…`, `BUSINESS_OBJECT-…`) — never legacy abbreviations like `APP-` / `INT-`.
 - Carries `derived_from: [<FIELD-ARTEFACT-ID>]`.
 - Carries an admission record block with `admitted_to: pending` and `gate_checks: pending`.
 - Carries `valid_from` and `valid_to` per the primitive lifecycle ([CONTRACT.md](../../../../notations/CONTRACT.md) §7).
@@ -155,17 +155,17 @@ valid_from: "2024-08-01"
 valid_to: null
 ```
 
-### `INFORMATION_ENTITY` example
+### `BUSINESS_OBJECT` example
 
 ```yaml
-id: INFORMATION_ENTITY-CUSTOMER-MASTER-RECORD-1
+id: BUSINESS_OBJECT-CUSTOMER-MASTER-RECORD-1
 name: "Customer Master Record"
 description: >
   Canonical record of a customer's identity, contact details, account
   status, and segmentation tags. Sourced from CRM; replicated read-only
   to OMS and the data warehouse. The CRM is the system of record.
 
-# Per IDS §3.1 INFORMATION_ENTITY is used by the Process Blueprint
+# Per IDS §3.1 BUSINESS_OBJECT is used by the Process Blueprint
 # notation. The extraction agent emits these as standalone canonical
 # primitives that can be referenced from Process Blueprint stages later.
 
@@ -251,7 +251,7 @@ Same handling as sibling prompts: emit **both** candidates with `confidence: low
 - **Do NOT emit SERVICE as a separate TYPE.** "Application service" in ArchiMate is not a canonical TYPE in v1 IDS §3.1 — describe service surfaces inside the parent `APPLICATION` description, or surface in `cross_layer_hints:` if the org models services as first-class.
 - **Do NOT use INTEGRATION TYPE for application sub-modules.** INTEGRATION is a connection between two distinct applications. A sub-component inside an application stays inside that application's `description:`.
 - **Do NOT translate vendor names.** "Salesforce" stays "Salesforce" regardless of input language.
-- **Do NOT invent new TYPE prefixes.** Only the three TYPEs in §"Extraction target" (APPLICATION, INTEGRATION, INFORMATION_ENTITY) are valid output for this layer.
+- **Do NOT invent new TYPE prefixes.** Only the three TYPEs in §"Extraction target" (APPLICATION, INTEGRATION, BUSINESS_OBJECT) are valid output for this layer.
 
 ---
 

--- a/transitrix/skills/onboard/extraction/README.md
+++ b/transitrix/skills/onboard/extraction/README.md
@@ -12,7 +12,7 @@ One prompt per ArchiMate 3.2 layer:
 |---|---|---|
 | [`01_motivation.md`](01_motivation.md) | Motivation | `DRIVER`, `GOAL`, `CONSTRAINT`, `REQUIREMENT` |
 | [`02_business.md`](02_business.md) | Business | `ROLE`, `UNIT`, `EMPLOYEE`, `PROCESS`, `RULE`, `PRODUCT` |
-| [`03_application.md`](03_application.md) | Application | `APPLICATION`, `INTEGRATION`, `INFORMATION_ENTITY` |
+| [`03_application.md`](03_application.md) | Application | `APPLICATION`, `INTEGRATION`, `BUSINESS_OBJECT` |
 
 Each prompt carries the same eight sections: **Role**, **Inputs**, **Extraction target**, **Output schema** (with full YAML examples per TYPE), **Edge cases** (multilingual, uncertain, cross-layer hints, contradictions), **Anti-goals**, **See also**.
 

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -193,7 +193,7 @@ Every typed element ID follows the canonical grammar in `notations/IDS_AND_REFER
 <TYPE>-[<middle segment(s)>-]<INTEGER>
 ```
 
-- **TYPE** — uppercase, letters / digits / underscore, starts with a letter (`DRIVER`, `GOAL`, `PROCESS_BLUEPRINT`, `INFORMATION_ENTITY`).
+- **TYPE** — uppercase, letters / digits / underscore, starts with a letter (`DRIVER`, `GOAL`, `PROCESS_BLUEPRINT`, `BUSINESS_OBJECT`).
 - **Middle segments** — optional, notation-specific, for disambiguation (`GOAL-RETENTION-12`, `ACTIVITY-Q3-2026-7`).
 - **INTEGER** — terminal positive integer, **no leading zeros** (`-1`, not `-001`).
 - **Exception:** `CAPABILITY-V1.2`, `CAPABILITY-H1.2.3` — capabilities use V/H diagram addresses instead of plain integers (capped at three levels).

--- a/transitrix/skills/onboard/templates/process-blueprint.process-blueprint.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/process-blueprint.process-blueprint.transitrix.yaml
@@ -4,7 +4,7 @@ spec_version: "0.1"
 # Process Blueprint — wide value-chain blueprint. Spec:
 # notations/views/diagrams/13-process-blueprint.md
 # Stages laid out left-to-right; per-stage aspects (systems, actors,
-# equipment, information entities) reference the stages they touch.
+# equipment, business objects) reference the stages they touch.
 
 name: "FILL-ME process blueprint"      # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"            # optional per CONTRACT.md §4
@@ -42,7 +42,7 @@ process_blueprint:
       name: "FILL-ME — physical instrument / facility"
       stages: [STAGE-2]
 
-  information_entities:
-    - id: INFORMATION_ENTITY-FILL-ME-1
+  business_objects:
+    - id: BUSINESS_OBJECT-FILL-ME-1
       name: "FILL-ME — data / document produced or consumed"
       stages: [STAGE-1, STAGE-2]


### PR DESCRIPTION
## What changed
Every ingest and onboard extraction prompt still told agents to emit the retired `INFORMATION_ENTITY` TYPE (renamed to `BUSINESS_OBJECT` by the 2026-06-08 ADR). A first-pass extraction over any business-information concept failed `BOBJ-D001` validation and had to be renamed by hand.

- `transitrix/skills/ingest/prompts/03_application.md` — front-matter `extracts:`, the "what to extract" table, the anti-goals note.
- `transitrix/skills/ingest/prompts/README.md` — layer/TYPE table.
- `transitrix/skills/ingest/SKILL.md` §1 promotion rule — no longer lists `INFORMATION_ENTITY` as `view-defined`/`contained` (that status was reversed by the same ADR).
- `transitrix/skills/onboard/extraction/03_application.md` — extraction target, worked example (renamed to `BUSINESS_OBJECT-CUSTOMER-MASTER-RECORD-1`), "only these TYPEs are valid output" note.
- `transitrix/skills/onboard/extraction/README.md` — extraction-targets table.
- `transitrix/skills/onboard/SKILL.md`, `transitrix/skills/onboard/templates/AGENTS.md` — TYPE-format examples.
- `transitrix/skills/onboard/templates/process-blueprint.process-blueprint.transitrix.yaml` — template field renamed `information_entities:` → `business_objects:`, id `INFORMATION_ENTITY-FILL-ME-1` → `BUSINESS_OBJECT-FILL-ME-1`.

Scope: items 1-2 of THQ-217 only, per the issue owner's splitting guidance ("mechanical, land them without waiting on item 3"). Item 3 — whether `BOBJ-D001` is the still-open warning or the hard error the 1.0.0 CHANGELOG announced — is a contract call, parked as a separate issue.

Left untouched (deliberately historical): `CHANGELOG.md`, `migrations/0.7-to-1.0/**`, the `BOBJ-D001` rule row and `deprecated_element_types.INFORMATION_ENTITY` registration in `notations/vocabulary.yaml`.

Also noticed but out of scope: `skills/ingest/SKILL.md`'s same promotion-rule line still lists `EQUIPMENT` as view-defined, which the identical 2026-06-08 ADR also promoted to standalone (`ELEMENT_PRIMITIVES.md` ELEM-004). Not fixed here since THQ-217 only flagged the `INFORMATION_ENTITY` half.

## Test plan
- [x] `grep -rn INFORMATION_ENTITY transitrix/skills/` returns no matches
- [x] `node scripts/check-notations.mjs` — clean (pre-existing SIZE1 warnings only, unrelated)