### PR TITLE
fix(ids): underscore is TYPE-only, not a middle segment

### DIFF
--- a/.github/workflows/ingest-skill-test.yml
+++ b/.github/workflows/ingest-skill-test.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run ADL one-step join (L0) unit tests
         run: node --test packages/ingest-cli/src/adl-join.test.mjs
 
+      - name: Run ID grammar unit tests
+        run: node --test packages/ingest-cli/src/ids.test.mjs
+
       - name: Run Ingest pipeline test (deterministic)
         run: python transitrix/skills/ingest/tests/test_ingest_integrity.py
 

--- a/notations/IDS_AND_REFERENCES.md
+++ b/notations/IDS_AND_REFERENCES.md
@@ -12,8 +12,8 @@ Recorded 2026-05-20 as the canonical decision for the methodology.
 <TYPE>-[<middle segment(s)>-]<INTEGER>
 ```
 
-- **TYPE** — uppercase entity-type prefix from the registry in §3. The prefix names *what kind of thing* the ID refers to. The TYPE segment is composed of uppercase letters `A`–`Z`, digits `0`–`9`, and the underscore `_`; it MUST start with a letter. The underscore allows multi-word TYPE names — `PROCESS_BLUEPRINT` (the first registered TYPE to use one, decided 2026-05-21) and `INFORMATION_ENTITY` (registered alongside it).
-- **Middle segments** — optional, notation-specific. Add for disambiguation (a domain code, a period, a programme name). The grammar fixes only the start and the end of an ID; a notation MAY define one or more middle segments where needed. A middle segment may be alphanumeric or purely numeric, and a numeric middle segment **MAY carry leading zeros** where it is a zero-padded date or period component — e.g. the month and day of an ISO date, `INTERVIEW-cfo-onboarding-2026-04-15-1` (`04`, `15`). The no-leading-zeros rule below constrains the **terminal** integer only; middle segments are labels, not the sort key.
+- **TYPE** — uppercase entity-type prefix from the registry in §3. The prefix names *what kind of thing* the ID refers to. The TYPE segment is composed of uppercase letters `A`–`Z`, digits `0`–`9`, and the underscore `_`; it MUST start with a letter. The underscore is **TYPE-only** — it allows multi-word TYPE names (`PROCESS_BLUEPRINT`, `INTERNAL_STANDARD`, `INFORMATION_ENTITY`) and MUST NOT appear in a middle segment.
+- **Middle segments** — optional, notation-specific. Add for disambiguation (a domain code, a period, a programme name). The grammar fixes only the start and the end of an ID; a notation MAY define one or more middle segments where needed. A middle segment is `[A-Za-z0-9]+` (letters and digits only — no underscore). A hyphen splits segments; it is not a character inside one. A middle segment may be purely numeric, and a numeric middle segment **MAY carry leading zeros** where it is a zero-padded date or period component — e.g. the month and day of an ISO date, `INTERVIEW-cfo-onboarding-2026-04-15-1` (`04`, `15`). The no-leading-zeros rule below constrains the **terminal** integer only; middle segments are labels, not the sort key.
 - **INTEGER** — terminal positive integer, ≥ 1, **no leading zeros** — this constraint applies to the **terminal** integer only (it is the numeric sort key; numeric middle segments are exempt, see above). Sorting and comparison MUST parse it numerically, never lexically. There is no fixed width and no upper bound.
 
 **Examples:**
@@ -29,6 +29,8 @@ Recorded 2026-05-20 as the canonical decision for the methodology.
 | `DRIVER-` | — | — | — | **invalid** — missing terminal integer. |
 | `PROCESS_BLUEPRINT-FULFIL-1` | PROCESS_BLUEPRINT | FULFIL | 1 | underscore in TYPE — permitted |
 | `BUSINESS_OBJECT-ORDER-3` | BUSINESS_OBJECT | ORDER | 3 | underscore in TYPE — permitted |
+| `LAW-PERSONAL-DATA-1` | LAW | PERSONAL, DATA | 1 | hyphen splits middle segments |
+| `LAW-PERSONAL_DATA-1` | — | — | — | **invalid** — underscore in a middle segment. Use `LAW-PERSONAL-DATA-1`. |
 
 ---
 

--- a/packages/ingest-cli/src/ids.mjs
+++ b/packages/ingest-cli/src/ids.mjs
@@ -1,8 +1,8 @@
 // Canonical ID grammar — IDS_AND_REFERENCES.md §1: <TYPE>-[<middle>-]<INTEGER>.
-// Uppercase TYPE (letter-led, letters/digits/underscore), optional middle
-// segments, terminal positive integer with NO leading zeros.
+// Uppercase TYPE (letter-led, letters/digits/underscore — underscore is TYPE-only),
+// optional alphanumeric middle segments, terminal positive integer with NO leading zeros.
 
-export const ID_RE = /^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$/;
+export const ID_RE = /^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9]+)*-[1-9][0-9]*$/;
 
 // Capability V/H diagram-address exception (IDS_AND_REFERENCES.md §1): a capability
 // is addressed by a vertical/horizontal diagram path instead of a terminal integer —
@@ -57,13 +57,14 @@ export function makeId(type, middle, ordinal) {
   return id;
 }
 
-// Lower-case a free-text label into a safe middle segment (letters/digits/underscore,
-// hyphen-free so it does not collide with the ID separator). Empty → null.
+// Lower-case a free-text label into hyphen-separated middle segments
+// (letters/digits only). Non-alphanumerics split segments; they are not
+// collapsed to underscore (underscore is TYPE-only, IDS §1). Empty → null.
 export function slugSegment(text) {
   const s = String(text || '')
     .normalize('NFKD')
-    .replace(/[^A-Za-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
+    .replace(/[^A-Za-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
     .toLowerCase();
   return s || null;
 }

--- a/packages/ingest-cli/src/ids.test.mjs
+++ b/packages/ingest-cli/src/ids.test.mjs
@@ -1,0 +1,26 @@
+// Unit tests for the canonical ID grammar helper (ids.mjs — IDS_AND_REFERENCES.md §1).
+// Underscore is TYPE-only; a middle segment is [A-Za-z0-9]+.
+// Run: node --test packages/ingest-cli/src/ids.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isValidId, slugSegment, makeId } from './ids.mjs';
+
+test('isValidId: underscore is TYPE-only', () => {
+  assert.equal(isValidId('TYPE-foo_bar-1'), false);
+  assert.equal(isValidId('TYPE-foo-bar-1'), true);
+  assert.equal(isValidId('TYPE_NAME-foo-1'), true);
+});
+
+test('slugSegment: splits a label on non-alphanumerics, does not emit underscore', () => {
+  assert.equal(slugSegment('Personal Data'), 'personal-data');
+  assert.equal(slugSegment('PERSONAL_DATA'), 'personal-data');
+  assert.equal(slugSegment('coding-conventions'), 'coding-conventions');
+  assert.ok(!String(slugSegment('Personal Data')).includes('_'));
+});
+
+test('slugSegment: a generated id from a multi-word label passes isValidId', () => {
+  const id = makeId('LAW', [slugSegment('Personal Data')], 1);
+  assert.equal(id, 'LAW-personal-data-1');
+  assert.equal(isValidId(id), true);
+});

--- a/scripts/check-notations.mjs
+++ b/scripts/check-notations.mjs
@@ -1363,6 +1363,11 @@ export function validateIdToken(token) {
   if (!/^[1-9]\d*$/.test(terminal)) {
     return { valid: false, reason: `terminal segment "${terminal}" is not a positive integer with no leading zeros (§1)` };
   }
+  for (const seg of segments.slice(0, -1)) {
+    if (!/^[A-Za-z0-9]+$/.test(seg)) {
+      return { valid: false, reason: `middle segment "${seg}" is not alphanumeric (§1 — underscore is TYPE-only; a hyphen splits segments)` };
+    }
+  }
   return { valid: true };
 }
 

--- a/scripts/check-notations.test.mjs
+++ b/scripts/check-notations.test.mjs
@@ -608,6 +608,20 @@ test('validateIdToken — negative: a malformed CAPABILITY address is invalid', 
   assert.match(result.reason, /V\/H diagram-address form/);
 });
 
+test('validateIdToken — positive: underscore in TYPE is valid', () => {
+  assert.deepEqual(validateIdToken('PROCESS_BLUEPRINT-FULFIL-1'), { valid: true });
+});
+
+test('validateIdToken — positive: hyphen-separated middle segments are valid', () => {
+  assert.deepEqual(validateIdToken('LAW-PERSONAL-DATA-1'), { valid: true });
+});
+
+test('validateIdToken — negative: underscore in a middle segment is invalid', () => {
+  const result = validateIdToken('LAW-PERSONAL_DATA-1');
+  assert.equal(result.valid, false);
+  assert.match(result.reason, /underscore is TYPE-only/);
+});
+
 test('findIdCandidates — positive: a backtick span outside a fence is scanned', () => {
   const out = findIdCandidates('See `GOAL-CUST-1` for the target.');
   assert.deepEqual(out, [{ token: 'GOAL-CUST-1', line: 1 }]);

--- a/transitrix/skills/ingest/tests/test_ingest_integrity.py
+++ b/transitrix/skills/ingest/tests/test_ingest_integrity.py
@@ -102,7 +102,7 @@ def _presets_version():
 
 PRESETS_VERSION = _presets_version()
 
-ID_RE = re.compile(r"^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9_]+)*-[1-9][0-9]*$")
+ID_RE = re.compile(r"^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9]+)*-[1-9][0-9]*$")
 SOURCE_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SOURCE_QUALITY = {"authoritative", "corroborated", "single_source", "unverified"}
 
@@ -421,7 +421,7 @@ def part_e_ig2():
                     "--admitted-at", "2026-06-07", "--monitoring")
         check(r.returncode == 0, "IG-2: codex-artefact failed: %s" % (r.stderr or r.stdout))
 
-        art = os.path.join(org, "codex", "external", "eu", "LAW-conveyor_safety-1.yaml")
+        art = os.path.join(org, "codex", "external", "eu", "LAW-conveyor-safety-1.yaml")
         if check(os.path.isfile(art), "IG-2: codex artefact not written under codex/external/eu/"):
             d = yaml.safe_load(open(art, encoding="utf-8"))
             check(d.get("zone") == "codex", "IG-2: codex artefact zone is not 'codex'")
@@ -451,12 +451,16 @@ def part_e_ig2():
         r = run_cli("emit-candidates", art, "--from", res, "--candidates-dir", cdir)
         check(r.returncode == 0, "IG-2: emit-candidates from a codex artefact failed: %s" % (r.stderr or r.stdout))
 
-        req = json.load(open(os.path.join(cdir, "REQUIREMENT-CONVEYOR-CERT-1.json"), encoding="utf-8"))
-        ass = json.load(open(os.path.join(cdir, "ASSERTION-FLEXLINE-CERT-1.json"), encoding="utf-8"))
-        check(req.get("derived_from") == ["LAW-conveyor_safety-1"],
-              "IG-2: REQUIREMENT candidate does not cite the codex LAW: %r" % req.get("derived_from"))
-        check(ass.get("kind") == "assertion" and ass.get("derived_from") == ["LAW-conveyor_safety-1"],
-              "IG-2: ASSERTION candidate does not cite the codex LAW: %r" % ass.get("derived_from"))
+        req_path = os.path.join(cdir, "REQUIREMENT-CONVEYOR-CERT-1.json")
+        ass_path = os.path.join(cdir, "ASSERTION-FLEXLINE-CERT-1.json")
+        if check(os.path.isfile(req_path), "IG-2: REQUIREMENT candidate was not written"):
+            req = json.load(open(req_path, encoding="utf-8"))
+            check(req.get("derived_from") == ["LAW-conveyor-safety-1"],
+                  "IG-2: REQUIREMENT candidate does not cite the codex LAW: %r" % req.get("derived_from"))
+        if check(os.path.isfile(ass_path), "IG-2: ASSERTION candidate was not written"):
+            ass = json.load(open(ass_path, encoding="utf-8"))
+            check(ass.get("kind") == "assertion" and ass.get("derived_from") == ["LAW-conveyor-safety-1"],
+                  "IG-2: ASSERTION candidate does not cite the codex LAW: %r" % ass.get("derived_from"))
         r = run_cli("validate", cdir)
         check(r.returncode == 0, "IG-2: codex-derived candidates did not validate clean: %s" % (r.stdout + r.stderr))
 
@@ -468,7 +472,7 @@ def part_e_ig2():
         if check(os.path.isfile(rq), "F13: review-queue.yaml was not created"):
             q = yaml.safe_load(open(rq, encoding="utf-8"))
             fas = q.get("field_artefacts") or []
-            law = next((fa for fa in fas if fa.get("id") == "LAW-conveyor_safety-1"), None)
+            law = next((fa for fa in fas if fa.get("id") == "LAW-conveyor-safety-1"), None)
             if check(law is not None, "F13: review queue did not list the cited codex LAW source"):
                 check(law.get("zone") == "codex", "F13: codex source not marked zone:codex (got %r)" % law.get("zone"))
                 check(law.get("found") is True, "F13: codex source did not resolve (found != True)")


### PR DESCRIPTION
## Summary

- Clarify `IDS_AND_REFERENCES.md` §1: a middle segment is `[A-Za-z0-9]+`; underscore stays TYPE-only; a hyphen splits segments.
- Align `ingest-cli` `ID_RE` / `slugSegment` with that grammar so a generated id (e.g. from `Personal Data`) is `TYPE-personal-data-1`, which the published CLI already accepts.
- Show `LAW-PERSONAL_DATA-1` as invalid next to the TYPE-underscore-permitted examples; `validateIdToken` and `ids.test.mjs` cover `TYPE-foo_bar-1` (fail) vs `TYPE-foo-bar-1` / `TYPE_NAME-foo-1` (pass).

Addresses THQ-319.

## Test plan

- [x] `node --test packages/ingest-cli/src/ids.test.mjs`
- [x] `node --test scripts/check-notations.test.mjs`
- [x] `node scripts/check-notations.mjs` (clean; two pre-existing SIZE1 warnings)
- [x] remaining ingest-cli unit tests already in CI

Made with [Cursor](https://cursor.com)