### PR TITLE
build: bump to v4.2.0 — STANDARD TYPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+---
+
+## [4.2.0] — 2026-08-27
+
+Bump category: **MINOR** — highest change since the 4.1.0 pin is a new catalogued TYPE (`STANDARD`). Parser/lint/batch-path/reg-intel fixes in the same window ride along. No migration recipe: a repository that never admits a `STANDARD` validates as it did on 4.1.0. New `error` enforcement that only names already-specified rules (`TTRS-002`, relation `from`/`to`) is grandfathered for already-admitted adopter canon per CONTRACT §10.4.
+
 ### Added
 
-- **`STANDARD` — a new codex TYPE for a technical standard issued by a standards-developing organisation** (`notations/elements/14-codex.md` §2, §2.2). Lives in `codex/external/<jurisdiction>/` with `LAW`/`REGULATION`; internationally issued bodies use `intl` (no longer reserved). Discriminator at admission: statute → `REGULATION` (or `LAW`); org writes it for itself → `INTERNAL_STANDARD`/`POLICY`/`PRINCIPLE`; an SDO issues it → `STANDARD`. A regulation that incorporates a standard by reference stays a `REGULATION` and cites the `STANDARD`. Required fields are `jurisdiction`, `effective_date`, and `issuing_authority` (the issuing body). Permitted-TYPE lists for `REQ-003`, `TERM-002`, `COVMET-003`, `RIF-002`, `SEGMENT-002`, and `AMENDMENT-002` widen to include `STANDARD`; `PRINCIPLE` stays out of rules-in-force. `@transitrix/ingest-cli` accepts `--type STANDARD` with `--jurisdiction` and `--issuing-authority`. Purely additive: no existing field became required on `LAW`/`REGULATION`, and a repository with no `STANDARD` artefact validates as before. (transitrix-hq#318)
+- **`STANDARD` — a new codex TYPE for a technical standard issued by a standards-developing organisation** (`notations/elements/14-codex.md` §2, §2.2). Lives in `codex/external/<jurisdiction>/` with `LAW`/`REGULATION`; internationally issued bodies use `intl` (no longer reserved). Discriminator at admission: statute → `REGULATION` (or `LAW`); org writes it for itself → `INTERNAL_STANDARD`/`POLICY`/`PRINCIPLE`; an SDO issues it → `STANDARD`. A regulation that incorporates a standard by reference stays a `REGULATION` and cites the `STANDARD`. Required fields are `jurisdiction`, `effective_date`, and `issuing_authority` (the issuing body). Permitted-TYPE lists for `REQ-003`, `TERM-002`, `COVMET-003`, `RIF-002`, `SEGMENT-002`, and `AMENDMENT-002` widen to include `STANDARD`; `PRINCIPLE` stays out of rules-in-force. `@transitrix/ingest-cli` accepts `--type STANDARD` with `--jurisdiction` and `--issuing-authority`. Purely additive: no existing field became required on `LAW`/`REGULATION`, and a repository with no `STANDARD` artefact validates as before. (transitrix-hq#318, #539)
+
+### Fixed
+
+- **`tools/lint.py` reads relation `from`/`to`.** Missing or non-string endpoints are errors; the advertised empty ArchiMate semantics pass is removed (use `@transitrix/cli --scope=repo`). (#536)
+- **Document parsers reject unknown directive attributes and leftover text** on `view` / `figure`, matching `DIRECTIVE_LANGUAGE` §7 (`TTRS-002`). (#535)
+- **Ingest and reg-intel batch paths no longer overwrite an unresolved flat file** when a second run has different content; identity is `run_id`. (#538)
+- **`reg-intel` discovery reads `operations/config/scan-sources.yaml`**, and date checks reject impossible or unpadded ISO dates. (#537)
+- **Plugin `--check` treats CRLF and LF manifests as equal**; the plugin description names the document views the skill offers. (#534)
 
 ---
 

--- a/method/06-team-operations.md
+++ b/method/06-team-operations.md
@@ -104,7 +104,7 @@ Deliberately **not** one-file-per-record like ADR/WI: a single file, `operations
 ---
 ### FB-0002
 type: notation-gap
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 raised_by: modeler
 date: "2026-07-27"
 status: sent-upstream

--- a/notations/CONTRACT.md
+++ b/notations/CONTRACT.md
@@ -912,7 +912,7 @@ Structural layout of a view document:
 ```yaml
 notation: dgca                # §1 — required header
 spec_version: "0.1"           # §1 — optional header
-methodology_version: "4.1.0"  # manifest-pinned methodology version
+methodology_version: "4.2.0"  # manifest-pinned methodology version
 name: "Retail strategy chain" # §1.1 — required document name
 
 view:                         # view identity block — id only; name lives at root per §1.1
@@ -1011,7 +1011,7 @@ views/
 ```yaml
 view_id: DGCA-RETAIL-1               # canonical ID of the view being captured
 generated_at: "2026-06-20T14:30:00Z" # ISO-8601 UTC timestamp — matches the file name
-methodology_version: "4.1.0"          # methodology version in use at generation time
+methodology_version: "4.2.0"          # methodology version in use at generation time
 # …notation-specific element list follows (format defined per notation spec)…
 ```
 

--- a/notations/COVERAGE_PROFILES.md
+++ b/notations/COVERAGE_PROFILES.md
@@ -24,7 +24,7 @@ A profile is declared at the repository root in `transitrix.yaml` under the `cov
 
 ```yaml
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core         # short form — name a shipped preset
@@ -250,7 +250,7 @@ The shipped presets (`minimal`, `core`, `full`) are *re-defined per methodology 
 ```yaml
 # transitrix.yaml
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [dgca, goals, activities, capability-map, applications]
 zones: [canon, field]
 # coverage_profile omitted → defaults to `full`

--- a/notations/CURRENT_VERSION.yaml
+++ b/notations/CURRENT_VERSION.yaml
@@ -5,4 +5,4 @@
 # placeholder allowlist in scripts/check-notations.mjs. Enforced by that
 # script's V1 check. See notations/CONTRACT.md §10 for the versioning and
 # compatibility policy this pin follows.
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"

--- a/notations/MANIFEST.md
+++ b/notations/MANIFEST.md
@@ -29,7 +29,7 @@ A worked example lives at `transitrix.yaml` in the [acme-corp reference repo](ht
 
 ```yaml
 transitrix: 1                       # manifest schema version (integer)
-methodology_version: "4.1.0"        # the methodology release this repo conforms to
+methodology_version: "4.2.0"        # the methodology release this repo conforms to
 notations: [dgca, goals, action, capability-map, codex]
 zones: [canon, field, codex]
 coverage_profile: full              # optional — see COVERAGE_PROFILES.md

--- a/notations/PACKAGES.md
+++ b/notations/PACKAGES.md
@@ -20,7 +20,7 @@ A package is declared at the repository root in `transitrix.yaml` under the `pac
 
 ```yaml
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [dgca, goals, activities, capability-map]
 zones: [canon, field]
 coverage_profile: core

--- a/notations/examples/action/root-action-scope/scoped.action.transitrix.yaml
+++ b/notations/examples/action/root-action-scope/scoped.action.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: action
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 id: ACTION_SCHED-LAUNCH-1
 name: "Launch — scoped by root_action"
 generated_at: "2026-08-25"

--- a/notations/examples/action/root-action-scope/transitrix.yaml
+++ b/notations/examples/action/root-action-scope/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [action]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/action/root-action-scope/unscoped.action.transitrix.yaml
+++ b/notations/examples/action/root-action-scope/unscoped.action.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: action
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 id: ACTION_SCHED-LAUNCH-UNSCOPED-1
 name: "Launch — no root_action"
 generated_at: "2026-08-25"

--- a/notations/examples/codex/standard/transitrix.yaml
+++ b/notations/examples/codex/standard/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [codex]
 zones: [codex]
 coverage_profile: core

--- a/notations/examples/compliance-impact/README.md
+++ b/notations/examples/compliance-impact/README.md
@@ -25,7 +25,7 @@ A compliance-impact view file carries the shared envelope (`notation:`, `spec_ve
 ```yaml
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: COMPLIANCE_IMPACT-<NAME>-1

--- a/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
+++ b/notations/examples/compliance-impact/retail-gdpr.compliance-impact.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: compliance-impact
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 name: "Retail product — GDPR obligations"
 
 view:

--- a/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
+++ b/notations/examples/dgca/constraint-driven.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 id: DGCA-DATA-RESIDENCY-1
 name: "EU data-residency DGCA chain"

--- a/notations/examples/dgca/startup.dgca.transitrix.yaml
+++ b/notations/examples/dgca/startup.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 id: DGCA-STARTUP-1
 name: "Product launch — strategy chain"

--- a/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026-dga.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 id: DGCA-STRATEGY-2026-DGA
 name: "Strategy 2026 — DGA view"

--- a/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
+++ b/notations/examples/dgca/strategy-2026.dgca.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: dgca
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 id: DGCA-STRAT-1
 name: "Strategy 2026 — DGCA chain"

--- a/notations/examples/integration-map/README.md
+++ b/notations/examples/integration-map/README.md
@@ -26,7 +26,7 @@ An integration-map view file carries the shared envelope (`notation:`, `spec_ver
 ```yaml
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: INTEGRATION_MAP-<NAME>-1

--- a/notations/examples/integration-map/enterprise.integration-map.transitrix.yaml
+++ b/notations/examples/integration-map/enterprise.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 name: "Enterprise integration landscape"
 
 view:

--- a/notations/examples/integration-map/rule-violations/attempted-inline-edge.integration-map.transitrix.yaml
+++ b/notations/examples/integration-map/rule-violations/attempted-inline-edge.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 name: "Attempted inline edge — invalid on purpose"
 
 view:

--- a/notations/examples/mrd/README.md
+++ b/notations/examples/mrd/README.md
@@ -34,7 +34,7 @@ An MRD view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: mrd
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: MRD-<NAME>-1

--- a/notations/examples/mrd/incident-status.mrd.transitrix.yaml
+++ b/notations/examples/mrd/incident-status.mrd.transitrix.yaml
@@ -2,7 +2,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Incident status communication — MRD"
 generated_at: "2026-08-04"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: MRD-INCIDENT-STATUS-1

--- a/notations/examples/mrd/transitrix.yaml
+++ b/notations/examples/mrd/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [mrd, requirement, stakeholder, actor]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/packages/reqif-workflow/transitrix.yaml
+++ b/notations/examples/packages/reqif-workflow/transitrix.yaml
@@ -4,7 +4,7 @@
 # (packages/reqif-cli/tests/test_reqif_integrity.py Part B) stays unaffected
 # by content the XML converter does not carry (see this folder's README).
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/packages/reqif/transitrix.yaml
+++ b/notations/examples/packages/reqif/transitrix.yaml
@@ -3,7 +3,7 @@
 # permitted cross-reference (Transitrix.CanonRef, reqif.md §3) something real
 # to cite, plus the reqif/ package folder itself.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/relations/depends-on/transitrix.yaml
+++ b/notations/examples/relations/depends-on/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [relation, requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/relations/process-parent/transitrix.yaml
+++ b/notations/examples/relations/process-parent/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [relation, process-blueprint]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/relations/required-for/transitrix.yaml
+++ b/notations/examples/relations/required-for/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [relation, requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/release-qualifiers-rule-violations/transitrix.yaml
+++ b/notations/examples/release-qualifiers-rule-violations/transitrix.yaml
@@ -4,7 +4,7 @@
 # manifest may enclose another, which is also why this fixture moved out
 # from under its parent folder.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [requirement, assertion, verification]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/release-qualifiers/transitrix.yaml
+++ b/notations/examples/release-qualifiers/transitrix.yaml
@@ -3,7 +3,7 @@
 # notations/examples/release-qualifiers-rule-violations/ rather than its
 # parent — no manifest may enclose another.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [requirement, assertion, verification]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/requirement-parent/transitrix.yaml
+++ b/notations/examples/requirement-parent/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/scenarios/README.md
+++ b/notations/examples/scenarios/README.md
@@ -26,7 +26,7 @@ A post-reclassification scenarios view file carries no canonical content. It dec
 ```yaml
 notation: scenarios
 spec_version: "0.3"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: SCENARIOS-2027-CUT-1

--- a/notations/examples/sdd/README.md
+++ b/notations/examples/sdd/README.md
@@ -35,7 +35,7 @@ An SDD view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: sdd
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: SDD-<NAME>-1

--- a/notations/examples/sdd/data-export.sdd.transitrix.yaml
+++ b/notations/examples/sdd/data-export.sdd.transitrix.yaml
@@ -2,7 +2,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Data export capability — SDD"
 generated_at: "2026-08-04"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: SDD-DATA-EXPORT-1

--- a/notations/examples/sdd/transitrix.yaml
+++ b/notations/examples/sdd/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [sdd, requirement, assertion]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/srs/README.md
+++ b/notations/examples/srs/README.md
@@ -33,7 +33,7 @@ An SRS view file carries the shared envelope (`notation:`, `spec_version:`, `met
 ```yaml
 notation: srs
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: SRS-<NAME>-1

--- a/notations/examples/srs/backup-power.srs.transitrix.yaml
+++ b/notations/examples/srs/backup-power.srs.transitrix.yaml
@@ -2,7 +2,7 @@ notation: srs
 spec_version: "0.1"
 name: "Backup-power controller — SRS"
 generated_at: "2026-08-04"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: SRS-BACKUP-POWER-1

--- a/notations/examples/srs/transitrix.yaml
+++ b/notations/examples/srs/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [srs, requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/validation/transitrix.yaml
+++ b/notations/examples/validation/transitrix.yaml
@@ -2,7 +2,7 @@
 # Its own catalogue root (MANIFEST.md §4): declares the boundary the
 # uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [validation, requirement, stakeholder, actor]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/verification-reverse-trace-gaps/transitrix.yaml
+++ b/notations/examples/verification-reverse-trace-gaps/transitrix.yaml
@@ -4,7 +4,7 @@
 # manifest may enclose another, which is also why this fixture moved out
 # from under its parent folder.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [verification, requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/examples/verification/transitrix.yaml
+++ b/notations/examples/verification/transitrix.yaml
@@ -3,7 +3,7 @@
 # notations/examples/verification-reverse-trace-gaps/ rather than its
 # parent — no manifest may enclose another.
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [verification, requirement]
 zones: [canon]
 coverage_profile: core

--- a/notations/packages/reqif.md
+++ b/notations/packages/reqif.md
@@ -21,7 +21,7 @@ This is a package, not a core notation: nothing here changes `IDS_AND_REFERENCES
 
 ```yaml
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 packages: [reqif]
 ```
 

--- a/notations/views/diagrams/02-dgca.md
+++ b/notations/views/diagrams/02-dgca.md
@@ -154,7 +154,7 @@ A DGCA document opens with a shared header block (`notation:`, `spec_version:`, 
 ```yaml
 notation: dgca
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 id: DGCA-LAUNCH-1
 name: "Product launch strategy chain"
 period: "2026"
@@ -188,7 +188,7 @@ notation: dgca
 spec_version: "0.1"
 id: DGCA-RETAIL-1
 name: "Retail strategy chain 2026"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view_config:
   goals:

--- a/notations/views/diagrams/04-goals.md
+++ b/notations/views/diagrams/04-goals.md
@@ -117,7 +117,7 @@ After goals are promoted to `canon/elements/01_motivation/goals/`, the view beco
 ```yaml
 notation: goals
 spec_version: "0.1"
-methodology_version: "4.1.0"          # required from v2.0 onward
+methodology_version: "4.2.0"          # required from v2.0 onward
 
 id: GOALS-STRAT-2026-1                 # required — GOALS-[<middle>-]<INTEGER>
 name: "Strategy 2026 — Goals Tree"    # required per CONTRACT.md §1.1

--- a/notations/views/diagrams/07-action.md
+++ b/notations/views/diagrams/07-action.md
@@ -128,7 +128,7 @@ After actions are promoted to `canon/elements/05_implementation/actions/`, the v
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "4.1.0"          # required from v2.0 onward
+methodology_version: "4.2.0"          # required from v2.0 onward
 
 id: ACTION_SCHED-PLATFORM-2026-1      # required — ACTION_SCHED-[<middle>-]<INTEGER>
 name: "Platform Launch 2026"          # required per CONTRACT.md §1.1
@@ -351,7 +351,7 @@ Both views are projections of the same underlying schedule. A document never "be
 ```yaml
 notation: action
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 id: ACTION_SCHED-MINIMAL-1
 name: "Minimal schedule example"           # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                # optional per CONTRACT.md §4

--- a/notations/views/diagrams/12-integration-map.md
+++ b/notations/views/diagrams/12-integration-map.md
@@ -45,7 +45,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   # ... see §3
 ```
@@ -86,7 +86,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Enterprise integration landscape"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: INTEGRATION_MAP-ENTERPRISE-1
@@ -169,7 +169,7 @@ notation: integration-map
 spec_version: "0.1"
 name: "Full integration map"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   id: INTEGRATION_MAP-ALL-1
   name: "Full integration map"

--- a/notations/views/documents/29-mrd.md
+++ b/notations/views/documents/29-mrd.md
@@ -45,7 +45,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Incident status communication — MRD"   # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: MRD-INCIDENT-STATUS-1
@@ -168,7 +168,7 @@ notation: mrd
 spec_version: "0.1"
 name: "Full MRD — all needs"           # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"             # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   id: MRD-ALL-1
   name: "Full MRD — all needs"

--- a/notations/views/documents/30-srs.md
+++ b/notations/views/documents/30-srs.md
@@ -45,7 +45,7 @@ notation: srs
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   # ... see §3
 ```
@@ -97,7 +97,7 @@ notation: srs
 spec_version: "0.1"
 name: "Backup-power controller — SRS"          # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                     # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: SRS-BACKUP-POWER-1
@@ -158,7 +158,7 @@ notation: srs
 spec_version: "0.1"
 name: "Full SRS — all software-tier requirements"    # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                           # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   id: SRS-ALL-1
   name: "Full SRS — all software-tier requirements"

--- a/notations/views/documents/31-sdd.md
+++ b/notations/views/documents/31-sdd.md
@@ -45,7 +45,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   # ... see §3
 ```
@@ -101,7 +101,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Data export capability — SDD"          # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"                    # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: SDD-DATA-EXPORT-1
@@ -170,7 +170,7 @@ notation: sdd
 spec_version: "0.1"
 name: "Full SDD — all design elements"   # required per CONTRACT.md §1.1
 generated_at: "2026-08-04"               # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   id: SDD-ALL-1
   name: "Full SDD — all design elements"

--- a/notations/views/reports/11-scenarios.md
+++ b/notations/views/reports/11-scenarios.md
@@ -45,7 +45,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   # ... see §3
 ```
@@ -95,7 +95,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "Optimistic vs Conservative — 2027 cut"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                       # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: SCENARIOS-<NAME>-1
@@ -152,7 +152,7 @@ notation: scenarios
 spec_version: "0.3"
 name: "All scenarios"                   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   id: SCENARIOS-ALL-1
   name: "All scenarios"

--- a/notations/views/reports/21-compliance-impact.md
+++ b/notations/views/reports/21-compliance-impact.md
@@ -45,7 +45,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   # ... see §3
 ```
@@ -104,7 +104,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Retail product — GDPR obligations"   # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: COMPLIANCE_IMPACT-RETAIL-GDPR-1
@@ -191,7 +191,7 @@ notation: compliance-impact
 spec_version: "0.1"
 name: "Full compliance matrix"          # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   id: COMPLIANCE_IMPACT-ALL-1
   name: "Full compliance matrix"

--- a/notations/views/reports/22-coverage-metric.md
+++ b/notations/views/reports/22-coverage-metric.md
@@ -45,7 +45,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   # ... see §3
 ```
@@ -99,7 +99,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Retail product — regime coverage"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: COVERAGE_METRIC-RETAIL-1
@@ -199,7 +199,7 @@ notation: coverage-metric
 spec_version: "0.1"
 name: "Full coverage metric"            # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   id: COVERAGE_METRIC-ALL-1
   name: "Full coverage metric"

--- a/notations/views/reports/24-rules-in-force.md
+++ b/notations/views/reports/24-rules-in-force.md
@@ -45,7 +45,7 @@ notation: rules-in-force
 spec_version: "0.1"
 name: "Human-readable title"    # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"      # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   # ... see §3
 ```
@@ -94,7 +94,7 @@ notation: rules-in-force
 spec_version: "0.1"
 name: "Rules in force"                      # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"                  # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 view:
   id: RULES_IN_FORCE-ALL-1
@@ -163,7 +163,7 @@ notation: rules-in-force
 spec_version: "0.1"
 name: "Rules in force"                 # required per CONTRACT.md §1.1
 generated_at: "YYYY-MM-DD"             # optional per CONTRACT.md §4
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 view:
   id: RULES_IN_FORCE-ALL-1
   name: "Rules in force"

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -27,7 +27,7 @@
 # the ingest CLI needs to place and validate it.
 
 # Must equal notations/CURRENT_VERSION.yaml (enforced by check V1).
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 # ---------------------------------------------------------------------------
 # Element TYPE registry — ELEMENT_PRIMITIVES.md §4 (mode table) and §6 (layer

--- a/packages/ingest-cli/src/coverage-presets.mjs
+++ b/packages/ingest-cli/src/coverage-presets.mjs
@@ -23,7 +23,7 @@
 // notations/CURRENT_VERSION.yaml, or when the tables below stop matching the §3 / §3.1
 // tables they encode. A release PR that bumps the pin and not this file cannot go green.
 
-export const PRESETS_VERSION = '4.1.0';
+export const PRESETS_VERSION = '4.2.0';
 
 export const LAYERS = ['01_motivation', '02_business', '03_application', '04_technology', '05_implementation'];
 

--- a/transitrix/skills/feedback/SKILL.md
+++ b/transitrix/skills/feedback/SKILL.md
@@ -179,7 +179,7 @@ element"* — which passes.
    ---
    ### FB-0003
    type: notation-gap
-   methodology_version: "4.1.0"
+   methodology_version: "4.2.0"
    raised_by: Modeler
    date: "2026-07-28"
    status: open

--- a/transitrix/skills/onboard/templates/AGENTS.md
+++ b/transitrix/skills/onboard/templates/AGENTS.md
@@ -158,7 +158,7 @@ The root `transitrix.yaml` pins which methodology release this repo conforms to 
 
 ```yaml
 transitrix: 1
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 notations: [dgca, goals, activities, issues, capability-map, codex]
 zones: [canon, field, codex]
 ```

--- a/transitrix/skills/onboard/templates/action.action.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/action.action.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: action
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 # Action schedule — pure projection over standalone ACTION elements.
 # Spec: notations/views/diagrams/07-action.md (v2.0). No action data is authored inline.

--- a/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/coverage-metric.coverage-metric.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: coverage-metric
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 # Coverage Metric. Spec: notations/views/reports/22-coverage-metric.md
 # Report-config over the coverage read of canon (sibling of Compliance Impact).

--- a/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/goals.goals.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: goals
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 # Goals tree — pure projection over standalone GOAL elements.
 # Spec: notations/views/diagrams/04-goals.md (v2.0). No element data is authored inline.

--- a/transitrix/skills/onboard/templates/integration-map.integration-map.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/integration-map.integration-map.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: integration-map
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 # Integration Map. Spec: notations/views/diagrams/12-integration-map.md
 # Application-cooperation / data-flow graph, projected from admitted

--- a/transitrix/skills/onboard/templates/rules-in-force.rules-in-force.transitrix.yaml
+++ b/transitrix/skills/onboard/templates/rules-in-force.rules-in-force.transitrix.yaml
@@ -1,6 +1,6 @@
 notation: rules-in-force
 spec_version: "0.1"
-methodology_version: "4.1.0"
+methodology_version: "4.2.0"
 
 # Rules in Force. Spec: notations/views/reports/24-rules-in-force.md
 # Report-config over the codex zone itself (sibling of Compliance Impact and


### PR DESCRIPTION
## Summary

MINOR release since the 4.1.0 pin. Highest change is a new catalogued TYPE (`STANDARD`, THQ-318 / #539). Additive: a repo that never admits a `STANDARD` validates as on 4.1.0. No migration recipe.

Also in this window (ride along):

- #534 plugin `--check` CRLF / document-view mention
- #535 unknown `view`/`figure` attributes → `TTRS-002`
- #536 `lint.py` `from`/`to` as errors; drop empty ArchiMate pass
- #537 reg-intel `scan-sources.yaml` + date checks
- #538 batch-path `run_id` (no silent overwrite)

## Changes

- `notations/CURRENT_VERSION.yaml` and `PRESETS_VERSION`: 4.1.0 → 4.2.0
- `CHANGELOG.md` `[4.2.0]`
- Concrete `methodology_version:` pins (V1). `node scripts/check-notations.mjs` exits 0 (SIZE1 / CAT-001 warnings only, same as before)

## Public surface / consumer

Adopters receive the GitHub Release, tag `v4.2.0`, and notes. Specs, vocabulary, ingest-cli `--type STANDARD`, and onboard templates already on `main` become the contract of that tag.

## Not in this PR

`transitrix/acme-corp` pin is still `4.0.0`. Companion bump after this tag exists (Discovery / human-ratified pin). Do not merge a pin to an untagged version.

## Test plan

- [x] `node scripts/check-notations.mjs` clean (exit 0)
- [ ] After merge: tag `v4.2.0` on the merge commit and publish the GitHub Release