### PR TITLE
fix: feedback register version boundary (v4.3.0 → v5.0.0)

### DIFF
--- a/transitrix/skills/feedback/SKILL.md
+++ b/transitrix/skills/feedback/SKILL.md
@@ -60,9 +60,9 @@ The register is a directory with a journal file and optional attachment subfolde
 
 **Detect which layout the repo carries:**
 
-1. **New layout (v4.3.0+)** — `operations/feedback/` directory with `operations/feedback/feedback.md` inside:
+1. **New layout (v5.0.0+)** — `operations/feedback/` directory with `operations/feedback/feedback.md` inside:
    - Use it as-is. The journal carries all entries; attachment folders live at `operations/feedback/YYYYMMDD/` (one dated folder per attached finding).
-2. **Old layout (pre-v4.3.0)** — single file at `operations/feedback.md`:
+2. **Old layout (pre-v5.0.0)** — single file at `operations/feedback.md`:
    - The file is still valid and must be preserved. If this is the only register, continue using it; the old layout is still supported.
    - **Never migrate automatically**. If the repo has the old layout and you are asked to author an entry, check whether someone is simultaneously trying to create the new layout — if both exist or are being created at once, it's an error (see "Migration hazard" below).
 3. **Missing both** — a repo onboarded before the Feedback Record convention shipped, or one that hand-rolled its `operations/` folder, may not have either yet. Scaffold the **new layout** now:

--- a/transitrix/skills/onboard/SKILL.md
+++ b/transitrix/skills/onboard/SKILL.md
@@ -137,8 +137,8 @@ Additionally, write these generated files inline (no template):
 
 - `<repo-root>/README.md` — a minimal org stub. Three sections: (1) one-paragraph intro naming the repo purpose and linking to `github.com/transitrix/methodology`; (2) "Getting started" pointing newcomers at `AGENTS.md` and the `/transitrix:onboard` skill; (3) "Tooling" recommending the two VS Code extensions — **Transitrix Studio** (`transitrix.transitrix-studio`, VS Code Marketplace) for live Transitrix notation preview (including `.puml` files — no separate PlantUML extension needed), and **Markdown Preview Mermaid Support** (`bierner.markdown-mermaid`, VS Code Marketplace and Open VSX) for Mermaid diagram preview in Markdown files. Leave `ADOPTER-FILL-ME` placeholders for org name, purpose, and team.
 - **Feedback register — detect old layout, scaffold new layout** (`method/06-team-operations.md` §3.2). Before scaffolding, check whether the repo already has a feedback register:
-  - **If `operations/feedback.md` exists (pre-v4.3.0 single-file layout)**: preserve it as-is. Do not modify or migrate it automatically.
-  - **If `operations/feedback/feedback.md` exists (v4.3.0+ directory layout)**: use it as-is.
+  - **If `operations/feedback.md` exists (pre-v5.0.0 single-file layout)**: preserve it as-is. Do not modify or migrate it automatically.
+  - **If `operations/feedback/feedback.md` exists (v5.0.0+ directory layout)**: use it as-is.
   - **If neither exists (new repo)**: scaffold the **new directory layout**:
     - Create `operations/feedback/` directory.
     - Write `operations/feedback/feedback.md` with the empty register (same content as the old single-file layout, now held in the directory). A `# Feedback register` heading, a one-line pointer at `method/06-team-operations.md` §3.2 and the opt-in `hello@transitrix.com` submission route, and an empty `## Register` section — no entries; the first `FB-0001` is added the first time a finding is actually raised, not at scaffold time.
@@ -413,7 +413,7 @@ Each notation template carries the canonical `notation:` and `spec_version:` hea
 | Shared protocol — raising a finding | `templates/FINDINGS.md` | `<repo-root>/FINDINGS.md` |
 | GitHub Copilot pointer | `templates/copilot-instructions.md` | `<repo-root>/.github/copilot-instructions.md` |
 | VS Code extension recommendations | `templates/extensions.json` | `<repo-root>/.vscode/extensions.json` |
-| Upstream feedback register (empty) | *authored inline, no template* | `<repo-root>/operations/feedback/feedback.md` (new layout, v4.3.0+) or `<repo-root>/operations/feedback.md` (legacy single-file, pre-v4.3.0) |
+| Upstream feedback register (empty) | *authored inline, no template* | `<repo-root>/operations/feedback/feedback.md` (new layout, v5.0.0+) or `<repo-root>/operations/feedback.md` (legacy single-file, pre-v5.0.0) |
 
 The whole-repo validator (`.validators/lint.py` + `requirements.txt`) and the CI workflow (`.github/workflows/architecture-validate.yaml`) are **not** bundled templates — they are fetched from the methodology canon at scaffold time. See "Scaffold validation tooling + CI" in Step 2.
 


### PR DESCRIPTION
## Summary

Corrects the version boundary documented in feedback skills that describe the register layout change. The directory restructure shipped in 5.0.0, not a non-existent 4.3.0.

Addresses FB-0016 raised in PR #561.

## Changes

- `transitrix/skills/feedback/SKILL.md`: Lines 63, 65 — new layout v5.0.0+, old layout pre-v5.0.0
- `transitrix/skills/onboard/SKILL.md`: Lines 139–141, 416 — same boundary, stated in Step 2 (scaffold feedback register) and template table

An adopter pinned at 4.2.0 now correctly learns the single-file layout is current for them; one pinned at 5.0.0 finds the right boundary statement.

🤖 Generated with Claude Code