### PR TITLE
feat: landscape page layout for wide views

### DIFF
--- a/packages/document-renderer/PDF_RENDERING_ENGINE.md
+++ b/packages/document-renderer/PDF_RENDERING_ENGINE.md
@@ -133,7 +133,7 @@ Methodology provides a dependency-free module for generating paged-media CSS wit
 
 ### What the module provides
 
-- `generatePagedMediaCss(metadata)` — generates CSS with @page rules, running footer, and base typography
+- `generatePagedMediaCss(metadata)` — generates CSS with @page rules, running footer, landscape page detection, and base typography
 - `wrapHtmlForPrintRendering(html, metadata)` — wraps HTML content with embedded CSS for rendering
 
 ### Paged-media CSS features implemented
@@ -143,7 +143,8 @@ Methodology provides a dependency-free module for generating paged-media CSS wit
 | Running footer | ✓ Done | Shows issuer, date, identity, commit, page number |
 | Page margins and size | ✓ Done | A4 (595 × 842 pt), 20mm margins |
 | Page counters | ✓ Done | `counter(page)` and `counter(pages)` available |
-| Landscape pages | ✓ Done | `@page landscape` rule for wide diagrams |
+| Landscape pages | ✓ Done | `@page landscape` rule; A4 rotated (842 × 595 pt) |
+| Wide view detection | ✓ Done | Automatically detects views where width > height and applies landscape page |
 | Typography rules | ✓ Done | Headings, paragraphs, lists, code, blockquotes, tables |
 | Page break avoidance | ✓ Done | Headings and figures use `page-break-after/inside: avoid` |
 | First page footer suppression | ✓ Done | Title page has no footer |
@@ -155,15 +156,24 @@ For adopters or tools that need to render HTML to PDF:
 ```javascript
 import { wrapHtmlForPrintRendering } from '@transitrix/document-renderer/src/render-vivliostyle.mjs';
 
-// Your HTML content
-const html = '<h1>Title</h1><p>Content...</p>';
+// Your HTML content (with id attributes on diagrams)
+const html = `
+  <h1>Title</h1>
+  <p>Content...</p>
+  <div id="diagram-architecture">
+    <svg><!-- wide diagram, 1200 x 600 --></svg>
+  </div>
+`;
 
-// Metadata for the footer
+// Metadata for the footer and view dimensions
 const metadata = {
   issuer: 'Acme Corp',
   issued_at: '2026-09-02T15:30:00Z',
   document_identity: 'PRODUCT-MRD-1.0',
   repository_commit: 'a1b2c3d4',
+  views: [
+    { id: 'diagram-architecture', width: 1200, height: 600 }, // wide: uses landscape page
+  ],
 };
 
 // Get HTML with embedded CSS
@@ -171,7 +181,10 @@ const htmlWithCss = wrapHtmlForPrintRendering(html, metadata);
 
 // Pass to Vivliostyle (or your chosen engine) for PDF rendering
 // E.g., via documents-cli or a headless browser
+// The wide diagram automatically renders on a landscape page.
 ```
+
+**Wide view handling:** Pass a `views` array in metadata. For each view with `width > height`, the CSS generator creates a rule that applies landscape page layout automatically. The HTML element must have an `id` matching the view's `id`.
 
 The HTML output is ready for any CSS Paged Media Module Level 3 compliant renderer.
 

--- a/packages/document-renderer/src/render-vivliostyle.mjs
+++ b/packages/document-renderer/src/render-vivliostyle.mjs
@@ -26,7 +26,7 @@ function escapeHtml(text) {
 }
 
 /**
- * Generate CSS for paged-media including running footer.
+ * Generate CSS for paged-media including running footer and landscape pages.
  * Defines @page rules for footer styling, landscape pages, and typography.
  *
  * @param {object} metadata - Document metadata
@@ -34,6 +34,7 @@ function escapeHtml(text) {
  * @param {string} metadata.issued_at - ISO 8601 timestamp
  * @param {string} metadata.document_identity - Recipe ID or document identifier
  * @param {string} [metadata.repository_commit] - Git commit hash
+ * @param {array} [metadata.views] - View specifications with width/height
  * @returns {string} CSS text with @page rules and base typography
  */
 export function generatePagedMediaCss(metadata = {}) {
@@ -61,6 +62,25 @@ export function generatePagedMediaCss(metadata = {}) {
   const footerParts = [issuer, issued, identity];
   if (commit) footerParts.push(commit);
   const footerText = footerParts.join(' • ');
+
+  // Detect wide views (width > height) and generate CSS for them
+  let wideViewsCss = '';
+  if (metadata.views && Array.isArray(metadata.views)) {
+    const wideViews = metadata.views.filter(view =>
+      view && view.width && view.height && view.width > view.height && view.id
+    );
+    if (wideViews.length > 0) {
+      wideViewsCss = wideViews.map(view => {
+        // View IDs come from trusted model data; CSS selectors don't need HTML escaping
+        // Use a safe identifier pattern: alphanumeric, hyphens, underscores
+        const safeId = String(view.id).replace(/[^a-zA-Z0-9_-]/g, '-');
+        return `#${safeId} {
+  page: landscape;
+  page-break-inside: avoid;
+}`;
+      }).join('\n\n');
+    }
+  }
 
   return `/* Paged Media CSS — footer, typography, page breaks */
 
@@ -210,6 +230,8 @@ a {
   color: #0066cc;
   text-decoration: underline;
 }
+
+${wideViewsCss}
 `;
 }
 

--- a/packages/document-renderer/tests/test_paged_media_css.mjs
+++ b/packages/document-renderer/tests/test_paged_media_css.mjs
@@ -114,5 +114,89 @@ function check(condition, message) {
   check(!css.includes('undefined'), 'No undefined values in CSS');
 }
 
+// Test 11: Wide views detected and landscaped
+{
+  const css = generatePagedMediaCss({
+    views: [
+      { id: 'diagram-arch', width: 1200, height: 600 }, // wide
+      { id: 'diagram-flow', width: 400, height: 800 },  // portrait
+    ],
+  });
+  check(css.includes('#diagram-arch'), 'Wide view CSS selector generated');
+  check(css.includes('page: landscape'), 'Wide view uses landscape page rule');
+  check(!css.includes('#diagram-flow'), 'Portrait view not marked as landscape');
+}
+
+// Test 12: Empty views array handled
+{
+  const css = generatePagedMediaCss({ views: [] });
+  check(css.includes('@page {'), 'CSS generated with empty views array');
+  check(!css.includes('undefined'), 'No undefined values with empty views');
+}
+
+// Test 13: Views with missing dimensions ignored
+{
+  const css = generatePagedMediaCss({
+    views: [
+      { id: 'no-width', height: 600 },
+      { id: 'no-height', width: 800 },
+      { id: 'no-dims' },
+    ],
+  });
+  check(!css.includes('#no-width'), 'View without width ignored');
+  check(!css.includes('#no-height'), 'View without height ignored');
+  check(!css.includes('#no-dims'), 'View without dimensions ignored');
+}
+
+// Test 14: Wide view at exact square boundary
+{
+  const css = generatePagedMediaCss({
+    views: [
+      { id: 'square', width: 600, height: 600 },       // not wide
+      { id: 'slightly-wide', width: 601, height: 600 }, // wide
+    ],
+  });
+  check(!css.includes('#square'), 'Square view not marked as landscape');
+  check(css.includes('#slightly-wide'), 'View with width > height marked as landscape');
+}
+
+// Test 15: Special characters in view IDs are sanitized
+{
+  const css = generatePagedMediaCss({
+    views: [
+      { id: 'diagram-with-"quotes"', width: 800, height: 400 },
+      { id: 'diagram<script>', width: 800, height: 400 },
+    ],
+  });
+  check(css.includes('#diagram-with--quotes-'), 'Quotes in view ID are removed/sanitized');
+  check(css.includes('#diagram-script-'), 'Special characters in view ID are removed/sanitized');
+  check(!css.includes('<script>'), 'No unescaped <script> tags in CSS');
+}
+
+// Test 16: Multiple wide views generate multiple selectors
+{
+  const css = generatePagedMediaCss({
+    views: [
+      { id: 'wide-1', width: 1000, height: 500 },
+      { id: 'wide-2', width: 900, height: 400 },
+      { id: 'portrait', width: 300, height: 600 },
+    ],
+  });
+  check(css.includes('#wide-1'), 'First wide view CSS selector generated');
+  check(css.includes('#wide-2'), 'Second wide view CSS selector generated');
+  check(!css.includes('#portrait'), 'Portrait view not included');
+  const count = (css.match(/page: landscape/g) || []).length;
+  check(count >= 2, `Multiple landscape rules generated (found ${count})`);
+}
+
+// Test 17: Landscape pages have correct dimensions (A4 rotated: 842 × 595 pt)
+{
+  const css = generatePagedMediaCss();
+  check(css.includes('size: A4 landscape'), 'Landscape page size rule exists');
+  // Verify margins are set for landscape pages
+  const landscapeSection = css.match(/@page landscape[\s\S]*?}/);
+  check(landscapeSection && landscapeSection[0].includes('margin:'), 'Landscape pages have margins');
+}
+
 console.log(`\nExit: ${failures === 0 ? 0 : 1} (${failures === 0 ? 'all pass' : failures + ' failures'})`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Implements automatic detection and CSS generation for wide views, applying landscape page layout without manual CSS class assignment.

## What's new

**Wide view detection in CSS generation:**
- Extends `generatePagedMediaCss(metadata)` to accept view specifications with width/height dimensions
- Detects views where `width > height` and automatically applies `page: landscape` CSS rule
- Sanitizes view IDs for safe CSS identifier generation

**Landscape page handling:**
- A4 landscape page size correctly declared (842 × 595 pt)
- Running footer adjusts to landscape page width (15mm margins)
- Page-break-inside avoid ensures diagrams stay intact

**Tests:**
- 47 test cases covering wide/portrait view detection, edge cases, special characters
- All tests passing

## Architecture

Wide view detection happens at CSS generation time:
1. Caller provides view specifications with width/height to `generatePagedMediaCss()`
2. Module detects wide views (`width > height`) and generates CSS selectors
3. HTML elements with matching `id` automatically render on landscape pages
4. No manual class assignment needed; detection is automatic

## Integration example

```javascript
const metadata = {
  issuer: 'Acme Corp',
  document_identity: 'PRODUCT-MRD-1.0',
  views: [
    { id: 'diagram-arch', width: 1200, height: 600 }, // wide → landscape
    { id: 'diagram-flow', width: 400, height: 800 },  // portrait → portrait
  ],
};
const html = wrapHtmlForPrintRendering(content, metadata);
// diagram-arch renders on landscape page; diagram-flow on portrait page
```

## Acceptance criteria met

✓ Wide views automatically use landscape pages
✓ Portrait views stay portrait
✓ Page size correctly declared (landscape A4: 842 × 595 pt)
✓ Layout is stable across renders

## Part of larger work

This implements automatic landscape page detection for wide diagram views:
- Engine selection and paged-media CSS specification (merged)
- Running footer paged-media CSS (merged)
- Wide view detection for landscape pages (this PR)

## Testing

```bash
cd packages/document-renderer
node tests/test_paged_media_css.mjs
```