### PR TITLE
docs(integration): clarify PlantUML rendering is VS Code capability

### DIFF
--- a/integration/plantuml.md
+++ b/integration/plantuml.md
@@ -8,7 +8,7 @@ An adopter repository may use [PlantUML](https://plantuml.com) for supplementary
 
 **VS Code:** Transitrix Studio renders `.puml` files natively — no separate PlantUML extension needed. If you have followed [`GETTING_STARTED.md`](../GETTING_STARTED.md), Studio (`transitrix.transitrix-studio`) is already installed. Open any `.puml` file and run **Transitrix: Preview PlantUML** from the Command Palette (`Ctrl+Shift+P` → `transitrixStudio.previewPuml`).
 
-**JetBrains (IntelliJ IDEA, PyCharm, …):** install "PlantUML Integration" by Eugene Steinberg from the JetBrains Marketplace (`com.github.eightpillow.plantuml`).
+**JetBrains (IntelliJ IDEA, PyCharm, …):** install "PlantUML Integration" by Eugene Steinberg from the JetBrains Marketplace (`com.github.eightpillow.plantuml`). PlantUML rendering is a Transitrix Studio capability for VS Code only; this is a deliberate design choice.
 
 **Recommended VS Code workspace extensions** are listed in the repo's `.vscode/extensions.json` — VS Code will prompt you to install them when you open the repo.
 


### PR DESCRIPTION
## Summary

Explains that PlantUML rendering in Transitrix Studio is a VS Code–only feature by deliberate design, not a gap awaiting a JetBrains implementation.

Per transitrix-hq#484:
- Adds one sentence to `integration/plantuml.md` §JetBrains explaining the architectural split
- Does not change the version pin (that's transitrix-hq#482, already merged)
- Clarifies this is a decided design choice, not a future enhancement

## Acceptance criteria

- [x] §JetBrains still names the third-party plugin
- [x] One sentence states the split as decided, not as a missing feature  
- [x] The PlantUML version strings in the file are untouched