### PR TITLE
docs(patterns): one repository may hold both project and central roles

### DIFF
--- a/patterns/enterprise-adr-registry.md
+++ b/patterns/enterprise-adr-registry.md
@@ -21,7 +21,7 @@ Two layers, unchanged from the canon:
 | Per-repo decision records | `operations/decisions/ADR-YYYY-MM-DD-<slug>.md` (or legacy `ADR-NNNN-<slug>.md`), each project repo | [`method/07-decisions.md`](../method/07-decisions.md) §2 |
 | Enterprise ADL | `architecture/decision-log/`, the central architecture repo | `method/07-decisions.md` §1, §5 |
 
-The per-repo layer is canonical — a decision's single source of truth is the repo where it was made. The central log is a derived, harvested index plus full copies of *promoted* (enterprise-significant) records. There is no two-way sync.
+The per-repo layer is canonical — a decision's single source of truth is the repo where it was made. The central log is a derived, harvested index plus full copies of *promoted* (enterprise-significant) records. There is no two-way sync. Those two layers are **roles**, not a requirement that they live in two git repositories — see [One repository, both roles](#one-repository-both-roles).
 
 ```
    PROJECT REPOS (canonical)                    CENTRAL ARCHITECTURE REPO (derived)
@@ -61,7 +61,7 @@ Don't wait for a second repo to begin. An adopter with a single repo can stand u
    *Don't hand-write the front-matter.* The [`adr` skill](../transitrix/skills/adr/SKILL.md) — `/transitrix:adr` once the plugin is installed — runs the Context → Decision → Consequences interview, derives the id from today's date and a slug, validates the record, and opens the PR. It is the authoring workflow for the flow `method/07-decisions.md` specifies; it never self-accepts (§4's gate).
 3. **Optionally wire the CI guard** — `scripts/check-adl.mjs` (`method/07-decisions.md` §7) lints the folder on every PR that touches it, including the uniqueness guard (A5) that makes two authors on separate branches safe to allocate independently.
 
-That is a complete, working ADL for one repo. Move to the sections below only once a **second** repo needs to see the first repo's decisions.
+That is a complete, working ADL for one repo. Add the central half — in a second repository, or in this same one — only once another project needs its decisions indexed or admitted here. See [One repository, both roles](#one-repository-both-roles) if this repository will also be the central log.
 
 ## When to add the enterprise layer (multi-repo)
 
@@ -70,10 +70,37 @@ That is a complete, working ADL for one repo. Move to the sections below only on
 - Recurring coordination overhead from repos silently diverging on a decision another repo already made.
 - An autonomous agent needs to make architecturally-significant changes across repos with a gated, auditable trace (`method/07-decisions.md` §4).
 
+The central role can sit in a dedicated architecture repository, or in a repository that already holds its own project decisions. Two distinct repositories are typical, not required.
+
+## One repository, both roles
+
+A repository may hold both the project role and the central role. It keeps its own `operations/decisions/` as any project repository does, and it is also the log other projects treat as central. Dual-role does not fuse ownership: **each decision record has exactly one canonical owner.**
+
+Two flows. Do not conflate them.
+
+| Flow | Already true | What moves | Owner after |
+|---|---|---|---|
+| **Harvest / index** | An ADR already ratified and owned by a project | The index entry — and, for records in `promote.scopes`, a copy under `architecture/decision-log/promoted/` | Unchanged. The project still owns the canonical record. |
+| **Central admission / promotion** | An external *candidate*, not yet a canonical central record | A human-admitted ADR, created centrally | The central role. This is a new canonical record, not a harvested copy. |
+
+**Harvest / index** is the pull job in `method/07-decisions.md` §5. The record never changes owner; only its index (and, in scope, a copy) moves. `promoted/` in that job is still this flow — a copy of a record owned elsewhere, not a transfer of ownership.
+
+**Central admission / promotion** is a pull request into **namespaced non-canonical intake**, then a human admits it. On admission the canonical ADR is created and owned centrally. Do not call this a harvest, and do not run a candidate through the harvest job to "make it central." Harvest indexes what is already owned; admission creates what the central role will own.
+
+The analogue for elements is [Network Catalogue](network-catalogue.md) L3 — same shape, applied to canon elements rather than decision records.
+
+When both roles share one repository, the boundary is the **role**, not a second clone:
+
+- `operations/decisions/` holds this repository's own, project-owned records.
+- `architecture/decision-log/` holds the harvested index and copies of records still owned at their source.
+- Intake holds non-canonical candidates until a human admits a centrally-owned record.
+
+An agent does not write the admitted central record. It may open the intake pull request; a human admits. Same gate `method/07-decisions.md` §4 already places on `author: agent`.
+
 ## How to stand up the central ADL
 
 1. **Every source repo already has `operations/decisions/`** (see "Start here" above) — nothing to change per-repo to onboard it into the harvest.
-2. **Create the central architecture repo's `architecture/decision-log/`** with a `harvest.config.yaml` listing every source repo (`method/07-decisions.md` §5).
+2. **Create `architecture/decision-log/`** in the repository that holds the central role — a dedicated architecture repository, or the same repository that already holds `operations/decisions/` — with a `harvest.config.yaml` listing every source (`method/07-decisions.md` §5).
 3. **Run the harvest** (`scripts/adl-harvest.mjs`, scheduled + on demand) to regenerate `INDEX.md` and pull full copies of promoted records into `promoted/`.
 4. **Set the promotion scope** — which records count as enterprise-significant (`method/07-decisions.md` §5's `promote.scopes`) — and who has authority to mark a record as promoted.
 5. **Respect the ratification gate** — an `author: agent` record is never accepted until a human ratifies it (`method/07-decisions.md` §4). This is what makes it safe for an autonomous agent to author decisions across repos.

--- a/patterns/network-catalogue.md
+++ b/patterns/network-catalogue.md
@@ -12,7 +12,9 @@ Two or more repositories each hold their own Transitrix canon, and the same real
 
 ## When *not* to do this
 
-**One repository, alone, needs none of this.** If nothing outside your own canon should ever recognise one of your elements, stop — this pattern (and the mechanism behind it) has nothing to offer a single, unfederated repository. Adopting it anyway adds an opt-in field and a check that never fires; harmless, but not what you came here for. The signal to start is external: **a second repository's canon should be able to recognise the first's.**
+**One repository, alone, needs none of this.** If nothing outside your own canon should ever recognise one of your elements, and no other repository will bind to a catalogue you publish, stop — this pattern (and the mechanism behind it) has nothing to offer a single, unfederated repository. Adopting it anyway adds an opt-in field and a check that never fires; harmless, but not what you came here for. The signal to start is external: **a second repository's canon should be able to recognise the first's.**
+
+A repository that is itself the central catalogue **and** holds its own project canon is not that exemption — that is the dual-role case below.
 
 ## Solution
 
@@ -23,7 +25,7 @@ Adopt the [catalogue integration levels](../method/09-releases-and-propagation.m
 | **L0 — decisions** | The [Enterprise ADR Registry](enterprise-adr-registry.md) mechanism, unchanged. Already covered if you've adopted that pattern. |
 | **L1 — vocabulary** | Pins the published central catalogue; a report-only CI check flags terminology divergence. |
 | **L2 — recognition** | A locally authored element is matched against the pinned catalogue; a binding is **proposed**, never written unattended. |
-| **L3 — promotion** | A local element is proposed for import centrally; on admission, the local element gains its binding. |
+| **L3 — promotion** | A local element is proposed for import; on human admission the central role owns it, and the local element gains a binding. [Central admission / promotion](#one-repository-both-roles) — not a harvest. |
 
 **The ownership rule underneath all four:** exactly one repository owns each element. The central repository owns what it has admitted — id, name, content; every other repository relates to it by reference, never by copy. A project repository's own elements keep their own `id` forever; binding to a central element (L2/L3) adds a fact about the element, it never substitutes the central identity for the local one. **No tool ever rewrites a local `id`.**
 
@@ -43,7 +45,7 @@ Adopt the [catalogue integration levels](../method/09-releases-and-propagation.m
 Three properties the diagram encodes, each load-bearing:
 
 - **Propose, never auto-merge**, at every level — L1 reports, L2 proposes, L3 emits a proposal for a human admission gate. Nothing writes admitted canon unattended.
-- **No two-way sync**, at any level — the central repository never edits a project repository's canon, and a project repository never writes into the central repository. Same discipline the ADR registry already applies to decisions, generalised to elements.
+- **No two-way sync**, at any level — the central role never edits a project role's admitted canon, and a project role never writes admitted central canon. A project may open a candidate for [central admission](#one-repository-both-roles); a human admits. Same discipline the ADR registry already applies to decisions, generalised to elements. When both roles share one repository, that boundary is the role, not a second clone.
 - **Levels are separable in the tooling**, not merely in the documentation — each is built, and useful, independently of the ones after it. A repository at L1 alone has a pinned vocabulary and a divergence report; nothing about it requires L2 or L3 to ever happen.
 
 ## Start here — L0, right now, before a second repository exists
@@ -58,6 +60,23 @@ See [`guides/adl-adopter-setup.md`](../guides/adl-adopter-setup.md) Step 1 for w
 
 **A repository at L0 alone is a complete, valid state** — no pin, no new field, no reference to a central catalogue anywhere in its own canon.
 
+## One repository, both roles
+
+A repository may hold both the project role and the central role. It keeps its own canon as any project repository does, and it is also the catalogue other projects pin, recognise, and propose into. Dual-role does not fuse ownership: **each element has exactly one canonical owner** — the rule in `method/09-releases-and-propagation.md` §6.1, unchanged.
+
+Two flows. Do not conflate them. The same distinction [Enterprise ADR Registry](enterprise-adr-registry.md) draws for decision records applies here to elements.
+
+| Flow | Already true | What moves | Owner after |
+|---|---|---|---|
+| **Harvest / index** | A ratified ADR, owned by a project | The index entry (L0 — the ADR registry's pull job) | Unchanged. The project still owns the canonical record. |
+| **Central admission / promotion** | A local element, owned by a project | A human-admitted central element; the local element keeps its `id` and gains a binding | The central role owns the admitted element. The project still owns the local `id`. |
+
+**Harvest / index** is L0. The record never changes owner; only its index moves. Do not call a later admission a harvest.
+
+**Central admission / promotion** is L3: a local object is proposed for import; a human admits it into the central catalogue; the local element gains `canon_id` and the central element carries `origin`. This is not a harvest. Harvest indexes what is already owned; L3 creates what the central role will own.
+
+When both roles share one repository, the boundary is the **role**, not a second clone. Project-owned elements stay project-owned until a human admits a centrally-owned counterpart. An agent working the project role may propose a promotion; it never writes admitted central canon.
+
 ## When to add L1 (vocabulary)
 
 - A central repository already publishes a catalogue slice you want your own terminology checked against.
@@ -68,7 +87,7 @@ See [`guides/adl-adopter-setup.md`](../guides/adl-adopter-setup.md) Step 1 for w
 ## When to add L2 / L3 (recognition, promotion)
 
 - L2, once you want locally authored elements checked for an existing central match, staged for human review rather than silently left unbound.
-- L3, once you're ready to propose one of your own elements for adoption centrally — the reverse direction, a local object becoming a shared one.
+- L3, once you're ready to propose one of your own elements for adoption centrally — [central admission / promotion](#one-repository-both-roles): a local object becoming a shared one, owned centrally after a human gate. Not a harvest.
 
 Both are commands (`catalogue-recognize`, `catalogue-bind`, `catalogue-promote`) — `method/09-releases-and-propagation.md` §6.6 and [`packages/ingest-cli/README.md`](../packages/ingest-cli/README.md) for the full reference.
 
@@ -78,7 +97,7 @@ Both are commands (`catalogue-recognize`, `catalogue-bind`, `catalogue-promote`)
 
 Network Catalogue answers the opposite shape: *several repositories each hold their own complete canon*, and the question is how one repository's model recognises another's, without either giving up ownership of what it already modelled. If your repositories are producing raw material for one team to curate, use Knowledge Store. If your repositories are each already modelling independently and need to recognise each other's elements, use this pattern instead.
 
-## Constraints (inherited from the mechanism, unchanged)
+## Constraints (inherited from the mechanism)
 
 - **Additive and backwards-compatible.** Every repository stays valid unchanged; adopting no level here changes nothing.
-- **No agent writes across a repository boundary.** An agent working a project repository may propose a promotion; it never writes into the central repository.
+- **No agent writes admitted central canon.** An agent working a project role may propose a promotion; it never writes the admitted central record. When the two roles share one repository, that is still a role boundary, not a reason to skip the human gate.


### PR DESCRIPTION
## Summary

- A repository may hold both the project role and the central role. Each decision record and each element still has exactly one canonical owner.
- Two flows, named the same way in both pattern docs: **harvest / index** (the record stays owned at source; only the index, and for ADRs in scope a copy, moves) and **central admission / promotion** (a candidate becomes centrally owned after a human gate; not a harvest).
- Catalogue L3 is the second flow applied to elements. The ADR pattern now has the analogue for decision records (PR into namespaced non-canonical intake, then human admission).

Addresses THQ-288.

## Test plan

- [ ] Read `patterns/enterprise-adr-registry.md` § One repository, both roles against the harvest diagram above it — harvest's `promoted/` is still flow 1.
- [ ] Read `patterns/network-catalogue.md` L3 row and the same section — L3 is flow 2, not a harvest.
- [ ] Follow the cross-links between the two pattern docs and to `method/07-decisions.md` / `method/09-releases-and-propagation.md`.

Made with [Cursor](https://cursor.com)