### PR TITLE
feat(rule-codes): rename repo-scope rules FGCA → DGCA-REPO, deprecate to 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [4.3.0] — 2026-08-30
+
+Bump category: **MINOR** — all changes are additive; the renamed rule codes are backward-compatible with aliases accepted through 4.x. No migration recipe: existing validators accept both the old codes and the new ones through 5.0.0.
+
+### Added
+
+- **`DGCA-REPO-008..011` — renamed repo-scope rules, formerly `FGCA-008..011`.** The codes print DGCA-REPO-008 (GOAL's missing DRIVER), DGCA-REPO-009 (CHANGE's missing GOAL), DGCA-REPO-010 (ACTION's missing CHANGE), DGCA-REPO-011 (ACTION's missing GOAL). Accepted aliases: `FGCA-008..011` resolve to the new codes through 5.0.0 (`notations/vocabulary.yaml`, `notations/views/diagrams/02-dgca.md` § Cross-element validation rules).
+
+### Deprecated
+
+- **`FGCA-008..011` — accepted aliases for `DGCA-REPO-008..011`, deprecated in favor of the renamed codes. Removal release: 5.0.0.** A tooling finding naming `FGCA-008` and the adopter's own validator accepting it read as the same finding; at 5.0.0 the old codes stop being recognized.
+- **`FGCA-012..014` — deprecated without replacement. Removal release: 5.0.0.** These three warnings (unreferenced driver, unreferenced goal, unreferenced change) are becoming a coverage observation rather than a per-element finding; the per-element codes are being retired. The observation lands under a separate code.
+
+---
+
 ## [Unreleased]
 
 ### Added

--- a/notations/views/diagrams/02-dgca.md
+++ b/notations/views/diagrams/02-dgca.md
@@ -397,13 +397,13 @@ The rules below apply when validating the **canonical element files** (`canon/el
 
 | Rule | Severity | Description |
 |---|---|---|
-| `FGCA-008` | error | GOAL element carries `factors: [DRIVER-…]` entry that does not resolve to an admitted DRIVER element in canon. |
-| `FGCA-009` | error | CHANGE element carries `goals: [GOAL-…]` entry that does not resolve to an admitted GOAL element in canon. |
-| `FGCA-010` | error | ACTION element carries `delivers_changes: [CHANGE-…]` entry that does not resolve to an admitted CHANGE element in canon. |
-| `FGCA-011` | error | ACTION element carries `goals: [GOAL-…]` entry that does not resolve to an admitted GOAL element in canon. |
-| `FGCA-012` | warning | DRIVER element is not referenced by any `GOAL.factors[]` across canon (unreferenced driver). Advisory; does not indicate an error. |
-| `FGCA-013` | warning | GOAL element is not referenced by any `CHANGE.goals[]` or `ACTION.goals[]` across canon (unreferenced goal). Advisory; does not indicate an error. |
-| `FGCA-014` | warning | CHANGE element is not referenced by any `ACTION.delivers_changes[]` across canon (unreferenced change). Advisory; does not indicate an error. |
+| `DGCA-REPO-008` | error | GOAL element carries `factors: [DRIVER-…]` entry that does not resolve to an admitted DRIVER element in canon. Accepted alias: `FGCA-008` (deprecated, removed at 5.0.0). |
+| `DGCA-REPO-009` | error | CHANGE element carries `goals: [GOAL-…]` entry that does not resolve to an admitted GOAL element in canon. Accepted alias: `FGCA-009` (deprecated, removed at 5.0.0). |
+| `DGCA-REPO-010` | error | ACTION element carries `delivers_changes: [CHANGE-…]` entry that does not resolve to an admitted CHANGE element in canon. Accepted alias: `FGCA-010` (deprecated, removed at 5.0.0). |
+| `DGCA-REPO-011` | error | ACTION element carries `goals: [GOAL-…]` entry that does not resolve to an admitted GOAL element in canon. Accepted alias: `FGCA-011` (deprecated, removed at 5.0.0). |
+| `FGCA-012` | warning | Deprecated. DRIVER element is not referenced by any `GOAL.factors[]` across canon (unreferenced driver). This becomes a coverage observation; no successor code. Removed at 5.0.0. |
+| `FGCA-013` | warning | Deprecated. GOAL element is not referenced by any `CHANGE.goals[]` or `ACTION.goals[]` across canon (unreferenced goal). This becomes a coverage observation; no successor code. Removed at 5.0.0. |
+| `FGCA-014` | warning | Deprecated. CHANGE element is not referenced by any `ACTION.delivers_changes[]` across canon (unreferenced change). This becomes a coverage observation; no successor code. Removed at 5.0.0. |
 
 ---
 

--- a/notations/vocabulary.yaml
+++ b/notations/vocabulary.yaml
@@ -369,6 +369,32 @@ deprecated_relation_types:
     rule: ACTION-005
 
 # ---------------------------------------------------------------------------
+# Retired rule CODE names. A deprecated code carries `removed_in`, the release
+# that ends the deprecation window; a code that has a successor names it with
+# `replaced_by`. An entry carries `removed_in` on every code, since a deprecation
+# with no stated end is not a deprecation.
+# ---------------------------------------------------------------------------
+deprecated_rule_codes:
+  FGCA-008:
+    replaced_by: DGCA-REPO-008
+    removed_in: "5.0.0"
+  FGCA-009:
+    replaced_by: DGCA-REPO-009
+    removed_in: "5.0.0"
+  FGCA-010:
+    replaced_by: DGCA-REPO-010
+    removed_in: "5.0.0"
+  FGCA-011:
+    replaced_by: DGCA-REPO-011
+    removed_in: "5.0.0"
+  FGCA-012:
+    removed_in: "5.0.0"
+  FGCA-013:
+    removed_in: "5.0.0"
+  FGCA-014:
+    removed_in: "5.0.0"
+
+# ---------------------------------------------------------------------------
 # Closed value vocabularies. Keyed `<owner>.<field>` where `<owner>` is the
 # element TYPE, relation kind, or artefact that carries the field. A field whose
 # enum is explicitly open (e.g. BUSINESS_OBJECT.type, §7.15) is NOT listed here —
@@ -958,6 +984,18 @@ rule_codes:
   DGCA-018:
     severity: warning
     spec: notations/views/diagrams/02-dgca.md
+  DGCA-REPO-008:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-REPO-009:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-REPO-010:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-REPO-011:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
   ELEM-001:
     severity: error
     spec: notations/ELEMENT_PRIMITIVES.md
@@ -988,18 +1026,6 @@ rule_codes:
   FRESHNESS-001:
     severity: warning
     spec: notations/CONTRACT.md
-  FGCA-008:
-    severity: error
-    spec: notations/views/diagrams/02-dgca.md
-  FGCA-009:
-    severity: error
-    spec: notations/views/diagrams/02-dgca.md
-  FGCA-010:
-    severity: error
-    spec: notations/views/diagrams/02-dgca.md
-  FGCA-011:
-    severity: error
-    spec: notations/views/diagrams/02-dgca.md
   FGCA-012:
     severity: warning
     spec: notations/views/diagrams/02-dgca.md


### PR DESCRIPTION
## Summary

- Add `DGCA-REPO-008..011` rule codes to replace `FGCA-008..011`
- Deprecate `FGCA-008..011` with removal in 5.0.0; validators accept both code names through 4.x
- Deprecate `FGCA-012..014` without replacement (become coverage observations); removal in 5.0.0
- Update spec table and CHANGELOG per decision on transitrix-hq#409 (Valerii decided 2026-08-30)

## Acceptance

- ✅ `DGCA-REPO-008..011` added to `notations/vocabulary.yaml` `rule_codes:`
- ✅ `deprecated_rule_codes:` section created for all `FGCA-0xx`
- ✅ `notations/views/diagrams/02-dgca.md` table updated with new codes + deprecated aliases
- ✅ `CHANGELOG.md` records Added/Deprecated entries under 4.3.0
- ✅ `scripts/check-notations.mjs` passes VOC4 check
- ✅ Backward-compatible: validators accept both old and new code names through 5.0.0

## Related

- Task: transitrix-hq#416
- Decision: transitrix-hq#409 (Valerii 2026-08-30)
- Gates: #417, #418, #419 in other projects

🤖 Generated with Claude Code