### PR TITLE
feat(integration): pin PlantUML version 1.2026.6 across all surfaces

### DIFF
--- a/.github/workflows/plantuml-version-check.yml
+++ b/.github/workflows/plantuml-version-check.yml
@@ -1,0 +1,34 @@
+name: PlantUML version check
+
+# Ensures that the PlantUML version pinned in integration/plantuml.md matches
+# the version locked in transitrix/transitrix-studio's package-lock.json.
+#
+# The adopter guide must stay in sync with Studio's bundled engine to ensure
+# reproducible rendering across VS Code / JetBrains / CI.
+#
+# CI is red on drift — the check exits non-zero and the job fails.
+
+on:
+  pull_request:
+    paths:
+      - 'integration/plantuml.md'
+  workflow_dispatch:
+  schedule:
+    # Mondays 09:10 UTC — weekly safety net for drift introduced via
+    # direct-commit changes to main that bypass PR review.
+    - cron: '10 9 * * 1'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check PlantUML version consistency
+        run: node scripts/check-plantuml-version.mjs

--- a/integration/plantuml.md
+++ b/integration/plantuml.md
@@ -6,7 +6,7 @@ An adopter repository may use [PlantUML](https://plantuml.com) for supplementary
 
 ## 1. Install the extension
 
-**VS Code:** Transitrix Studio renders `.puml` files natively — no separate PlantUML extension needed. If you have followed [`GETTING_STARTED.md`](../GETTING_STARTED.md), Studio (`transitrix.transitrix-studio`) is already installed. Open any `.puml` file and run **Transitrix: Preview PlantUML** from the Command Palette (`Ctrl+Shift+P` → `transitrixStudio.previewPuml`).
+**VS Code:** Transitrix Studio renders `.puml` files natively — no separate PlantUML extension needed. If you have followed [`GETTING_STARTED.md`](../GETTING_STARTED.md), Studio (`transitrix.transitrix-studio`) is already installed, bundling PlantUML `1.2026.6`. Open any `.puml` file and run **Transitrix: Preview PlantUML** from the Command Palette (`Ctrl+Shift+P` → `transitrixStudio.previewPuml`).
 
 **JetBrains (IntelliJ IDEA, PyCharm, …):** install "PlantUML Integration" by Eugene Steinberg from the JetBrains Marketplace (`com.github.eightpillow.plantuml`).
 
@@ -44,7 +44,7 @@ The theme file (`diagrams/transitrix-theme.puml`) does two things:
 
 1. Download the pinned JAR:
    ```
-   https://github.com/plantuml/plantuml/releases/download/v1.2024.8/plantuml-1.2024.8.jar
+   https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar
    ```
    Save it to `.plantuml/plantuml.jar` (gitignored; each contributor downloads once).
 

--- a/scripts/check-plantuml-version.mjs
+++ b/scripts/check-plantuml-version.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that:
+ * 1. All PlantUML version strings in integration/plantuml.md are identical
+ * 2. The version matches what's locked in transitrix/transitrix-studio package-lock.json
+ *
+ * Exits non-zero if any check fails.
+ */
+
+import fs from 'fs';
+import https from 'https';
+import { createReadStream } from 'fs';
+
+// Extract version from integration/plantuml.md
+const guidePath = 'integration/plantuml.md';
+const guideContent = fs.readFileSync(guidePath, 'utf8');
+
+// Find all PlantUML version references in the guide
+// Looking for patterns like "1.2024.8" or "1.2026.6"
+const versionPattern = /1\.2\d{3}\.\d+/g;
+const versionsInGuide = [...new Set(guideContent.match(versionPattern) || [])];
+
+console.log('PlantUML versions found in integration/plantuml.md:');
+versionsInGuide.forEach(v => console.log(`  ${v}`));
+
+if (versionsInGuide.length === 0) {
+  console.error('ERROR: No PlantUML version found in integration/plantuml.md');
+  process.exit(1);
+}
+
+if (versionsInGuide.length > 1) {
+  console.error(`ERROR: Multiple different PlantUML versions found in guide:`);
+  versionsInGuide.forEach(v => console.error(`  ${v}`));
+  process.exit(1);
+}
+
+const guideVersion = versionsInGuide[0];
+console.log(`Guide version: ${guideVersion}`);
+
+// Fetch Studio's package-lock.json to get the canonical version
+console.log('\nFetching transitrix-studio package-lock.json...');
+
+const url = 'https://raw.githubusercontent.com/transitrix/transitrix-studio/main/package-lock.json';
+let lockfileContent = '';
+
+https.get(url, (res) => {
+  if (res.statusCode !== 200) {
+    console.error(`ERROR: Failed to fetch Studio lockfile (status ${res.statusCode})`);
+    process.exit(1);
+  }
+
+  res.on('data', (chunk) => {
+    lockfileContent += chunk;
+  });
+
+  res.on('end', () => {
+    try {
+      const lockfile = JSON.parse(lockfileContent);
+      const plantumlNode = lockfile.packages?.['node_modules/@plantuml/core'];
+
+      if (!plantumlNode || !plantumlNode.version) {
+        console.error('ERROR: Could not extract PlantUML version from Studio lockfile');
+        process.exit(1);
+      }
+
+      const studioVersion = plantumlNode.version;
+      console.log(`Studio version: ${studioVersion}`);
+
+      // Compare versions
+      if (guideVersion !== studioVersion) {
+        console.error(`\nERROR: Version mismatch!`);
+        console.error(`  Guide has: ${guideVersion}`);
+        console.error(`  Studio has: ${studioVersion}`);
+        console.error('\nUpdate integration/plantuml.md to match Studio\'s lockfile.');
+        process.exit(1);
+      }
+
+      console.log('\n✓ All PlantUML versions match');
+      process.exit(0);
+    } catch (err) {
+      console.error(`ERROR: Failed to parse Studio lockfile: ${err.message}`);
+      process.exit(1);
+    }
+  });
+}).on('error', (err) => {
+  console.error(`ERROR: Failed to fetch Studio lockfile: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Synchronize PlantUML version across all surfaces to match transitrix/transitrix-studio's locked version (1.2026.6).

## Changes

- Update integration/plantuml.md to document PlantUML 1.2026.6 everywhere (VS Code bundled, JetBrains JAR, CI)
- Add scripts/check-plantuml-version.mjs to validate version consistency
- Add .github/workflows/plantuml-version-check.yml to run check on every PR and weekly

## Acceptance

- [x] All PlantUML version strings in guide are identical (1.2026.6)
- [x] Version matches transitrix-studio's @plantuml/core in package-lock.json
- [x] Mechanical check fails if guide versions disagree or Studio version changes
- [x] New workflow runs on plantuml.md edits and weekly schedule

Closes transitrix-hq#482