### PR TITLE
fix(plugin): manifest --check handles EOLs; description names document views (THQ-358)

### DIFF
--- a/packages/document-renderer/README.md
+++ b/packages/document-renderer/README.md
@@ -278,12 +278,12 @@ one that was never in the recipe at all.
 ## PDF output
 
 The third artefact per run alongside Markdown and the run record — a
-**hand-rolled, dependency-free** Markdown-to-PDF writer. Every package in this
-repository ships zero runtime dependencies (`package.json`); a full HTML/PDF
-pipeline would break that posture for one output format, so this module
-assembles a minimal, valid PDF directly (a Catalog, a Pages tree, one shared
-Type1 Helvetica font, one Page + content stream per page) rather than shelling
-out to an external renderer.
+**hand-rolled, dependency-free** Markdown-to-PDF writer. This package ships
+zero runtime dependencies (`package.json`); a full HTML/PDF pipeline would
+break that posture for one output format, so this module assembles a minimal,
+valid PDF directly (a Catalog, a Pages tree, one shared Type1 Helvetica font,
+one Page + content stream per page) rather than shelling out to an external
+renderer.
 
 ```js
 import { renderMarkdownToPdf } from '@transitrix/document-renderer/src/render-pdf.mjs';

--- a/scripts/generate-plugin-manifests.mjs
+++ b/scripts/generate-plugin-manifests.mjs
@@ -65,7 +65,9 @@ async function main() {
       process.exitCode = 1;
       return;
     }
-    if (existing !== generated) {
+    // Normalize line endings before comparison so CRLF checkouts don't report as stale
+    const normalizeEol = (str) => str.replace(/\r\n/g, '\n');
+    if (normalizeEol(existing) !== normalizeEol(generated)) {
       console.error(`generate-plugin-manifests: ${TARGET_PATH} is stale relative to ${SOURCE_PATH}.`);
       console.error('Run: node scripts/generate-plugin-manifests.mjs');
       process.exitCode = 1;

--- a/transitrix/.claude-plugin/plugin.json
+++ b/transitrix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix",
-  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 12 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Integration map, Products, Action Card) + PlantUML rendering, or one of the 6 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric, Rules in Force, Glossary), or a codex artefact.",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 12 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Integration map, Products, Action Card) + PlantUML rendering, one of the 6 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric, Rules in Force, Glossary), or a document view (MRD, SRS, SDD) or a codex artefact.",
   "version": "0.1.0",
   "author": {
     "name": "Transitrix"

--- a/transitrix/plugin.json
+++ b/transitrix/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "transitrix",
   "version": "0.1.0",
-  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 12 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Integration map, Products, Action Card) + PlantUML rendering, or one of the 6 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric, Rules in Force, Glossary), or a codex artefact.",
+  "description": "Scaffold a Transitrix enterprise-architecture-as-text repository and author your first notation file with inline canonical validation. Drops the canonical zoned canon/ + field/ + codex/ layout with an assistant-neutral AGENTS.md guide and a pinned transitrix.yaml manifest, then walks the user through one of the 12 diagram views (BPMN, DGCA / DGA, Goals, Capability map, Process landscape map, Process Blueprint, Action schedule, Nested blocks, Applications, Integration map, Products, Action Card) + PlantUML rendering, one of the 6 report views (Scenarios, Actions tree, Compliance Impact, Coverage Metric, Rules in Force, Glossary), or a document view (MRD, SRS, SDD) or a codex artefact.",
   "author": {
     "name": "Transitrix"
   },


### PR DESCRIPTION
## Summary
Fixes task THQ-358 — three small corrections to match contract:

- `--check` now compares EOL-normalized manifests so CRLF checkouts report clean
- Plugin description now mentions the three document views (MRD, SRS, SDD) that the skill offers
- Renderer README corrected from "every package has zero dependencies" to "this package has zero dependencies" (others do have them)

## Test plan
- [x] `--check` passes on existing manifest
- [x] Generated portable manifest contains document view mention
- [x] Renderer README claim is accurate to this package only