### PR TITLE
spec(feedback): raised_by records adopter's own role, not closed list

### DIFF
--- a/method/06-team-operations.md
+++ b/method/06-team-operations.md
@@ -124,7 +124,7 @@ Fields:
 - `id` — `FB-NNNN`, carried by the entry's `###` heading (not repeated as a YAML key inside the block). Four-digit zero-padded. **Default (single-writer):** monotonically increasing within the single `operations/feedback/feedback.md` journal file. **Multi-writer variant:** when multiple concurrent writers are in use, the partition scheme (per-author ranges or equivalent) MUST be specified in the adopter's local `operations/README.md`.
 - `type` — `notation-gap` | `tooling-friction` | `doc-gap` | `model-suggestion` (below).
 - `methodology_version` — **required**. A finding is always raised against a specific methodology version; record the one the repo's `transitrix.yaml` pins at the time.
-- `raised_by` — the role that raised it: `Ingest` | `Modeler` | `Analyst` | `Validator`, per `FINDINGS.md` §3.
+- `raised_by` — the adopter's own role that raised the finding. Any role the adopter's model admits is valid. The four shipped role guides (`Ingest`, `Modeler`, `Analyst`, `Validator`) are defaults and examples; an adopter with a richer role model uses their own role names.
 - `date` — ISO date the entry was written.
 - `status` — `open` | `triaged` | `resolved-locally` | `sent-upstream` | `answered` | `closed` | `wont-fix` (below).
 - `upstream` — `not-sent` | `sent <date>` | `answered <date>` (below).

--- a/transitrix/skills/feedback/SKILL.md
+++ b/transitrix/skills/feedback/SKILL.md
@@ -126,9 +126,10 @@ Extract, conversationally, in this order:
    made this harder than it should be" (`tooling-friction`), "the docs didn't say" or
    said something wrong (`doc-gap`), "this works but could be guided better"
    (`model-suggestion`).
-4. **`raised_by`** — the role that raised it: `Ingest` | `Modeler` | `Analyst` |
-   `Validator` (if this skill is being invoked as the tail end of `FINDINGS.md`'s
-   protocol from one of those roles), or ask the user directly if invoked standalone.
+4. **`raised_by`** — the adopter's own role that raised the finding. Any role the
+   adopter's model admits is valid. If this skill is invoked as the tail end of
+   `FINDINGS.md`'s protocol from one of the four shipped guides (`Ingest`, `Modeler`,
+   `Analyst`, `Validator`), use that role name; if invoked standalone, ask the user directly.
 5. **`proposed`** (optional) — what the team believes the fix would be.
 
 State your understanding back before composing the entry — the scrub gate in Step 3

--- a/transitrix/skills/onboard/templates/FINDINGS.md
+++ b/transitrix/skills/onboard/templates/FINDINGS.md
@@ -36,7 +36,7 @@ No role auto-applies its own proposed fill. Raising a finding is never itself a 
 
 ```yaml
 type: data-error | model-suggestion | methodology-feedback
-raised_by: <role>              # Ingest | Modeler | Analyst | Validator
+raised_by: <role>              # the role that authored this finding — any role the adopter's model admits
 subject: <element/artefact ID or area, e.g. CAPABILITY-V2 or "GOAL relation kinds">
 confidence: structural | business-judgement
 observation: <what was seen, in plain language>


### PR DESCRIPTION
## Summary

The Feedback Record's `raised_by` field now accepts any role the adopter's model admits, not only the four shipped guides (`Ingest`, `Modeler`, `Analyst`, `Validator`). The four guides remain defaults and examples; an adopter with a richer role model uses their own role names.

**Closes transitrix-hq#486**

## Changes

- Updated field descriptions in `method/06-team-operations.md` §3.2 to clarify `raised_by` records the adopter's own role that did the work
- Updated `FINDINGS.md` §3 (onboard template) to remove the closed list
- Updated feedback skill `SKILL.md` Step 2 to allow any role and clarify the new meaning

## Acceptance

- ✓ An entry whose `raised_by` is a role the adopter's model admits is valid
- ✓ An adopter using only the four shipped guides still writes those four names
- ✓ Examples and onboard template still show the four shipped guides as defaults
- ✓ Specification clearly states which of the two the field records in one sentence