### PR TITLE
notations: example:true admission-record field — ADMIT-010/ADMIT-011

### DIFF
--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -202,6 +202,8 @@ For `admission_state: proposed`, the §6 requirement on `admitted_at` / `admitte
 | `ADMIT-007` | error | The admitter does not match the tier: `reviewer_authority: ai_reviewed` but `admitted_by` identifies a human, or `reviewer_authority: expert_confirmed` but `admitted_by` identifies a tool. A tool writes `ai_reviewed`; a human writes `expert_confirmed` (§6.2). |
 | `ADMIT-008` | warning | `admission_state: proposed` and `owner_to_confirm` is absent — the open item has no designated reviewer and will not route to any inbox. |
 | `ADMIT-009` | warning | An admitted artefact (`admission_state: active` or absent) in the `canon` zone carries `extraction_confidence` — a review flag that belongs to an ingest candidate and is never persisted into canon (§11.1). Cite the provenance through `derived_from` and the field artefact it came from instead. Does not apply to `canon/unresolved/` (§13, untyped) or to candidates under `_intake/`, where the flag is correct. |
+| `ADMIT-010` | error | `example` is present and is not `true`. The field is a marker; omit it or write `true` (§6.4). |
+| `ADMIT-011` | error | An artefact without `example: true` references one that has it. Cross-cutting — requires the full catalogue (§6.4). |
 
 This lifecycle is what an automated regulatory-intelligence collector (a separate task) depends on: the collector emits `proposed` drafts plus a review digest, and the human gate admits or rejects. The per-TYPE specs note it where relevant ([15-requirement.md](elements/15-requirement.md), [16-assertion.md](elements/16-assertion.md)).
 
@@ -269,6 +271,24 @@ agreed_at: "2026-08-04"      # optional; quoted ISO 8601 date (§4) — when thi
 | `AGREE-003` | error | `agreement` is present (any of the three values) but `agreed_by` is missing. |
 
 `AGREE-002` and `AGREE-003` can both describe an `agreement: agreed` record with no `agreed_by`; a validator MAY report either or both. A reference implementation of this check lives in [`scripts/check-agreement.mjs`](../scripts/check-agreement.mjs).
+
+### 6.4 Example marker — an artefact that illustrates rather than reports
+
+Every field above assumes the artefact describes something real about the organisation. Some do not: the worked examples bundled under `notations/examples/**/canon/` carry a full admission record — `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks` — because a fixture that cut corners would be a poor illustration of a contract whose whole subject is that the gate leaves a record. The `example` field says so in the document itself, so a consumer never has to guess it from a path segment (per the 2026-08-19 example-declares-itself decision).
+
+```yaml
+example: true   # absent ⇒ real; only `true` is valid — ADMIT-010
+```
+
+| Field | Required | Type | Semantics |
+|---|---|---|---|
+| `example` | no | boolean | `true` — marks the artefact as an illustration, not a report about a real organisation. **Absent ⇒ real**, matching every other axis on this record (`admission_state`, `reviewer_authority`, `agreement`), so no existing file changes. `example: false` is an error, not a synonym for absence (`ADMIT-010`) — one fact should have one way to write it. |
+
+**What it asserts.** The artefact describes no real organisation; its admission record is part of the illustration and is still validated in full, so the fixture stays a genuine, checkable example rather than becoming one exempt from the contract it demonstrates.
+
+**Exclusion from derived views.** A consumer computing what counts as admitted canon — for aggregation, coverage, compliance, or any derived total — MUST exclude an artefact carrying `example: true`. This is the same treatment §6.1 already gives `proposed` and `rejected` artefacts (**Exclusion from derived views and cross-cutting checks**, above); the new field is a second reason to be outside the admitted set, not a second mechanism.
+
+**Nothing real may reference an example.** An artefact without `example: true` MUST NOT cross-reference one that has it — `ADMIT-005` pointed at this axis, at **error** rather than warning: a `proposed` artefact is expected to be admitted, so a reference to one is premature, while an example never becomes real and a reference into the example set never resolves (`ADMIT-011`, cross-cutting — requires the full catalogue). An example MAY reference another example.
 
 ---
 

--- a/notations/examples/dgca/elements/ACTION-1.yaml
+++ b/notations/examples/dgca/elements/ACTION-1.yaml
@@ -5,6 +5,7 @@ changes: [CHANGE-1]
 description: "Customer and competitor research to inform product specification."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/ACTION-2.yaml
+++ b/notations/examples/dgca/elements/ACTION-2.yaml
@@ -5,6 +5,7 @@ changes: [CHANGE-1]
 description: "Build and release the minimum viable product for the new product line."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/ACTION-3.yaml
+++ b/notations/examples/dgca/elements/ACTION-3.yaml
@@ -5,6 +5,7 @@ changes: [CHANGE-2]
 description: "Inventory and assess all manual processes eligible for automation."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/ACTION-4.yaml
+++ b/notations/examples/dgca/elements/ACTION-4.yaml
@@ -5,6 +5,7 @@ changes: [CHANGE-2]
 description: "Deploy and configure RPA tooling for the highest-volume manual workflows."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/ACTION-5.yaml
+++ b/notations/examples/dgca/elements/ACTION-5.yaml
@@ -5,6 +5,7 @@ changes: [CHANGE-3]
 description: "Implement and integrate a modern CRM to improve customer support visibility."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/CHANGE-1.yaml
+++ b/notations/examples/dgca/elements/CHANGE-1.yaml
@@ -5,6 +5,7 @@ goals: [GOAL-1]
 description: "New product development to capture incremental market share."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/CHANGE-2.yaml
+++ b/notations/examples/dgca/elements/CHANGE-2.yaml
@@ -5,6 +5,7 @@ goals: [GOAL-2]
 description: "Replace high-volume manual workflows with RPA and digital tooling."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/CHANGE-3.yaml
+++ b/notations/examples/dgca/elements/CHANGE-3.yaml
@@ -5,6 +5,7 @@ goals: [GOAL-3]
 description: "Modernise the customer support toolchain to improve first-contact resolution."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/CHANGE-EU-REGION-1.yaml
+++ b/notations/examples/dgca/elements/CHANGE-EU-REGION-1.yaml
@@ -5,6 +5,7 @@ goals: [GOAL-COMPLY-RESIDENCY-1]
 description: "Migrate all datastores that hold EU customer personal data to an EU/EEA-resident cloud region."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/DRIVER-1.yaml
+++ b/notations/examples/dgca/elements/DRIVER-1.yaml
@@ -8,6 +8,7 @@ description: >
   the organisation to grow revenue and differentiate its offering.
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/DRIVER-2.yaml
+++ b/notations/examples/dgca/elements/DRIVER-2.yaml
@@ -8,6 +8,7 @@ description: >
   channels that the organisation must ride to remain competitive.
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/DRIVER-DATA-RESIDENCY-1.yaml
+++ b/notations/examples/dgca/elements/DRIVER-DATA-RESIDENCY-1.yaml
@@ -12,6 +12,7 @@ description: >
   records it as a strategic force the organisation acts on.
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/GOAL-1.yaml
+++ b/notations/examples/dgca/elements/GOAL-1.yaml
@@ -5,6 +5,7 @@ factors: [DRIVER-1, DRIVER-2]
 description: "Primary financial growth target for the 2026 plan."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/GOAL-2.yaml
+++ b/notations/examples/dgca/elements/GOAL-2.yaml
@@ -5,6 +5,7 @@ factors: [DRIVER-2]
 description: "Cost efficiency target — automation-driven savings across manual processes."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/GOAL-3.yaml
+++ b/notations/examples/dgca/elements/GOAL-3.yaml
@@ -5,6 +5,7 @@ factors: [DRIVER-1]
 description: "Retention target — reduce churn by enhancing the customer support experience."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/dgca/elements/GOAL-COMPLY-RESIDENCY-1.yaml
+++ b/notations/examples/dgca/elements/GOAL-COMPLY-RESIDENCY-1.yaml
@@ -5,6 +5,7 @@ factors: [DRIVER-DATA-RESIDENCY-1]
 description: "Achieve and maintain full data-residency compliance for all EU customer personal data."
 
 zone: canon
+example: true
 admitted_at: "2026-05-26"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/mrd/canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml
+++ b/notations/examples/mrd/canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml
@@ -10,6 +10,7 @@ description: >
 stakeholder: STAKEHOLDER-ENTERPRISE-CUSTOMERS-1
 
 zone: canon
+example: true
 admitted_at: "2026-07-30"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/mrd/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-EMAIL-1.yaml
+++ b/notations/examples/mrd/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-EMAIL-1.yaml
@@ -8,6 +8,7 @@ severity: medium
 serves: NEED-TIMELY-OUTAGE-STATUS-1
 
 zone: canon
+example: true
 admitted_at: "2026-08-04"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/mrd/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-PAGE-1.yaml
+++ b/notations/examples/mrd/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-PAGE-1.yaml
@@ -8,6 +8,7 @@ severity: high
 serves: NEED-TIMELY-OUTAGE-STATUS-1
 
 zone: canon
+example: true
 admitted_at: "2026-07-30"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/mrd/canon/elements/01_motivation/stakeholders/STAKEHOLDER-ENTERPRISE-CUSTOMERS-1.yaml
+++ b/notations/examples/mrd/canon/elements/01_motivation/stakeholders/STAKEHOLDER-ENTERPRISE-CUSTOMERS-1.yaml
@@ -9,6 +9,7 @@ influence: medium
 description: "Enterprise-tier customers whose own operations depend on this service staying up, or on being told quickly when it is not."
 
 zone: canon
+example: true
 admitted_at: "2026-07-30"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/mrd/canon/elements/02_business/actors/ACTOR-ENTERPRISE-CUSTOMERS-1.yaml
+++ b/notations/examples/mrd/canon/elements/02_business/actors/ACTOR-ENTERPRISE-CUSTOMERS-1.yaml
@@ -5,6 +5,7 @@ type: business_unit
 description: "External organisations on an enterprise support tier; not part of the modelled org, represented here as a business_unit-typed actor for identity purposes."
 
 zone: canon
+example: true
 admitted_at: "2026-07-30"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/packages/reqif-workflow/canon/elements/01_motivation/requirements/REQUIREMENT-BATTERY-LOW-POWER-SHUTDOWN-1.yaml
+++ b/notations/examples/packages/reqif-workflow/canon/elements/01_motivation/requirements/REQUIREMENT-BATTERY-LOW-POWER-SHUTDOWN-1.yaml
@@ -7,6 +7,7 @@ origin: project-product
 severity: high
 
 zone: canon
+example: true
 admitted_at: "2026-07-28"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/packages/reqif/canon/elements/01_motivation/requirements/REQUIREMENT-PRINT-QUEUE-RETRY-1.yaml
+++ b/notations/examples/packages/reqif/canon/elements/01_motivation/requirements/REQUIREMENT-PRINT-QUEUE-RETRY-1.yaml
@@ -7,6 +7,7 @@ origin: project-product
 severity: medium
 
 zone: canon
+example: true
 admitted_at: "2026-07-28"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/relations/depends-on/canon/elements/01_motivation/requirements/REQUIREMENT-COMPLIANCE-REPORTING-1.yaml
+++ b/notations/examples/relations/depends-on/canon/elements/01_motivation/requirements/REQUIREMENT-COMPLIANCE-REPORTING-1.yaml
@@ -6,6 +6,7 @@ level: system
 kind: functional
 
 zone: canon
+example: true
 admitted_at: "2026-08-05"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/depends-on/canon/elements/01_motivation/requirements/REQUIREMENT-DATA-RESIDENCY-1.yaml
+++ b/notations/examples/relations/depends-on/canon/elements/01_motivation/requirements/REQUIREMENT-DATA-RESIDENCY-1.yaml
@@ -6,6 +6,7 @@ level: system
 kind: quality
 
 zone: canon
+example: true
 admitted_at: "2026-08-05"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/depends-on/canon/relations/REL-COMPLIANCE-REPORTING-DEPENDS-ON-RESIDENCY-1.yaml
+++ b/notations/examples/relations/depends-on/canon/relations/REL-COMPLIANCE-REPORTING-DEPENDS-ON-RESIDENCY-1.yaml
@@ -5,6 +5,7 @@ from: REQUIREMENT-COMPLIANCE-REPORTING-1
 to: REQUIREMENT-DATA-RESIDENCY-1
 
 zone: canon
+example: true
 admitted_at: "2026-08-05"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/elements/01_motivation/requirements/REQUIREMENT-LEGACY-CIPHER-SUITE-1.yaml
+++ b/notations/examples/relations/required-for/canon/elements/01_motivation/requirements/REQUIREMENT-LEGACY-CIPHER-SUITE-1.yaml
@@ -6,6 +6,7 @@ level: system
 kind: quality
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/elements/01_motivation/requirements/REQUIREMENT-PAYMENT-AVAILABILITY-1.yaml
+++ b/notations/examples/relations/required-for/canon/elements/01_motivation/requirements/REQUIREMENT-PAYMENT-AVAILABILITY-1.yaml
@@ -6,6 +6,7 @@ level: system
 kind: quality
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/elements/01_motivation/requirements/REQUIREMENT-STRONG-AUTH-1.yaml
+++ b/notations/examples/relations/required-for/canon/elements/01_motivation/requirements/REQUIREMENT-STRONG-AUTH-1.yaml
@@ -6,6 +6,7 @@ level: system
 kind: functional
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/elements/03_application/applications/APPLICATION-PAYMENTS-GATEWAY-1.yaml
+++ b/notations/examples/relations/required-for/canon/elements/03_application/applications/APPLICATION-PAYMENTS-GATEWAY-1.yaml
@@ -3,6 +3,7 @@ id: APPLICATION-PAYMENTS-GATEWAY-1
 name: Payments Gateway
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/elements/05_implementation/releases/RELEASE-PAYMENTS-GATEWAY-1.yaml
+++ b/notations/examples/relations/required-for/canon/elements/05_implementation/releases/RELEASE-PAYMENTS-GATEWAY-1.yaml
@@ -7,6 +7,7 @@ version: "2.3.0"
 released_at: "2026-03-02"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/elements/05_implementation/releases/RELEASE-PAYMENTS-GATEWAY-2.yaml
+++ b/notations/examples/relations/required-for/canon/elements/05_implementation/releases/RELEASE-PAYMENTS-GATEWAY-2.yaml
@@ -8,6 +8,7 @@ predecessor: RELEASE-PAYMENTS-GATEWAY-1
 released_at: "2026-07-15"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/relations/REL-AVAILABILITY-REQUIRED-FOR-GATEWAY-1-1.yaml
+++ b/notations/examples/relations/required-for/canon/relations/REL-AVAILABILITY-REQUIRED-FOR-GATEWAY-1-1.yaml
@@ -5,6 +5,7 @@ from: REQUIREMENT-PAYMENT-AVAILABILITY-1
 to: RELEASE-PAYMENTS-GATEWAY-1
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/relations/REL-LEGACY-CIPHER-REQUIRED-FOR-GATEWAY-1-1.yaml
+++ b/notations/examples/relations/required-for/canon/relations/REL-LEGACY-CIPHER-REQUIRED-FOR-GATEWAY-1-1.yaml
@@ -5,6 +5,7 @@ from: REQUIREMENT-LEGACY-CIPHER-SUITE-1
 to: RELEASE-PAYMENTS-GATEWAY-1
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/relations/required-for/canon/relations/REL-STRONG-AUTH-REQUIRED-FOR-GATEWAY-2-1.yaml
+++ b/notations/examples/relations/required-for/canon/relations/REL-STRONG-AUTH-REQUIRED-FOR-GATEWAY-2-1.yaml
@@ -5,6 +5,7 @@ from: REQUIREMENT-STRONG-AUTH-1
 to: RELEASE-PAYMENTS-GATEWAY-2
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "example"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/assertions/ASSERTION-TELEMETRY-PLATFORM-AUDIT-TRAIL-1.yaml
+++ b/notations/examples/release-qualifiers/canon/assertions/ASSERTION-TELEMETRY-PLATFORM-AUDIT-TRAIL-1.yaml
@@ -13,6 +13,7 @@ assessed_by: "ROLE-COMPLIANCE-LEAD-1"
 next_review_at: "2027-06-25"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/assertions/ASSERTION-TELEMETRY-PLATFORM-DATA-SEGREGATION-1.yaml
+++ b/notations/examples/release-qualifiers/canon/assertions/ASSERTION-TELEMETRY-PLATFORM-DATA-SEGREGATION-1.yaml
@@ -11,6 +11,7 @@ assessed_at: "2026-06-25"
 assessed_by: "ROLE-COMPLIANCE-LEAD-1"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/elements/01_motivation/requirements/REQUIREMENT-INGEST-AUDIT-TRAIL-1.yaml
+++ b/notations/examples/release-qualifiers/canon/elements/01_motivation/requirements/REQUIREMENT-INGEST-AUDIT-TRAIL-1.yaml
@@ -7,6 +7,7 @@ origin: process-product
 severity: high
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/elements/01_motivation/requirements/REQUIREMENT-OPERATOR-DATA-SEGREGATION-1.yaml
+++ b/notations/examples/release-qualifiers/canon/elements/01_motivation/requirements/REQUIREMENT-OPERATOR-DATA-SEGREGATION-1.yaml
@@ -7,6 +7,7 @@ origin: process-product
 severity: high
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/elements/02_business/products/PRODUCT-TELEMETRY-PLATFORM-1.yaml
+++ b/notations/examples/release-qualifiers/canon/elements/02_business/products/PRODUCT-TELEMETRY-PLATFORM-1.yaml
@@ -6,6 +6,7 @@ domain: "Connected equipment monitoring"
 description: "Platform that collects, stores, and reports operating telemetry from deployed field equipment on behalf of the equipment's operators."
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/elements/05_implementation/releases/RELEASE-TELEMETRY-PLATFORM-1.yaml
+++ b/notations/examples/release-qualifiers/canon/elements/05_implementation/releases/RELEASE-TELEMETRY-PLATFORM-1.yaml
@@ -11,6 +11,7 @@ version: "1.3.0"
 released_at: "2026-03-02"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/elements/05_implementation/releases/RELEASE-TELEMETRY-PLATFORM-2.yaml
+++ b/notations/examples/release-qualifiers/canon/elements/05_implementation/releases/RELEASE-TELEMETRY-PLATFORM-2.yaml
@@ -11,6 +11,7 @@ predecessor: RELEASE-TELEMETRY-PLATFORM-1
 released_at: "2026-06-18"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/verifications/VERIFICATION-INGEST-AUDIT-TRAIL-TEST-1.yaml
+++ b/notations/examples/release-qualifiers/canon/verifications/VERIFICATION-INGEST-AUDIT-TRAIL-TEST-1.yaml
@@ -15,6 +15,7 @@ performed_at: "2026-03-20"
 performed_by: "ROLE-VERIFICATION-ENG-1"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/canon/verifications/VERIFICATION-INGEST-AUDIT-TRAIL-TEST-2.yaml
+++ b/notations/examples/release-qualifiers/canon/verifications/VERIFICATION-INGEST-AUDIT-TRAIL-TEST-2.yaml
@@ -15,6 +15,7 @@ performed_at: "2026-06-24"
 performed_by: "ROLE-VERIFICATION-ENG-1"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/assertions/ASSERTION-TELEMETRY-PLATFORM-AUDIT-TRAIL-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/assertions/ASSERTION-TELEMETRY-PLATFORM-AUDIT-TRAIL-1.yaml
@@ -14,6 +14,7 @@ evidence:
 assessed_at: "2026-06-25"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/assertions/ASSERTION-TELEMETRY-PLATFORM-DATA-SEGREGATION-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/assertions/ASSERTION-TELEMETRY-PLATFORM-DATA-SEGREGATION-1.yaml
@@ -13,6 +13,7 @@ evidence:
 assessed_at: "2026-06-25"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/elements/01_motivation/requirements/REQUIREMENT-INGEST-AUDIT-TRAIL-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/elements/01_motivation/requirements/REQUIREMENT-INGEST-AUDIT-TRAIL-1.yaml
@@ -7,6 +7,7 @@ origin: process-product
 severity: high
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/elements/01_motivation/requirements/REQUIREMENT-OPERATOR-DATA-SEGREGATION-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/elements/01_motivation/requirements/REQUIREMENT-OPERATOR-DATA-SEGREGATION-1.yaml
@@ -7,6 +7,7 @@ origin: process-product
 severity: high
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/elements/02_business/products/PRODUCT-EDGE-COLLECTOR-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/elements/02_business/products/PRODUCT-EDGE-COLLECTOR-1.yaml
@@ -6,6 +6,7 @@ domain: "Connected equipment monitoring"
 description: "On-site appliance that buffers telemetry from field equipment and forwards it upstream. A separate product from the platform, with its own release line — present here only so that a release of the wrong subject exists to point at."
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/elements/02_business/products/PRODUCT-TELEMETRY-PLATFORM-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/elements/02_business/products/PRODUCT-TELEMETRY-PLATFORM-1.yaml
@@ -6,6 +6,7 @@ domain: "Connected equipment monitoring"
 description: "Platform that collects, stores, and reports operating telemetry from deployed field equipment on behalf of the equipment's operators."
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/elements/05_implementation/releases/RELEASE-EDGE-COLLECTOR-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/elements/05_implementation/releases/RELEASE-EDGE-COLLECTOR-1.yaml
@@ -11,6 +11,7 @@ version: "4.1.0"
 released_at: "2026-05-11"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/verifications/VERIFICATION-INGEST-AUDIT-TRAIL-TEST-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/verifications/VERIFICATION-INGEST-AUDIT-TRAIL-TEST-1.yaml
@@ -17,6 +17,7 @@ performed_at: "2026-06-24"
 performed_by: "ROLE-VERIFICATION-ENG-1"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/release-qualifiers/rule-violations/canon/verifications/VERIFICATION-OPERATOR-DATA-SEGREGATION-TEST-1.yaml
+++ b/notations/examples/release-qualifiers/rule-violations/canon/verifications/VERIFICATION-OPERATOR-DATA-SEGREGATION-TEST-1.yaml
@@ -18,6 +18,7 @@ performed_at: "2026-06-24"
 performed_by: "ROLE-VERIFICATION-ENG-1"
 
 zone: canon
+example: true
 admitted_at: "2026-08-07"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/sdd/canon/assertions/ASSERTION-CUSTOMER-PORTAL-DATA-EXPORT-1.yaml
+++ b/notations/examples/sdd/canon/assertions/ASSERTION-CUSTOMER-PORTAL-DATA-EXPORT-1.yaml
@@ -14,6 +14,7 @@ assessed_at: "2026-08-04"
 next_review_at: "2027-02-04"
 
 zone: canon
+example: true
 admitted_at: "2026-08-04"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/sdd/canon/elements/01_motivation/requirements/REQUIREMENT-DATA-EXPORT-SLA-1.yaml
+++ b/notations/examples/sdd/canon/elements/01_motivation/requirements/REQUIREMENT-DATA-EXPORT-SLA-1.yaml
@@ -9,6 +9,7 @@ level: system
 kind: functional
 
 zone: canon
+example: true
 admitted_at: "2026-08-04"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/sdd/canon/elements/02_business/products/PRODUCT-CUSTOMER-PORTAL-1.yaml
+++ b/notations/examples/sdd/canon/elements/02_business/products/PRODUCT-CUSTOMER-PORTAL-1.yaml
@@ -6,6 +6,7 @@ domain: "Customer experience"
 description: "Web and mobile portal through which a registered customer manages their account, including requesting an export of their own personal data."
 
 zone: canon
+example: true
 admitted_at: "2026-08-04"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/sdd/canon/elements/03_application/applications/APPLICATION-DATA-EXPORT-SERVICE-1.yaml
+++ b/notations/examples/sdd/canon/elements/03_application/applications/APPLICATION-DATA-EXPORT-SERVICE-1.yaml
@@ -6,6 +6,7 @@ domain: "Customer experience"
 description: "Backend service that receives a verified data-export request from the Customer Self-Service Portal, assembles the requesting subject's personal data, and generates a downloadable export package."
 
 zone: canon
+example: true
 admitted_at: "2026-08-04"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/sdd/canon/elements/04_technology/nodes/NODE-EXPORT-QUEUE-HOST-1.yaml
+++ b/notations/examples/sdd/canon/elements/04_technology/nodes/NODE-EXPORT-QUEUE-HOST-1.yaml
@@ -7,6 +7,7 @@ provider: "AWS"
 region: "eu-central-1"
 
 zone: canon
+example: true
 admitted_at: "2026-08-04"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/sdd/canon/elements/04_technology/services/TECHNOLOGY_SERVICE-EXPORT-QUEUE-1.yaml
+++ b/notations/examples/sdd/canon/elements/04_technology/services/TECHNOLOGY_SERVICE-EXPORT-QUEUE-1.yaml
@@ -7,6 +7,7 @@ node: NODE-EXPORT-QUEUE-HOST-1
 endpoint: "export-queue.internal:5671"
 
 zone: canon
+example: true
 admitted_at: "2026-08-04"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/srs/canon/elements/01_motivation/requirements/REQUIREMENT-BACKUP-POWER-1.yaml
+++ b/notations/examples/srs/canon/elements/01_motivation/requirements/REQUIREMENT-BACKUP-POWER-1.yaml
@@ -9,6 +9,7 @@ level: software
 kind: functional
 
 zone: canon
+example: true
 admitted_at: "2026-07-17"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/srs/canon/elements/01_motivation/requirements/REQUIREMENT-BACKUP-POWER-COVERAGE-1.yaml
+++ b/notations/examples/srs/canon/elements/01_motivation/requirements/REQUIREMENT-BACKUP-POWER-COVERAGE-1.yaml
@@ -9,6 +9,7 @@ level: system
 kind: functional
 
 zone: canon
+example: true
 admitted_at: "2026-07-17"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/srs/canon/elements/01_motivation/requirements/REQUIREMENT-FAILOVER-1.yaml
+++ b/notations/examples/srs/canon/elements/01_motivation/requirements/REQUIREMENT-FAILOVER-1.yaml
@@ -9,6 +9,7 @@ level: software
 kind: functional
 
 zone: canon
+example: true
 admitted_at: "2026-07-17"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/srs/canon/elements/01_motivation/requirements/REQUIREMENT-SESSION-TIMEOUT-1.yaml
+++ b/notations/examples/srs/canon/elements/01_motivation/requirements/REQUIREMENT-SESSION-TIMEOUT-1.yaml
@@ -9,6 +9,7 @@ level: software
 kind: quality
 
 zone: canon
+example: true
 admitted_at: "2026-07-17"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/validation/canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml
+++ b/notations/examples/validation/canon/elements/01_motivation/needs/NEED-TIMELY-OUTAGE-STATUS-1.yaml
@@ -10,6 +10,7 @@ description: >
 stakeholder: STAKEHOLDER-ENTERPRISE-CUSTOMERS-1
 
 zone: canon
+example: true
 admitted_at: "2026-07-30"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/validation/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-PAGE-1.yaml
+++ b/notations/examples/validation/canon/elements/01_motivation/requirements/REQUIREMENT-OUTAGE-STATUS-PAGE-1.yaml
@@ -8,6 +8,7 @@ severity: high
 serves: NEED-TIMELY-OUTAGE-STATUS-1
 
 zone: canon
+example: true
 admitted_at: "2026-07-30"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/validation/canon/elements/01_motivation/stakeholders/STAKEHOLDER-ENTERPRISE-CUSTOMERS-1.yaml
+++ b/notations/examples/validation/canon/elements/01_motivation/stakeholders/STAKEHOLDER-ENTERPRISE-CUSTOMERS-1.yaml
@@ -9,6 +9,7 @@ influence: medium
 description: "Enterprise-tier customers whose own operations depend on this service staying up, or on being told quickly when it is not."
 
 zone: canon
+example: true
 admitted_at: "2026-07-30"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/validation/canon/elements/02_business/actors/ACTOR-ENTERPRISE-CUSTOMERS-1.yaml
+++ b/notations/examples/validation/canon/elements/02_business/actors/ACTOR-ENTERPRISE-CUSTOMERS-1.yaml
@@ -5,6 +5,7 @@ type: business_unit
 description: "External organisations on an enterprise support tier; not part of the modelled org, represented here as a business_unit-typed actor for identity purposes."
 
 zone: canon
+example: true
 admitted_at: "2026-07-30"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/validation/canon/validations/VALIDATION-OUTAGE-STATUS-UAT-1.yaml
+++ b/notations/examples/validation/canon/validations/VALIDATION-OUTAGE-STATUS-UAT-1.yaml
@@ -14,6 +14,7 @@ performed_at: "2026-07-22"
 performed_by: "ROLE-UX-RESEARCH-LEAD-1"
 
 zone: canon
+example: true
 admitted_at: "2026-07-23"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/verification/canon/elements/01_motivation/requirements/REQUIREMENT-BACKUP-POWER-1.yaml
+++ b/notations/examples/verification/canon/elements/01_motivation/requirements/REQUIREMENT-BACKUP-POWER-1.yaml
@@ -7,6 +7,7 @@ origin: process-product
 severity: high
 
 zone: canon
+example: true
 admitted_at: "2026-07-17"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/verification/canon/verifications/VERIFICATION-BACKUP-POWER-TEST-1.yaml
+++ b/notations/examples/verification/canon/verifications/VERIFICATION-BACKUP-POWER-TEST-1.yaml
@@ -14,6 +14,7 @@ performed_at: "2026-07-20"
 performed_by: "ROLE-VERIFICATION-ENG-1"
 
 zone: canon
+example: true
 admitted_at: "2026-07-21"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/verification/reverse-trace-gaps/canon/elements/01_motivation/requirements/REQUIREMENT-BACKUP-POWER-1.yaml
+++ b/notations/examples/verification/reverse-trace-gaps/canon/elements/01_motivation/requirements/REQUIREMENT-BACKUP-POWER-1.yaml
@@ -7,6 +7,7 @@ origin: process-product
 severity: high
 
 zone: canon
+example: true
 admitted_at: "2026-07-17"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/verification/reverse-trace-gaps/canon/elements/01_motivation/requirements/REQUIREMENT-FAILOVER-1.yaml
+++ b/notations/examples/verification/reverse-trace-gaps/canon/elements/01_motivation/requirements/REQUIREMENT-FAILOVER-1.yaml
@@ -7,6 +7,7 @@ origin: process-product
 severity: high
 
 zone: canon
+example: true
 admitted_at: "2026-07-17"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/verification/reverse-trace-gaps/canon/elements/01_motivation/requirements/REQUIREMENT-SESSION-TIMEOUT-1.yaml
+++ b/notations/examples/verification/reverse-trace-gaps/canon/elements/01_motivation/requirements/REQUIREMENT-SESSION-TIMEOUT-1.yaml
@@ -7,6 +7,7 @@ origin: process-product
 severity: medium
 
 zone: canon
+example: true
 admitted_at: "2026-07-17"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/verification/reverse-trace-gaps/canon/verifications/VERIFICATION-BACKUP-POWER-TEST-1.yaml
+++ b/notations/examples/verification/reverse-trace-gaps/canon/verifications/VERIFICATION-BACKUP-POWER-TEST-1.yaml
@@ -14,6 +14,7 @@ performed_at: "2026-07-20"
 performed_by: "ROLE-VERIFICATION-ENG-1"
 
 zone: canon
+example: true
 admitted_at: "2026-07-21"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/examples/verification/reverse-trace-gaps/canon/verifications/VERIFICATION-FAILOVER-DRILL-1.yaml
+++ b/notations/examples/verification/reverse-trace-gaps/canon/verifications/VERIFICATION-FAILOVER-DRILL-1.yaml
@@ -7,6 +7,7 @@ result: null
 outcome: not_yet_run
 
 zone: canon
+example: true
 admitted_at: "2026-07-21"
 admitted_by: "v.korobeinikov"
 gate_checks:

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -601,6 +601,12 @@ rule_codes:
   ADMIT-009:
     severity: warning
     spec: notations/CONTRACT.md
+  ADMIT-010:
+    severity: error
+    spec: notations/CONTRACT.md
+  ADMIT-011:
+    severity: error
+    spec: notations/CONTRACT.md
   AGREE-001:
     severity: error
     spec: notations/CONTRACT.md

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -77,6 +77,11 @@
 //   SIZE1 per-file soft ceiling (warn-only) — a method/*.md file over 250
 //       lines or with more than nine `##` sections warns. Never fails the
 //       build — see main()'s separate warnings collection.
+//   EX1  example marker — every notations/examples/**/*.yaml carrying a
+//       top-level `zone: canon` admission record also carries `example: true`
+//       (CONTRACT.md §6.4). Keeps the fixtures' own admission records from
+//       silently regressing into being indistinguishable from adopter canon,
+//       the defect the field exists to prevent (transitrix-hq#218/#219).
 //   PRESETS1 shipped coverage presets — packages/ingest-cli/src/coverage-presets.mjs
 //       carries `PRESETS_VERSION` equal to the version source of truth, and its
 //       `PRESETS` tables encode exactly the preset membership stated in
@@ -254,6 +259,26 @@ async function checkExamples(catalogue, failures) {
       failures.push({
         check: 'E2',
         message: `${rel}: \`notation: ${nm[1]}\` is not valid for extension ".${extShort}.transitrix.yaml" (accepted: ${[...validDirs].join(', ')}).`,
+      });
+    }
+  }
+}
+
+// EX1: every zone:canon example fixture carries example: true (CONTRACT.md §6.4).
+//
+// Scoped to `zone: canon` because that is the admission record the field
+// exists to mark — a fixture in a different zone, or one with no admission
+// record at all, carries nothing for `example` to disambiguate.
+async function checkExampleMarker(failures) {
+  const files = await walk(EXAMPLES_DIR, '.yaml');
+  for (const abs of files) {
+    const rel = relPosix(abs);
+    const text = await readFile(abs, 'utf8');
+    if (!/^zone:\s*canon\s*$/m.test(text)) continue;
+    if (!/^example:\s*true\s*$/m.test(text)) {
+      failures.push({
+        check: 'EX1',
+        message: `${rel}: zone: canon admission record with no \`example: true\` marker — every fixture under notations/examples/** must declare itself (CONTRACT.md §6.4).`,
       });
     }
   }
@@ -1718,6 +1743,7 @@ async function main() {
   try {
     catalogue = await parseCatalogue();
     await checkExamples(catalogue, failures);
+    await checkExampleMarker(failures);
     await checkLinks(failures);
     await checkVersion(failures);
     await checkNotationCounts(failures);


### PR DESCRIPTION
## Summary
- Implements the accepted ADR [`2026-08-19-an-example-declares-itself`](https://github.com/transitrix/transitrix-hq/blob/main/canon-published/architecture/decisions/methodology/2026-08-19-an-example-declares-itself.md), as renumbered by its 2026-08-20 amendment.
- New optional admission-record field `example: true` (`CONTRACT.md` §6.4), documented beside `admission_state`/`reviewer_authority`/`agreement` with the same rigour: absent ⇒ real, `example: false` is an error not a synonym for absence (`ADMIT-010`), excluded from every derived view/coverage total, and nothing without the field may reference something that has it (`ADMIT-011`, cross-cutting — `ADMIT-005` pointed at the new axis).
- `vocabulary.yaml` registers both codes.
- `scripts/check-notations.mjs` gets a new `EX1` check: every `notations/examples/**` fixture carrying a `zone: canon` admission record also carries `example: true`, so the marking can't silently regress the next time a fixture is added.
- All 75 `zone: canon` fixtures under `notations/examples/**` are marked.

`ADMIT-009` is untouched — it stays with the already-merged `extraction_confidence` rule (`methodology#505`), per the ADR's amendment. This work was held pending that numbering-collision resolution (methodology agent's status updates on `THQ-219`) and was unblocked by the Strategist on 2026-08-20.

Refs `THQ-219`, `THQ-221`.

## Test plan
- [x] `node scripts/check-notations.mjs` — clean (only two pre-existing, unrelated `SIZE1` warnings)
- [x] `node --test scripts/*.test.mjs` — 135/135 passing