### PR TITLE
feat(readme): front page leads with the generated Goals-tree example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Transitrix
 
+![A Goals tree rendered from this repository's own worked example — three levels of strategy, from a top-level revenue goal down through EU and MENA market goals to their supporting project goals](https://raw.githubusercontent.com/transitrix/methodology/main/transitrix/examples/goals.svg)
+
+Real output, not a mockup — rendered from this repository's own worked example (`notations/examples/goals/`) by [`@transitrix/diagrams`](https://www.npmjs.com/package/@transitrix/diagrams), the same shared rendering library that draws every notation in Studio and in DSM. Regenerate with `node packages/plugin-examples/src/generate.mjs`; CI fails the build if the committed image drifts from its source by a single byte.
+
 > **Open methodology and tools to describe an enterprise as text — and let humans and machines run it together.**
 
 ## Two ways in


### PR DESCRIPTION
## What changed

`README.md` (root, the repository front page) now leads with the rendered Goals-tree example above the fold — before any prose — referenced by absolute `https://raw.githubusercontent.com/...` URL so it renders for every consumer (not rewritten/broken by ones that mangle relative paths).

No new artefact: reuses the already-generated, already byte-reproducible `transitrix/examples/goals.svg` (see THQ-244 — closed by reuse, no code change needed there). Same generator, same command: `node packages/plugin-examples/src/generate.mjs`.

## Why this artefact

- Goals is `documented` status (not `draft`), with no open item against it in `NOTATIONS_AUDIT.md` — a stable spec, per the acceptance criteria.
- The repo's own README already calls Goals "a common starting point, the simplest notation to start from."
- The source example (`notations/examples/goals/strategy-2026.goals.transitrix.yaml`) is generic — no client name, internal code, machine, account, or file path outside the example itself.

## Test plan

- [x] `node scripts/check-notations.mjs` — clean (pre-existing unrelated soft-ceiling warnings only)
- [x] `node scripts/check-link-suspicion.mjs` — clean
- [x] Regenerated into a scratch dir via `packages/plugin-examples`'s own drift-check command — byte-identical to committed `transitrix/examples/goals.svg`
- [x] Fetched the absolute raw URL used in the README (`curl -I`) — `200`, `image/svg+xml`, matches committed byte size (7764 bytes)
- [x] `grep -rn goals.svg` — exactly one committed copy of the artefact (`transitrix/examples/goals.svg`); two references to it (root README, `transitrix/README.md`), no duplicate files

Closes THQ-245.