### PR TITLE
wire documents package removal integrity test

### DIFF
--- a/.github/workflows/documents-cli-test.yml
+++ b/.github/workflows/documents-cli-test.yml
@@ -1,0 +1,41 @@
+name: Documents package test
+
+# Integration test for @transitrix/documents-cli + the Documents domain package's
+# worked examples (notations/packages/documents.md, packages/documents-cli/).
+# Deterministic, no API key. Drives the real CLI end-to-end against the
+# worked fixture (validate, removal integrity — test_documents_integrity.py).
+
+on:
+  pull_request:
+    paths:
+      - 'packages/documents-cli/**'
+      - 'notations/packages/documents.md'
+      - 'notations/examples/packages/documents/**'
+      - '.github/workflows/documents-cli-test.yml'
+  workflow_dispatch:
+  schedule:
+    # Mondays 09:50 UTC — weekly safety net, offset from other package test runs
+    - cron: '50 9 * * 1'
+
+jobs:
+  integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Run Documents package integrity test
+        run: python packages/documents-cli/tests/test_documents_integrity.py

--- a/AUDIT_DOCUMENTS_REFERENCES.md
+++ b/AUDIT_DOCUMENTS_REFERENCES.md
@@ -1,0 +1,83 @@
+# Audit: Documents Package Reference Direction
+
+**Task:** transitrix-hq#533 — audit package→canon reference direction for documents package  
+**Date:** 2026-09-02  
+**Status:** Complete — no violations found
+
+---
+
+## Scope
+
+This audit verifies that the newly declared documents package (per PR #567, transitrix-hq#506 epic) follows the one-way reference rule defined in PACKAGES.md §4.1:
+
+> **Reference direction:** Package objects may reference canonical material; canonical material must never reference package-specific types, validators, or removal procedures.
+
+For the documents package specifically, violations would include:
+1. Any canonical file (outside `packages/documents/`) that references document-package types (`doct-*`, `doc-*`)
+2. Any canonical recipe (`canon/views/`) that includes documents extension or validators
+3. Any snapshot or figure path that assumes documents package in place
+4. Existing imports/dependencies that violate the direction rule
+
+---
+
+## Method
+
+Systematic search across canonical material:
+
+1. **Canonical material searched:**
+   - `./notations/` — all spec files, views, examples (except package examples)
+   - `./integration/` — integration guides
+   - `./docs/` — documentation
+   - `./guides/` — operational guides
+   - `./method/` — methodology material
+
+2. **Search terms used:**
+   - Package object type IDs: `doct-*`, `doc-*`
+   - Package validator codes: `DOCS-001` through `DOCS-007`
+   - Package one-way reference: `canon_refs`
+   - Package folder path: `documents/` (filtered for false positives like `document-view`, `doc-lint`)
+   - Package CLI: `documents-cli`, `documents-validator`
+
+3. **Results reviewed for context:**
+   - All matches examined to distinguish true violations from:
+     - References to document VIEW specs (`views/documents/`) — permitted, part of canonical material
+     - References to document-view rendering notation — not a package reference
+     - Tool references (`doc-lint`) — not package-related
+     - Generic language ("documents you can", "documents are") — not type references
+
+---
+
+## Findings
+
+**Zero violations identified.**
+
+No canonical material references:
+- Document package object types (no `doct-*` or `doc-*` IDs in canonical files)
+- Document package validators (no `DOCS-*` codes in canonical material)
+- Document package folders (no `documents/` path references from canonical layer)
+- Document package specific fields (no `canon_refs` in canonical examples)
+
+---
+
+## Disposition
+
+**All violations: none.** Reference direction is correct as-is.
+
+The documents package correctly:
+- Declares its own spec in `notations/packages/documents.md` (package-level material)
+- Carries examples in `notations/examples/packages/documents/` (package-level examples, not canonical)
+- Implements validation only in `packages/documents-cli` (package-level tooling)
+- Defines one-way reference via `canon_refs` field (package→canon, never canon→package)
+
+No canonical material needs to move or be modified to achieve compliance with the package→canon reference rule.
+
+---
+
+## Ready for Next Phase
+
+Per task #533 acceptance criteria:
+- ✓ Audit complete with all violations identified (zero)
+- ✓ Violations documented with disposition (N/A — none found)
+- ✓ Ready for Part 3 (removal-test fixture) — removal test will verify these don't move back into canon
+
+Part 3 can proceed; the reference direction is clean.

--- a/AUDIT_DOCUMENTS_REFERENCES.md
+++ b/AUDIT_DOCUMENTS_REFERENCES.md
@@ -1,6 +1,5 @@
 # Audit: Documents Package Reference Direction
 
-**Task:** transitrix-hq#533 — audit package→canon reference direction for documents package  
 **Date:** 2026-09-02  
 **Status:** Complete — no violations found
 
@@ -8,7 +7,7 @@
 
 ## Scope
 
-This audit verifies that the newly declared documents package (per PR #567, transitrix-hq#506 epic) follows the one-way reference rule defined in PACKAGES.md §4.1:
+This audit verifies that the newly declared documents package follows the one-way reference rule defined in PACKAGES.md §4.1:
 
 > **Reference direction:** Package objects may reference canonical material; canonical material must never reference package-specific types, validators, or removal procedures.
 
@@ -75,9 +74,9 @@ No canonical material needs to move or be modified to achieve compliance with th
 
 ## Ready for Next Phase
 
-Per task #533 acceptance criteria:
+Audit acceptance criteria met:
 - ✓ Audit complete with all violations identified (zero)
 - ✓ Violations documented with disposition (N/A — none found)
-- ✓ Ready for Part 3 (removal-test fixture) — removal test will verify these don't move back into canon
+- ✓ Reference direction verified and documented
 
-Part 3 can proceed; the reference direction is clean.
+The reference direction is clean and ready for downstream phases.


### PR DESCRIPTION
**From: methodology.**

## Summary

Wire the documents package removal integrity test into CI.

## What this PR does

Adds workflow to run the documents package removal test on changes to:
- `packages/documents-cli/`
- `notations/packages/documents.md`
- `notations/examples/packages/documents/`
- The workflow itself

Test runs weekly (Monday 09:50 UTC) as a safety net.

## Test coverage

The test validates both parts of the removal integrity contract:
- **Part A (Removal is clean):** After deleting `documents/` folders and dropping from `packages:`, validation passes with zero leftover references
- **Part B (Absence is silent):** A repository that never declared the package is unaffected by the methodology change

Both parts pass:
```
[PASS] Part A: Removal leaves no trace
[PASS] Part B: Absence is truly silent
[PASS] All documents integrity tests passed
```

## Acceptance

- ✓ Removal test fixture created (test_documents_integrity.py, already complete)
- ✓ Positive case: package removal produces passing, document-free validation
- ✓ Negative case: virgin repo produces identical validation result
- ✓ Test wired into CI and documented (this PR)

The removal gate is closed: the documentary function is mechanically separate.