### PR TITLE
ci: a scheduled auto-merge run stays dry, as its own comment always claimed

### DIFF
--- a/.github/workflows/simple-pr-automerge.yml
+++ b/.github/workflows/simple-pr-automerge.yml
@@ -25,4 +25,13 @@ jobs:
   simple-pr-automerge:
     uses: transitrix/templates/.github/workflows/simple-pr-automerge.yml@main
     with:
-      dry_run: ${{ inputs.dry_run != false }}
+      # Written against the EVENT, not against the input. On a scheduled run there
+      # are no inputs at all, and GitHub renders the absent input and `false` the
+      # same way, so `inputs.dry_run != false` evaluated to false and the hourly
+      # run went LIVE - the exact opposite of what the header above promises.
+      # Observed 2026-08-22 in this workflow's own env dump (`DRY_RUN: false` on a
+      # schedule run). Nothing was merged only because the checklist rejected the
+      # open pull requests on their titles, so the gate covered for the mode.
+      # Keep the event test: it does not depend on how an absent input compares
+      # to anything.
+      dry_run: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run }}


### PR DESCRIPTION
## The header and the behaviour disagreed, and the behaviour won

This workflow's own comment says:

> DRY_RUN defaults to true - flip it only via a manual run with the input explicitly set to false.

It did not. The scheduled hourly run has been evaluating pull requests **live**, with merge, branch-delete and label-change enabled.

**Evidence, from the workflow's own log rather than from reasoning about the expression** (`transitrix.github.io`, 2026-08-22T11:52Z, `event: schedule`):

```
env:
  DRY_RUN: false
Evaluating open PRs in transitrix/transitrix.github.io (dry_run=false)
```

**Cause.** `dry_run: ${{ inputs.dry_run != false }}` asks a question about an input that does not exist on a `schedule` event. GitHub renders the absent input and `false` the same way, so the comparison is false, and `false` is what gets passed — overriding the reusable workflow's own `default: true`, which was safe all along.

**Fix.** Ask about the event instead: `${{ github.event_name != 'workflow_dispatch' || inputs.dry_run }}`. Scheduled run is always dry; a manual run is dry unless someone explicitly sets the input to false, which is the documented behaviour. The reasoning is written next to the line so it does not get simplified back.

## What this did and did not cause

**It merged nothing.** Every open pull request it evaluated was rejected by the checklist on its title (`not a docs:/chore: Conventional Commit`) and left labelled `needs:human-merge`. The gate covered for the mode, which is the good news and also the reason this went unnoticed — a fail-closed checklist makes a wrong mode invisible until the day a qualifying pull request is open.

**Scope.** The same caller file, with the same line, is in `methodology`, `transitrix-studio` and `transitrix.github.io` — all three public. One pull request each; this is one of the three. The reusable workflow in `transitrix/templates` needs no change: its default is already `true`, and it was the caller that overrode it.

Found while auditing how a pull request reached `main` in `transitrix.github.io` without a human merge. That one turned out to be GitHub's native auto-merge, a different mechanism, since disabled on the repository — but the audit surfaced this.

Merge gate unchanged: this is Valerii's to merge, and its title is deliberately `ci:` rather than `chore:` so that the very workflow it repairs cannot merge it.
