### PR TITLE
feat(lint): validate inline element field references

### DIFF
--- a/tests/fixtures/inline-refs-dangling-parent/canon/elements/child-elem.yaml
+++ b/tests/fixtures/inline-refs-dangling-parent/canon/elements/child-elem.yaml
@@ -1,0 +1,6 @@
+id: CHILD-001
+type: ACTIVITY
+display_name: Child Activity
+parent: PARENT-DOES-NOT-EXIST-9
+metadata:
+  status: Active

--- a/tests/fixtures/inline-refs-dangling-parent/canon/elements/parent-elem.yaml
+++ b/tests/fixtures/inline-refs-dangling-parent/canon/elements/parent-elem.yaml
@@ -1,0 +1,5 @@
+id: PARENT-001
+type: ACTIVITY
+display_name: Parent Activity
+metadata:
+  status: Active

--- a/tests/fixtures/inline-refs-valid/canon/elements/child-elem.yaml
+++ b/tests/fixtures/inline-refs-valid/canon/elements/child-elem.yaml
@@ -1,0 +1,6 @@
+id: CHILD-001
+type: ACTIVITY
+display_name: Child Activity
+parent: PARENT-001
+metadata:
+  status: Active

--- a/tests/fixtures/inline-refs-valid/canon/elements/parent-elem.yaml
+++ b/tests/fixtures/inline-refs-valid/canon/elements/parent-elem.yaml
@@ -1,0 +1,5 @@
+id: PARENT-001
+type: ACTIVITY
+display_name: Parent Activity
+metadata:
+  status: Active

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -8,10 +8,30 @@ import os
 import sys
 import yaml
 import glob
+import subprocess
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 from dataclasses import dataclass
 
+__version__ = "4.2.0"
+
+def _get_version() -> str:
+    """Get linter version, attempting to read from git tag if in a repo."""
+    try:
+        repo_root = os.getenv("REPO_ROOT", ".")
+        result = subprocess.run(
+            ["git", "-C", repo_root, "describe", "--tags", "--abbrev=0"],
+            capture_output=True,
+            text=True,
+            timeout=2
+        )
+        if result.returncode == 0:
+            tag = result.stdout.strip()
+            # Strip 'v' prefix if present (e.g. v4.2.0 -> 4.2.0)
+            return tag.lstrip('v')
+    except (subprocess.TimeoutExpired, Exception):
+        pass
+    return __version__
 
 def _ensure_utf8_stdio() -> None:
     # A legacy Windows console code page (e.g. cp1252) can't encode the status
@@ -42,7 +62,8 @@ class TransitrixLinter:
 
     def run(self) -> bool:
         """Run all validation checks. Returns True if no errors found."""
-        print("🔍 Transitrix Linter v1.0")
+        version = _get_version()
+        print(f"🔍 Transitrix Linter v{version}")
         print(f"📂 Scanning: {self.repo_root}")
         print()
 
@@ -204,11 +225,6 @@ class TransitrixLinter:
                     message=f"Referential integrity: Relation uses deprecated 'source'/'target' fields (use 'from' and 'to')",
                     severity="error"
                 ))
-
-    def _check_semantic_rules(self):
-        """Validate semantic constraints (e.g., layer-appropriate relations)."""
-        # Example: ApplicationComponent should not directly serve BusinessRole without an Interface
-        pass
 
     def _check_policies(self):
         """Check organizational policies (e.g., Active elements must have owner)."""

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -169,7 +169,8 @@ class TransitrixLinter:
                 ))
 
     def _check_referential_integrity(self):
-        """Verify 'from' and 'to' references point to existing elements."""
+        """Verify element and relation references point to existing elements."""
+        # Check relation from/to references
         for rel_id, relation_data in self.relations.items():
             from_id = relation_data.get('from')
             to_id = relation_data.get('to')
@@ -225,6 +226,33 @@ class TransitrixLinter:
                     message=f"Referential integrity: Relation uses deprecated 'source'/'target' fields (use 'from' and 'to')",
                     severity="error"
                 ))
+
+        # Check inline element field references
+        inline_ref_fields = ['parent', 'goals', 'delivers_changes', 'predecessors', 'owner_role']
+        for element_id, element_data in self.elements.items():
+            for field in inline_ref_fields:
+                if field not in element_data:
+                    continue
+
+                ref_value = element_data[field]
+                # Handle both single ID strings and lists of IDs
+                ref_ids = [ref_value] if isinstance(ref_value, str) else (ref_value if isinstance(ref_value, list) else [])
+
+                for ref_id in ref_ids:
+                    if not isinstance(ref_id, str):
+                        self.errors.append(LintError(
+                            file=f"canon/elements/*/{element_id}.yaml",
+                            line=0,
+                            message=f"Referential integrity: Element '{element_id}' field '{field}' contains non-string ID: {type(ref_id).__name__}",
+                            severity="error"
+                        ))
+                    elif ref_id not in self.elements:
+                        self.errors.append(LintError(
+                            file=f"canon/elements/*/{element_id}.yaml",
+                            line=0,
+                            message=f"Referential integrity: Element '{element_id}' field '{field}' references non-existent element '{ref_id}'",
+                            severity="error"
+                        ))
 
     def _check_policies(self):
         """Check organizational policies (e.g., Active elements must have owner)."""


### PR DESCRIPTION
## Summary
Inline fields on elements (parent, goals, delivers_changes, predecessors, owner_role) are now resolved during Phase 4 referential integrity checks. A missing reference causes validation to fail with a clear error message.

- Add validation for inline element field references
- Detect dangling references (e.g., parent: ID-DOES-NOT-EXIST)
- Fixtures demonstrating valid and invalid references

Depends on PR #542 for the version and phase 5 cleanup.

🤖 Generated with Claude Code