### PR TITLE
ci(plugin-examples): guard the front-page README against a stale example too

### DIFF
--- a/.github/workflows/plugin-examples-drift.yml
+++ b/.github/workflows/plugin-examples-drift.yml
@@ -2,10 +2,11 @@ name: Plugin examples drift check
 
 # transitrix/README.md leads with rendered SVG examples of the notation views
 # the plugin's onboard skill lets a user author (epic transitrix-hq#158,
-# deliverable 2). The images are generated, not hand-drawn — regenerating
-# them from this repository's own notations/examples/ sources via
-# @transitrix/plugin-examples must reproduce the committed
-# transitrix/examples/*.svg files byte-for-byte.
+# deliverable 2), and the repository front page (README.md) leads with one
+# of the same generated examples (epic transitrix-hq#241). The images are
+# generated, not hand-drawn — regenerating them from this repository's own
+# notations/examples/ sources via @transitrix/plugin-examples must reproduce
+# the committed transitrix/examples/*.svg files byte-for-byte.
 #
 # This regenerates into a scratch directory and diffs it against what's
 # committed, failing the build on any difference — same style as the
@@ -18,6 +19,7 @@ on:
       - 'notations/examples/**'
       - 'transitrix/examples/**'
       - 'transitrix/README.md'
+      - 'README.md'
       - '.github/workflows/plugin-examples-drift.yml'
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
## What changed

Adds root `README.md` to the trigger paths of `.github/workflows/plugin-examples-drift.yml`, and updates its header comment to note the front page (THQ-241/#245) alongside the existing plugin-listing (THQ-158) use of the same generated artefact.

No new script or workflow: `README.md` reuses `transitrix/examples/goals.svg` (THQ-245, itself a reuse of the artefact from THQ-244 — no new file), and the existing `diff -rq transitrix/examples "$RUNNER_TEMP/plugin-examples-scratch"` step already regenerates and diffs the whole `transitrix/examples/` directory, `goals.svg` included. The only gap was the trigger: an edit to the root README's embed wouldn't have re-run the check. Regenerating remains the single documented command from THQ-244 (`node packages/plugin-examples/src/generate.mjs`) — nothing invents a second way to produce the artefact.

## Test plan

- [x] **Positive test:** regenerated into a scratch dir, diffed against the committed tree — clean, no output, exit 0.
- [x] **Negative test:** hand-edited the committed `transitrix/examples/goals.svg` without regenerating, re-ran the diff — failed **by name**: `Files transitrix/examples/goals.svg and .../goals.svg differ`, exit 1. Reverted before committing.
- [x] Trigger scope: `pull_request` on generator/source/artefact/both READMEs/the workflow file itself, `workflow_dispatch`, existing weekly `schedule` (Mondays 10:35 UTC, unchanged, still offset from other Monday crons) — same convention as the rest of the workflow, no new schedule added since this extends the existing workflow rather than adding a sibling.

Closes THQ-246.