### PR TITLE
fix(goals-tree): level 0 is the top goal, not the organisation's vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Bump category: **MINOR** — all changes are additive; the renamed rule codes ar
 ### Fixed
 
 - **`tools/lint.py` validates inline element field references** (`parent`, `goals`, `delivers_changes`, `predecessors`, `owner_role`): a missing target or a non-string ID is an error, same grain as relation `from`/`to`.
+- **`notations/views/diagrams/04-goals.md` — goal tree level 0 description clarified.** §7.1 table no longer describes level 0 as the organisation's vision (which moved to `ORGANIZATION` element type); level 0 is now described as the top goal.
 
 ---
 

--- a/notations/views/diagrams/04-goals.md
+++ b/notations/views/diagrams/04-goals.md
@@ -221,7 +221,7 @@ The hierarchy depth is **not hardcoded** — it is configured in the `view_confi
 
 | Level | Name | Scope |
 |:---:|---|---|
-| **0** | Strategy | Single root — the organisation's overall vision |
+| **0** | Strategy | Single root — the top goal |
 | **1** | Strategic Intention | Broad areas of focus |
 | **2** | Strategic Goal | Measurable strategic milestones |
 | **3** | Business Goal | Department / unit level outcomes |


### PR DESCRIPTION
## Summary

Clarify that the Goals Tree notation's level 0 represents the top goal in the hierarchy, not the organisation's vision (which is now held separately on the ORGANIZATION element type).

- **Section:** notations/views/diagrams/04-goals.md §7.1
- **Change:** Updated the level 0 table entry description from "the organisation's overall vision" to "the top goal"
- **Changelog:** Added entry to [Unreleased] section

Purely clarifying. No field changes, no spec restructuring, no validator changes. A repository without a separate ORGANIZATION element continues to validate as before.