### PR TITLE
docs(readme): state where work is filed (#600)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Transitrix — including the DGCA notation that forms part of it — is authored
 
 **Contact:** [hello@transitrix.com](mailto:hello@transitrix.com)
 
+## Contributing
+
+Work for this repository is filed in [`transitrix/transitrix-hq`](https://github.com/transitrix/transitrix-hq), not in this repository's issue tracker. That repository is private; if you'd like to contribute or report feedback, open a pull request here or email [hello@transitrix.com](mailto:hello@transitrix.com).
+
 ---
 
 **Methodology status:** 1.0 (stable) — see [`CHANGELOG.md`](CHANGELOG.md) for the current release and [`notations/CONTRACT.md`](notations/CONTRACT.md) §10 for the compatibility policy.


### PR DESCRIPTION
## Summary

Adds a section to the README stating that work for this repository is filed in `transitrix/transitrix-hq`, not in the GitHub issue tracker. The note informs both contributors and agents where to file work or provide feedback, with routing for outsiders via pull request or email.

## Testing

- README parses and renders correctly
- Link to `transitrix/transitrix-hq` is valid
- Paragraph is one logical unit as required

🤖 Generated with [Claude Code](https://claude.com/claude-code)